### PR TITLE
docs: homepage copy — tagline, functionality bullets, local + Action review

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@
 
 # lgtmaybe
 
+</div>
+
 Provider-agnostic PR reviewer. Five providers, one flag, and no static keys for
 cloud providers. It posts inline comments and a summary straight onto the pull
 request.
-
-</div>
 
 lgtmaybe fetches the diff from the GitHub API and reviews the lines a pull
 request changes. It never checks out or runs your code. To judge each change in

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,18 +10,22 @@ Provider-agnostic PR reviewer. Five providers, one flag, and no static keys for
 cloud providers. It posts inline comments and a summary straight onto the pull
 request.
 
-lgtmaybe fetches the diff from the GitHub API and reviews the lines a pull
-request changes. It never checks out or runs your code. To judge each change in
-context it also reads a few surrounding lines from the file, so a finding lands
-with the function around it in view, but it only ever comments on what the PR
+lgtmaybe reviews the lines a change touches, and it runs in two places: as a
+GitHub Action on a pull request, or locally from the command line against your
+`git` diff before you push. As an Action it fetches the diff from the GitHub API
+and never checks out or runs your code; locally it reads your working branch.
+Either way it pads each change with a few surrounding lines, so a finding lands
+with the function around it in view, but it only ever comments on the lines that
 actually changed.
 
-Reviews surface the things you'd want a careful reviewer to catch: correctness
-bugs, security weaknesses, and readability problems. Every finding is graded from
-`info` up to `critical` and posted as an inline comment on the exact line, with
-one summary at the top. Generated files and binaries are skipped, secrets are
-redacted before anything leaves for the model, and a clean PR just gets a
-👍 **LGTM!**.
+Reviews surface the things you'd want a careful reviewer to catch:
+
+- **Correctness bugs, security weaknesses, and readability problems** — the substance of a change, not just style nits.
+- **Severity grading** — every finding is rated from `info` up to `critical`, so you can set the floor that matters to you.
+- **Inline, on the exact line** — each finding is a comment where the problem is, with one summary at the top (on the CLI, the same findings print to your terminal).
+
+Generated files and binaries are skipped, secrets are redacted before anything
+leaves for the model, and a clean PR just gets a 👍 **LGTM!**.
 
 ## Start here
 


### PR DESCRIPTION
Homepage (`docs/index.md`) copy follow-ups to #10:

- **Left-align the tagline** — moved out of the centered `.hero` block, so the logo and `lgtmaybe` wordmark stay centered while the tagline reads left-aligned.
- **Cover both review modes** — the merged local CLI (`feat/local-cli`) added a `review` command that reads the local `git` diff with no GitHub involvement. The intro now describes both: GitHub Action on a PR (diff via the API, no checkout), or local CLI against your `git` diff before you push.
- **Bullet the functionality** — what it catches, severity grading (`info` → `critical`), and inline-on-the-exact-line placement, with the CLI's terminal output noted.
- **Own paragraph** for the skip-generated / redact-secrets / clean-PR-LGTM note.

`mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)