### PR TITLE
fix: reliable local reviews — provider-aware timeout/concurrency + fail loud

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -159,9 +159,15 @@ A few things worth knowing when a local run misbehaves:
   can therefore "succeed" with zero findings even though every call struggled —
   check the debug log, and prefer a model that follows the structured-output
   instruction. `parse.py` tolerates fenced JSON but not arbitrary prose.
-- **Fan-out makes N concurrent calls** (one per category, five by default), so a
-  slow local model multiplies wall-clock pressure. Narrow `categories` in
-  `.lgtmaybe.yml` while iterating, and raise `--timeout` for large models on CPU.
+- **Fan-out makes N calls** (one per category, five by default). They run
+  **concurrently for cloud** providers but **serially for ollama** (a single
+  ollama instance serves one request at a time, so concurrency would only cause
+  timeouts). A slow local model therefore takes ≈ `categories × per-call time` —
+  narrow `categories` in `.lgtmaybe.yml` while iterating. ollama gets a **300 s
+  default timeout** automatically; raise it with `--timeout` for very large models.
+- **`⚠️ review incomplete` (non-zero exit)** means every category call errored or
+  returned unparseable output — lgtmaybe reports this rather than a false LGTM.
+  Raise `--timeout`, pick a more reliable model, or check `LITELLM_LOG=DEBUG`.
 - **`--no-reflect`** removes the extra confidence-filtering call — useful when a
   weaker model drops valid findings during reflection, and one fewer call to wait
   on.

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -130,6 +130,19 @@ context_lines: 10   # at most 10 lines either side of each hunk; 0 disables
 
 Default: `20`.
 
+### timeout
+
+Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
+**provider-aware default**: **300 s for ollama** (local models are slow) and 60 s
+for cloud providers. Set it explicitly to raise it for a large local model.
+
+```yaml
+timeout: 900   # 15 minutes per call, e.g. for a big model on CPU
+```
+
+Default: auto (ollama 300 s, cloud 60 s). See
+[Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
+
 ## CLI flag overrides
 
 Every config field can be overridden at the command line:

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -85,12 +85,50 @@ agent (such as Claude Code) can read and apply, so you can review and fix a
 branch locally before opening a PR. See
 [Fix findings with an AI agent](fix-findings-with-an-ai-agent.md).
 
+## Slow models and timeouts
+
+Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
+long default per-request timeout (300 seconds)** automatically — you don't need
+to set anything for a normal run. (Cloud providers default to 60 s.)
+
+If a big model still times out — you'll see
+`litellm.Timeout: Connection timed out after 300.0 seconds` — raise it explicitly:
+
+```bash
+# CLI flag (seconds):
+lgtmaybe review --provider ollama --model qwen3.6:35b \
+  --api-base http://localhost:11434 --timeout 900
+```
+
+```yaml
+# or in .lgtmaybe.yml (also how the GitHub Action picks it up):
+provider: ollama
+model: qwen3.6:35b
+timeout: 900
+```
+
+The review fans out one call per category. lgtmaybe runs those **serially for
+ollama** (a single ollama instance serves one request at a time, so firing them
+concurrently would only make each wait and time out). The trade-off is wall-clock
+time — a slow model takes roughly `categories × per-call time`. To go faster,
+narrow the lenses with `categories:` in `.lgtmaybe.yml` (e.g. just `security` and
+`correctness`), use a smaller model, or give ollama more GPU. If you have the VRAM
+to truly serve requests in parallel, raise `OLLAMA_NUM_PARALLEL` on the **ollama
+server** — lgtmaybe still issues ollama calls one at a time, but a faster server
+shortens each.
+
 ## Troubleshooting
 
 **`Connection refused` on port 11434** — ensure `ollama serve` is running and
 the `--api-base` URL is reachable.
 
 **Model not found** — run `ollama pull <model>` before using it.
+
+**`review incomplete — the model returned no usable output`** — every category
+call timed out or returned output that wasn't valid JSON. Raise `--timeout`, try a
+model that follows instructions more reliably, or check `LITELLM_LOG=DEBUG` output
+for the underlying error. lgtmaybe reports this (and exits non-zero) rather than
+pretending the PR is clean.
 
 **Review is empty or truncated** — the diff may exceed the model's context
 window. Add a path filter in `.lgtmaybe.yml` to reduce diff size, or set

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -24,7 +24,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openrouter` / `vertex` | Yes | — |  |
 | `reflect` | boolean | No | `True` | Reflect |
 | `temperature` | number | No | `0.0` | Temperature |
-| `timeout` | integer | No | `60` | Timeout |
+| `timeout` | integer / null | No | `null` | Timeout |
 
 ## Enums
 
@@ -216,9 +216,16 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "number"
     },
     "timeout": {
-      "default": 60,
-      "title": "Timeout",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timeout"
     }
   },
   "required": [

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -119,9 +119,11 @@ class ReviewConfig(_Strict):
     # Ceiling on surrounding context lines added around each hunk. The engine
     # uses min(context_lines, what the token budget allows); 0 disables it.
     context_lines: int = 20
-    # Per-request timeout (seconds) for each provider completion call. Raise it
-    # for slow local models (e.g. a large model on CPU).
-    timeout: int = 60
+    # Per-request timeout (seconds) for each provider completion call. None means
+    # "auto": the factory picks a provider-aware default (ollama gets a long one,
+    # since local models are slow; cloud providers a short one). An explicit value
+    # always wins.
+    timeout: int | None = None
     # Sampling temperature for completions. Defaults to 0.0 for deterministic,
     # reproducible reviews (and steadier instruction-following on small models).
     temperature: float = 0.0

--- a/src/lgtmaybe/engine/__init__.py
+++ b/src/lgtmaybe/engine/__init__.py
@@ -1,7 +1,7 @@
 """lgtmaybe.engine — the review pipeline (Track C)."""
 
 from .compress import batch_files, context_lines_for_budget, count_tokens
-from .engine import LLMReviewEngine
+from .engine import LLMReviewEngine, ReviewIncompleteError
 from .injection import wrap_diff
 from .parse import ParseError, parse_findings
 from .prompt import build_system_prompt
@@ -10,6 +10,7 @@ from .reflect import reflect_findings
 
 __all__ = [
     "LLMReviewEngine",
+    "ReviewIncompleteError",
     # building blocks
     "batch_files",
     "context_lines_for_budget",

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1,8 +1,8 @@
 """LLMReviewEngine: the full review pipeline.
 
 Pipeline: redact → compress/batch → (per batch) fan out one call per review
-         category concurrently → parse → merge/dedupe → self-reflect/filter →
-         filter by min_severity → return findings + summary.
+         category (concurrent for cloud, serial for ollama) → parse → merge/dedupe
+         → self-reflect/filter → filter by min_severity → return findings + summary.
 """
 
 from __future__ import annotations
@@ -11,7 +11,14 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
 from lgtmaybe.core.diffparse import split_by_file
-from lgtmaybe.core.models import PRContext, ReviewCategory, ReviewConfig, ReviewFinding
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ReviewCategory,
+    ReviewConfig,
+    ReviewFinding,
+)
 from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
 from lgtmaybe.github import is_reviewable
 
@@ -21,6 +28,27 @@ from .parse import ParseError, parse_findings
 from .prompt import build_system_prompt
 from .redact import redact
 from .reflect import reflect_findings
+
+_log = get_logger(__name__)
+
+# A single ollama instance serves a model serially, so concurrent calls only
+# queue up and time out; every other provider parallelises across categories.
+_MAX_WORKERS = 8
+
+
+class ReviewIncompleteError(Exception):
+    """Every review call failed (timeout or unparseable output) — no usable result.
+
+    Raised instead of silently reporting a clean review, so the CLI surfaces a
+    failure (non-zero exit / failure comment) rather than a false 👍 LGTM.
+    """
+
+
+def _worker_count(cfg: ReviewConfig) -> int:
+    """How many category calls to run at once: 1 for ollama (serial backend)."""
+    if cfg.provider is Provider.ollama:
+        return 1
+    return min(len(cfg.categories), _MAX_WORKERS) or 1
 
 
 class LLMReviewEngine(ReviewEngine):
@@ -61,17 +89,32 @@ class LLMReviewEngine(ReviewEngine):
         batches = batch_files(file_patches, max_tokens=cfg.max_input_tokens)
 
         all_findings: list[ReviewFinding] = []
+        total_calls = 0
+        failed_calls = 0
 
-        # 5. For each batch, fan out one call per review category, concurrently.
-        #    Each category gets a focused prompt; their findings are merged.
-        workers = min(len(cfg.categories), 8) or 1
+        # 5. For each batch, fan out one call per review category. Each category
+        #    gets a focused prompt; their findings are merged. Concurrency is
+        #    provider-aware — serial for ollama so calls don't queue and time out.
+        workers = _worker_count(cfg)
         for batch in batches:
             batch_diff = "\n".join(patch for _, patch in batch)
             wrapped = wrap_diff(batch_diff)
             review_one = partial(self._review_category, wrapped, cfg.model)
             with ThreadPoolExecutor(max_workers=workers) as pool:
-                for findings in pool.map(review_one, cfg.categories):
+                for findings, ok in pool.map(review_one, cfg.categories):
+                    total_calls += 1
+                    if not ok:
+                        failed_calls += 1
                     all_findings.extend(findings)
+
+        # 5b. Fail loud: if EVERY call errored or returned unparseable output, we
+        #     have no signal — never pass that off as a clean review.
+        if total_calls > 0 and failed_calls == total_calls:
+            raise ReviewIncompleteError(
+                "review incomplete — the model returned no usable output "
+                "(timeout or unparseable response). Check the model and timeout "
+                "(ollama: a larger model needs a longer --timeout) and retry."
+            )
 
         # 6. Merge: a finding can surface under more than one lens (a shell
         #    injection is both a security and a correctness issue), so collapse
@@ -91,13 +134,24 @@ class LLMReviewEngine(ReviewEngine):
 
         plural = "s" if len(filtered) != 1 else ""
         summary_line = f"{len(filtered)} finding{plural} · model {cfg.model}"
+
+        notices = []
         if capped_files:
-            notice = (
+            notices.append(
                 f"⚠️ Reviewed the top {cfg.max_files} of {total_files} changed files "
                 f"(file cap {cfg.max_files}). Raise max_files to review them all."
             )
-            return filtered, f"{notice}\n\n{summary_line}"
-        # A genuinely clean review (nothing flagged, every file reviewed) gets an
+        # Some — but not all — lenses failed: the result may be incomplete, so say
+        # so and don't claim a clean bill of health.
+        if failed_calls:
+            notices.append(
+                f"⚠️ {failed_calls} of {total_calls} review calls failed "
+                "(timeout or unparseable output); results may be incomplete."
+            )
+
+        if notices:
+            return filtered, "\n\n".join([*notices, summary_line])
+        # A genuinely clean review (nothing flagged, every call succeeded) gets an
         # explicit thumbs-up rather than a bare "0 findings".
         if not filtered:
             return filtered, f"👍 LGTM!\n\n{summary_line}"
@@ -105,17 +159,28 @@ class LLMReviewEngine(ReviewEngine):
 
     def _review_category(
         self, wrapped: str, model: str, category: ReviewCategory
-    ) -> list[ReviewFinding]:
-        """Run one focused review call for a single category and parse its findings."""
+    ) -> tuple[list[ReviewFinding], bool]:
+        """Run one focused review call for a single category.
+
+        Returns ``(findings, ok)``. ``ok`` is False when the call errored (e.g. a
+        timeout that exhausted retries) or returned output we couldn't parse — the
+        engine counts those so it can fail loud instead of reporting a false LGTM.
+        A failing category never aborts the others.
+        """
         messages: list[Message] = [
             {"role": "system", "content": build_system_prompt(category)},
             {"role": "user", "content": wrapped},
         ]
-        result = self._provider.complete(messages, model=model)
         try:
-            return parse_findings(result.text)
+            result = self._provider.complete(messages, model=model)
+        except Exception:
+            _log.warning("review call failed", extra={"category": category.value}, exc_info=True)
+            return [], False
+        try:
+            return parse_findings(result.text), True
         except ParseError:
-            return []
+            _log.warning("unparseable model output", extra={"category": category.value})
+            return [], False
 
 
 def _dedupe(findings: list[ReviewFinding]) -> list[ReviewFinding]:

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -28,6 +28,17 @@ _PREFIXES: dict[Provider, str] = {
     Provider.ollama: "ollama",
 }
 
+# Default per-request timeout (seconds) when the caller doesn't set one. Local
+# models on ollama are slow — and the per-category fan-out runs them serially —
+# so ollama gets a generous default; cloud providers respond fast.
+_OLLAMA_TIMEOUT = 300
+_CLOUD_TIMEOUT = 60
+
+
+def default_timeout_for(provider: Provider) -> int:
+    """The auto timeout (seconds) for a provider when none is given explicitly."""
+    return _OLLAMA_TIMEOUT if provider is Provider.ollama else _CLOUD_TIMEOUT
+
 
 def litellm_model_string(provider: Provider, model: str) -> str:
     """Return the litellm model string for the given provider and model name."""
@@ -42,12 +53,20 @@ def build_provider(
     api_base: str | None = None,
     azure_ad_token: str | None = None,
     fallback_model: str | None = None,
+    timeout: int | None = None,
     **extra_opts: Any,
 ) -> LiteLLMProvider:
-    """Build a configured LiteLLMProvider for the given provider and model."""
+    """Build a configured LiteLLMProvider for the given provider and model.
+
+    ``timeout`` of ``None`` resolves to a provider-aware default
+    (:func:`default_timeout_for`) — so ollama always gets a long timeout without
+    the caller having to ask. An explicit value is honoured as-is.
+    """
     resolved_model = litellm_model_string(provider, model)
     resolved_fallback = litellm_model_string(provider, fallback_model) if fallback_model else None
     opts: dict[str, Any] = dict(extra_opts)
+
+    opts["timeout"] = timeout if timeout is not None else default_timeout_for(provider)
 
     if api_key is not None:
         opts["api_key"] = api_key

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from lgtmaybe.core.models import (
     PRContext,
     Provider,
@@ -13,7 +15,7 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
-from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
 from lgtmaybe.engine.redact import REDACTED_PLACEHOLDER
 from tests.fakes import FakeProvider
 
@@ -414,3 +416,84 @@ def test_categories_config_narrows_the_fan_out() -> None:
     engine.review(_CTX, cfg)
 
     assert len(_review_calls(provider)) == 1
+
+
+# ---------------------------------------------------------------------------
+# provider-aware concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_fans_out_serially() -> None:
+    from lgtmaybe.engine.engine import _worker_count
+
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+    assert _worker_count(cfg) == 1  # one ollama instance serves serially
+
+
+def test_cloud_fans_out_concurrently() -> None:
+    from lgtmaybe.engine.engine import _worker_count
+
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4o")
+    assert _worker_count(cfg) == len(cfg.categories)
+
+
+# ---------------------------------------------------------------------------
+# fail loud: don't pass off a failed run as a clean review
+# ---------------------------------------------------------------------------
+
+
+class _UnparseableProvider(FakeProvider):
+    """Returns prose (never valid findings JSON) for every review call."""
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        return ProviderResult(text="I think this looks fine!", input_tokens=10, output_tokens=5)
+
+
+class _TimeoutProvider(FakeProvider):
+    """Raises on every review call (e.g. a timeout that exhausted retries)."""
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        raise TimeoutError("connection timed out")
+
+
+def test_all_categories_unparseable_raises_incomplete() -> None:
+    engine = LLMReviewEngine(_UnparseableProvider())
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", reflect=False)
+
+    with pytest.raises(ReviewIncompleteError):
+        engine.review(_CTX, cfg)
+
+
+def test_all_categories_error_raises_incomplete_not_lgtm() -> None:
+    engine = LLMReviewEngine(_TimeoutProvider())
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", reflect=False)
+
+    with pytest.raises(ReviewIncompleteError):
+        engine.review(_CTX, cfg)
+
+
+def test_partial_failure_keeps_findings_with_a_notice_and_no_lgtm() -> None:
+    # security returns a real finding; every other category is unparseable.
+    class _MixedProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            system = messages[0]["content"].lower()
+            if "owasp" in system:
+                f = ReviewFinding(
+                    path="a.py", line=1, severity=Severity.high, title="bug", body="x"
+                )
+                return ProviderResult(
+                    text=json.dumps([f.model_dump(mode="json")]), input_tokens=10, output_tokens=5
+                )
+            return ProviderResult(text="no JSON here", input_tokens=10, output_tokens=5)
+
+    engine = LLMReviewEngine(_MixedProvider())
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", reflect=False)
+
+    findings, summary = engine.review(_CTX, cfg)
+
+    assert [f.title for f in findings] == ["bug"]  # the good finding survives
+    assert "incomplete" in summary.lower()
+    assert "LGTM" not in summary

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -102,6 +102,25 @@ class TestBuildProvider:
         provider = build_provider(Provider.ollama, "llama2", timeout=600)
         assert provider.default_opts.get("timeout") == 600
 
+    def test_ollama_gets_a_long_default_timeout_when_unset(self) -> None:
+        provider = build_provider(Provider.ollama, "llama2")
+        assert provider.default_opts.get("timeout") == 300
+
+    def test_cloud_gets_a_short_default_timeout_when_unset(self) -> None:
+        provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")
+        assert provider.default_opts.get("timeout") == 60
+
+    def test_explicit_timeout_overrides_the_provider_default(self) -> None:
+        provider = build_provider(Provider.ollama, "llama2", timeout=45)
+        assert provider.default_opts.get("timeout") == 45
+
+
+class TestDefaultTimeout:
+    def test_ollama_default_is_longer_than_cloud(self) -> None:
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert default_timeout_for(Provider.ollama) > default_timeout_for(Provider.openai)
+
     def test_build_provider_threads_temperature_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", temperature=0.0)
         assert provider.default_opts.get("temperature") == 0.0

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -119,9 +119,16 @@
       "type": "number"
     },
     "timeout": {
-      "default": 60,
-      "title": "Timeout",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Timeout"
     }
   },
   "required": [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,9 +79,10 @@ def test_review_config_api_base_defaults_to_none() -> None:
     assert cfg.api_base is None
 
 
-def test_review_config_timeout_defaults_to_60() -> None:
+def test_review_config_timeout_defaults_to_none_auto() -> None:
+    # None means "auto" — the factory resolves a provider-aware default.
     cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
-    assert cfg.timeout == 60
+    assert cfg.timeout is None
 
 
 def test_review_config_accepts_timeout() -> None:


### PR DESCRIPTION
Fixes problems **1 (timeout)** and **3 (silent false-LGTM)** from #27. Follows the now-merged #26 (per-category fan-out).

## Timeout & concurrency
- **Provider-aware default timeout.** `ReviewConfig.timeout` is now `int | None` (None = auto); `build_provider` resolves **ollama → 300 s**, cloud → 60 s. An explicit `--timeout` / `.lgtmaybe.yml` value always wins, so ollama always gets a long timeout with no flag needed.
- **Provider-aware fan-out concurrency.** Serial (1 worker) for ollama — a single ollama instance serves requests one at a time, so the 5 concurrent category calls only queued and blew past the 60 s timeout. Cloud keeps concurrent fan-out.

## Fail loud
- `_review_category` returns `(findings, ok)`. A category that errors (a timeout that exhausted retries) or returns unparseable output no longer aborts the others — it's counted as failed.
- **All calls failed → `ReviewIncompleteError`** → the CLI surfaces a non-zero exit / failure comment instead of a false `👍 LGTM\!`. **Some failed →** post the findings we have with a "n of m review calls failed" notice (and no LGTM).

## Docs
Ollama slow-model/timeout section + the review-incomplete signal in the ollama how-to; documented the `timeout` config field; DEVELOPMENT.md debugging notes.

## Verification
Re-ran the original repro (`ollama` / `qwen3.6:35b`) that previously crashed with `litellm.Timeout`:
- 5 calls now run **serially in ~76 s — no timeout**.
- The model returned prose (not JSON), so the run reported **`review incomplete` + non-zero exit** instead of a false LGTM. (Structured outputs to make such models emit valid JSON is the follow-up, #27 problem 2.)

Gate: **385 tests pass**, ruff + format + mypy clean, no lockfile drift.

Tracking: #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)