### PR TITLE
docs: theme to logo colours, center hero, note context-line review

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ cloud providers. Posts inline review comments and a summary.
 
 ## What it reviews
 
-lgtmaybe reviews the **changed lines in a pull request** — nothing else. It
-fetches the PR diff from the GitHub API (it never checks out or runs your code)
-and looks only at what the PR adds or changes, not the whole repository.
-Generated and non-reviewable files — lockfiles, minified bundles, vendored
-directories, binaries — are skipped automatically, and secrets are redacted from
-the diff before it is sent to the model.
+lgtmaybe fetches the PR diff from the GitHub API and reviews the lines a pull
+request changes. It never checks out or runs your code. To judge each change in
+context it also reads a few surrounding lines from the file, but it only ever
+comments on what the PR actually changed, not the whole repository.
+
+Reviews surface the kind of thing a careful reviewer would flag: correctness
+bugs, security weaknesses, and readability problems, each graded from `info` up
+to `critical`. Generated and non-reviewable files (lockfiles, minified bundles,
+vendored directories, binaries) are skipped automatically, and secrets are
+redacted from the diff before it is sent to the model.
 
 **How the scope is bounded.** Every run is capped so a large PR can't blow up
 latency or cost:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: Provider-agnostic PR reviewer — five providers, one flag, no stat
 author: Matt Coles
 branding:
   icon: check-circle
-  color: purple
+  color: green
 
 inputs:
   provider:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,27 @@
-<p align="center" markdown>
-  ![lgtmaybe logo — a shrugging face with curly-brace arms](assets/logo.svg){ width="128" }
-</p>
+<div class="hero" markdown>
+
+![lgtmaybe logo — a shrugging face with curly-brace arms](assets/logo.svg){ width="128" }
 
 # lgtmaybe
 
-Provider-agnostic PR reviewer. Five providers, one flag, no static keys for
-cloud providers. It posts inline review comments and a summary on a pull request.
+Provider-agnostic PR reviewer. Five providers, one flag, and no static keys for
+cloud providers. It posts inline comments and a summary straight onto the pull
+request.
 
-lgtmaybe reviews the **changed lines in a pull request** — it fetches the PR diff
-from the GitHub API (it never checks out or runs your code), skips generated and
-binary files, redacts secrets, and returns structured findings: a comment on the
-exact changed line plus one summary. A clean PR gets a 👍 **LGTM!**.
+</div>
+
+lgtmaybe fetches the diff from the GitHub API and reviews the lines a pull
+request changes. It never checks out or runs your code. To judge each change in
+context it also reads a few surrounding lines from the file, so a finding lands
+with the function around it in view, but it only ever comments on what the PR
+actually changed.
+
+Reviews surface the things you'd want a careful reviewer to catch: correctness
+bugs, security weaknesses, and readability problems. Every finding is graded from
+`info` up to `critical` and posted as an inline comment on the exact line, with
+one summary at the top. Generated files and binaries are skipped, secrets are
+redacted before anything leaves for the model, and a clean PR just gets a
+👍 **LGTM!**.
 
 ## Start here
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,35 @@
+/* Brand palette, taken straight from the logo: slate #2f3b45, mint #54d090. */
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        #2f3b45;
+  --md-primary-fg-color--light: #3c4a56;
+  --md-primary-fg-color--dark:  #232c34;
+  --md-primary-bg-color:        #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+
+  --md-accent-fg-color:             #54d090;
+  --md-accent-fg-color--transparent: rgba(84, 208, 144, 0.1);
+
+  /* Body links use a deepened mint so they clear WCAG AA on white. */
+  --md-typeset-a-color:         #157a4b;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #2f3b45;
+  --md-primary-fg-color--light: #3c4a56;
+  --md-primary-fg-color--dark:  #232c34;
+
+  /* On the dark scheme the bright mint reads well as both link and accent. */
+  --md-accent-fg-color:             #54d090;
+  --md-accent-fg-color--transparent: rgba(84, 208, 144, 0.1);
+  --md-typeset-a-color:         #54d090;
+}
+
+/* Homepage hero: centre the logo, wordmark, and tagline as a single block. */
+.md-typeset .hero {
+  text-align: center;
+}
+
+.md-typeset .hero h1 {
+  margin-top: 0.4rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,12 +20,14 @@ theme:
     repo: fontawesome/brands/github
   palette:
     - scheme: default
-      primary: deep purple
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - scheme: slate
-      primary: deep purple
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
@@ -36,6 +38,9 @@ theme:
     - content.code.copy
     - search.suggest
     - search.highlight
+
+extra_css:
+  - stylesheets/extra.css
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 lgtmaybe = "lgtmaybe.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/lgtmaybe/lgtmaybe"
+Homepage = "https://mattjcoles.github.io/lgtmaybe/"
+Repository = "https://github.com/MattJColes/lgtmaybe"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## What

Brings the docs site and README in line with the new logo and the merged `diff-context-lines` feature.

- **Theme matches the logo** — new `docs/stylesheets/extra.css` drives a slate (`#2f3b45`) header/primary with a mint (`#54d090`) accent across both light and dark schemes; `mkdocs.yml` palette switched from `deep purple` to `custom`. `action.yml` branding colour `purple` → `green` (Actions branding has no hex; green is closest to the mint face). Body links use a deepened mint (`#157a4b`) in light mode to clear WCAG AA on white.
- **Centered hero** — the homepage logo, `# lgtmaybe` wordmark, and tagline are wrapped in a `.hero` block and centered as one unit.
- **Reviews-in-context messaging** — homepage and README now say the reviewer reads a few surrounding lines to judge each change in context, while only ever commenting on the changed lines. Reconciles the old "changed lines, nothing else" copy with the context-lines feature.
- **Lightweight "what it looks for"** — one honest, high-level line per page (correctness bugs, security weaknesses, readability problems; graded `info` → `critical`), grounded in the severity ladder in `src/lgtmaybe/engine/prompt.py` rather than claiming a fixed checklist.
- **Voice pass** (homepage + README intros only) — toned down em-dash chains and run-ons; facts, commands, tables, and links unchanged.
- **Homepage URL consistency** — `pyproject.toml` `Homepage` now points at `https://mattjcoles.github.io/lgtmaybe/`, with an explicit `Repository` URL.

`CLAUDE.md` already documents the context-lines feature accurately, so it needs no change.

## Verification

- `mkdocs build --strict` passes.
- Built HTML contains the `.hero` block, the linked `extra.css`, `data-md-color-primary="custom"`, and the new copy.
- Homepage URL references are consistent across `mkdocs.yml`, `pyproject.toml`, and `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)