### PR TITLE
docs: fix CLI usage for the local-only review command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ pattern, event bus, plugin framework.
    - **Track C** — hardening: **prompt-injection defense** (PR text trying to
      steer the reviewer), **secret redaction in diffs before they leave for the
      LLM**, fork-PR exposure (already handled by `pull_request_target` + no checkout).
-   - **CLI track** — PyPI packaging, `--dry-run` for local dev.
+   - **CLI track** — PyPI packaging; a local `lgtmaybe review` of your `git` diff
+     (prints findings, no GitHub) for local dev.
 3. **Integration (sequential, last) — DONE:** the tracks are wired together.
    `cli.build_review_context` swaps the fakes for the real `LiteLLMProvider` +
    `RestGitHubGateway`; `python -m lgtmaybe` (the Docker ENTRYPOINT) is the live

--- a/README.md
+++ b/README.md
@@ -36,27 +36,29 @@ title, an explanation, and an optional suggested fix — so it renders the same
 everywhere:
 
 - **On a GitHub PR** — an inline comment on the exact changed line for each finding, plus one summary comment naming the model and approximate cost. Re-running updates the same comments instead of duplicating them, and a clean PR gets a 👍 **LGTM!**.
-- **On the CLI** (`--dry-run`) — the summary line followed by the findings as a JSON array on stdout; nothing is posted to GitHub.
+- **On the CLI** — `lgtmaybe review` reads your local `git` diff and prints the findings (a readable listing, or a JSON array with `--json`); nothing is posted to GitHub.
 
 A fuller walkthrough with example output is in
 [What gets reviewed](docs/explanation/what-gets-reviewed.md).
 
 ## Quick start (60 seconds, local, zero cost)
 
+From inside a git repo, on a branch with changes, review your diff against the
+default branch and print the findings:
+
 ```bash
 pip install lgtmaybe
-export GITHUB_TOKEN=ghp_your_token_here
 
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider ollama \
   --model qwen3.6:27b \
-  --api-base http://localhost:11434 \
-  --dry-run
+  --api-base http://localhost:11434
 ```
 
-See [Getting Started](docs/tutorial/getting-started.md) for the full first-run
-walkthrough.
+No GitHub token and no pull request needed — `lgtmaybe review` reads your local
+`git` diff and prints the findings. To post reviews on real pull requests, wire
+up the [GitHub Action](#use-as-a-github-action). See
+[Getting Started](docs/tutorial/getting-started.md) for the full walkthrough.
 
 ## Providers
 

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -86,22 +86,31 @@ If the file cap kicked in, the summary says so (e.g. "Reviewed the top 50 of 120
 changed files"). lgtmaybe never fails silently — any error is surfaced back to
 the PR as a short comment.
 
-### On the command line (`--dry-run`)
+### On the command line
 
-`--dry-run` runs the full pipeline but posts nothing — it prints the summary
-line and the findings as a JSON array to stdout, so you can see exactly what
-would be posted:
+`lgtmaybe review` runs the same pipeline over your local `git` diff and prints
+the findings — it posts nothing and needs no GitHub token. By default it diffs
+the current branch against the default branch; `--working` reviews uncommitted
+edits and `--base <ref>` picks a different base. The default output is a readable
+listing followed by the summary line:
 
 ```console
-$ lgtmaybe review --pr-url https://github.com/owner/repo/pull/42 \
-    --provider ollama --model qwen3.6:27b --api-base http://localhost:11434 --dry-run
-[dry-run] 1 finding · model qwen3.6:27b · approx cost $0.0000
+$ lgtmaybe review --provider ollama --model qwen3.6:27b --api-base http://localhost:11434
+src/app.py:2  [MEDIUM] Import order
+  sys should be sorted before os
+
+1 finding · model qwen3.6:27b · approx cost $0.0000
+```
+
+Add `--json` to print the findings as a JSON array instead, so the same
+structured data can be piped into other tooling:
+
+```console
+$ lgtmaybe review --provider ollama --model qwen3.6:27b --api-base http://localhost:11434 --json
 [{"path": "src/app.py", "line": 2, "side": "RIGHT", "severity": "medium",
   "title": "Import order", "body": "sys should be sorted before os",
   "suggestion": null}]
 ```
-
-Because findings are structured, the same JSON can be piped into other tooling.
 
 ## See also
 

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -128,7 +128,6 @@ Every config field can be overridden at the command line:
 
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider anthropic \
   --model claude-haiku-4-5 \
   --min-severity high

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -85,11 +85,11 @@ account.
 
 ## Running locally with ambient AWS credentials
 
-If your local shell has AWS credentials (via `~/.aws`, SSO, or an assumed role):
+If your local shell has AWS credentials (via `~/.aws`, SSO, or an assumed role),
+you can review your current branch's changes with Bedrock:
 
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider bedrock \
   --model anthropic.claude-haiku-4-5
 ```

--- a/docs/how-to/review-with-vertex-wif.md
+++ b/docs/how-to/review-with-vertex-wif.md
@@ -84,12 +84,12 @@ export VERTEXAI_PROJECT=my-project
 export VERTEXAI_LOCATION=us-central1
 
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider vertex \
   --model gemini-3-pro
 ```
 
-lgtmaybe does not accept a static API key for Vertex.
+This reviews your current branch's changes with Vertex; lgtmaybe does not accept
+a static API key for it.
 
 ## Troubleshooting
 

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -1,13 +1,15 @@
 # Run Locally with ollama
 
-Use this guide to review pull requests using a local ollama model — zero API
-cost, zero egress, no keys required.
+Use this guide to review your local changes with a local ollama model — zero API
+cost, zero egress, no keys required. The CLI reviews your `git` diff and prints
+the findings; to post reviews on real pull requests, use the
+[GitHub Action](use-as-github-action.md).
 
 ## Prerequisites
 
 - lgtmaybe installed (`pip install lgtmaybe`)
 - [ollama](https://ollama.com) installed and running
-- `GITHUB_TOKEN` set in the environment
+- A local git repository with changes to review
 
 ## Pull the model you want
 
@@ -24,13 +26,18 @@ ollama list
 
 ## Run the review
 
+From inside the repo, on the branch you want reviewed:
+
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider ollama \
   --model qwen3.6:27b \
   --api-base http://localhost:11434
 ```
+
+This diffs your current branch against the default branch and prints the
+findings. Add `--working` to review only your uncommitted edits, or `--base <ref>`
+to diff against a different base.
 
 ## Use a remote ollama instance
 
@@ -38,7 +45,6 @@ If ollama runs on another machine (e.g. a Tailscale peer):
 
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider ollama \
   --model qwen3.6:27b \
   --api-base http://100.x.x.x:11434
@@ -47,27 +53,30 @@ lgtmaybe review \
 No authentication is added — ollama has no built-in auth. Ensure network access
 is restricted at the host or firewall level.
 
-## Use inside Docker (GitHub Action)
+## Inside the GitHub Action's container
 
-When running inside a Docker container, substitute `host.docker.internal` for
-`localhost`:
+The Action runs lgtmaybe in a container, so ollama on the runner host is reached
+at `host.docker.internal` rather than `localhost`. Set it in `.lgtmaybe.yml`,
+since the Action reads its provider settings from config:
 
-```bash
---api-base http://host.docker.internal:11434
+```yaml
+provider: ollama
+model: qwen3.6:27b
+api_base: http://host.docker.internal:11434
 ```
 
-## Dry run to inspect findings without posting
+## Get findings as JSON
+
+The CLI prints a readable listing by default and never posts anywhere. Add
+`--json` for a machine-readable array you can pipe into other tooling:
 
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider ollama \
   --model qwen3.6:27b \
   --api-base http://localhost:11434 \
-  --dry-run
+  --json
 ```
-
-Findings are printed to stdout; nothing is written to GitHub.
 
 ## Troubleshooting
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,16 +1,15 @@
 # Getting Started with lgtmaybe
 
-This tutorial walks you through your first PR review using **ollama** — a fully
-local model that costs nothing and requires no API keys. By the end you will
-have posted a real review comment on a pull request.
+This tutorial walks you through your first review using **ollama** — a fully
+local model that costs nothing and needs no API keys. By the end you will have
+reviewed a branch and seen the findings in your terminal, with no GitHub token
+and no pull request required.
 
 ## What you need
 
 - Python 3.12 or later
 - [ollama](https://ollama.com) running locally
-- A GitHub personal access token with `repo` scope (or `pull_requests: write`
-  for a fine-grained token)
-- A GitHub pull request URL to review
+- A local git repository with some changes on a branch to review
 
 ## Step 1 — Install lgtmaybe
 
@@ -33,57 +32,57 @@ ollama pull qwen3.6:27b    # or any model you prefer
 
 Leave `ollama serve` running in a separate terminal.
 
-## Step 3 — Export your GitHub token
+## Step 3 — Review your changes
 
-```bash
-export GITHUB_TOKEN=ghp_your_token_here
-```
-
-lgtmaybe reads `GITHUB_TOKEN` from the environment; no config file needed for
-this first run.
-
-## Step 4 — Run a dry run first
-
-Before posting anything to GitHub, use `--dry-run` to see what the reviewer
-would say:
+From inside a git repo, on a branch with some changes, run:
 
 ```bash
 lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
-  --provider ollama \
-  --model qwen3.6:27b \
-  --api-base http://localhost:11434 \
-  --dry-run
-```
-
-lgtmaybe fetches the PR diff via the GitHub API, sends it to your local qwen3.6:27b
-instance, and prints the findings to stdout. Nothing is written to GitHub.
-
-## Step 5 — Post a real review
-
-Remove `--dry-run` to post the review:
-
-```bash
-lgtmaybe review \
-  --pr-url https://github.com/owner/repo/pull/42 \
   --provider ollama \
   --model qwen3.6:27b \
   --api-base http://localhost:11434
 ```
 
-lgtmaybe posts inline comments for each finding and a summary comment on the PR.
-Re-running it is safe — it updates the existing summary comment rather than
-creating a duplicate.
+lgtmaybe diffs your current branch against the default branch, sends the changed
+lines to your local qwen3.6:27b instance, and prints the findings to your
+terminal:
+
+```console
+src/app.py:2  [MEDIUM] Import order
+  sys should be sorted before os
+
+1 finding · model qwen3.6:27b · approx cost $0.0000
+```
+
+No GitHub token is involved and nothing is posted anywhere. To review only your
+uncommitted edits, add `--working`; to diff against a different base, pass
+`--base main`.
+
+## Step 4 — Get the findings as JSON
+
+Add `--json` to print the findings as a JSON array instead of a listing, ready
+to pipe into other tooling:
+
+```bash
+lgtmaybe review --provider ollama --model qwen3.6:27b \
+  --api-base http://localhost:11434 --json
+```
+
+## Step 5 — Post reviews on real pull requests
+
+The CLI reviews local changes. To run lgtmaybe on actual pull requests — inline
+comments and a summary posted back to GitHub — add the GitHub Action to your
+repo. See [Use as a GitHub Action](../how-to/use-as-github-action.md).
 
 ## What happened under the hood
 
-lgtmaybe ran five pipeline stages:
+lgtmaybe ran its pipeline over your local diff:
 
-1. **fetch** — pulled the PR diff and metadata from the GitHub REST API
+1. **fetch** — read the diff from your local repo with `git diff`
 2. **compress** — stripped generated files, binaries, and lockfiles
 3. **prompt** — built a structured prompt asking for JSON output
 4. **parse** — validated the model's JSON against the `ReviewFinding` schema
-5. **post** — batched the findings into a single GitHub review request
+5. **render** — printed the findings (the Action posts them to the PR instead)
 
 ## Next steps
 


### PR DESCRIPTION
## Why

`feat/local-cli` (merged) changed `lgtmaybe review` into a **local-only** command: it diffs your `git` branch and prints findings (`--base`, `--working`, `--json`), with **no `--pr-url`, no `--dry-run`, and no GitHub token**. Posting on real PRs now happens only via the GitHub Action. The docs still showed the old `review --pr-url … --dry-run` form everywhere, which no longer runs.

Verified against `lgtmaybe review --help` and `mkdocs build --strict`.

## Changes

- **README** quick-start → local review form; drop `GITHUB_TOKEN`/`--pr-url`; fix the "On the CLI" output line.
- **Getting-started tutorial** → reworked around reviewing a local branch and reading findings in the terminal; posting-on-PRs points at the Action.
- **Run-locally-with-ollama** → drop `--pr-url`/`--dry-run`; add `--json`; correct the container note (the Action reads ollama's `api_base` from `.lgtmaybe.yml`, not an `--api-base` flag).
- **What-gets-reviewed** → rewrite the CLI section with the real human + `--json` output.
- **Bedrock / Vertex / Configure** → drop `--pr-url` from the local snippets.
- **CLAUDE.md** → CLI-track note no longer references `--dry-run`.

## ⚠️ Deliberately out of scope — needs a decision

`examples/workflows/review-ollama.yml` still drives the **CLI** to post a review on a PR (`lgtmaybe review --pr-url …`). The local `review` can no longer post or take a PR URL, so that workflow is **behaviourally broken**, not just stale wording. The fix is a product decision (switch it to the container Action with `api_base` in `.lgtmaybe.yml`, confirming `host.docker.internal` reachability from the action's `docker run`), so I left it out of this docs PR. Flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)