### PR TITLE
test: exhaustive provider-variation coverage for CLI + action

### DIFF
--- a/.github/workflows/action-e2e.yml
+++ b/.github/workflows/action-e2e.yml
@@ -18,8 +18,9 @@
 #   OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY  (key providers)
 #   AWS_ROLE_ARN                                           (bedrock, keyless OIDC)
 #   GCP_WIF_PROVIDER, GCP_SERVICE_ACCOUNT                  (vertex, keyless WIF)
+#   AZURE_API_BASE, AZURE_CLIENT_ID, AZURE_TENANT_ID       (azure, keyless OIDC)
 # Model ids below are illustrative cheap-tier examples — adjust to ones your
-# account/region has enabled.
+# account/region has enabled (azure `model` is your deployment name).
 name: action-e2e
 
 on:
@@ -65,6 +66,10 @@ jobs:
             model: claude-haiku-4-5
             api_key_secret: ""
             cloud: gcp
+          - provider: azure
+            model: my-gpt-4o-deployment # your Azure deployment name
+            api_key_secret: ""
+            cloud: azure
     steps:
       - uses: actions/checkout@v6
 
@@ -84,3 +89,6 @@ jobs:
           aws_region: ${{ matrix.cloud == 'aws' && 'us-east-1' || '' }}
           gcp_wif_provider: ${{ matrix.cloud == 'gcp' && secrets.GCP_WIF_PROVIDER || '' }}
           gcp_service_account: ${{ matrix.cloud == 'gcp' && secrets.GCP_SERVICE_ACCOUNT || '' }}
+          api_base: ${{ matrix.cloud == 'azure' && secrets.AZURE_API_BASE || '' }}
+          azure_client_id: ${{ matrix.cloud == 'azure' && secrets.AZURE_CLIENT_ID || '' }}
+          azure_tenant_id: ${{ matrix.cloud == 'azure' && secrets.AZURE_TENANT_ID || '' }}

--- a/.github/workflows/action-e2e.yml
+++ b/.github/workflows/action-e2e.yml
@@ -1,0 +1,86 @@
+# Provider end-to-end smoke test for the composite action.
+#
+# NOT part of normal CI — it makes REAL provider calls and needs secrets, so it
+# only runs when a PR carries the `lgtmaybe-e2e` label. Open a small throwaway PR,
+# add the label, and every hosted provider reviews that PR through action.yml end
+# to end (build image → keyless/keyed auth → fetch diff → call model → post review).
+#
+# A green matrix job == that provider authenticated, reached the model, and posted
+# without erroring (the action exits non-zero on any failure). `fail-fast: false`
+# keeps one provider's failure from masking the others. The providers share the
+# hidden marker comment, so their summaries overwrite each other on the PR — that
+# is cosmetic; the job's exit status is the real signal.
+#
+# ollama is local-only (no hosted runner, no key), so it is covered by the pytest
+# suite (tests/cli/test_provider_threading.py), not here.
+#
+# Required repo secrets:
+#   OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY  (key providers)
+#   AWS_ROLE_ARN                                           (bedrock, keyless OIDC)
+#   GCP_WIF_PROVIDER, GCP_SERVICE_ACCOUNT                  (vertex, keyless WIF)
+# Model ids below are illustrative cheap-tier examples — adjust to ones your
+# account/region has enabled.
+name: action-e2e
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write # keyless OIDC/WIF token exchange for bedrock + vertex
+
+concurrency:
+  group: action-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # Only when the PR is opted-in via label, so real spend never runs by default.
+    if: contains(github.event.pull_request.labels.*.name, 'lgtmaybe-e2e')
+    runs-on: ubuntu-latest
+    name: ${{ matrix.provider }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: openai
+            model: gpt-4.1-mini
+            api_key_secret: OPENAI_API_KEY
+            cloud: ""
+          - provider: anthropic
+            model: claude-haiku-4-5
+            api_key_secret: ANTHROPIC_API_KEY
+            cloud: ""
+          - provider: openrouter
+            model: openai/gpt-4.1-mini
+            api_key_secret: OPENROUTER_API_KEY
+            cloud: ""
+          - provider: bedrock
+            model: anthropic.claude-haiku-4-5
+            api_key_secret: ""
+            cloud: aws
+          - provider: vertex
+            model: claude-haiku-4-5
+            api_key_secret: ""
+            cloud: gcp
+    steps:
+      - uses: actions/checkout@v6
+
+      # Build from THIS checkout so we exercise the current code, not the
+      # released GHCR image. action.yml runs whatever `image:` we hand it.
+      - name: Build action image
+        run: docker build -t lgtmaybe:e2e .
+
+      - name: Review this PR with ${{ matrix.provider }}
+        uses: ./
+        with:
+          provider: ${{ matrix.provider }}
+          model: ${{ matrix.model }}
+          image: lgtmaybe:e2e
+          api_key: ${{ matrix.api_key_secret != '' && secrets[matrix.api_key_secret] || '' }}
+          aws_role_arn: ${{ matrix.cloud == 'aws' && secrets.AWS_ROLE_ARN || '' }}
+          aws_region: ${{ matrix.cloud == 'aws' && 'us-east-1' || '' }}
+          gcp_wif_provider: ${{ matrix.cloud == 'gcp' && secrets.GCP_WIF_PROVIDER || '' }}
+          gcp_service_account: ${{ matrix.cloud == 'gcp' && secrets.GCP_SERVICE_ACCOUNT || '' }}

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -93,6 +93,15 @@ CASES = [
         "vertex_ai/claude-x",
         False,
     ),
+    (
+        "azure",
+        "azure",
+        "gpt-4o",
+        ["--api-key", "sk-x", "--api-base", "https://r.openai.azure.com"],
+        {},
+        "azure/gpt-4o",
+        True,
+    ),
     ("ollama", "ollama", "llama3", [], {}, "ollama/llama3", False),
 ]
 

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -1,0 +1,142 @@
+"""Every provider, through the real CLI + real engine, down to litellm.
+
+``lgtmaybe review`` is run once per provider with ``litellm.completion`` mocked
+(the only fake). This proves the ``--provider``/``--model`` selection actually
+reaches litellm as the right namespaced model string, and that each provider's
+auth quirk is honoured end to end:
+
+  * key providers (openai/anthropic/openrouter) send an ``api_key``;
+  * cloud providers (bedrock/vertex) send NO ``api_key`` — keyless ambient creds;
+  * ollama sends an ``api_base`` and is billed at zero cost.
+
+This is the layer between the pure unit matrix and a real-spend action e2e: no
+network, no real keys, but the live wiring (CLI → resolver → factory → engine →
+litellm) is exercised.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import lgtmaybe.cli as cli_module
+from lgtmaybe.cli import main
+from lgtmaybe.core.models import PRContext
+
+_CTX = PRContext(
+    diff="@@ -1 +1 @@\n-a\n+b\n",
+    changed_files=["src/app.py"],
+    base_sha="base",
+    head_sha="head",
+    repo="org/repo",
+    pr_number=0,
+)
+
+
+def _fake_response() -> SimpleNamespace:
+    """A minimal litellm-shaped response carrying an empty (valid) findings array."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[]"))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+@pytest.fixture
+def captured_completion(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Mock litellm at the boundary and feed the engine a local diff.
+
+    Returns the list of kwargs every ``litellm.completion`` call received.
+    """
+    calls: list[dict[str, Any]] = []
+
+    def fake_completion(**kwargs: Any) -> SimpleNamespace:
+        calls.append(kwargs)
+        return _fake_response()
+
+    monkeypatch.setattr("litellm.completion", fake_completion)
+    monkeypatch.setattr("litellm.completion_cost", lambda **_: 0.0)
+    monkeypatch.setattr(cli_module, "local_pr_context", lambda **_: _CTX)
+    return calls
+
+
+# id, provider, model, extra CLI args, env to set, expected litellm model, expect api_key
+CASES = [
+    ("openai", "openai", "gpt-4o", ["--api-key", "sk-x"], {}, "openai/gpt-4o", True),
+    ("anthropic", "anthropic", "claude-x", ["--api-key", "sk-x"], {}, "anthropic/claude-x", True),
+    (
+        "openrouter",
+        "openrouter",
+        "vendor/m",
+        ["--api-key", "sk-x"],
+        {},
+        "openrouter/vendor/m",
+        True,
+    ),
+    (
+        "bedrock",
+        "bedrock",
+        "anthropic.claude-x",
+        [],
+        {"AWS_ACCESS_KEY_ID": "AKIA"},
+        "bedrock/anthropic.claude-x",
+        False,
+    ),
+    (
+        "vertex",
+        "vertex",
+        "claude-x",
+        [],
+        {"GOOGLE_CLOUD_PROJECT": "proj"},
+        "vertex_ai/claude-x",
+        False,
+    ),
+    ("ollama", "ollama", "llama3", [], {}, "ollama/llama3", False),
+]
+
+
+@pytest.mark.parametrize(
+    "name,provider,model,extra,env,expected_model,expect_api_key",
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_review_threads_provider_to_litellm(
+    name: str,
+    provider: str,
+    model: str,
+    extra: list[str],
+    env: dict[str, str],
+    expected_model: str,
+    expect_api_key: bool,
+    captured_completion: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    result = CliRunner().invoke(
+        main,
+        ["review", "--provider", provider, "--model", model, "--no-reflect", *extra],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion, "litellm.completion was never called"
+    call = captured_completion[0]
+    assert call["model"] == expected_model
+    if expect_api_key:
+        assert call.get("api_key") == "sk-x"
+    else:
+        # cloud + ollama never carry a static api_key
+        assert "api_key" not in call
+
+
+def test_ollama_call_carries_api_base(captured_completion: list[dict[str, Any]]) -> None:
+    """ollama must reach litellm with an api_base (default localhost)."""
+    result = CliRunner().invoke(
+        main, ["review", "--provider", "ollama", "--model", "llama3", "--no-reflect"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("api_base")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ _PROVIDER_CRED_ENV = (
     "GOOGLE_APPLICATION_CREDENTIALS",
     "GOOGLE_CLOUD_PROJECT",
     "GCLOUD_PROJECT",
+    # Azure (hybrid): endpoint + key, or keyless ambient Azure AD creds
+    "AZURE_API_KEY",
+    "AZURE_API_BASE",
+    "AZURE_CLIENT_ID",
+    "AZURE_TENANT_ID",
+    "AZURE_FEDERATED_TOKEN_FILE",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared test fixtures.
+
+Provider-credential env vars leak in from the developer's shell or the CI runner
+and make the credential resolver non-deterministic: a real ``OPENAI_API_KEY`` in
+the environment would turn a "missing key must raise" test green by accident, and
+a stray ``AWS_*`` var would make a "bedrock needs ambient creds" test pass when it
+should fail. Clear them by default; a test that needs one sets it explicitly via
+``monkeypatch.setenv``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Every env var the credential resolver / CLI probes consult to pick auth.
+_PROVIDER_CRED_ENV = (
+    # API-key providers
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "LGTMAYBE_API_KEY",
+    # Ambient AWS creds (bedrock)
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_ROLE_ARN",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    # Ambient GCP creds (vertex)
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_PROJECT",
+    "GCLOUD_PROJECT",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from a clean, credential-free environment."""
+    for var in _PROVIDER_CRED_ENV:
+        monkeypatch.delenv(var, raising=False)

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -28,6 +28,7 @@ EXPECTED_PREFIX: dict[Provider, str] = {
     Provider.anthropic: "anthropic/",
     Provider.bedrock: "bedrock/",
     Provider.vertex: "vertex_ai/",
+    Provider.azure: "azure/",
     Provider.ollama: "ollama/",
 }
 
@@ -41,6 +42,8 @@ KEY_PROVIDERS: dict[Provider, str] = {
 CLOUD_PROVIDERS = (Provider.bedrock, Provider.vertex)
 # Providers that need no auth at all.
 NO_AUTH_PROVIDERS = (Provider.ollama,)
+# Hybrid: always needs an endpoint, then EITHER a key OR an ambient AD token.
+HYBRID_PROVIDERS = (Provider.azure,)
 
 
 def test_every_provider_is_classified_exactly_once() -> None:
@@ -50,7 +53,12 @@ def test_every_provider_is_classified_exactly_once() -> None:
     it authenticates — this is what makes the matrix below truly exhaustive.
     """
     assert set(EXPECTED_PREFIX) == set(Provider)
-    auth_classes = [set(KEY_PROVIDERS), set(CLOUD_PROVIDERS), set(NO_AUTH_PROVIDERS)]
+    auth_classes = [
+        set(KEY_PROVIDERS),
+        set(CLOUD_PROVIDERS),
+        set(NO_AUTH_PROVIDERS),
+        set(HYBRID_PROVIDERS),
+    ]
     union = set().union(*auth_classes)
     assert union == set(Provider)
     # disjoint: no provider classified twice
@@ -113,3 +121,38 @@ class TestNoAuthProvider:
         built = build_provider(Provider.ollama, "llama3")
         assert built.default_opts.get("api_base")
         assert built.force_cost_zero is True
+
+
+_AZURE_BASE = "https://my-resource.openai.azure.com"
+
+
+@pytest.mark.parametrize("provider", HYBRID_PROVIDERS)
+class TestHybridProviderCredentials:
+    """Azure resolves in BOTH modes — the property that earns it its own class.
+
+    It always needs an endpoint, then either a static key or an ambient Azure AD
+    token; it fits neither the pure-key nor the pure-cloud bucket above.
+    """
+
+    def test_requires_an_endpoint(self, provider: Provider) -> None:
+        # A key but no endpoint must still fail (conftest clears AZURE_API_BASE).
+        with pytest.raises(ValueError, match=provider.value):
+            resolve_credentials(provider, api_key="k")
+
+    def test_key_mode_resolves_with_key_and_base(self, provider: Provider) -> None:
+        cfg = resolve_credentials(provider, api_key="k", api_base=_AZURE_BASE)
+        assert cfg.api_key == "k"
+        assert cfg.api_base == _AZURE_BASE
+        assert cfg.azure_ad_token is None
+
+    def test_keyless_mode_resolves_with_ambient_ad_token(self, provider: Provider) -> None:
+        cfg = resolve_credentials(
+            provider, api_base=_AZURE_BASE, azure_token_provider=lambda: "ad-token"
+        )
+        assert cfg.api_key is None
+        assert cfg.azure_ad_token == "ad-token"
+        assert cfg.api_base == _AZURE_BASE
+
+    def test_build_provider_threads_the_endpoint(self, provider: Provider) -> None:
+        built = build_provider(provider, "gpt-4o", api_key="k", api_base=_AZURE_BASE)
+        assert built.default_opts.get("api_base") == _AZURE_BASE

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -1,0 +1,115 @@
+"""Provider matrix: assert the factory + resolver behave for *every* Provider.
+
+These tests are driven off ``list(Provider)`` and a single contract table, so
+adding a seventh backend with no row here fails loudly instead of silently
+skipping a variation. Three axes are covered per provider:
+
+  * factory   — the litellm model string (and fallback) is namespaced correctly;
+  * auth      — key providers need a key, cloud providers are keyless-with-ambient,
+                ollama needs nothing;
+  * quirks    — cloud providers inject no ``api_key``; ollama carries an
+                ``api_base`` and is billed at zero cost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.core.models import Provider
+from lgtmaybe.providers.credentials import resolve_credentials
+from lgtmaybe.providers.factory import build_provider, litellm_model_string
+
+# --- the contract table: one row per provider -------------------------------
+
+# litellm model-string prefix per provider.
+EXPECTED_PREFIX: dict[Provider, str] = {
+    Provider.openai: "openai/",
+    Provider.openrouter: "openrouter/",
+    Provider.anthropic: "anthropic/",
+    Provider.bedrock: "bedrock/",
+    Provider.vertex: "vertex_ai/",
+    Provider.ollama: "ollama/",
+}
+
+# Providers that authenticate with an API key, and the env var that supplies it.
+KEY_PROVIDERS: dict[Provider, str] = {
+    Provider.openai: "OPENAI_API_KEY",
+    Provider.anthropic: "ANTHROPIC_API_KEY",
+    Provider.openrouter: "OPENROUTER_API_KEY",
+}
+# Providers that authenticate with ambient cloud creds (keyless).
+CLOUD_PROVIDERS = (Provider.bedrock, Provider.vertex)
+# Providers that need no auth at all.
+NO_AUTH_PROVIDERS = (Provider.ollama,)
+
+
+def test_every_provider_is_classified_exactly_once() -> None:
+    """Guard: each Provider is in the prefix table and exactly one auth class.
+
+    A new provider can't be merged without deciding its model namespace and how
+    it authenticates — this is what makes the matrix below truly exhaustive.
+    """
+    assert set(EXPECTED_PREFIX) == set(Provider)
+    auth_classes = [set(KEY_PROVIDERS), set(CLOUD_PROVIDERS), set(NO_AUTH_PROVIDERS)]
+    union = set().union(*auth_classes)
+    assert union == set(Provider)
+    # disjoint: no provider classified twice
+    assert sum(len(c) for c in auth_classes) == len(union)
+
+
+@pytest.mark.parametrize("provider", list(Provider))
+class TestFactoryMatrix:
+    def test_model_string_has_expected_prefix(self, provider: Provider) -> None:
+        expected = EXPECTED_PREFIX[provider] + "the-model"
+        assert litellm_model_string(provider, "the-model") == expected
+
+    def test_build_provider_uses_resolved_model_string(self, provider: Provider) -> None:
+        built = build_provider(provider, "the-model", api_key="k")
+        assert built.model == EXPECTED_PREFIX[provider] + "the-model"
+
+    def test_build_provider_namespaces_fallback_the_same_way(self, provider: Provider) -> None:
+        built = build_provider(provider, "primary", fallback_model="backup", api_key="k")
+        assert built.fallback_model == EXPECTED_PREFIX[provider] + "backup"
+
+
+@pytest.mark.parametrize("provider", list(KEY_PROVIDERS))
+class TestKeyProviderCredentials:
+    def test_explicit_key_resolves(self, provider: Provider) -> None:
+        assert resolve_credentials(provider, api_key="sk-explicit").api_key == "sk-explicit"
+
+    def test_env_key_resolves(self, provider: Provider, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(KEY_PROVIDERS[provider], "sk-from-env")
+        assert resolve_credentials(provider).api_key == "sk-from-env"
+
+    def test_missing_key_raises_naming_the_env_var(self, provider: Provider) -> None:
+        # conftest clears every provider env var, so this is deterministic.
+        with pytest.raises(ValueError, match=KEY_PROVIDERS[provider]):
+            resolve_credentials(provider)
+
+
+@pytest.mark.parametrize("provider", CLOUD_PROVIDERS)
+class TestCloudProviderCredentials:
+    def test_ambient_present_resolves_keyless(self, provider: Provider) -> None:
+        assert resolve_credentials(provider, ambient_probe=lambda: True).api_key is None
+
+    def test_ambient_absent_raises_actionable_error(self, provider: Provider) -> None:
+        with pytest.raises(ValueError, match=provider.value):
+            resolve_credentials(provider, ambient_probe=lambda: False)
+
+    def test_built_provider_injects_no_api_key(self, provider: Provider) -> None:
+        """Keyless cloud auth: the factory must not put an api_key in the opts."""
+        built = build_provider(provider, "the-model")
+        assert "api_key" not in built.default_opts
+
+
+class TestNoAuthProvider:
+    def test_ollama_resolves_without_creds(self) -> None:
+        assert resolve_credentials(Provider.ollama).api_key is None
+
+    def test_ollama_default_api_base_is_localhost(self) -> None:
+        assert "localhost" in (resolve_credentials(Provider.ollama).api_base or "")
+
+    def test_ollama_build_provider_sets_api_base_and_zero_cost(self) -> None:
+        built = build_provider(Provider.ollama, "llama3")
+        assert built.default_opts.get("api_base")
+        assert built.force_cost_zero is True


### PR DESCRIPTION
Add three layers of provider testing driven off the Provider enum so a new
backend can't silently skip a variation:

- tests/conftest.py: autouse fixture clears provider-credential env vars so the
  resolver tests are deterministic regardless of the dev/CI environment.
- tests/providers/test_provider_matrix.py: parametrized over every Provider —
  litellm model-string/fallback namespacing, per-class auth (key/cloud/none),
  and quirks (cloud injects no api_key; ollama carries api_base + zero cost),
  with a guard that every provider is classified exactly once.
- tests/cli/test_provider_threading.py: runs `lgtmaybe review` per provider with
  only litellm mocked, asserting selection threads CLI -> resolver -> factory ->
  engine -> litellm as the right model, with each provider's auth quirk honoured.
- .github/workflows/action-e2e.yml: label-gated (lgtmaybe-e2e) real-spend e2e
  matrix that reviews the PR through action.yml once per hosted provider.