### PR TITLE
feat: eval harness — measure whether a model produces usable reviews

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -251,6 +251,28 @@ docker run --rm lgtmaybe:dev --help
 uv run --group docs mkdocs serve   # http://127.0.0.1:8000
 ```
 
+## Evaluating a model (evals/)
+
+Whether a given model/setting actually produces *usable* reviews depends on the
+model — so there's a small eval harness under `evals/` to measure it, rather than
+finding out by hand. Each fixture is a diff with planted bugs plus a manifest of
+the findings a good review should catch (`evals/fixtures/<name>/`).
+
+```bash
+# Needs a live model — NOT part of the pytest gate. Run on demand:
+uv run python -m evals.run --provider ollama --model qwen3.6:35b \
+  --api-base http://localhost:11434
+```
+
+It reviews each fixture and reports, per fixture, whether the model produced
+parseable output and its **recall** against the expected findings, then exits
+non-zero if any fixture failed to parse or fell below `--min-recall` (default
+0.6) — so it can gate a model or prompt change.
+
+The scorer (`evals/scorer.py`) is pure and unit-tested (`tests/evals/`); only the
+runner needs a live model. To add a fixture, drop a `diff.txt` and an
+`expected.json` (matching the `Fixture` schema) under `evals/fixtures/<name>/`.
+
 ## Testing in GitHub Actions
 
 Two distinct CI workflows cover two different things.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,8 @@
+"""lgtmaybe evals — measure whether a model/setting produces usable reviews.
+
+Not part of the per-PR test gate (the runner needs a live model). The scorer is
+pure and unit-tested; the runner is invoked on demand:
+
+    python -m evals.run --provider ollama --model qwen3.6:35b \
+        --api-base http://localhost:11434
+"""

--- a/evals/fixtures/badcode/diff.txt
+++ b/evals/fixtures/badcode/diff.txt
@@ -1,0 +1,36 @@
+diff --git a/badcode.py b/badcode.py
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/badcode.py
+@@ -0,0 +1,30 @@
++"""Demo helpers — deliberately buggy, for the reviewer eval."""
++import subprocess
++import requests
++
++API_TOKEN = "ghp_aB3xK9mP2qR7sT1vW4yZ6cD8eF0gH2jK4lM"
++
++
++def fetch_user(user_id):
++    url = "http://internal-api/users/" + user_id
++    resp = requests.get(url, headers={"Authorization": f"Bearer {API_TOKEN}"})
++    return resp.json()["name"]
++
++
++def average(values):
++    total = 0
++    for i in range(1, len(values)):
++        total += values[i]
++    return total / len(values)
++
++
++def find_admin(users):
++    for user in users:
++        if user["role"] == "admin":
++            return user
++    return user
++
++
++def run_report(report_name):
++    cmd = "generate-report --name " + report_name
++    subprocess.run(cmd, shell=True)

--- a/evals/fixtures/badcode/expected.json
+++ b/evals/fixtures/badcode/expected.json
@@ -1,0 +1,35 @@
+{
+  "name": "badcode",
+  "changed_file": "badcode.py",
+  "expected": [
+    {
+      "label": "hardcoded GitHub token (API_TOKEN)",
+      "line": 5,
+      "keywords": ["secret", "token", "hardcoded", "credential", "api key"],
+      "severity_at_least": "high"
+    },
+    {
+      "label": "insecure HTTP / missing timeout in fetch_user",
+      "line": 10,
+      "keywords": ["http", "insecure", "timeout", "ssrf", "tls"]
+    },
+    {
+      "label": "off-by-one in average() — range starts at 1",
+      "line": 16,
+      "keywords": ["off-by-one", "index", "range", "first element", "skip", "boundary"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "leaked loop variable / UnboundLocalError in find_admin",
+      "line": 25,
+      "keywords": ["unbound", "loop variable", "undefined", "nameerror", "not defined", "no admin"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "command injection via shell=True in run_report",
+      "line": 30,
+      "keywords": ["injection", "shell", "command"],
+      "severity_at_least": "high"
+    }
+  ]
+}

--- a/evals/run.py
+++ b/evals/run.py
@@ -1,0 +1,83 @@
+"""Eval runner: review each fixture with a live model and report parse-rate + recall.
+
+    python -m evals.run --provider ollama --model qwen3.6:35b \
+        --api-base http://localhost:11434
+
+Exits non-zero if any fixture failed to parse or fell below --min-recall, so it
+can gate a model/setting change. Needs a live model, so it is NOT in the pytest
+gate — run it on demand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from lgtmaybe.core.models import PRContext, Provider, ReviewConfig
+from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
+from lgtmaybe.providers.factory import build_provider
+
+from .scorer import Fixture, FixtureScore, score_fixture
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_fixtures() -> list[tuple[str, Fixture]]:
+    out: list[tuple[str, Fixture]] = []
+    for d in sorted(p for p in _FIXTURES.iterdir() if p.is_dir()):
+        diff = (d / "diff.txt").read_text()
+        manifest = Fixture.model_validate_json((d / "expected.json").read_text())
+        out.append((diff, manifest))
+    return out
+
+
+def _review(diff: str, manifest: Fixture, provider: Provider, model: str, api_base: str | None):
+    ctx = PRContext(
+        diff=diff,
+        changed_files=[manifest.changed_file],
+        base_sha="0",
+        head_sha="1",
+        repo="eval/eval",
+        pr_number=0,
+    )
+    cfg = ReviewConfig(provider=provider, model=model, api_base=api_base)
+    engine = LLMReviewEngine(build_provider(provider, model, api_base=api_base))
+    try:
+        findings, _summary = engine.review(ctx, cfg)
+        return score_fixture(manifest.name, findings, manifest.expected, parsed_ok=True)
+    except ReviewIncompleteError:
+        return score_fixture(manifest.name, [], manifest.expected, parsed_ok=False)
+
+
+def _print(score: FixtureScore) -> None:
+    status = "ok" if score.parsed_ok else "PARSE-FAIL"
+    print(
+        f"{score.name:14} parsed={status:10} "
+        f"recall={score.recall:5.0%} ({score.matched_count}/{score.expected_count}) "
+        f"findings={score.findings_count}"
+    )
+    for miss in score.missed:
+        print(f"    missed: {miss}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Run lgtmaybe review evals against a model.")
+    ap.add_argument("--provider", required=True, choices=[p.value for p in Provider])
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--api-base", default=None)
+    ap.add_argument("--min-recall", type=float, default=0.6, help="fail below this recall")
+    args = ap.parse_args(argv)
+
+    provider = Provider(args.provider)
+    scores = [_review(diff, m, provider, args.model, args.api_base) for diff, m in _load_fixtures()]
+    for score in scores:
+        _print(score)
+
+    ok = all(s.parsed_ok and s.recall >= args.min_recall for s in scores)
+    print("\n" + ("PASS" if ok else "FAIL") + f" (min recall {args.min_recall:.0%})")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/scorer.py
+++ b/evals/scorer.py
@@ -1,0 +1,89 @@
+"""Pure scoring for the eval harness.
+
+Given the findings a review produced and a fixture's manifest of *expected*
+findings, compute how many expected issues were caught (recall) and whether the
+model produced parseable output at all. No I/O, no model — unit-tested.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from lgtmaybe.core.models import ReviewFinding, Severity
+
+# How far a reported line may drift from the expected line and still count — models
+# attribute a finding to a nearby line (the call vs the def) often enough.
+_LINE_TOLERANCE = 3
+
+
+class ExpectedFinding(BaseModel):
+    """One issue a fixture expects the reviewer to catch."""
+
+    label: str  # human description, e.g. "off-by-one in average()"
+    line: int
+    keywords: list[str]  # matches if ANY appears (case-insensitive) in title+body
+    severity_at_least: Severity | None = None
+
+
+class Fixture(BaseModel):
+    """A fixture manifest: the changed file and the issues it plants."""
+
+    name: str
+    changed_file: str
+    expected: list[ExpectedFinding]
+
+
+class FixtureScore(BaseModel):
+    """The outcome of scoring one fixture's findings against its manifest."""
+
+    name: str
+    parsed_ok: bool
+    expected_count: int
+    matched_count: int
+    findings_count: int
+    missed: list[str]
+
+    @property
+    def recall(self) -> float:
+        if self.expected_count == 0:
+            return 1.0
+        return self.matched_count / self.expected_count
+
+
+def _matches(finding: ReviewFinding, expected: ExpectedFinding) -> bool:
+    """True if *finding* plausibly reports *expected* (line + keyword + severity)."""
+    if abs(finding.line - expected.line) > _LINE_TOLERANCE:
+        return False
+    haystack = f"{finding.title} {finding.body}".lower()
+    if expected.keywords and not any(k.lower() in haystack for k in expected.keywords):
+        return False
+    if expected.severity_at_least is not None and not (
+        finding.severity >= expected.severity_at_least
+    ):
+        return False
+    return True
+
+
+def score_fixture(
+    name: str,
+    findings: list[ReviewFinding],
+    expected: list[ExpectedFinding],
+    *,
+    parsed_ok: bool = True,
+) -> FixtureScore:
+    """Score *findings* against the *expected* manifest for one fixture."""
+    matched = 0
+    missed: list[str] = []
+    for exp in expected:
+        if any(_matches(f, exp) for f in findings):
+            matched += 1
+        else:
+            missed.append(exp.label)
+    return FixtureScore(
+        name=name,
+        parsed_ok=parsed_ok,
+        expected_count=len(expected),
+        matched_count=matched,
+        findings_count=len(findings),
+        missed=missed,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,12 @@ src = ["src", "tests"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["lgtmaybe", "evals"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 # Code-quality gate: using a deprecated API (ours, the stdlib's, or a dependency's

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -1,0 +1,47 @@
+"""Runner wiring test — fixture load → engine → score, with a fake provider."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from evals import run as run_mod
+from lgtmaybe.core.models import ProviderResult, ReviewFinding, Severity
+from tests.fakes import FakeProvider
+
+
+class _ShellInjectionProvider(FakeProvider):
+    """Returns the badcode shell-injection finding for every review call."""
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        finding = ReviewFinding(
+            path="badcode.py",
+            line=30,
+            severity=Severity.high,
+            title="Command injection via shell=True",
+            body="report_name is concatenated into a shell command.",
+        )
+        return ProviderResult(
+            text=json.dumps({"findings": [finding.model_dump(mode="json")]}),
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+
+def test_runner_loads_fixtures_and_scores(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    # The provider catches 1 of the 5 planted issues — passes a low bar, fails a high one.
+    assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"]) == 0
+    assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.9"]) == 1
+
+
+def test_runner_fails_when_review_incomplete(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Unparseable(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            return ProviderResult(text="I cannot help with that.", input_tokens=1, output_tokens=1)
+
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _Unparseable())
+    assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"]) == 1

--- a/tests/evals/test_scorer.py
+++ b/tests/evals/test_scorer.py
@@ -1,0 +1,83 @@
+"""Unit tests for the eval scorer (pure — no model)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.scorer import ExpectedFinding, Fixture, score_fixture
+from lgtmaybe.core.models import ReviewFinding, Severity
+
+
+def _finding(line: int, title: str, body: str = "", severity: Severity = Severity.high):
+    return ReviewFinding(path="badcode.py", line=line, severity=severity, title=title, body=body)
+
+
+def _expected(line: int, keywords: list[str], severity: Severity | None = None):
+    return ExpectedFinding(
+        label=f"line {line}", line=line, keywords=keywords, severity_at_least=severity
+    )
+
+
+def test_finding_matches_on_line_keyword_and_severity() -> None:
+    findings = [_finding(30, "Command injection via shell=True")]
+    expected = [_expected(30, ["injection", "shell"], Severity.high)]
+    score = score_fixture("f", findings, expected)
+    assert score.recall == 1.0
+    assert score.missed == []
+
+
+def test_line_drift_within_tolerance_still_matches() -> None:
+    findings = [_finding(32, "shell injection")]  # expected line 30, drift 2
+    score = score_fixture("f", findings, [_expected(30, ["injection"])])
+    assert score.matched_count == 1
+
+
+def test_line_too_far_misses() -> None:
+    findings = [_finding(40, "shell injection")]  # expected 30, drift 10
+    score = score_fixture("f", findings, [_expected(30, ["injection"])])
+    assert score.matched_count == 0
+    assert score.recall == 0.0
+
+
+def test_keyword_mismatch_misses() -> None:
+    findings = [_finding(30, "style nit")]
+    score = score_fixture("f", findings, [_expected(30, ["injection", "shell"])])
+    assert score.matched_count == 0
+
+
+def test_severity_below_floor_misses() -> None:
+    findings = [_finding(30, "shell injection", severity=Severity.low)]
+    score = score_fixture("f", findings, [_expected(30, ["injection"], Severity.high)])
+    assert score.matched_count == 0
+
+
+def test_keyword_matches_in_body_not_only_title() -> None:
+    findings = [_finding(16, "Logic bug", body="classic off-by-one in the range")]
+    score = score_fixture("f", findings, [_expected(16, ["off-by-one"])])
+    assert score.matched_count == 1
+
+
+def test_partial_recall_lists_missed_labels() -> None:
+    findings = [_finding(30, "shell injection")]
+    expected = [
+        ExpectedFinding(label="injection", line=30, keywords=["injection"]),
+        ExpectedFinding(label="off-by-one", line=16, keywords=["off-by-one"]),
+    ]
+    score = score_fixture("f", findings, expected)
+    assert score.recall == 0.5
+    assert score.missed == ["off-by-one"]
+
+
+def test_parse_fail_recorded_with_zero_findings() -> None:
+    score = score_fixture("f", [], [_expected(30, ["injection"])], parsed_ok=False)
+    assert score.parsed_ok is False
+    assert score.recall == 0.0
+
+
+def test_committed_badcode_fixture_manifest_is_valid() -> None:
+    """The shipped fixture parses and its expected lines fall within the diff."""
+    fixtures = Path(__file__).resolve().parents[2] / "evals" / "fixtures" / "badcode"
+    manifest = Fixture.model_validate_json((fixtures / "expected.json").read_text())
+    assert manifest.changed_file == "badcode.py"
+    assert len(manifest.expected) >= 5
+    assert all(e.keywords for e in manifest.expected)


### PR DESCRIPTION
Addresses **#27 fix 4**. Stacked on #29 (structured outputs) — review/merge that first; GitHub retargets this to main when #29 lands.

## Why
Whether a given model/setting actually yields valid, on-target reviews is model-dependent (we just learned this the hard way with ollama). This measures it instead of finding out by hand.

## What
- **`evals/scorer.py`** — pure scoring: given a review's findings and a fixture's manifest of expected findings, compute **parse-rate** and **recall** (line-proximity + keyword + optional severity-floor matching). Unit-tested in `tests/evals/`.
- **`evals/run.py`** — runner: reviews each fixture with a live model, prints per-fixture parse status + recall, exits non-zero below `--min-recall` (default 0.6) so it can gate a model/prompt change. Needs a live model — **not** in the pytest gate.
- **`evals/fixtures/badcode/`** — a planted-bug diff (hardcoded token, insecure HTTP, off-by-one, leaked loop variable, shell injection) + `expected.json` manifest.
- `pyproject`: pytest `pythonpath += "."`, ruff `known-first-party += "evals"`.
- `DEVELOPMENT.md` documents running it and adding fixtures.

```bash
uv run python -m evals.run --provider ollama --model qwen3.6:35b \
  --api-base http://localhost:11434
```

## Tests
The scorer is pure and fully unit-tested (line tolerance, keyword/severity matching, partial recall, parse-fail); the runner is exercised end-to-end with a fake provider (fixture load → engine → score, plus the review-incomplete path). 409 tests pass, ruff + format + mypy clean, no lockfile drift.

Tracking: #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)