### PR TITLE
Add Azure OpenAI as a provider option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /app
 COPY pyproject.toml README.md uv.lock ./
 COPY src ./src
 
-RUN uv sync --no-dev --frozen
+# Bundle the azure extra so keyless Azure (Azure AD via OIDC) works out of the box.
+RUN uv sync --no-dev --frozen --extra azure
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ up the [GitHub Action](#use-as-a-github-action). See
 | `openrouter` | `OPENROUTER_API_KEY` |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
-| `azure` | `AZURE_API_KEY` + `AZURE_API_BASE` (resource endpoint) |
+| `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |
 | `ollama` | None — local only, zero cost |
 
 ## Documentation
@@ -146,9 +146,10 @@ jobs:
 ```
 
 Copy-paste workflows for every cloud and API-key provider live in
-[`examples/workflows/`](examples/workflows/). Cloud providers (Bedrock, Vertex)
-are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` and the action does
-the OIDC/WIF exchange for you (needs `id-token: write`). See
+[`examples/workflows/`](examples/workflows/). Cloud providers (Bedrock, Vertex,
+Azure) are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` /
+`azure_client_id` and the action does the OIDC/WIF exchange for you (needs
+`id-token: write`). See
 [Use as a GitHub Action](docs/how-to/use-as-github-action.md). ollama is local
 only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instead.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # lgtmaybe
 
-Provider-agnostic PR reviewer. Five providers, one flag, no static keys for
+Provider-agnostic PR reviewer. Six providers, one flag, no static keys for
 cloud providers. Posts inline review comments and a summary.
 
 📖 **Full documentation:** <https://mattjcoles.github.io/lgtmaybe/>
@@ -85,6 +85,7 @@ up the [GitHub Action](#use-as-a-github-action). See
 | `openrouter` | `OPENROUTER_API_KEY` |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
+| `azure` | `AZURE_API_KEY` + `AZURE_API_BASE` (resource endpoint) |
 | `ollama` | None — local only, zero cost |
 
 ## Documentation
@@ -101,6 +102,7 @@ Markdown sources below.
 - [Run locally with ollama](docs/how-to/run-locally-with-ollama.md)
 - [Review with Bedrock OIDC](docs/how-to/review-with-bedrock-oidc.md)
 - [Review with Vertex WIF](docs/how-to/review-with-vertex-wif.md)
+- [Review with Azure OpenAI](docs/how-to/review-with-azure.md)
 - [Use as a GitHub Action](docs/how-to/use-as-github-action.md)
 - [Configure .lgtmaybe.yml](docs/how-to/configure-lgtmaybe-yml.md)
 - [Releasing (maintainers)](docs/how-to/releasing.md)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: lgtmaybe
-description: Provider-agnostic PR reviewer — five providers, one flag, no static keys for cloud.
+description: Provider-agnostic PR reviewer — six providers, one flag, no static keys for cloud.
 author: Matt Coles
 branding:
   icon: check-circle
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   provider:
-    description: "LLM provider: openai, anthropic, openrouter, bedrock, vertex, or ollama."
+    description: "LLM provider: openai, anthropic, openrouter, bedrock, vertex, azure, or ollama."
     required: false
     default: ""
   model:
@@ -19,7 +19,11 @@ inputs:
     required: false
     default: ""
   api_key:
-    description: "API key for key-based providers (openai/anthropic/openrouter). Leave empty for bedrock/vertex/ollama."
+    description: "API key for key-based providers (openai/anthropic/openrouter/azure). Leave empty for bedrock/vertex/ollama."
+    required: false
+    default: ""
+  api_base:
+    description: "Resource endpoint for azure (https://<resource>.openai.azure.com), or a custom base URL for other providers."
     required: false
     default: ""
   aws_role_arn:
@@ -76,6 +80,7 @@ runs:
         INPUT_MODEL: ${{ inputs.model }}
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}
         INPUT_API_KEY: ${{ inputs.api_key }}
+        INPUT_API_BASE: ${{ inputs.api_base }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -85,7 +90,7 @@ runs:
           -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH \
           -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL \
           -e INPUT_PROVIDER -e INPUT_MODEL -e INPUT_FALLBACK_MODEL \
-          -e INPUT_API_KEY -e INPUT_CONFIG_PATH \
+          -e INPUT_API_KEY -e INPUT_API_BASE -e INPUT_CONFIG_PATH \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,14 @@ inputs:
     description: "GCP service account email to impersonate via WIF (used with gcp_wif_provider)."
     required: false
     default: ""
+  azure_client_id:
+    description: "Entra (Azure AD) client ID with a federated credential trusting this repo — keyless azure via GitHub OIDC. No static key is stored."
+    required: false
+    default: ""
+  azure_tenant_id:
+    description: "Entra (Azure AD) tenant ID for keyless azure (used with azure_client_id)."
+    required: false
+    default: ""
   config_path:
     description: "Path to the .lgtmaybe.yml config file, relative to the repo root."
     required: false
@@ -72,6 +80,29 @@ runs:
         workload_identity_provider: ${{ inputs.gcp_wif_provider }}
         service_account: ${{ inputs.gcp_service_account }}
 
+    - name: Federate to Azure (OIDC, keyless)
+      if: ${{ inputs.azure_client_id != '' }}
+      shell: bash
+      env:
+        AZURE_CLIENT_ID: ${{ inputs.azure_client_id }}
+        AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
+      run: |
+        set -euo pipefail
+        # Exchange the workflow's GitHub OIDC token (needs `id-token: write`) for a
+        # file that azure-identity's WorkloadIdentityCredential reads inside the
+        # container. No client secret or static key is ever stored.
+        token_file="${RUNNER_TEMP}/lgtmaybe-azure-oidc-token"
+        resp=$(curl -fsSL \
+          -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange")
+        python3 -c "import json,sys; sys.stdout.write(json.load(sys.stdin)['value'])" \
+          <<<"$resp" > "$token_file"
+        {
+          echo "AZURE_FEDERATED_TOKEN_FILE=${token_file}"
+          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}"
+          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}"
+        } >> "$GITHUB_ENV"
+
     - name: Run lgtmaybe
       shell: bash
       env:
@@ -95,6 +126,8 @@ runs:
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \
           -e CLOUDSDK_CORE_PROJECT -e GOOGLE_CLOUD_PROJECT \
+          -e AZURE_FEDERATED_TOKEN_FILE -e AZURE_CLIENT_ID -e AZURE_TENANT_ID \
+          -e AZURE_AUTHORITY_HOST \
           -v "${GITHUB_EVENT_PATH}:${GITHUB_EVENT_PATH}:ro" \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \

--- a/docs/explanation/auth-model.md
+++ b/docs/explanation/auth-model.md
@@ -1,11 +1,12 @@
 # Auth Model
 
-lgtmaybe supports six providers with three distinct auth approaches. The design
-principle is **no static cloud credentials**: cloud providers use ambient,
-short-lived tokens; key-based providers (openai, anthropic, openrouter, azure)
-require an API key, and even those stay in secrets rather than being committed to
-config. Azure additionally needs the resource endpoint (`AZURE_API_BASE`), since
-each Azure OpenAI deployment lives at its own URL.
+lgtmaybe supports six providers. The design principle is **no static cloud
+credentials**: cloud providers use ambient, short-lived tokens; key-based SaaS
+providers (openai, anthropic, openrouter) require an API key that stays in
+secrets rather than being committed to config. Azure straddles both — it prefers
+ambient Azure AD (Entra) credentials but accepts a resource key — and always
+needs the resource endpoint (`AZURE_API_BASE`), since each Azure OpenAI
+deployment lives at its own URL.
 
 ## Why keyless for cloud
 
@@ -14,7 +15,8 @@ Static credentials — an AWS access key pair or a GCP service-account JSON file
 manager misconfiguration, or a compromised runner, an attacker retains access
 until the key is manually rotated.
 
-OIDC (AWS) and Workload Identity Federation (GCP) issue tokens that:
+OIDC (AWS), Workload Identity Federation (GCP), and federated credentials on an
+Entra app (Azure) issue tokens that:
 
 - Expire in minutes, not years
 - Are scoped to a single workflow run
@@ -23,7 +25,10 @@ OIDC (AWS) and Workload Identity Federation (GCP) issue tokens that:
 - Are tied to the specific repository and branch via the OIDC claim set
 
 For these reasons, lgtmaybe treats Bedrock and Vertex as **ambient-credential
-only** providers. There is no `--api-key` flag for them.
+only** providers. There is no `--api-key` flag for them. Azure defaults to the
+same keyless path (GitHub OIDC → Entra, via `azure-identity`'s
+`DefaultAzureCredential`) but additionally accepts a resource key for teams that
+can't yet adopt federation.
 
 ## Chain of responsibility
 
@@ -37,11 +42,12 @@ chain:
 3. **API key** — for openai, anthropic, and openrouter, lgtmaybe reads the
    key from the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
    `OPENROUTER_API_KEY`). The `--api-key` flag can override this at the CLI.
-4. **API key + endpoint** — azure reads `AZURE_API_KEY` and `AZURE_API_BASE`
-   (the resource endpoint) from the environment, overridable with `--api-key`
-   and `--api-base`. litellm reads `AZURE_API_VERSION` directly (it has a
-   sensible default). If either the key or the endpoint is missing, lgtmaybe
-   fails with a message naming the one to set.
+4. **Azure** — always needs the resource endpoint (`AZURE_API_BASE` or
+   `--api-base`). For the credential it prefers a key when one is present
+   (`AZURE_API_KEY` / `--api-key`); otherwise it goes **keyless**, minting an
+   Azure AD token from ambient creds (GitHub OIDC federation in CI, or a local
+   `az login` / managed identity). If neither a key nor an ambient credential is
+   available, lgtmaybe fails with a message naming both options.
 5. **None** — ollama requires no credentials. Only `--api-base` is needed
    to reach the local or remote server.
 
@@ -54,7 +60,7 @@ chain:
 | openrouter | API key | `OPENROUTER_API_KEY` env var or `--api-key` |
 | bedrock | Ambient AWS creds | GitHub OIDC role or local `~/.aws`; IAM requires only `bedrock:InvokeModel*` |
 | vertex | Ambient GCP creds | GitHub WIF or local ADC (`gcloud auth application-default login`) |
-| azure | API key + endpoint | `AZURE_API_KEY` + `AZURE_API_BASE` env vars, or `--api-key` + `--api-base` |
+| azure | Ambient Azure AD creds (keyless) or API key, + endpoint | GitHub OIDC → Entra federated credential, or local `az login` / managed identity; or `AZURE_API_KEY`. Always with `AZURE_API_BASE` / `--api-base` |
 | ollama | None | `--api-base` pointing to the local or remote server |
 
 ## Least-privilege IAM
@@ -65,6 +71,11 @@ permissions are needed or requested.
 
 For Vertex, `roles/aiplatform.user` on the project is sufficient.
 `roles/editor` or `roles/owner` must not be used.
+
+For Azure (keyless), the Entra app needs only the **Cognitive Services OpenAI
+User** role on the Azure OpenAI resource — enough to call deployments, not to
+manage them — plus a federated credential scoped to your repository. No owner or
+contributor role is required.
 
 ## API keys in secrets, not config
 

--- a/docs/explanation/auth-model.md
+++ b/docs/explanation/auth-model.md
@@ -1,10 +1,11 @@
 # Auth Model
 
-lgtmaybe supports five providers with three distinct auth approaches. The design
+lgtmaybe supports six providers with three distinct auth approaches. The design
 principle is **no static cloud credentials**: cloud providers use ambient,
-short-lived tokens; only key-based SaaS providers (openai, anthropic,
-openrouter) require an API key, and even those stay in secrets rather than being
-committed to config.
+short-lived tokens; key-based providers (openai, anthropic, openrouter, azure)
+require an API key, and even those stay in secrets rather than being committed to
+config. Azure additionally needs the resource endpoint (`AZURE_API_BASE`), since
+each Azure OpenAI deployment lives at its own URL.
 
 ## Why keyless for cloud
 
@@ -36,7 +37,12 @@ chain:
 3. **API key** — for openai, anthropic, and openrouter, lgtmaybe reads the
    key from the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
    `OPENROUTER_API_KEY`). The `--api-key` flag can override this at the CLI.
-4. **None** — ollama requires no credentials. Only `--api-base` is needed
+4. **API key + endpoint** — azure reads `AZURE_API_KEY` and `AZURE_API_BASE`
+   (the resource endpoint) from the environment, overridable with `--api-key`
+   and `--api-base`. litellm reads `AZURE_API_VERSION` directly (it has a
+   sensible default). If either the key or the endpoint is missing, lgtmaybe
+   fails with a message naming the one to set.
+5. **None** — ollama requires no credentials. Only `--api-base` is needed
    to reach the local or remote server.
 
 ## Provider auth summary
@@ -48,6 +54,7 @@ chain:
 | openrouter | API key | `OPENROUTER_API_KEY` env var or `--api-key` |
 | bedrock | Ambient AWS creds | GitHub OIDC role or local `~/.aws`; IAM requires only `bedrock:InvokeModel*` |
 | vertex | Ambient GCP creds | GitHub WIF or local ADC (`gcloud auth application-default login`) |
+| azure | API key + endpoint | `AZURE_API_KEY` + `AZURE_API_BASE` env vars, or `--api-key` + `--api-base` |
 | ollama | None | `--api-base` pointing to the local or remote server |
 
 ## Least-privilege IAM

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -134,7 +134,8 @@ def generate() -> str:
             "Provider",
             [p.value for p in Provider],
             "LLM backend selected by `--provider`. "
-            "Cloud providers (`bedrock`, `vertex`) use ambient credentials.",
+            "Cloud providers (`bedrock`, `vertex`) use ambient credentials; "
+            "`azure` uses an API key plus the resource endpoint (`--api-base`).",
         )
     )
     sections.append(

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -134,8 +134,9 @@ def generate() -> str:
             "Provider",
             [p.value for p in Provider],
             "LLM backend selected by `--provider`. "
-            "Cloud providers (`bedrock`, `vertex`) use ambient credentials; "
-            "`azure` uses an API key plus the resource endpoint (`--api-base`).",
+            "Cloud providers (`bedrock`, `vertex`, `azure`) use ambient "
+            "credentials — `azure` also needs the resource endpoint "
+            "(`--api-base`) and accepts a key as an alternative.",
         )
     )
     sections.append(

--- a/docs/how-to/review-with-azure.md
+++ b/docs/how-to/review-with-azure.md
@@ -1,0 +1,94 @@
+# Review with Azure OpenAI
+
+Use this guide to run lgtmaybe against **Azure OpenAI** — your models hosted on
+your own Azure resource, billed through your Azure subscription.
+
+## How it works
+
+Azure OpenAI serves each model from a per-resource endpoint and authenticates
+with a resource key. lgtmaybe needs two things:
+
+- **`AZURE_API_KEY`** — a key for your Azure OpenAI resource.
+- **`AZURE_API_BASE`** — the resource endpoint, e.g.
+  `https://<resource>.openai.azure.com`.
+
+litellm reads `AZURE_API_VERSION` directly from the environment and falls back
+to a sensible default, so you only need to set it when you must pin a specific
+API version. Unlike Bedrock and Vertex, Azure is **key-based** — the key lives
+in a GitHub Actions secret, never in `.lgtmaybe.yml`.
+
+## One-time Azure setup
+
+Do this once in the Azure portal (or with the `az` CLI):
+
+1. Create an **Azure OpenAI** resource and note its **endpoint**
+   (`https://<resource>.openai.azure.com`) — this is `AZURE_API_BASE`.
+2. **Deploy** the model you want (e.g. `gpt-4o`) and note the **deployment
+   name** — this is what you pass as `model`, *not* the upstream OpenAI name.
+3. Copy a **key** from the resource's *Keys and Endpoint* blade — this is
+   `AZURE_API_KEY`.
+4. Store both as repo secrets (`AZURE_API_KEY`, `AZURE_API_BASE`).
+
+## Workflow example
+
+```yaml
+name: lgtmaybe
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write     # required to post review comments
+
+jobs:
+  review:
+    if: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lgtmaybe/lgtmaybe@v1
+        with:
+          provider: azure
+          model: my-gpt-4o-deployment   # your deployment name
+          api_key: ${{ secrets.AZURE_API_KEY }}
+          api_base: ${{ secrets.AZURE_API_BASE }}
+```
+
+## Choosing the model name
+
+For Azure, `model` is the **deployment name** you chose in the portal, not the
+underlying OpenAI model id. A deployment of `gpt-4o` named `my-gpt-4o-deployment`
+is referenced as `model: my-gpt-4o-deployment`. litellm routes it as
+`azure/<deployment-name>`.
+
+## Running locally
+
+Set the two environment variables and review your current branch's changes:
+
+```bash
+export AZURE_API_KEY="…"
+export AZURE_API_BASE="https://<resource>.openai.azure.com"
+
+lgtmaybe review \
+  --provider azure \
+  --model my-gpt-4o-deployment
+```
+
+You can also pass them inline with `--api-key` and `--api-base` instead of the
+environment variables.
+
+## Troubleshooting
+
+**`azure requires an API key`** / **`azure requires the resource endpoint`** —
+one of `AZURE_API_KEY` / `AZURE_API_BASE` (or `--api-key` / `--api-base`) is
+missing. The error names the one to set.
+
+**`DeploymentNotFound` / 404** — `model` must be the **deployment name**, not the
+upstream OpenAI model id, and the deployment must exist on the resource that
+`AZURE_API_BASE` points at.
+
+**`Unsupported API version`** — pin one explicitly by setting `AZURE_API_VERSION`
+(e.g. `2024-08-01-preview`) in the environment.

--- a/docs/how-to/review-with-azure.md
+++ b/docs/how-to/review-with-azure.md
@@ -1,35 +1,45 @@
-# Review with Azure OpenAI
+# Review with Azure OpenAI (keyless OIDC)
 
-Use this guide to run lgtmaybe against **Azure OpenAI** — your models hosted on
-your own Azure resource, billed through your Azure subscription.
+Use this guide to run lgtmaybe against **Azure OpenAI** using GitHub's OIDC token
+federated to Entra (Azure AD) — no static Azure key stored in secrets. A
+key-based fallback is covered at the end.
 
 ## How it works
 
-Azure OpenAI serves each model from a per-resource endpoint and authenticates
-with a resource key. lgtmaybe needs two things:
+GitHub Actions issues a short-lived OIDC token. Entra (Azure AD) exchanges it —
+via a **federated credential** on an app registration or managed identity — for
+an Azure AD access token scoped to your Azure OpenAI resource. The action does
+that exchange for you (pass `azure_client_id` / `azure_tenant_id`) and lgtmaybe
+picks up the ambient token through `azure-identity`'s `DefaultAzureCredential` —
+no `AZURE_API_KEY` in your secrets.
 
-- **`AZURE_API_KEY`** — a key for your Azure OpenAI resource.
-- **`AZURE_API_BASE`** — the resource endpoint, e.g.
-  `https://<resource>.openai.azure.com`.
-
-litellm reads `AZURE_API_VERSION` directly from the environment and falls back
-to a sensible default, so you only need to set it when you must pin a specific
-API version. Unlike Bedrock and Vertex, Azure is **key-based** — the key lives
-in a GitHub Actions secret, never in `.lgtmaybe.yml`.
+Azure still needs two non-secret values: the **deployment name** (`model`) and
+the **resource endpoint** (`api_base`, `https://<resource>.openai.azure.com`).
 
 ## One-time Azure setup
 
-Do this once in the Azure portal (or with the `az` CLI):
+This is the human-only part — do it once in your Azure tenant:
 
-1. Create an **Azure OpenAI** resource and note its **endpoint**
-   (`https://<resource>.openai.azure.com`) — this is `AZURE_API_BASE`.
-2. **Deploy** the model you want (e.g. `gpt-4o`) and note the **deployment
-   name** — this is what you pass as `model`, *not* the upstream OpenAI name.
-3. Copy a **key** from the resource's *Keys and Endpoint* blade — this is
-   `AZURE_API_KEY`.
-4. Store both as repo secrets (`AZURE_API_KEY`, `AZURE_API_BASE`).
+1. Register an **Entra app** (or use a user-assigned **managed identity**). Note
+   its **client ID** (`azure_client_id`) and your **tenant ID**
+   (`azure_tenant_id`).
+2. Add a **federated credential** to it for GitHub Actions:
+   - Issuer: `https://token.actions.githubusercontent.com`
+   - Subject: scope it to your repo, e.g.
+     `repo:<org>/<repo>:pull_request` (or `:ref:refs/heads/main`, `:environment:…`)
+   - Audience: `api://AzureADTokenExchange`
+3. On the **Azure OpenAI resource**, grant the app the
+   **Cognitive Services OpenAI User** role (least privilege — it can call models,
+   not manage the resource).
+4. **Deploy** the model you want and note the **deployment name** — that is what
+   you pass as `model`, not the upstream OpenAI model id.
+5. Note the resource **endpoint** (`https://<resource>.openai.azure.com`) — it
+   becomes `api_base`. No static key is ever stored.
 
 ## Workflow example
+
+The action performs the OIDC exchange for you — no separate `azure/login` step
+needed. `id-token: write` is required so GitHub will mint the OIDC token.
 
 ```yaml
 name: lgtmaybe
@@ -40,8 +50,9 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  id-token: write          # required for the OIDC token exchange (keyless)
   pull-requests: write     # required to post review comments
+  contents: read
 
 jobs:
   review:
@@ -52,9 +63,10 @@ jobs:
       - uses: lgtmaybe/lgtmaybe@v1
         with:
           provider: azure
-          model: my-gpt-4o-deployment   # your deployment name
-          api_key: ${{ secrets.AZURE_API_KEY }}
-          api_base: ${{ secrets.AZURE_API_BASE }}
+          model: my-gpt-4o-deployment            # your deployment name
+          api_base: ${{ secrets.AZURE_API_BASE }} # https://<resource>.openai.azure.com
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
 ```
 
 ## Choosing the model name
@@ -64,12 +76,15 @@ underlying OpenAI model id. A deployment of `gpt-4o` named `my-gpt-4o-deployment
 is referenced as `model: my-gpt-4o-deployment`. litellm routes it as
 `azure/<deployment-name>`.
 
-## Running locally
+## Running locally with ambient Azure credentials
 
-Set the two environment variables and review your current branch's changes:
+Keyless works locally too. Install the azure extra, sign in (or use a managed
+identity), set the endpoint, and review your current branch's changes:
 
 ```bash
-export AZURE_API_KEY="…"
+pip install 'lgtmaybe[azure]'
+az login
+
 export AZURE_API_BASE="https://<resource>.openai.azure.com"
 
 lgtmaybe review \
@@ -77,18 +92,47 @@ lgtmaybe review \
   --model my-gpt-4o-deployment
 ```
 
-You can also pass them inline with `--api-key` and `--api-base` instead of the
-environment variables.
+`DefaultAzureCredential` finds your `az login` session (or a managed identity, or
+`AZURE_*` env vars) and lgtmaybe never stores a static key.
+
+## Key-based alternative
+
+If you would rather use a resource key, set `AZURE_API_KEY` and `AZURE_API_BASE`
+(no `id-token` permission, no `azure_client_id` needed). The `azure-identity`
+extra is not required in this mode.
+
+```yaml
+      - uses: lgtmaybe/lgtmaybe@v1
+        with:
+          provider: azure
+          model: my-gpt-4o-deployment
+          api_key: ${{ secrets.AZURE_API_KEY }}
+          api_base: ${{ secrets.AZURE_API_BASE }}
+```
+
+Locally: `export AZURE_API_KEY=… AZURE_API_BASE=…` (or pass `--api-key` /
+`--api-base`).
 
 ## Troubleshooting
 
-**`azure requires an API key`** / **`azure requires the resource endpoint`** —
-one of `AZURE_API_KEY` / `AZURE_API_BASE` (or `--api-key` / `--api-base`) is
-missing. The error names the one to set.
+**`azure requires credentials`** — neither a key nor an ambient AD credential was
+found. For keyless, check `id-token: write` is present and the federated
+credential's subject matches the triggering ref/event. For key mode, set
+`AZURE_API_KEY`.
 
-**`DeploymentNotFound` / 404** — `model` must be the **deployment name**, not the
-upstream OpenAI model id, and the deployment must exist on the resource that
-`AZURE_API_BASE` points at.
+**`azure requires the resource endpoint`** — set `api_base` (or `AZURE_API_BASE`)
+to `https://<resource>.openai.azure.com`.
 
-**`Unsupported API version`** — pin one explicitly by setting `AZURE_API_VERSION`
-(e.g. `2024-08-01-preview`) in the environment.
+**`keyless azure needs the azure-identity package`** — running keyless on the CLI
+without the extra; install `lgtmaybe[azure]`. (The Action image already bundles
+it.)
+
+**`AADSTS70021` / no matching federated identity** — the federated credential's
+issuer/subject/audience don't match this workflow. Audience must be
+`api://AzureADTokenExchange` and the subject must match the repo and event.
+
+**`DeploymentNotFound` / 404** — `model` must be the **deployment name** on the
+resource that `api_base` points at, not the upstream OpenAI model id.
+
+**`Unsupported API version`** — pin one by setting `AZURE_API_VERSION`
+(e.g. `2024-08-01-preview`) in the environment; litellm otherwise uses a default.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 </div>
 
-Provider-agnostic PR reviewer. Five providers, one flag, and no static keys for
+Provider-agnostic PR reviewer. Six providers, one flag, and no static keys for
 cloud providers. It posts inline comments and a summary straight onto the pull
 request.
 
@@ -39,7 +39,7 @@ before anything leaves for the model, and a clean PR just gets a 👍 **LGTM!**.
 <div class="grid cards" markdown>
 
 - **Tutorial** — [Getting started](tutorial/getting-started.md): your first review with ollama, locally and free.
-- **How-to** — task recipes: [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [GitHub Action](how-to/use-as-github-action.md).
+- **How-to** — task recipes: [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
 - **Reference** — [Configuration](reference/config.md): every config field and schema.
 - **Explanation** — [What gets reviewed](explanation/what-gets-reviewed.md), [Architecture](explanation/architecture.md), [Auth model](explanation/auth-model.md), [Data & privacy](explanation/data-and-privacy.md).
 
@@ -54,4 +54,5 @@ before anything leaves for the model, and a clean PR just gets a 👍 **LGTM!**.
 | `openrouter` | `OPENROUTER_API_KEY` |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
+| `azure` | `AZURE_API_KEY` + `AZURE_API_BASE` (resource endpoint) |
 | `ollama` | None — local only, zero cost |

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,5 +54,5 @@ before anything leaves for the model, and a clean PR just gets a 👍 **LGTM!**.
 | `openrouter` | `OPENROUTER_API_KEY` |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
-| `azure` | `AZURE_API_KEY` + `AZURE_API_BASE` (resource endpoint) |
+| `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |
 | `ollama` | None — local only, zero cost |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,7 +21,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `info` |  |
 | `model` | string | Yes | — | Model |
-| `provider` | `anthropic` / `bedrock` / `ollama` / `openai` / `openrouter` / `vertex` | Yes | — |  |
+| `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openrouter` / `vertex` | Yes | — |  |
 | `reflect` | boolean | No | `True` | Reflect |
 | `temperature` | number | No | `0.0` | Temperature |
 | `timeout` | integer | No | `60` | Timeout |
@@ -30,9 +30,10 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 
 ### Provider
 
-LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`) use ambient credentials.
+LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`) use ambient credentials; `azure` uses an API key plus the resource endpoint (`--api-base`).
 
 - `anthropic`
+- `azure`
 - `bedrock`
 - `ollama`
 - `openai`
@@ -105,6 +106,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "anthropic",
         "bedrock",
         "vertex",
+        "azure",
         "ollama"
       ],
       "title": "Provider",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -30,7 +30,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 
 ### Provider
 
-LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`) use ambient credentials; `azure` uses an API key plus the resource endpoint (`--api-base`).
+LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`, `azure`) use ambient credentials — `azure` also needs the resource endpoint (`--api-base`) and accepts a key as an alternative.
 
 - `anthropic`
 - `azure`

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -1,0 +1,36 @@
+# Copy into your repo at .github/workflows/lgtmaybe.yml
+#
+# Azure OpenAI (key-based). Add two repo secrets:
+#   AZURE_API_KEY  — a key for your Azure OpenAI resource
+#   AZURE_API_BASE — the resource endpoint, e.g. https://<resource>.openai.azure.com
+# `model` is your Azure *deployment* name, not the upstream OpenAI model name.
+name: lgtmaybe (azure)
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+# pull_request_target runs against the BASE repo (secrets available); the action
+# only ever reads the diff via the API and never checks out PR code.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip comments that aren't on a pull request.
+    if: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6 # base repo only — for .lgtmaybe.yml config
+      - uses: lgtmaybe/lgtmaybe@v1
+        with:
+          provider: azure
+          model: my-gpt-4o-deployment
+          api_key: ${{ secrets.AZURE_API_KEY }}
+          api_base: ${{ secrets.AZURE_API_BASE }}

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -1,9 +1,14 @@
 # Copy into your repo at .github/workflows/lgtmaybe.yml
 #
-# Azure OpenAI (key-based). Add two repo secrets:
-#   AZURE_API_KEY  — a key for your Azure OpenAI resource
-#   AZURE_API_BASE — the resource endpoint, e.g. https://<resource>.openai.azure.com
-# `model` is your Azure *deployment* name, not the upstream OpenAI model name.
+# Azure OpenAI, keyless via GitHub OIDC → Entra (Azure AD). No static key stored.
+# One-time setup: register an Entra app (or managed identity), add a *federated
+# credential* trusting this repo, and grant it the "Cognitive Services OpenAI
+# User" role on your Azure OpenAI resource. Then set two repo secrets:
+#   AZURE_CLIENT_ID, AZURE_TENANT_ID
+# `model` is your Azure *deployment* name; `api_base` is the resource endpoint.
+#
+# Prefer a key instead? Drop azure_client_id/azure_tenant_id and the
+# id-token permission, and pass `api_key: ${{ secrets.AZURE_API_KEY }}`.
 name: lgtmaybe (azure)
 
 on:
@@ -14,6 +19,7 @@ on:
 # pull_request_target runs against the BASE repo (secrets available); the action
 # only ever reads the diff via the API and never checks out PR code.
 permissions:
+  id-token: write          # required for the OIDC token exchange (keyless)
   contents: read
   pull-requests: write
 
@@ -31,6 +37,7 @@ jobs:
       - uses: lgtmaybe/lgtmaybe@v1
         with:
           provider: azure
-          model: my-gpt-4o-deployment
-          api_key: ${{ secrets.AZURE_API_KEY }}
-          api_base: ${{ secrets.AZURE_API_BASE }}
+          model: my-gpt-4o-deployment      # your Azure deployment name
+          api_base: ${{ secrets.AZURE_API_BASE }}  # https://<resource>.openai.azure.com
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: lgtmaybe
-site_description: Provider-agnostic PR reviewer — five providers, one flag, no keys in secrets for cloud.
+site_description: Provider-agnostic PR reviewer — six providers, one flag, no keys in secrets for cloud.
 site_url: https://mattjcoles.github.io/lgtmaybe/
 repo_url: https://github.com/MattJColes/lgtmaybe
 repo_name: MattJColes/lgtmaybe
@@ -62,6 +62,7 @@ nav:
       - Fix findings with an AI agent: how-to/fix-findings-with-an-ai-agent.md
       - Review with Bedrock OIDC: how-to/review-with-bedrock-oidc.md
       - Review with Vertex WIF: how-to/review-with-vertex-wif.md
+      - Review with Azure OpenAI: how-to/review-with-azure.md
       - Use as a GitHub Action: how-to/use-as-github-action.md
       - Configure .lgtmaybe.yml: how-to/configure-lgtmaybe-yml.md
       - Releasing (maintainers): how-to/releasing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ dependencies = [
     "tenacity>=9.1.4",
 ]
 
+[project.optional-dependencies]
+# Keyless Azure OpenAI (Azure AD / Entra token via GitHub OIDC or local creds).
+# Only needed for `--provider azure` without an API key; the Action image bundles it.
+azure = [
+    "azure-identity>=1.19",
+]
+
 [project.scripts]
 lgtmaybe = "lgtmaybe.cli:main"
 
@@ -74,4 +81,9 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = ["litellm", "litellm.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# azure-identity is an optional extra (keyless Azure); it ships no stubs.
+module = ["azure.*"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lgtmaybe"
 version = "0.0.1"
-description = "Provider-agnostic PR reviewer — five providers, one flag, no keys in secrets for cloud."
+description = "Provider-agnostic PR reviewer — six providers, one flag, no keys in secrets for cloud."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -150,6 +150,7 @@ def build_review_context(
         cfg.model,
         api_key=auth.api_key,
         api_base=auth.api_base,
+        azure_ad_token=auth.azure_ad_token,
         fallback_model=runtime.get("fallback_model"),
         timeout=cfg.timeout,
         temperature=cfg.temperature,
@@ -210,7 +211,7 @@ def main() -> None:
     "--api-key",
     default=None,
     envvar="LGTMAYBE_API_KEY",
-    help="API key (not needed for bedrock/vertex with ambient creds, or ollama)",
+    help="API key (not needed for bedrock/vertex/keyless-azure ambient creds, or ollama)",
 )
 @click.option(
     "--api-base",
@@ -350,6 +351,7 @@ def execute_local_review(
             cfg.model,
             api_key=auth.api_key,
             api_base=auth.api_base,
+            azure_ad_token=auth.azure_ad_token,
             fallback_model=runtime.get("fallback_model"),
             timeout=cfg.timeout,
             temperature=cfg.temperature,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -198,7 +198,7 @@ def main() -> None:
 @click.option(
     "--provider",
     default=None,
-    help="LLM provider (openai, anthropic, bedrock, vertex, ollama, openrouter)",
+    help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, openrouter)",
 )
 @click.option("--model", default=None, help="Model name understood by the chosen provider")
 @click.option(
@@ -213,7 +213,10 @@ def main() -> None:
     help="API key (not needed for bedrock/vertex with ambient creds, or ollama)",
 )
 @click.option(
-    "--api-base", default=None, help="API base URL (useful for ollama: http://localhost:11434)"
+    "--api-base",
+    default=None,
+    help="API base URL (ollama: http://localhost:11434; "
+    "azure: https://<resource>.openai.azure.com)",
 )
 @click.option(
     "--min-severity",
@@ -544,6 +547,7 @@ def _action_inputs() -> dict[str, str | None]:
         "model": get("MODEL"),
         "fallback_model": get("FALLBACK_MODEL"),
         "api_key": get("API_KEY"),
+        "api_base": get("API_BASE"),
         "config_path": os.environ.get("INPUT_CONFIG_PATH") or ".lgtmaybe.yml",
     }
 
@@ -563,7 +567,7 @@ def action() -> None:
     )
     runtime: dict[str, Any] = {
         "api_key": inputs["api_key"],
-        "api_base": None,
+        "api_base": inputs["api_base"],
         "fallback_model": inputs["fallback_model"],
     }
 

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -52,6 +52,7 @@ class Provider(StrEnum):
     anthropic = "anthropic"
     bedrock = "bedrock"
     vertex = "vertex"
+    azure = "azure"
     ollama = "ollama"
 
 

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -79,6 +79,24 @@ def resolve_credentials(
             )
         return AuthConfig()
 
+    if provider is Provider.azure:
+        import os
+
+        key = api_key or os.environ.get("AZURE_API_KEY")
+        base = api_base or os.environ.get("AZURE_API_BASE")
+        if not key:
+            raise ValueError(
+                "azure requires an API key. Set the AZURE_API_KEY environment "
+                "variable or pass --api-key."
+            )
+        if not base:
+            raise ValueError(
+                "azure requires the resource endpoint. Set the AZURE_API_BASE "
+                "environment variable (e.g. https://<resource>.openai.azure.com) "
+                "or pass --api-base."
+            )
+        return AuthConfig(api_key=key, api_base=base)
+
     if provider is Provider.ollama:
         return AuthConfig(api_base=api_base or _DEFAULT_OLLAMA_BASE)
 

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -21,6 +21,13 @@ _DEFAULT_OLLAMA_BASE = "http://localhost:11434"
 class AuthConfig:
     api_key: str | None = None
     api_base: str | None = None
+    # An Azure AD (Entra) bearer token for keyless Azure OpenAI — set instead of
+    # api_key when ambient cloud creds (GitHub OIDC / managed identity) are used.
+    azure_ad_token: str | None = None
+
+
+# Data-plane scope for Azure OpenAI / Cognitive Services AD tokens.
+_AZURE_OPENAI_SCOPE = "https://cognitiveservices.azure.com/.default"
 
 
 def _default_aws_probe() -> bool:
@@ -46,12 +53,40 @@ def _default_gcp_probe() -> bool:
     )
 
 
+def _default_azure_token() -> str | None:
+    """Fetch an Azure AD access token for Azure OpenAI from ambient credentials.
+
+    Uses azure-identity's ``DefaultAzureCredential``, which transparently covers
+    GitHub OIDC workload-identity federation in CI (``AZURE_FEDERATED_TOKEN_FILE``
+    + ``AZURE_CLIENT_ID`` + ``AZURE_TENANT_ID``) and local creds when developing
+    (``az login``, a managed identity, or ``AZURE_*`` env vars). Returns ``None``
+    when no ambient credential is available so the resolver can fall through to a
+    clear error.
+    """
+    try:
+        from azure.identity import DefaultAzureCredential
+    except ImportError as exc:
+        raise ValueError(
+            "keyless azure needs the azure-identity package. "
+            "Install it with 'pip install lgtmaybe[azure]' (the GitHub Action "
+            "image already bundles it)."
+        ) from exc
+
+    try:
+        credential = DefaultAzureCredential()
+        token: str = credential.get_token(_AZURE_OPENAI_SCOPE).token
+        return token
+    except Exception:
+        return None
+
+
 def resolve_credentials(
     provider: Provider,
     *,
     api_key: str | None = None,
     api_base: str | None = None,
     ambient_probe: Callable[[], bool] | None = None,
+    azure_token_provider: Callable[[], str | None] | None = None,
 ) -> AuthConfig:
     """Resolve auth for the given provider.
 
@@ -82,20 +117,35 @@ def resolve_credentials(
     if provider is Provider.azure:
         import os
 
-        key = api_key or os.environ.get("AZURE_API_KEY")
         base = api_base or os.environ.get("AZURE_API_BASE")
-        if not key:
-            raise ValueError(
-                "azure requires an API key. Set the AZURE_API_KEY environment "
-                "variable or pass --api-key."
-            )
         if not base:
             raise ValueError(
                 "azure requires the resource endpoint. Set the AZURE_API_BASE "
                 "environment variable (e.g. https://<resource>.openai.azure.com) "
                 "or pass --api-base."
             )
-        return AuthConfig(api_key=key, api_base=base)
+
+        # Key-based auth wins when a key is supplied (explicit or env).
+        key = api_key or os.environ.get("AZURE_API_KEY")
+        if key:
+            return AuthConfig(api_key=key, api_base=base)
+
+        # Keyless: ambient Azure AD creds — GitHub OIDC federation in CI, or a
+        # local 'az login' / managed identity. No static key is stored.
+        get_token = (
+            azure_token_provider if azure_token_provider is not None else _default_azure_token
+        )
+        token = get_token()
+        if token:
+            return AuthConfig(api_base=base, azure_ad_token=token)
+
+        raise ValueError(
+            "azure requires credentials. Either set AZURE_API_KEY (or pass "
+            "--api-key) for key-based auth, or configure keyless Azure AD "
+            "credentials — GitHub OIDC via azure/login (needs id-token: write "
+            "and a federated credential on your Entra app), or a local "
+            "'az login' / managed identity."
+        )
 
     if provider is Provider.ollama:
         return AuthConfig(api_base=api_base or _DEFAULT_OLLAMA_BASE)

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -41,6 +41,7 @@ def build_provider(
     *,
     api_key: str | None = None,
     api_base: str | None = None,
+    azure_ad_token: str | None = None,
     fallback_model: str | None = None,
     **extra_opts: Any,
 ) -> LiteLLMProvider:
@@ -51,6 +52,10 @@ def build_provider(
 
     if api_key is not None:
         opts["api_key"] = api_key
+
+    # Keyless Azure: an Azure AD bearer token instead of a static key.
+    if azure_ad_token is not None:
+        opts["azure_ad_token"] = azure_ad_token
 
     is_ollama = provider is Provider.ollama
     if is_ollama:

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -6,6 +6,7 @@ litellm model-string conventions:
   openrouter → openrouter/<model>
   bedrock    → bedrock/<model>
   vertex     → vertex_ai/<model>
+  azure      → azure/<model>   (+ api_base = resource endpoint)
   ollama     → ollama/<model>  (+ api_base)
 """
 
@@ -24,6 +25,7 @@ _PREFIXES: dict[Provider, str] = {
     Provider.openrouter: "openrouter",
     Provider.bedrock: "bedrock",
     Provider.vertex: "vertex_ai",
+    Provider.azure: "azure",
     Provider.ollama: "ollama",
 }
 
@@ -53,6 +55,10 @@ def build_provider(
     is_ollama = provider is Provider.ollama
     if is_ollama:
         opts["api_base"] = api_base or _DEFAULT_OLLAMA_BASE
+    elif api_base is not None:
+        # Azure routes to a per-resource endpoint; any other provider that
+        # supplies an explicit base (e.g. a proxy) is honoured too.
+        opts["api_base"] = api_base
 
     return LiteLLMProvider(
         model=resolved_model,

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -124,3 +124,35 @@ class TestActionRouting:
             "model": "claude-3-5-sonnet",
             "fallback_model": "claude-3-haiku",
         }
+
+    def test_azure_api_base_input_reaches_runtime(self, tmp_path, monkeypatch):
+        """INPUT_API_BASE carries the azure resource endpoint into the run."""
+        captured: dict[str, object] = {}
+
+        import lgtmaybe.cli as cli_module
+
+        def fake_build(cfg, runtime):
+            captured["api_base"] = runtime.get("api_base")
+            captured["api_key"] = runtime.get("api_key")
+            return FakeGitHub(), FakeEngine(FakeProvider())
+
+        monkeypatch.setattr(cli_module, "build_adapters", fake_build)
+
+        event = _write_event(
+            tmp_path,
+            {"repository": {"full_name": "org/repo"}, "pull_request": {"number": 1}},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "azure")
+        monkeypatch.setenv("INPUT_MODEL", "gpt-4o")
+        monkeypatch.setenv("INPUT_API_KEY", "azure-secret")
+        monkeypatch.setenv("INPUT_API_BASE", "https://my-resource.openai.azure.com")
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert captured == {
+            "api_base": "https://my-resource.openai.azure.com",
+            "api_key": "azure-secret",
+        }

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -276,3 +276,25 @@ class TestBuildAdapters:
         _github, _engine, provider = build_review_context(cfg, runtime)
 
         assert provider.fallback_model == "ollama/llama2"
+
+    def test_azure_keyless_ad_token_threads_to_provider(self, monkeypatch):
+        """Keyless azure resolves an ambient AD token and threads it to litellm."""
+        from lgtmaybe.cli import build_review_context
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "lgtmaybe.providers.credentials._default_azure_token",
+            lambda: "ad-token-from-oidc",
+        )
+        cfg = _default_cfg(provider="azure", model="my-deployment")
+        runtime = {
+            "pr_url": "https://github.com/org/repo/pull/7",
+            "api_key": None,
+            "api_base": "https://my-resource.openai.azure.com",
+        }
+
+        _github, _engine, provider = build_review_context(cfg, runtime)
+
+        assert provider.default_opts.get("azure_ad_token") == "ad-token-from-oidc"
+        assert "api_key" not in provider.default_opts

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -106,6 +106,37 @@ class TestOpenRouter:
         assert "OPENROUTER_API_KEY" in str(exc_info.value)
 
 
+class TestAzure:
+    def test_azure_with_api_key_and_base_resolves(self) -> None:
+        config = resolve_credentials(
+            Provider.azure,
+            api_key="azure-secret",
+            api_base="https://my-resource.openai.azure.com",
+        )
+        assert config.api_key == "azure-secret"
+        assert config.api_base == "https://my-resource.openai.azure.com"
+
+    def test_azure_reads_key_and_base_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZURE_API_KEY", "env-secret")
+        monkeypatch.setenv("AZURE_API_BASE", "https://env-resource.openai.azure.com")
+        config = resolve_credentials(Provider.azure)
+        assert config.api_key == "env-secret"
+        assert config.api_base == "https://env-resource.openai.azure.com"
+
+    def test_azure_without_key_raises_helpful_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_API_BASE", "https://my-resource.openai.azure.com")
+        with pytest.raises(ValueError, match="azure") as exc_info:
+            resolve_credentials(Provider.azure)
+        assert "AZURE_API_KEY" in str(exc_info.value)
+
+    def test_azure_without_base_raises_helpful_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZURE_API_BASE", raising=False)
+        with pytest.raises(ValueError, match="azure") as exc_info:
+            resolve_credentials(Provider.azure, api_key="azure-secret")
+        assert "AZURE_API_BASE" in str(exc_info.value)
+
+
 class TestOllama:
     def test_ollama_resolves_with_no_key_or_creds(self) -> None:
         config = resolve_credentials(Provider.ollama)

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -115,6 +115,7 @@ class TestAzure:
         )
         assert config.api_key == "azure-secret"
         assert config.api_base == "https://my-resource.openai.azure.com"
+        assert config.azure_ad_token is None
 
     def test_azure_reads_key_and_base_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AZURE_API_KEY", "env-secret")
@@ -123,18 +124,54 @@ class TestAzure:
         assert config.api_key == "env-secret"
         assert config.api_base == "https://env-resource.openai.azure.com"
 
-    def test_azure_without_key_raises_helpful_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("AZURE_API_KEY", raising=False)
-        monkeypatch.setenv("AZURE_API_BASE", "https://my-resource.openai.azure.com")
-        with pytest.raises(ValueError, match="azure") as exc_info:
-            resolve_credentials(Provider.azure)
-        assert "AZURE_API_KEY" in str(exc_info.value)
-
     def test_azure_without_base_raises_helpful_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AZURE_API_BASE", raising=False)
         with pytest.raises(ValueError, match="azure") as exc_info:
             resolve_credentials(Provider.azure, api_key="azure-secret")
         assert "AZURE_API_BASE" in str(exc_info.value)
+
+    def test_azure_keyless_resolves_with_ambient_ad_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No key, but ambient Azure AD creds yield a token — the keyless path."""
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        config = resolve_credentials(
+            Provider.azure,
+            api_base="https://my-resource.openai.azure.com",
+            azure_token_provider=lambda: "ad-token-xyz",
+        )
+        assert config.api_key is None
+        assert config.azure_ad_token == "ad-token-xyz"
+        assert config.api_base == "https://my-resource.openai.azure.com"
+
+    def test_azure_key_mode_preferred_over_keyless(self) -> None:
+        """When a key is present the AD token provider is never consulted."""
+
+        def _must_not_run() -> str | None:
+            raise AssertionError("token provider should not be called in key mode")
+
+        config = resolve_credentials(
+            Provider.azure,
+            api_key="azure-secret",
+            api_base="https://my-resource.openai.azure.com",
+            azure_token_provider=_must_not_run,
+        )
+        assert config.api_key == "azure-secret"
+        assert config.azure_ad_token is None
+
+    def test_azure_no_key_and_no_ambient_creds_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="azure") as exc_info:
+            resolve_credentials(
+                Provider.azure,
+                api_base="https://my-resource.openai.azure.com",
+                azure_token_provider=lambda: None,
+            )
+        msg = str(exc_info.value)
+        assert "AZURE_API_KEY" in msg
+        assert "OIDC" in msg or "keyless" in msg.lower()
 
 
 class TestOllama:

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -76,6 +76,20 @@ class TestBuildProvider:
         assert provider.default_opts.get("api_base") == "https://my-resource.openai.azure.com"
         assert provider.model == "azure/gpt-4o"
 
+    def test_build_provider_azure_keyless_carries_ad_token(self) -> None:
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        provider = build_provider(
+            Provider.azure,
+            "gpt-4o",
+            api_base="https://my-resource.openai.azure.com",
+            azure_ad_token="ad-token-xyz",
+        )
+        assert isinstance(provider, LiteLLMProvider)
+        assert provider.default_opts.get("azure_ad_token") == "ad-token-xyz"
+        assert provider.default_opts.get("api_base") == "https://my-resource.openai.azure.com"
+        assert "api_key" not in provider.default_opts
+
     def test_build_provider_stores_resolved_model_string(self) -> None:
         provider = build_provider(Provider.bedrock, "anthropic.claude-3-haiku-20240307-v1:0")
         assert provider.model == "bedrock/anthropic.claude-3-haiku-20240307-v1:0"

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -37,6 +37,9 @@ class TestLiteLLMModelString:
     def test_ollama_prefix(self) -> None:
         assert litellm_model_string(Provider.ollama, "llama2") == "ollama/llama2"
 
+    def test_azure_prefix(self) -> None:
+        assert litellm_model_string(Provider.azure, "gpt-4o") == "azure/gpt-4o"
+
 
 class TestBuildProvider:
     def test_build_provider_returns_litellm_provider(self) -> None:
@@ -58,6 +61,20 @@ class TestBuildProvider:
         provider = build_provider(Provider.ollama, "llama2", api_base="http://localhost:11434")
         assert isinstance(provider, LiteLLMProvider)
         assert provider.default_opts.get("api_base") == "http://localhost:11434"
+
+    def test_build_provider_azure_carries_api_key_and_base(self) -> None:
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        provider = build_provider(
+            Provider.azure,
+            "gpt-4o",
+            api_key="azure-secret",
+            api_base="https://my-resource.openai.azure.com",
+        )
+        assert isinstance(provider, LiteLLMProvider)
+        assert provider.default_opts.get("api_key") == "azure-secret"
+        assert provider.default_opts.get("api_base") == "https://my-resource.openai.azure.com"
+        assert provider.model == "azure/gpt-4o"
 
     def test_build_provider_stores_resolved_model_string(self) -> None:
         provider = build_provider(Provider.bedrock, "anthropic.claude-3-haiku-20240307-v1:0")

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -8,6 +8,7 @@
         "anthropic",
         "bedrock",
         "vertex",
+        "azure",
         "ollama"
       ],
       "title": "Provider",

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,35 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -237,6 +266,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -331,6 +417,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -746,6 +885,11 @@ dependencies = [
     { name = "tenacity" },
 ]
 
+[package.optional-dependencies]
+azure = [
+    { name = "azure-identity" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -762,6 +906,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.19" },
     { name = "click", specifier = ">=8.4.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "litellm", specifier = ">=1.87.1" },
@@ -769,6 +914,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "tenacity", specifier = ">=9.1.4" },
 ]
+provides-extras = ["azure"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1034,6 +1180,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
 ]
 
 [[package]]
@@ -1347,6 +1519,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1443,6 +1624,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds `azure` to the provider set (now six). Azure is key-based but, unlike
the other SaaS providers, also needs the per-resource endpoint:

- Provider enum gains `azure`; factory maps it to litellm's `azure/<deployment>`
  and threads `api_base` (the resource endpoint) through for any non-ollama
  provider that supplies one.
- Credential resolver resolves `AZURE_API_KEY` + `AZURE_API_BASE` (overridable
  with --api-key / --api-base) and fails with a message naming whichever is
  missing. litellm reads AZURE_API_VERSION directly.
- Action: new `api_base` input, threaded as INPUT_API_BASE into the container
  and onto the run.
- Docs: provider tables, auth-model, generated config reference, a how-to
  guide, and an example workflow.

Tests cover the prefix, build_provider wiring, credential resolution (key+base,
env, and both missing-input errors), and INPUT_API_BASE reaching the runtime.