### PR TITLE
feat: structured output for the reflection pass

### DIFF
--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -93,6 +93,23 @@ class ReviewResult(_Strict):
     findings: list[ReviewFinding]
 
 
+class Verdict(_Strict):
+    """One reflection verdict: keep or drop the finding at ``index``."""
+
+    index: int
+    keep: bool
+
+
+class ReflectionResult(_Strict):
+    """Structured-output envelope for the reflection pass: ``{"verdicts": [...]}``.
+
+    A fixed-shape object (not a dynamic-key map) so it can be enforced as a JSON
+    schema via litellm ``response_format``, the same way reviews are.
+    """
+
+    verdicts: list[Verdict]
+
+
 class ProviderResult(_Strict):
     """The normalised return of one LLM completion, with token usage."""
 

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -1,28 +1,32 @@
 """Self-reflection pass: ask the provider to judge confidence in each finding.
 
-Drops findings the model marks as low-confidence (keep=False).
+Drops findings the model marks as low-confidence (keep=False). The verdict is
+constrained to a structured schema (litellm ``response_format``) the same way the
+review calls are, with a lenient parser + keep-all safe default as fallback.
 """
 
 from __future__ import annotations
 
 import json
+from typing import Any
 
-from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
+from lgtmaybe.core.models import PRContext, ReflectionResult, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ProviderClient
 
-from .parse import strip_fences
+from .parse import _strip_think_blocks, strip_fences
 
 _REFLECT_SYSTEM = """\
 You are a senior code reviewer auditing another reviewer's findings for false positives.
 
 Given a list of findings (as JSON) and the diff that generated them, return a JSON object \
-mapping each finding's index (as a string key) to a boolean: true to keep it, false to drop it.
+with a single key "verdicts": a list of {"index": <finding index>, "keep": <true|false>} objects, \
+one per finding.
 
 Keep a finding only if you are confident it is a real issue in the actual changed code.
 Drop it if it is speculative, out of scope, or referring to unchanged lines.
 
 Return ONLY the JSON object, nothing else. Example:
-{"0": true, "1": false, "2": true}
+{"verdicts": [{"index": 0, "keep": true}, {"index": 1, "keep": false}]}
 """
 
 
@@ -34,7 +38,9 @@ def reflect_findings(
 ) -> list[ReviewFinding]:
     """Filter *findings* by asking the provider to score confidence.
 
-    Returns only findings the provider marks as keep=True.
+    Returns only findings the provider marks as keep=True. If the verdict can't be
+    parsed, keeps everything (safe default — better an unfiltered finding than a
+    dropped real one).
     """
     if not findings:
         return []
@@ -46,27 +52,44 @@ def reflect_findings(
         "Return the confidence verdict JSON object."
     )
 
+    opts: dict[str, Any] = {"response_format": ReflectionResult} if cfg.structured_output else {}
     result = provider.complete(
         messages=[
             {"role": "system", "content": _REFLECT_SYSTEM},
             {"role": "user", "content": user_content},
         ],
         model=cfg.model,
+        **opts,
     )
 
     try:
-        # Strip markdown fences if present, then parse the verdict object.
-        raw = strip_fences(result.text.strip()).strip()
-        verdicts: dict[str, bool] = json.loads(raw)
+        verdicts = _parse_verdicts(result.text)
     except Exception:
-        # If reflection fails to parse, keep all findings (safe default)
+        # If reflection fails to parse, keep all findings (safe default).
         return findings
 
-    kept = []
-    for i, finding in enumerate(findings):
-        # Accept both int and string keys
-        keep = verdicts.get(str(i), verdicts.get(i, True))  # type: ignore[call-overload]
-        if keep:
-            kept.append(finding)
+    return [finding for i, finding in enumerate(findings) if verdicts.get(i, True)]
 
-    return kept
+
+def _parse_verdicts(raw: str) -> dict[int, bool]:
+    """Parse the reflection verdict into an ``{index: keep}`` map.
+
+    Accepts the structured ``{"verdicts": [{"index": i, "keep": bool}, ...]}``
+    envelope, and (as a fallback for models that ignore the schema) the legacy
+    ``{"0": true, "1": false}`` index-to-bool map. Reasoning blocks and code
+    fences are stripped first.
+    """
+    text = strip_fences(_strip_think_blocks(raw).strip()).strip()
+    data = json.loads(text)
+
+    if isinstance(data, dict) and isinstance(data.get("verdicts"), list):
+        out: dict[int, bool] = {}
+        for v in data["verdicts"]:
+            if isinstance(v, dict) and "index" in v and "keep" in v:
+                out[int(v["index"])] = bool(v["keep"])
+        return out
+
+    if isinstance(data, dict):  # legacy {"0": true, ...}
+        return {int(k): bool(val) for k, val in data.items()}
+
+    raise ValueError(f"unrecognised verdict shape: {type(data).__name__}")

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -425,11 +425,13 @@ def test_categories_config_narrows_the_fan_out() -> None:
 
 
 # ---------------------------------------------------------------------------
-# structured output: response_format on review calls, never on reflection
+# structured output: review calls use the findings schema, reflection its own
 # ---------------------------------------------------------------------------
 
 
 def test_structured_output_sets_response_format_on_review_calls() -> None:
+    from lgtmaybe.core.models import ReflectionResult
+
     provider = _provider_for([_HIGH], reflection_keeps_all=True)
     engine = LLMReviewEngine(provider)
     cfg = ReviewConfig(provider=Provider.ollama, model="llama3")  # structured_output default True
@@ -438,8 +440,11 @@ def test_structured_output_sets_response_format_on_review_calls() -> None:
 
     review = _review_calls(provider)
     assert review and all(c["opts"].get("response_format") is ReviewResult for c in review)
-    # The reflection call must NOT be forced into the findings schema.
-    assert all("response_format" not in c["opts"] for c in _reflection_calls(provider))
+    # The reflection call uses its OWN schema (verdicts), not the findings schema.
+    reflection = _reflection_calls(provider)
+    assert reflection and all(
+        c["opts"].get("response_format") is ReflectionResult for c in reflection
+    )
 
 
 def test_structured_output_disabled_omits_response_format() -> None:

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -8,6 +8,7 @@ from lgtmaybe.core.models import (
     PRContext,
     Provider,
     ProviderResult,
+    ReflectionResult,
     ReviewConfig,
     ReviewFinding,
     Severity,
@@ -83,3 +84,59 @@ def test_reflect_calls_provider_once() -> None:
     reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
 
     assert len(provider.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# structured-output verdict envelope
+# ---------------------------------------------------------------------------
+
+
+def _envelope(verdicts: list[tuple[int, bool]]) -> str:
+    return json.dumps({"verdicts": [{"index": i, "keep": k} for i, k in verdicts]})
+
+
+def _fake_with_text(text: str) -> FakeProvider:
+    return FakeProvider(result=ProviderResult(text=text, input_tokens=5, output_tokens=5))
+
+
+def test_structured_verdict_envelope_drops_low_confidence() -> None:
+    provider = _fake_with_text(_envelope([(0, True), (1, False)]))
+
+    survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
+
+    assert _HIGH in survivors
+    assert _LOW_CONF not in survivors
+
+
+def test_reflection_passes_response_format_when_structured() -> None:
+    provider = _fake_with_verdict({0: True})  # _CFG has structured_output=True (default)
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert provider.calls[0]["opts"].get("response_format") is ReflectionResult
+
+
+def test_reflection_omits_response_format_when_disabled() -> None:
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", structured_output=False)
+    provider = _fake_with_verdict({0: True})
+
+    reflect_findings([_HIGH], _CTX, cfg, provider)
+
+    assert "response_format" not in provider.calls[0]["opts"]
+
+
+def test_verdict_with_think_block_and_fence_parses() -> None:
+    text = "<think>let me judge</think>\n```json\n" + _envelope([(0, False)]) + "\n```"
+    provider = _fake_with_text(text)
+
+    survivors = reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert survivors == []  # the verdict (keep=false) was parsed through the noise
+
+
+def test_unparseable_verdict_keeps_all() -> None:
+    provider = _fake_with_text("I'm not really sure about these.")
+
+    survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
+
+    assert survivors == [_HIGH, _LOW_CONF]  # safe default


### PR DESCRIPTION
The review calls were constrained to a JSON schema (`response_format`) in #29, but the **reflection pass** still asked for a free-form `{"0": true}` verdict and parsed it leniently — the same gap that made local models unreliable for reviews. This gives reflection the same treatment.

- **`ReflectionResult` / `Verdict` models** — a fixed-shape `{"verdicts": [{"index", "keep"}]}` envelope (a dynamic-key `{"0": true}` map can't be expressed as a clean JSON schema).
- **`reflect_findings`** passes `response_format=ReflectionResult` when `cfg.structured_output` is on (off when disabled), and asks for the envelope in its prompt.
- **`_parse_verdicts`** accepts the new envelope **and** the legacy `{"0": true}` map (fallback for models that ignore the schema), stripping `<think>` blocks + code fences first. The keep-all **safe default** on parse failure is unchanged.

The `think=False` + `num_ctx` settings (applied to ollama in the factory) cover the reflect call too, so the same fix that made reviews emit valid JSON covers reflection — no separate live tuning needed.

## Tests
New: structured envelope drops/keeps correctly; `response_format` is `ReflectionResult` on the reflect call (and absent when `structured_output=False`); verdict survives `<think>`+fences; unparseable verdict keeps all. Existing legacy-format tests stay green via the fallback. 414 tests pass, ruff + format + mypy clean, no lockfile drift.

Follow-up to #27 / #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)