### PR TITLE
feat: expose timeout and temperature as GitHub Action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,14 @@ inputs:
     description: "Resource endpoint for azure (https://<resource>.openai.azure.com), or a custom base URL for other providers."
     required: false
     default: ""
+  timeout:
+    description: "Per-request timeout in seconds for each model call. Leave empty for the provider default (ollama 300, cloud 60)."
+    required: false
+    default: ""
+  temperature:
+    description: "Sampling temperature (default 0.0 for deterministic reviews)."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -112,6 +120,8 @@ runs:
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}
         INPUT_API_KEY: ${{ inputs.api_key }}
         INPUT_API_BASE: ${{ inputs.api_base }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_TEMPERATURE: ${{ inputs.temperature }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -122,6 +132,7 @@ runs:
           -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL \
           -e INPUT_PROVIDER -e INPUT_MODEL -e INPUT_FALLBACK_MODEL \
           -e INPUT_API_KEY -e INPUT_API_BASE -e INPUT_CONFIG_PATH \
+          -e INPUT_TIMEOUT -e INPUT_TEMPERATURE \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -100,6 +100,8 @@ or `gcp_wif_provider`. Both require `id-token: write` permission. See:
 | `model` | — | Model identifier for the chosen provider |
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex) |
+| `timeout` | provider default (ollama 300s, cloud 60s) | Per-request timeout in seconds for each model call |
+| `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `aws_role_arn` | — | IAM role ARN to assume via OIDC for bedrock (keyless) |
 | `aws_region` | `us-east-1` | AWS region for bedrock |
 | `gcp_wif_provider` | — | Workload Identity Federation provider resource name for vertex |

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -253,6 +253,8 @@ def action_inputs() -> dict[str, str | None]:
         "fallback_model": get("FALLBACK_MODEL"),
         "api_key": get("API_KEY"),
         "api_base": get("API_BASE"),
+        "timeout": get("TIMEOUT"),
+        "temperature": get("TEMPERATURE"),
         "config_path": os.environ.get("INPUT_CONFIG_PATH") or ".lgtmaybe.yml",
     }
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -195,6 +195,8 @@ def action() -> None:
         config_path=Path(inputs["config_path"] or ".lgtmaybe.yml"),
         provider=inputs["provider"],
         model=inputs["model"],
+        timeout=inputs["timeout"],
+        temperature=inputs["temperature"],
     )
     runtime = RuntimeOptions(
         api_key=inputs["api_key"],

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -125,6 +125,35 @@ class TestActionRouting:
             "fallback_model": "claude-3-haiku",
         }
 
+    def test_timeout_and_temperature_inputs_reach_config(self, tmp_path, monkeypatch):
+        """INPUT_TIMEOUT / INPUT_TEMPERATURE tune the run from the Action."""
+        captured: dict[str, object] = {}
+
+        import lgtmaybe.cli as cli_module
+
+        def fake_build(cfg, runtime):
+            captured["timeout"] = cfg.timeout
+            captured["temperature"] = cfg.temperature
+            return FakeGitHub(), FakeEngine(FakeProvider())
+
+        monkeypatch.setattr(cli_module, "build_adapters", fake_build)
+
+        event = _write_event(
+            tmp_path,
+            {"repository": {"full_name": "org/repo"}, "pull_request": {"number": 1}},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "ollama")
+        monkeypatch.setenv("INPUT_MODEL", "llama3")
+        monkeypatch.setenv("INPUT_TIMEOUT", "900")
+        monkeypatch.setenv("INPUT_TEMPERATURE", "0.2")
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert captured == {"timeout": 900, "temperature": 0.2}
+
     def test_azure_api_base_input_reaches_runtime(self, tmp_path, monkeypatch):
         """INPUT_API_BASE carries the azure resource endpoint into the run."""
         captured: dict[str, object] = {}


### PR DESCRIPTION
The CLI (`--timeout` / `--temperature`) and `.lgtmaybe.yml` could already set these, but the **GitHub Action** had no way to without a config file. This adds them as first-class Action inputs.

- `action.yml`: new `timeout` + `temperature` inputs, threaded as `INPUT_TIMEOUT` / `INPUT_TEMPERATURE` into the container `docker run`.
- `cli.action_inputs()`: reads the two new env vars.
- the `action` command: passes them to `load_config` (same path as provider/model). Empty inputs fall through to the **provider-aware defaults** (ollama 300 s, cloud 60 s; temperature 0.0).
- Documented in the Action how-to inputs table.

## Tests
`test_timeout_and_temperature_inputs_reach_config` asserts `INPUT_TIMEOUT=900` / `INPUT_TEMPERATURE=0.2` reach `cfg.timeout` / `cfg.temperature` (coerced to int/float). 410 tests pass, ruff + format + mypy clean.

Follow-up to #27 (the timeout/reliability work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)