### PR TITLE
Remove dead code and dedup provider/parse helpers

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -29,35 +29,6 @@ from lgtmaybe.providers.factory import build_provider
 _PR_URL_RE = re.compile(r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)")
 
 
-def has_ambient_aws_creds() -> bool:
-    """Return True when AWS credentials appear to be available in the environment.
-
-    Detection seam — real resolution belongs to Track A's credential resolver,
-    wired in the integration step.  Here we check the most common indicators
-    so the CLI can branch without requiring an explicit --api-key for bedrock.
-    """
-    return bool(
-        os.environ.get("AWS_ACCESS_KEY_ID")
-        or os.environ.get("AWS_ROLE_ARN")
-        or os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")
-        or os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
-        or Path(os.path.expanduser("~/.aws/credentials")).exists()
-    )
-
-
-def has_ambient_gcp_creds() -> bool:
-    """Return True when GCP Application Default Credentials appear to be available.
-
-    Detection seam — real resolution is Track A's responsibility.
-    """
-    adc_path = Path(os.path.expanduser("~/.config/gcloud/application_default_credentials.json"))
-    return bool(
-        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        or os.environ.get("GOOGLE_CLOUD_PROJECT")
-        or adc_path.exists()
-    )
-
-
 def parse_pr_url(pr_url: str) -> tuple[str, int]:
     """Parse a GitHub PR URL into ("owner/repo", pr_number).
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -1,8 +1,14 @@
-"""CLI entry point for lgtmaybe.
+"""CLI for lgtmaybe.
 
-The command loads config (applying CLI precedence), resolves runtime options,
-then delegates to ``run_review`` which is injected with ports — testable with
-fakes, and wired with real adapters in the integration step.
+This package is split into three layers:
+
+- ``runtime`` / ``render`` — small, pure helpers (call-time options, output
+  formatting).
+- this module — the *logic*: parsing, adapter/provider wiring, and the
+  ``execute_*`` entry points that the commands call. Kept together so the
+  pipeline stages resolve (and can be patched in tests) as one namespace.
+- ``commands`` — the Click command + option declarations, imported at the
+  bottom to register onto the groups defined here.
 """
 
 from __future__ import annotations
@@ -10,14 +16,12 @@ from __future__ import annotations
 import json
 import os
 import re
-from pathlib import Path
 from typing import Any
 
 import click
 
-from lgtmaybe.cli.slash import dispatch, parse_command
-from lgtmaybe.config import store
-from lgtmaybe.config.loader import load_config
+from lgtmaybe.cli.render import render_findings
+from lgtmaybe.cli.runtime import RuntimeOptions
 from lgtmaybe.core.models import ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
 from lgtmaybe.engine import LLMReviewEngine
@@ -43,66 +47,46 @@ def parse_pr_url(pr_url: str) -> tuple[str, int]:
     return f"{match['owner']}/{match['repo']}", int(match["number"])
 
 
-def render_findings(findings: list[ReviewFinding], summary: str, *, fmt: str = "human") -> str:
-    """Format findings for the local CLI.
+def build_provider_engine(
+    cfg: ReviewConfig, runtime: RuntimeOptions
+) -> tuple[LLMReviewEngine, ProviderClient]:
+    """Resolve credentials and build the provider + engine from config + runtime.
 
-    ``fmt`` selects the output: ``human`` (a readable listing + summary),
-    ``json`` (a machine-readable array), or ``agent`` (directive correction
-    instructions for an AI coding agent to read and apply).
+    Shared by every path that needs to talk to the model — the GitHub gateway
+    wiring and the local review alike — so credential resolution and provider
+    options stay in exactly one place. Raises ValueError with an actionable
+    message when a required credential is missing.
     """
-    if fmt == "json":
-        return json.dumps([f.model_dump(mode="json") for f in findings])
-    if fmt == "agent":
-        return _render_agent(findings, summary)
-
-    lines: list[str] = []
-    for f in findings:
-        lines.append(f"{f.path}:{f.line}  [{f.severity.upper()}] {f.title}")
-        lines.append(f"  {f.body}")
-        if f.suggestion is not None:
-            lines.append(f"  suggestion: {f.suggestion}")
-        lines.append("")
-    lines.append(summary)
-    return "\n".join(lines)
-
-
-def _render_agent(findings: list[ReviewFinding], summary: str) -> str:
-    """Render findings as correction instructions for an AI agent to apply."""
-    if not findings:
-        return f"No review findings — nothing to correct. {summary}"
-
-    lines = [
-        "Code review findings for your local changes. Act as the developer and "
-        "apply each correction below: open the file at the given path and line, "
-        "fix the issue, and apply the suggested change where one is given.",
-        "",
-    ]
-    for i, f in enumerate(findings, 1):
-        lines.append(f"[{i}] {f.path}:{f.line}  ({f.severity.upper()})  {f.title}")
-        lines.append(f"    Issue: {f.body}")
-        if f.suggestion is not None:
-            lines.append("    Suggested fix:")
-            lines.extend(f"        {s}" for s in f.suggestion.splitlines() or [f.suggestion])
-        lines.append("")
-    lines.append(
-        f"{len(findings)} finding(s) to address. After applying the fixes, re-run "
-        "`lgtmaybe review` to confirm they are resolved."
+    auth = resolve_credentials(
+        cfg.provider,
+        api_key=runtime.api_key,
+        api_base=runtime.api_base or cfg.api_base,
     )
-    return "\n".join(lines)
+    provider = build_provider(
+        cfg.provider,
+        cfg.model,
+        api_key=auth.api_key,
+        api_base=auth.api_base,
+        fallback_model=runtime.fallback_model,
+        timeout=cfg.timeout,
+        temperature=cfg.temperature,
+    )
+    return LLMReviewEngine(provider), provider
 
 
 def build_review_context(
-    cfg: ReviewConfig, runtime: dict[str, Any]
+    cfg: ReviewConfig, runtime: RuntimeOptions
 ) -> tuple[RestGitHubGateway, LLMReviewEngine, ProviderClient]:
     """Construct the gateway, engine, and provider from config + runtime.
 
-    Resolves provider credentials (ambient for cloud, key for the rest), builds a
-    litellm-backed provider, and points a REST gateway at the parsed PR. Raises
-    ValueError with an actionable message when a token or credential is missing.
-    The provider is returned too so slash commands (/ask, /describe) can use it
-    directly.
+    Builds the model side via ``build_provider_engine`` and points a REST gateway
+    at the parsed PR. Raises ValueError with an actionable message when the
+    GitHub token is missing. The provider is returned too so slash commands
+    (/ask, /describe) can use it directly.
     """
-    repo, pr_number = parse_pr_url(runtime["pr_url"])
+    if runtime.pr_url is None:
+        raise ValueError("a PR URL is required to build the GitHub review context")
+    repo, pr_number = parse_pr_url(runtime.pr_url)
 
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
@@ -111,28 +95,13 @@ def build_review_context(
             "Set it in the environment (the GitHub Action provides it automatically)."
         )
 
-    auth = resolve_credentials(
-        cfg.provider,
-        api_key=runtime.get("api_key"),
-        api_base=runtime.get("api_base"),
-    )
-    provider = build_provider(
-        cfg.provider,
-        cfg.model,
-        api_key=auth.api_key,
-        api_base=auth.api_base,
-        fallback_model=runtime.get("fallback_model"),
-        timeout=cfg.timeout,
-        temperature=cfg.temperature,
-    )
-
+    engine, provider = build_provider_engine(cfg, runtime)
     github = RestGitHubGateway(repo=repo, pr_number=pr_number, token=token)
-    engine = LLMReviewEngine(provider)
     return github, engine, provider
 
 
 def build_adapters(
-    cfg: ReviewConfig, runtime: dict[str, Any]
+    cfg: ReviewConfig, runtime: RuntimeOptions
 ) -> tuple[GitHubGateway, ReviewEngine]:
     """Construct the real GitHub gateway and review engine from config + runtime."""
     github, engine, _provider = build_review_context(cfg, runtime)
@@ -160,142 +129,9 @@ def run_review(
     return findings, summary
 
 
-@click.group()
-def main() -> None:
-    """lgtmaybe — provider-agnostic PR reviewer."""
-
-
-@main.command()
-@click.option(
-    "--provider",
-    default=None,
-    help="LLM provider (openai, anthropic, bedrock, vertex, ollama, openrouter)",
-)
-@click.option("--model", default=None, help="Model name understood by the chosen provider")
-@click.option(
-    "--fallback-model",
-    default=None,
-    help="Model to retry with if the primary model fails",
-)
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="LGTMAYBE_API_KEY",
-    help="API key (not needed for bedrock/vertex with ambient creds, or ollama)",
-)
-@click.option(
-    "--api-base", default=None, help="API base URL (useful for ollama: http://localhost:11434)"
-)
-@click.option(
-    "--min-severity",
-    default=None,
-    type=click.Choice(["info", "low", "medium", "high", "critical"]),
-    help="Minimum severity to report",
-)
-@click.option("--max-files", default=None, type=int, help="Maximum number of files to review")
-@click.option(
-    "--base",
-    default=None,
-    help="Base ref to diff the current branch against "
-    "(default: the remote's default branch, else main)",
-)
-@click.option(
-    "--working",
-    is_flag=True,
-    default=False,
-    help="Review uncommitted working-tree changes instead of the branch vs base",
-)
-@click.option(
-    "--format",
-    "output_format",
-    type=click.Choice(["human", "json", "agent"]),
-    default=None,
-    help="Output format: human listing (default), json array, or agent "
-    "(correction instructions for an AI coding agent to read and apply).",
-)
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Shorthand for --format json.",
-)
-@click.option(
-    "--context-lines",
-    default=None,
-    type=int,
-    help="Max unchanged lines added around each hunk for context (0 disables)",
-)
-@click.option(
-    "--timeout",
-    default=None,
-    type=int,
-    help="Per-request timeout in seconds for each model call (raise for slow local models)",
-)
-@click.option(
-    "--temperature",
-    default=None,
-    type=float,
-    help="Sampling temperature (default 0.0 for deterministic reviews)",
-)
-@click.option(
-    "--reflect/--no-reflect",
-    default=None,
-    help="Run the self-reflection pass that drops low-confidence findings "
-    "(--no-reflect keeps them all; useful for weaker models)",
-)
-@click.option(
-    "--config",
-    "config_path",
-    default=".lgtmaybe.yml",
-    show_default=True,
-    help="Path to a per-repo config file",
-)
-def review(
-    provider: str | None,
-    model: str | None,
-    fallback_model: str | None,
-    api_key: str | None,
-    api_base: str | None,
-    min_severity: str | None,
-    max_files: int | None,
-    base: str | None,
-    working: bool,
-    output_format: str | None,
-    as_json: bool,
-    context_lines: int | None,
-    timeout: int | None,
-    temperature: float | None,
-    reflect: bool | None,
-    config_path: str,
-) -> None:
-    """Review local git changes and print findings — no GitHub needed."""
-    cfg = load_config(
-        config_path=Path(config_path),
-        user_config_path=store.user_config_path(),
-        provider=provider,
-        model=model,
-        min_severity=min_severity,
-        max_files=max_files,
-        context_lines=context_lines,
-        timeout=timeout,
-        temperature=temperature,
-        reflect=reflect,
-    )
-
-    runtime: dict[str, Any] = {
-        "api_key": api_key,
-        "api_base": api_base,
-        "fallback_model": fallback_model,
-    }
-
-    fmt = output_format or ("json" if as_json else "human")
-    execute_local_review(cfg, runtime, base=base, working=working, fmt=fmt)
-
-
 def execute_local_review(
     cfg: ReviewConfig,
-    runtime: dict[str, Any],
+    runtime: RuntimeOptions,
     *,
     base: str | None,
     working: bool,
@@ -308,21 +144,7 @@ def execute_local_review(
     surfaces as a clean CLI error — there is no PR to post a notice to.
     """
     try:
-        auth = resolve_credentials(
-            cfg.provider,
-            api_key=runtime.get("api_key"),
-            api_base=runtime.get("api_base") or cfg.api_base,
-        )
-        provider = build_provider(
-            cfg.provider,
-            cfg.model,
-            api_key=auth.api_key,
-            api_base=auth.api_base,
-            fallback_model=runtime.get("fallback_model"),
-            timeout=cfg.timeout,
-            temperature=cfg.temperature,
-        )
-        engine = LLMReviewEngine(provider)
+        engine, _provider = build_provider_engine(cfg, runtime)
         ctx = local_pr_context(base=base, working=working)
         findings, summary = engine.review(ctx, cfg)
     except Exception as exc:
@@ -331,7 +153,7 @@ def execute_local_review(
     click.echo(render_findings(findings, summary, fmt=fmt))
 
 
-def execute_review(cfg: ReviewConfig, runtime: dict[str, Any], *, dry_run: bool) -> None:
+def execute_review(cfg: ReviewConfig, runtime: RuntimeOptions, *, dry_run: bool) -> None:
     """Build adapters, run the review, surface failures back to the PR.
 
     Shared by the ``review`` command and the ``action`` entrypoint.
@@ -357,111 +179,14 @@ def execute_review(cfg: ReviewConfig, runtime: dict[str, Any], *, dry_run: bool)
         click.echo(json.dumps([f.model_dump(mode="json") for f in findings]))
 
 
-def _post_failure(github: GitHubGateway, exc: Exception) -> None:
-    """Post a short failure notice to the PR; never raise from here."""
-    notice = f"⚠️ lgtmaybe review failed: {exc}"
-    try:
-        github.post_review([], notice)
-    except Exception:
-        # Posting the failure notice itself failed — nothing more we can do;
-        # the original error is still surfaced by the caller's ClickException.
-        pass
-
-
-@main.group(name="config")
-def config_cmd() -> None:
-    """Manage the user-level config (set provider/model/api_base once, reuse everywhere)."""
-
-
-@config_cmd.command("path")
-def config_path_command() -> None:
-    """Print the config file location."""
-    click.echo(str(store.user_config_path()))
-
-
-@config_cmd.command("show")
-def config_show() -> None:
-    """Print the current config."""
-    text = store.as_yaml()
-    click.echo(text if text else f"(no config yet at {store.user_config_path()})")
-
-
-@config_cmd.command("get")
-@click.argument("key")
-def config_get(key: str) -> None:
-    """Print one config value."""
-    value = store.get_key(key)
-    if value is not None:
-        click.echo(str(value))
-
-
-@config_cmd.command("set")
-@click.argument("key")
-@click.argument("value")
-def config_set(key: str, value: str) -> None:
-    """Set one config value (e.g. `config set model qwen3:27b`)."""
-    try:
-        coerced = store.set_key(key, value)
-    except ValueError as exc:
-        raise click.ClickException(str(exc)) from exc
-    click.echo(f"{key} = {coerced}")
-
-
-@config_cmd.command("init")
-def config_init() -> None:
-    """Interactively create the config file."""
-    provider = click.prompt("Provider", default="ollama")
-    model = click.prompt("Model", default="llama3")
-    api_base = click.prompt("API base (blank for none)", default="", show_default=False)
-    try:
-        store.set_key("provider", provider)
-        store.set_key("model", model)
-        if api_base.strip():
-            store.set_key("api_base", api_base)
-    except ValueError as exc:
-        raise click.ClickException(str(exc)) from exc
-    click.echo(f"Wrote {store.user_config_path()}")
-
-
-@main.command()
-@click.option(
-    "--event-path",
-    envvar="GITHUB_EVENT_PATH",
-    required=True,
-    help="Path to the issue_comment event payload (GitHub sets GITHUB_EVENT_PATH).",
-)
-@click.option("--provider", default=None, help="LLM provider override")
-@click.option("--model", default=None, help="Model name override")
-@click.option("--fallback-model", default=None, help="Model to retry with if the primary fails")
-@click.option("--api-key", default=None, envvar="LGTMAYBE_API_KEY", help="API key")
-@click.option("--api-base", default=None, help="API base URL (e.g. ollama)")
-@click.option("--config", "config_path", default=".lgtmaybe.yml", show_default=True)
-def comment(
-    event_path: str,
-    provider: str | None,
-    model: str | None,
-    fallback_model: str | None,
-    api_key: str | None,
-    api_base: str | None,
-    config_path: str,
-) -> None:
-    """Handle an issue_comment event: route a /slash command to the engine."""
-    event = json.loads(Path(event_path).read_text())
-    cfg = load_config(config_path=Path(config_path), provider=provider, model=model)
-    runtime: dict[str, Any] = {
-        "api_key": api_key,
-        "api_base": api_base,
-        "fallback_model": fallback_model,
-    }
-    execute_comment(event, cfg, runtime)
-
-
-def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: dict[str, Any]) -> None:
+def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: RuntimeOptions) -> None:
     """Route an issue_comment event's slash command to the engine/provider.
 
     Shared by the ``comment`` command and the ``action`` entrypoint. ``runtime``
     supplies api_key/api_base/fallback_model; the PR URL is derived here.
     """
+    from lgtmaybe.cli.slash import dispatch, parse_command
+
     parsed = parse_command(event.get("comment", {}).get("body", ""))
     if parsed is None:
         click.echo("No lgtmaybe slash command found; ignoring.")
@@ -474,7 +199,7 @@ def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: dict[str,
 
     repo = event["repository"]["full_name"]
     pr_number = issue["number"]
-    runtime = {**runtime, "pr_url": f"https://github.com/{repo}/pull/{pr_number}"}
+    runtime = runtime.with_pr_url(f"https://github.com/{repo}/pull/{pr_number}")
 
     try:
         github, engine, provider_client = build_review_context(cfg, runtime)
@@ -488,6 +213,17 @@ def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: dict[str,
         raise click.ClickException(f"/{parsed.name} failed: {exc}") from exc
 
 
+def _post_failure(github: GitHubGateway, exc: Exception) -> None:
+    """Post a short failure notice to the PR; never raise from here."""
+    notice = f"⚠️ lgtmaybe review failed: {exc}"
+    try:
+        github.post_review([], notice)
+    except Exception:
+        # Posting the failure notice itself failed — nothing more we can do;
+        # the original error is still surfaced by the caller's ClickException.
+        pass
+
+
 def pr_url_from_event(event: dict[str, Any]) -> str:
     """Build the PR URL from a pull_request(_target) event payload.
 
@@ -499,7 +235,7 @@ def pr_url_from_event(event: dict[str, Any]) -> str:
     return f"{server}/{repo}/pull/{number}"
 
 
-def _action_inputs() -> dict[str, str | None]:
+def action_inputs() -> dict[str, str | None]:
     """Read the action's declared inputs from the ``INPUT_*`` env vars.
 
     GitHub sets ``INPUT_<NAME>`` for each input of a container action; empty
@@ -519,31 +255,33 @@ def _action_inputs() -> dict[str, str | None]:
     }
 
 
-@main.command()
-def action() -> None:
-    """GitHub Action entrypoint: route by event, read inputs from env.
+@click.group()
+def main() -> None:
+    """lgtmaybe — provider-agnostic PR reviewer."""
 
-    ``issue_comment`` routes a slash command; any other event (``pull_request``
-    / ``pull_request_target``) runs a full review of the triggering PR.
-    """
-    inputs = _action_inputs()
-    cfg = load_config(
-        config_path=Path(inputs["config_path"] or ".lgtmaybe.yml"),
-        provider=inputs["provider"],
-        model=inputs["model"],
-    )
-    runtime: dict[str, Any] = {
-        "api_key": inputs["api_key"],
-        "api_base": None,
-        "fallback_model": inputs["fallback_model"],
-    }
 
-    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
-    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+@main.group(name="config")
+def config_cmd() -> None:
+    """Manage the user-level config (set provider/model/api_base once, reuse everywhere)."""
 
-    if event_name == "issue_comment":
-        execute_comment(event, cfg, runtime)
-        return
 
-    runtime["pr_url"] = pr_url_from_event(event)
-    execute_review(cfg, runtime, dry_run=False)
+# Importing the commands module registers every command onto the groups above.
+# Done last so the logic functions the commands call are already defined.
+from lgtmaybe.cli import commands as _commands  # noqa: E402,F401
+
+__all__ = [
+    "RuntimeOptions",
+    "action_inputs",
+    "build_adapters",
+    "build_provider_engine",
+    "build_review_context",
+    "config_cmd",
+    "execute_comment",
+    "execute_local_review",
+    "execute_review",
+    "main",
+    "parse_pr_url",
+    "pr_url_from_event",
+    "render_findings",
+    "run_review",
+]

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -32,7 +32,7 @@ from lgtmaybe.config.loader import load_config
 @click.option(
     "--provider",
     default=None,
-    help="LLM provider (openai, anthropic, bedrock, vertex, ollama, openrouter)",
+    help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, openrouter)",
 )
 @click.option("--model", default=None, help="Model name understood by the chosen provider")
 @click.option(
@@ -44,10 +44,13 @@ from lgtmaybe.config.loader import load_config
     "--api-key",
     default=None,
     envvar="LGTMAYBE_API_KEY",
-    help="API key (not needed for bedrock/vertex with ambient creds, or ollama)",
+    help="API key (not needed for bedrock/vertex/keyless-azure ambient creds, or ollama)",
 )
 @click.option(
-    "--api-base", default=None, help="API base URL (useful for ollama: http://localhost:11434)"
+    "--api-base",
+    default=None,
+    help="API base URL (ollama: http://localhost:11434; "
+    "azure: https://<resource>.openai.azure.com)",
 )
 @click.option(
     "--min-severity",
@@ -193,7 +196,11 @@ def action() -> None:
         provider=inputs["provider"],
         model=inputs["model"],
     )
-    runtime = RuntimeOptions(api_key=inputs["api_key"], fallback_model=inputs["fallback_model"])
+    runtime = RuntimeOptions(
+        api_key=inputs["api_key"],
+        api_base=inputs["api_base"],
+        fallback_model=inputs["fallback_model"],
+    )
 
     event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -1,0 +1,256 @@
+"""Click command + option declarations.
+
+The callbacks are thin: they resolve config and a ``RuntimeOptions`` from the
+flags / action inputs, then delegate to the ``execute_*`` functions in
+``lgtmaybe.cli``. Imported by ``lgtmaybe.cli`` at import time so the commands
+register onto the ``main`` / ``config`` groups defined there.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import click
+
+from lgtmaybe.cli import (
+    RuntimeOptions,
+    action_inputs,
+    config_cmd,
+    execute_comment,
+    execute_local_review,
+    execute_review,
+    main,
+    pr_url_from_event,
+)
+from lgtmaybe.config import store
+from lgtmaybe.config.loader import load_config
+
+
+@main.command()
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider (openai, anthropic, bedrock, vertex, ollama, openrouter)",
+)
+@click.option("--model", default=None, help="Model name understood by the chosen provider")
+@click.option(
+    "--fallback-model",
+    default=None,
+    help="Model to retry with if the primary model fails",
+)
+@click.option(
+    "--api-key",
+    default=None,
+    envvar="LGTMAYBE_API_KEY",
+    help="API key (not needed for bedrock/vertex with ambient creds, or ollama)",
+)
+@click.option(
+    "--api-base", default=None, help="API base URL (useful for ollama: http://localhost:11434)"
+)
+@click.option(
+    "--min-severity",
+    default=None,
+    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    help="Minimum severity to report",
+)
+@click.option("--max-files", default=None, type=int, help="Maximum number of files to review")
+@click.option(
+    "--base",
+    default=None,
+    help="Base ref to diff the current branch against "
+    "(default: the remote's default branch, else main)",
+)
+@click.option(
+    "--working",
+    is_flag=True,
+    default=False,
+    help="Review uncommitted working-tree changes instead of the branch vs base",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["human", "json", "agent"]),
+    default=None,
+    help="Output format: human listing (default), json array, or agent "
+    "(correction instructions for an AI coding agent to read and apply).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Shorthand for --format json.",
+)
+@click.option(
+    "--context-lines",
+    default=None,
+    type=int,
+    help="Max unchanged lines added around each hunk for context (0 disables)",
+)
+@click.option(
+    "--timeout",
+    default=None,
+    type=int,
+    help="Per-request timeout in seconds for each model call (raise for slow local models)",
+)
+@click.option(
+    "--temperature",
+    default=None,
+    type=float,
+    help="Sampling temperature (default 0.0 for deterministic reviews)",
+)
+@click.option(
+    "--reflect/--no-reflect",
+    default=None,
+    help="Run the self-reflection pass that drops low-confidence findings "
+    "(--no-reflect keeps them all; useful for weaker models)",
+)
+@click.option(
+    "--config",
+    "config_path",
+    default=".lgtmaybe.yml",
+    show_default=True,
+    help="Path to a per-repo config file",
+)
+def review(
+    provider: str | None,
+    model: str | None,
+    fallback_model: str | None,
+    api_key: str | None,
+    api_base: str | None,
+    min_severity: str | None,
+    max_files: int | None,
+    base: str | None,
+    working: bool,
+    output_format: str | None,
+    as_json: bool,
+    context_lines: int | None,
+    timeout: int | None,
+    temperature: float | None,
+    reflect: bool | None,
+    config_path: str,
+) -> None:
+    """Review local git changes and print findings — no GitHub needed."""
+    cfg = load_config(
+        config_path=Path(config_path),
+        user_config_path=store.user_config_path(),
+        provider=provider,
+        model=model,
+        min_severity=min_severity,
+        max_files=max_files,
+        context_lines=context_lines,
+        timeout=timeout,
+        temperature=temperature,
+        reflect=reflect,
+    )
+
+    runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
+    fmt = output_format or ("json" if as_json else "human")
+    execute_local_review(cfg, runtime, base=base, working=working, fmt=fmt)
+
+
+@main.command()
+@click.option(
+    "--event-path",
+    envvar="GITHUB_EVENT_PATH",
+    required=True,
+    help="Path to the issue_comment event payload (GitHub sets GITHUB_EVENT_PATH).",
+)
+@click.option("--provider", default=None, help="LLM provider override")
+@click.option("--model", default=None, help="Model name override")
+@click.option("--fallback-model", default=None, help="Model to retry with if the primary fails")
+@click.option("--api-key", default=None, envvar="LGTMAYBE_API_KEY", help="API key")
+@click.option("--api-base", default=None, help="API base URL (e.g. ollama)")
+@click.option("--config", "config_path", default=".lgtmaybe.yml", show_default=True)
+def comment(
+    event_path: str,
+    provider: str | None,
+    model: str | None,
+    fallback_model: str | None,
+    api_key: str | None,
+    api_base: str | None,
+    config_path: str,
+) -> None:
+    """Handle an issue_comment event: route a /slash command to the engine."""
+    event = json.loads(Path(event_path).read_text())
+    cfg = load_config(config_path=Path(config_path), provider=provider, model=model)
+    runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
+    execute_comment(event, cfg, runtime)
+
+
+@main.command()
+def action() -> None:
+    """GitHub Action entrypoint: route by event, read inputs from env.
+
+    ``issue_comment`` routes a slash command; any other event (``pull_request``
+    / ``pull_request_target``) runs a full review of the triggering PR.
+    """
+    inputs = action_inputs()
+    cfg = load_config(
+        config_path=Path(inputs["config_path"] or ".lgtmaybe.yml"),
+        provider=inputs["provider"],
+        model=inputs["model"],
+    )
+    runtime = RuntimeOptions(api_key=inputs["api_key"], fallback_model=inputs["fallback_model"])
+
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+
+    if event_name == "issue_comment":
+        execute_comment(event, cfg, runtime)
+        return
+
+    runtime = runtime.with_pr_url(pr_url_from_event(event))
+    execute_review(cfg, runtime, dry_run=False)
+
+
+@config_cmd.command("path")
+def config_path_command() -> None:
+    """Print the config file location."""
+    click.echo(str(store.user_config_path()))
+
+
+@config_cmd.command("show")
+def config_show() -> None:
+    """Print the current config."""
+    text = store.as_yaml()
+    click.echo(text if text else f"(no config yet at {store.user_config_path()})")
+
+
+@config_cmd.command("get")
+@click.argument("key")
+def config_get(key: str) -> None:
+    """Print one config value."""
+    value = store.get_key(key)
+    if value is not None:
+        click.echo(str(value))
+
+
+@config_cmd.command("set")
+@click.argument("key")
+@click.argument("value")
+def config_set(key: str, value: str) -> None:
+    """Set one config value (e.g. `config set model qwen3:27b`)."""
+    try:
+        coerced = store.set_key(key, value)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"{key} = {coerced}")
+
+
+@config_cmd.command("init")
+def config_init() -> None:
+    """Interactively create the config file."""
+    provider = click.prompt("Provider", default="ollama")
+    model = click.prompt("Model", default="llama3")
+    api_base = click.prompt("API base (blank for none)", default="", show_default=False)
+    try:
+        store.set_key("provider", provider)
+        store.set_key("model", model)
+        if api_base.strip():
+            store.set_key("api_base", api_base)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Wrote {store.user_config_path()}")

--- a/src/lgtmaybe/cli/render.py
+++ b/src/lgtmaybe/cli/render.py
@@ -1,0 +1,60 @@
+"""Output formatting for the local ``review`` command.
+
+Turns engine findings into one of three text shapes: ``human`` (a readable
+listing), ``json`` (a machine-readable array), or ``agent`` (correction
+instructions an AI coding agent can read and apply).
+"""
+
+from __future__ import annotations
+
+import json
+
+from lgtmaybe.core.models import ReviewFinding
+
+
+def render_findings(findings: list[ReviewFinding], summary: str, *, fmt: str = "human") -> str:
+    """Format findings for the local CLI.
+
+    ``fmt`` selects the output: ``human`` (a readable listing + summary),
+    ``json`` (a machine-readable array), or ``agent`` (directive correction
+    instructions for an AI coding agent to read and apply).
+    """
+    if fmt == "json":
+        return json.dumps([f.model_dump(mode="json") for f in findings])
+    if fmt == "agent":
+        return _render_agent(findings, summary)
+
+    lines: list[str] = []
+    for f in findings:
+        lines.append(f"{f.path}:{f.line}  [{f.severity.upper()}] {f.title}")
+        lines.append(f"  {f.body}")
+        if f.suggestion is not None:
+            lines.append(f"  suggestion: {f.suggestion}")
+        lines.append("")
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+def _render_agent(findings: list[ReviewFinding], summary: str) -> str:
+    """Render findings as correction instructions for an AI agent to apply."""
+    if not findings:
+        return f"No review findings — nothing to correct. {summary}"
+
+    lines = [
+        "Code review findings for your local changes. Act as the developer and "
+        "apply each correction below: open the file at the given path and line, "
+        "fix the issue, and apply the suggested change where one is given.",
+        "",
+    ]
+    for i, f in enumerate(findings, 1):
+        lines.append(f"[{i}] {f.path}:{f.line}  ({f.severity.upper()})  {f.title}")
+        lines.append(f"    Issue: {f.body}")
+        if f.suggestion is not None:
+            lines.append("    Suggested fix:")
+            lines.extend(f"        {s}" for s in f.suggestion.splitlines() or [f.suggestion])
+        lines.append("")
+    lines.append(
+        f"{len(findings)} finding(s) to address. After applying the fixes, re-run "
+        "`lgtmaybe review` to confirm they are resolved."
+    )
+    return "\n".join(lines)

--- a/src/lgtmaybe/cli/runtime.py
+++ b/src/lgtmaybe/cli/runtime.py
@@ -1,0 +1,25 @@
+"""Per-invocation runtime options.
+
+A small typed bag for the values that vary per call but aren't part of the
+persisted ``ReviewConfig``: credentials supplied at call time, an optional
+fallback model, and (for the GitHub paths) the PR URL. Frozen so it can't be
+mutated in place — use ``with_pr_url`` to derive a copy with the URL filled in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class RuntimeOptions:
+    """Call-time options resolved from CLI flags or GitHub Action inputs."""
+
+    api_key: str | None = None
+    api_base: str | None = None
+    fallback_model: str | None = None
+    pr_url: str | None = None
+
+    def with_pr_url(self, pr_url: str) -> RuntimeOptions:
+        """Return a copy with ``pr_url`` set (the rest unchanged)."""
+        return replace(self, pr_url=pr_url)

--- a/src/lgtmaybe/config/loader.py
+++ b/src/lgtmaybe/config/loader.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import IO, Any
 
 import yaml
-from pydantic import ValidationError
 
 from lgtmaybe.config import store
 from lgtmaybe.core.models import ReviewConfig
@@ -51,10 +50,7 @@ def load_config(
         if value is not None:
             merged[key] = value
 
-    try:
-        return ReviewConfig.model_validate(merged)
-    except ValidationError:
-        raise
+    return ReviewConfig.model_validate(merged)
 
 
 def _load_file(

--- a/src/lgtmaybe/core/diffparse.py
+++ b/src/lgtmaybe/core/diffparse.py
@@ -1,0 +1,68 @@
+"""Unified-diff parsing primitives.
+
+One home for the regexes and helpers that read a ``git diff``: splitting a diff
+into per-file patches and parsing hunk headers. Shared by the engine (batching,
+hunk expansion) and the github adapter (position map) so the patterns and their
+off-by-one rules live in exactly one place.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# "diff --git a/<old> b/<new>" — capture the new-side path. MULTILINE so it can
+# be used both with finditer over a whole diff and with match on a single line.
+FILE_HEADER_RE = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
+
+# "@@ -old_start[,old_len] +new_start[,new_len] @@[ section]"
+HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$")
+
+
+@dataclass(frozen=True)
+class HunkHeader:
+    """The parsed numbers from a unified-diff hunk header.
+
+    Lengths default to 1 when omitted (``@@ -3 +4 @@``), matching the diff spec.
+    """
+
+    old_start: int
+    old_len: int
+    new_start: int
+    new_len: int
+    section: str
+
+
+def parse_hunk_header(line: str) -> HunkHeader | None:
+    """Parse a hunk-header *line* into a HunkHeader, or None if it isn't one."""
+    m = HUNK_HEADER_RE.match(line)
+    if m is None:
+        return None
+    return HunkHeader(
+        old_start=int(m.group(1)),
+        old_len=int(m.group(2)) if m.group(2) is not None else 1,
+        new_start=int(m.group(3)),
+        new_len=int(m.group(4)) if m.group(4) is not None else 1,
+        section=m.group(5),
+    )
+
+
+def split_by_file(diff: str, changed_files: list[str]) -> list[tuple[str, str]]:
+    """Split a unified diff into per-file ``(path, patch)`` pairs.
+
+    Each patch runs from its ``diff --git`` header to the next one. When there
+    are no headers the whole diff is treated as one patch, associated with the
+    first changed file (or ``"unknown"`` when none is given).
+    """
+    matches = list(FILE_HEADER_RE.finditer(diff))
+    if not matches:
+        path = changed_files[0] if changed_files else "unknown"
+        return [(path, diff)]
+
+    result: list[tuple[str, str]] = []
+    for i, match in enumerate(matches):
+        path = match.group(1)
+        start = match.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(diff)
+        result.append((path, diff[start:end]))
+    return result

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -6,10 +6,7 @@ Provides a dynamic context-line calculator for the remaining budget.
 
 from __future__ import annotations
 
-import re
-
-# Hunk header: "@@ -old_start[,old_len] +new_start[,new_len] @@ optional section"
-_HUNK_HEADER = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$")
+from lgtmaybe.core.diffparse import parse_hunk_header
 
 _MAX_CONTEXT_LINES = 20
 _MIN_CONTEXT_LINES = 0
@@ -111,7 +108,7 @@ def expand_hunks(patch: str, file_content: str | None, n: int) -> str:
     pending_trailing: list[str] = []
 
     for line in patch.splitlines():
-        header = _HUNK_HEADER.match(line)
+        header = parse_hunk_header(line)
         if header is None:
             out.append(line)
             continue
@@ -119,11 +116,11 @@ def expand_hunks(patch: str, file_content: str | None, n: int) -> str:
         # A new hunk starts: flush the previous hunk's trailing context first.
         out.extend(f" {text}" for text in pending_trailing)
 
-        old_start = int(header.group(1))
-        old_len = int(header.group(2)) if header.group(2) is not None else 1
-        new_start = int(header.group(3))
-        new_len = int(header.group(4)) if header.group(4) is not None else 1
-        section = header.group(5)
+        old_start = header.old_start
+        old_len = header.old_len
+        new_start = header.new_start
+        new_len = header.new_len
+        section = header.section
 
         # Lines immediately before the hunk and after its last new-file line.
         leading = [content_lines[i - 1] for i in range(max(1, new_start - n), new_start)]

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -6,6 +6,7 @@ Pipeline: redact → compress/batch → (for each batch) build messages → prov
 
 from __future__ import annotations
 
+from lgtmaybe.core.diffparse import split_by_file
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
 from lgtmaybe.github import is_reviewable
@@ -30,7 +31,7 @@ class LLMReviewEngine(ReviewEngine):
         clean_diff = redact(ctx.diff)
 
         # 2. Split into per-file patches and drop generated/binary/vendored noise.
-        file_patches = _split_diff_by_file(clean_diff, ctx.changed_files)
+        file_patches = split_by_file(clean_diff, ctx.changed_files)
         file_patches = [(path, patch) for path, patch in file_patches if is_reviewable(path)]
 
         # 3. File cap: review only the first N reviewable files, note the rest.
@@ -114,32 +115,3 @@ class LLMReviewEngine(ReviewEngine):
             f"cap of ${cfg.max_cost_usd:.4f} (model {cfg.model}). "
             "Raise max_cost_usd to review the full PR."
         )
-
-
-def _split_diff_by_file(
-    diff: str,
-    changed_files: list[str],
-) -> list[tuple[str, str]]:
-    """Split a unified diff string into per-file (path, patch) pairs.
-
-    Falls back to treating the whole diff as one file if parsing fails.
-    """
-    import re
-
-    # Match 'diff --git a/... b/...' headers
-    pattern = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
-    matches = list(pattern.finditer(diff))
-
-    if not matches:
-        # No git diff headers — treat as a single chunk associated with the first changed file
-        path = changed_files[0] if changed_files else "unknown"
-        return [(path, diff)]
-
-    result: list[tuple[str, str]] = []
-    for i, match in enumerate(matches):
-        path = match.group(1)
-        start = match.start()
-        end = matches[i + 1].start() if i + 1 < len(matches) else len(diff)
-        result.append((path, diff[start:end]))
-
-    return result

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -25,7 +25,7 @@ class ParseError(Exception):
 _TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
 
 
-def _strip_fences(text: str) -> str:
+def strip_fences(text: str) -> str:
     """Remove markdown code fences, keeping only the content."""
     text = re.sub(r"```(?:json)?\s*", "", text)
     return text.replace("```", "")
@@ -58,7 +58,7 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
         raise ParseError("Empty response from provider")
 
     text = raw.strip()
-    text = _strip_fences(text)
+    text = strip_fences(text)
     text = text.strip()
     text = _extract_json_blob(text)
     text = _repair_trailing_commas(text)

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -10,6 +10,8 @@ import json
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ProviderClient
 
+from .parse import strip_fences
+
 _REFLECT_SYSTEM = """\
 You are a senior code reviewer auditing another reviewer's findings for false positives.
 
@@ -53,9 +55,8 @@ def reflect_findings(
     )
 
     try:
-        raw = result.text.strip()
-        # Strip markdown fences if present
-        raw = raw.replace("```json", "").replace("```", "").strip()
+        # Strip markdown fences if present, then parse the verdict object.
+        raw = strip_fences(result.text.strip()).strip()
         verdicts: dict[str, bool] = json.loads(raw)
     except Exception:
         # If reflection fails to parse, keep all findings (safe default)

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -11,17 +11,13 @@ files are dropped before review to save tokens and avoid noise.
 
 from __future__ import annotations
 
-import re
 from fnmatch import fnmatch
+
+from lgtmaybe.core.diffparse import FILE_HEADER_RE, parse_hunk_header
 
 # ---------------------------------------------------------------------------
 # Position map
 # ---------------------------------------------------------------------------
-
-# Match unified-diff file headers: "diff --git a/... b/..."
-_DIFF_FILE_HEADER = re.compile(r"^diff --git a/.+ b/(.+)$")
-# Match hunk headers: "@@ -old_start[,old_len] +new_start[,new_len] @@"
-_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 # Maps (filename, new_file_line_number) → 1-based diff position within that file's hunks.
 PositionMap = dict[tuple[str, int], int]
@@ -46,7 +42,7 @@ def build_position_map(diff: str) -> PositionMap:
     in_hunk = False
 
     for raw_line in diff.splitlines():
-        file_match = _DIFF_FILE_HEADER.match(raw_line)
+        file_match = FILE_HEADER_RE.match(raw_line)
         if file_match:
             current_file = file_match.group(1)
             diff_pos = 0
@@ -57,14 +53,14 @@ def build_position_map(diff: str) -> PositionMap:
         if current_file is None:
             continue
 
-        hunk_match = _HUNK_HEADER.match(raw_line)
-        if hunk_match:
+        hunk = parse_hunk_header(raw_line)
+        if hunk is not None:
             # Hunk header resets the new-file line counter; diff_pos keeps counting
             # across hunks within a file. The hunk header line does NOT occupy a
             # position itself — the first content line after it is position 1 (or
             # position N+1 if prior hunks exist). GitHub's position is a 1-based
             # count of content lines only.
-            new_line = int(hunk_match.group(1))
+            new_line = hunk.new_start
             in_hunk = True
             continue
 

--- a/src/lgtmaybe/providers/constants.py
+++ b/src/lgtmaybe/providers/constants.py
@@ -1,0 +1,8 @@
+"""Shared provider defaults."""
+
+from __future__ import annotations
+
+# Default ollama endpoint when none is supplied. Used by both the credential
+# resolver (to fill AuthConfig.api_base) and the factory (to configure the
+# litellm client) so the two never drift.
+DEFAULT_OLLAMA_BASE = "http://localhost:11434"

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -13,8 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from lgtmaybe.core.models import Provider
-
-_DEFAULT_OLLAMA_BASE = "http://localhost:11434"
+from lgtmaybe.providers.constants import DEFAULT_OLLAMA_BASE
 
 
 @dataclass(frozen=True)
@@ -80,7 +79,7 @@ def resolve_credentials(
         return AuthConfig()
 
     if provider is Provider.ollama:
-        return AuthConfig(api_base=api_base or _DEFAULT_OLLAMA_BASE)
+        return AuthConfig(api_base=api_base or DEFAULT_OLLAMA_BASE)
 
     # API-key providers: openai, anthropic, openrouter
     _ENV_VAR: dict[Provider, str] = {

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 from typing import Any
 
 from lgtmaybe.core.models import Provider
+from lgtmaybe.providers.constants import DEFAULT_OLLAMA_BASE
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
-
-_DEFAULT_OLLAMA_BASE = "http://localhost:11434"
 
 _PREFIXES: dict[Provider, str] = {
     Provider.openai: "openai",
@@ -52,7 +51,7 @@ def build_provider(
 
     is_ollama = provider is Provider.ollama
     if is_ollama:
-        opts["api_base"] = api_base or _DEFAULT_OLLAMA_BASE
+        opts["api_base"] = api_base or DEFAULT_OLLAMA_BASE
 
     return LiteLLMProvider(
         model=resolved_model,

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -101,7 +101,7 @@ class TestActionRouting:
         def fake_build(cfg, runtime):
             captured["provider"] = cfg.provider.value
             captured["model"] = cfg.model
-            captured["fallback_model"] = runtime.get("fallback_model")
+            captured["fallback_model"] = runtime.fallback_model
             return FakeGitHub(), FakeEngine(FakeProvider())
 
         monkeypatch.setattr(cli_module, "build_adapters", fake_build)

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -132,8 +132,8 @@ class TestActionRouting:
         import lgtmaybe.cli as cli_module
 
         def fake_build(cfg, runtime):
-            captured["api_base"] = runtime.get("api_base")
-            captured["api_key"] = runtime.get("api_key")
+            captured["api_base"] = runtime.api_base
+            captured["api_key"] = runtime.api_key
             return FakeGitHub(), FakeEngine(FakeProvider())
 
         monkeypatch.setattr(cli_module, "build_adapters", fake_build)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ import json
 import pytest
 from click.testing import CliRunner
 
-from lgtmaybe.cli import build_adapters, main, run_review
+from lgtmaybe.cli import RuntimeOptions, build_adapters, main, run_review
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ReviewEngine
 from tests.fakes import FakeEngine, FakeGitHub, FakeProvider
@@ -167,7 +167,7 @@ class TestGitHubReviewErrorSurfacing:
         )
 
         with pytest.raises(click.ClickException):
-            cli_module.execute_review(_default_cfg(), {"pr_url": "x"}, dry_run=False)
+            cli_module.execute_review(_default_cfg(), RuntimeOptions(pr_url="x"), dry_run=False)
 
         assert len(github.posted) == 1
         posted_findings, posted_summary = github.posted[0]
@@ -223,11 +223,7 @@ class TestBuildAdapters:
 
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
         cfg = _default_cfg(provider="ollama", model="llama3")
-        runtime = {
-            "pr_url": "https://github.com/org/repo/pull/7",
-            "api_key": None,
-            "api_base": None,
-        }
+        runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
         github, engine = build_adapters(cfg, runtime)
 
@@ -237,11 +233,7 @@ class TestBuildAdapters:
     def test_requires_github_token(self, monkeypatch):
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         cfg = _default_cfg(provider="ollama", model="llama3")
-        runtime = {
-            "pr_url": "https://github.com/org/repo/pull/7",
-            "api_key": None,
-            "api_base": None,
-        }
+        runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
         with pytest.raises(ValueError, match="GITHUB_TOKEN"):
             build_adapters(cfg, runtime)
@@ -251,11 +243,7 @@ class TestBuildAdapters:
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         cfg = _default_cfg(provider="openai", model="gpt-4o")
-        runtime = {
-            "pr_url": "https://github.com/org/repo/pull/7",
-            "api_key": None,
-            "api_base": None,
-        }
+        runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
         with pytest.raises(ValueError, match="OPENAI_API_KEY"):
             build_adapters(cfg, runtime)
@@ -266,12 +254,9 @@ class TestBuildAdapters:
 
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
         cfg = _default_cfg(provider="ollama", model="llama3")
-        runtime = {
-            "pr_url": "https://github.com/org/repo/pull/7",
-            "api_key": None,
-            "api_base": None,
-            "fallback_model": "llama2",
-        }
+        runtime = RuntimeOptions(
+            pr_url="https://github.com/org/repo/pull/7", fallback_model="llama2"
+        )
 
         _github, _engine, provider = build_review_context(cfg, runtime)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -273,11 +273,10 @@ class TestBuildAdapters:
             lambda: "ad-token-from-oidc",
         )
         cfg = _default_cfg(provider="azure", model="my-deployment")
-        runtime = {
-            "pr_url": "https://github.com/org/repo/pull/7",
-            "api_key": None,
-            "api_base": "https://my-resource.openai.azure.com",
-        }
+        runtime = RuntimeOptions(
+            pr_url="https://github.com/org/repo/pull/7",
+            api_base="https://my-resource.openai.azure.com",
+        )
 
         _github, _engine, provider = build_review_context(cfg, runtime)
 

--- a/tests/core/test_diffparse.py
+++ b/tests/core/test_diffparse.py
@@ -1,0 +1,61 @@
+"""Shared unified-diff parsing primitives."""
+
+from __future__ import annotations
+
+from lgtmaybe.core.diffparse import parse_hunk_header, split_by_file
+
+_TWO_FILE_DIFF = """\
+diff --git a/src/a.py b/src/a.py
+index 111..222 100644
+--- a/src/a.py
++++ b/src/a.py
+@@ -1,2 +1,3 @@
+ x = 1
++y = 2
+ z = 3
+diff --git a/src/b.py b/src/b.py
+index 333..444 100644
+--- a/src/b.py
++++ b/src/b.py
+@@ -10 +10 @@
+-old
++new
+"""
+
+
+class TestSplitByFile:
+    def test_splits_into_one_patch_per_file(self):
+        parts = split_by_file(_TWO_FILE_DIFF, ["src/a.py", "src/b.py"])
+        paths = [path for path, _ in parts]
+        assert paths == ["src/a.py", "src/b.py"]
+
+    def test_each_patch_keeps_its_own_header_and_hunk(self):
+        parts = dict(split_by_file(_TWO_FILE_DIFF, []))
+        assert "+y = 2" in parts["src/a.py"]
+        assert "+y = 2" not in parts["src/b.py"]
+        assert "+new" in parts["src/b.py"]
+
+    def test_no_headers_falls_back_to_first_changed_file(self):
+        parts = split_by_file("@@ -1 +1 @@\n-a\n+b\n", ["only.py"])
+        assert parts == [("only.py", "@@ -1 +1 @@\n-a\n+b\n")]
+
+    def test_no_headers_and_no_files_uses_unknown(self):
+        parts = split_by_file("just text", [])
+        assert parts == [("unknown", "just text")]
+
+
+class TestParseHunkHeader:
+    def test_parses_full_header_with_lengths_and_section(self):
+        h = parse_hunk_header("@@ -1,2 +3,4 @@ def foo():")
+        assert h is not None
+        assert (h.old_start, h.old_len, h.new_start, h.new_len) == (1, 2, 3, 4)
+        assert h.section == " def foo():"
+
+    def test_omitted_lengths_default_to_one(self):
+        h = parse_hunk_header("@@ -10 +20 @@")
+        assert h is not None
+        assert (h.old_start, h.old_len, h.new_start, h.new_len) == (10, 1, 20, 1)
+
+    def test_non_hunk_line_returns_none(self):
+        assert parse_hunk_header(" context line") is None
+        assert parse_hunk_header("diff --git a/x b/x") is None


### PR DESCRIPTION
- Delete unused has_ambient_aws_creds/has_ambient_gcp_creds from the CLI
  (superseded by providers/credentials probes, and drifted from them)
- Share DEFAULT_OLLAMA_BASE via providers/constants instead of two copies
- Reuse parse.strip_fences in reflect instead of a second fence stripper
- Drop the no-op try/except ValidationError in config loader

https://claude.ai/code/session_01HNHFBNZy1UULdNwiP3gUH1