### PR TITLE
feat: name provider+model and scope review marker per provider

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -97,7 +97,12 @@ def build_review_context(
         )
 
     engine, provider = build_provider_engine(cfg, runtime)
-    github = RestGitHubGateway(repo=repo, pr_number=pr_number, token=token)
+    github = RestGitHubGateway(
+        repo=repo,
+        pr_number=pr_number,
+        token=token,
+        marker_key=f"{cfg.provider}/{cfg.model}",
+    )
     return github, engine, provider
 
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -137,7 +137,9 @@ class LLMReviewEngine(ReviewEngine):
         filtered = [f for f in all_findings if f.severity >= cfg.min_severity]
 
         plural = "s" if len(filtered) != 1 else ""
-        summary_line = f"{len(filtered)} finding{plural} · model {cfg.model}"
+        summary_line = (
+            f"{len(filtered)} finding{plural} · provider {cfg.provider} · model {cfg.model}"
+        )
 
         notices = []
         if capped_files:

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -43,6 +43,7 @@ class RestGitHubGateway(GitHubGateway):
         pr_number: int,
         token: str,
         client: httpx.Client | None = None,
+        marker_key: str | None = None,
     ) -> None:
         self._repo = repo
         self._pr_number = pr_number
@@ -51,6 +52,10 @@ class RestGitHubGateway(GitHubGateway):
             "X-GitHub-Api-Version": "2022-11-28",
         }
         self._client = client if client is not None else httpx.Client(timeout=_TIMEOUT)
+        # Scope the idempotency marker to a provider/model so concurrent reviews
+        # from different backends on one PR update their own comment instead of
+        # clobbering each other. Unkeyed gateways keep the legacy marker.
+        self._marker = f"<!-- lgtmaybe:{marker_key} -->" if marker_key else _MARKER
 
     # ------------------------------------------------------------------
     # GitHubGateway implementation
@@ -119,7 +124,7 @@ class RestGitHubGateway(GitHubGateway):
         pos_map: PositionMap = build_position_map(diff)
         comments = self._build_comments(findings, pos_map)
 
-        body = f"{summary}\n\n{_MARKER}"
+        body = f"{summary}\n\n{self._marker}"
         existing_id = self._find_existing_review()
 
         reviews_url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
@@ -223,7 +228,7 @@ class RestGitHubGateway(GitHubGateway):
         reviews = self._get_json(reviews_url)
         for review in reviews:
             body: str = review.get("body", "") or ""
-            if _MARKER in body:
+            if self._marker in body:
                 review_id: int = review["id"]
                 return review_id
         return None

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -169,6 +169,19 @@ def test_summary_names_the_model_without_cost() -> None:
     assert "$" not in summary
 
 
+def test_summary_names_provider_and_model() -> None:
+    """The summary names both provider and model so concurrent multi-provider runs
+    on one PR are distinguishable."""
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.openrouter, model="openai/gpt-4.1-mini")
+
+    _, summary = engine.review(_CTX, cfg)
+
+    assert "openrouter" in summary
+    assert "openai/gpt-4.1-mini" in summary
+
+
 # ---------------------------------------------------------------------------
 # reflection toggle
 # ---------------------------------------------------------------------------

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -205,3 +205,66 @@ def test_post_review_drops_finding_on_expanded_context_line() -> None:
     gw.post_review(findings, "Summary", diff=SAMPLE_DIFF)
 
     assert created_bodies[0].get("comments", []) == []
+
+
+@respx.mock
+def test_post_review_uses_provider_scoped_marker() -> None:
+    """A gateway built with a marker_key embeds a provider/model-scoped marker."""
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    created_bodies: list[dict[object, object]] = []
+
+    def capture_create(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        created_bodies.append(body)
+        return httpx.Response(201, json={"id": 1, "body": body.get("body", "")})
+
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+
+    gw = RestGitHubGateway(
+        repo=REPO,
+        pr_number=PR_NUMBER,
+        token=TOKEN,
+        client=httpx.Client(),
+        marker_key="openai/gpt-4.1-mini",
+    )
+    gw.post_review(FINDINGS, "Summary text", diff=SAMPLE_DIFF)
+
+    assert "<!-- lgtmaybe:openai/gpt-4.1-mini -->" in str(created_bodies[0].get("body", ""))
+
+
+@respx.mock
+def test_post_review_with_distinct_marker_keys_coexist() -> None:
+    """A review from another provider/model is left intact; a gateway with a
+    different marker_key creates its own review instead of overwriting it."""
+    other = [
+        {"id": 7, "body": "Anthropic summary <!-- lgtmaybe:anthropic/claude-haiku-4-5 -->"}
+    ]
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=other))
+
+    create_bodies: list[dict[object, object]] = []
+    put_calls: list[httpx.Request] = []
+
+    def capture_create(request: httpx.Request) -> httpx.Response:
+        create_bodies.append(json.loads(request.content))
+        return httpx.Response(201, json={"id": 8})
+
+    def capture_put(request: httpx.Request) -> httpx.Response:
+        put_calls.append(request)
+        return httpx.Response(200, json={"id": 7})
+
+    respx.route(method="PUT").mock(side_effect=capture_put)
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+
+    gw = RestGitHubGateway(
+        repo=REPO,
+        pr_number=PR_NUMBER,
+        token=TOKEN,
+        client=httpx.Client(),
+        marker_key="openai/gpt-4.1-mini",
+    )
+    gw.post_review(FINDINGS, "OpenAI summary", diff=SAMPLE_DIFF)
+
+    assert len(put_calls) == 0, "must not overwrite another provider's review"
+    assert len(create_bodies) == 1
+    assert "<!-- lgtmaybe:openai/gpt-4.1-mini -->" in str(create_bodies[0].get("body", ""))

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -237,9 +237,7 @@ def test_post_review_uses_provider_scoped_marker() -> None:
 def test_post_review_with_distinct_marker_keys_coexist() -> None:
     """A review from another provider/model is left intact; a gateway with a
     different marker_key creates its own review instead of overwriting it."""
-    other = [
-        {"id": 7, "body": "Anthropic summary <!-- lgtmaybe:anthropic/claude-haiku-4-5 -->"}
-    ]
+    other = [{"id": 7, "body": "Anthropic summary <!-- lgtmaybe:anthropic/claude-haiku-4-5 -->"}]
     respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=other))
 
     create_bodies: list[dict[object, object]] = []


### PR DESCRIPTION
## What

1. **Summary names provider + model** — the summary line now reads `N findings · provider <p> · model <m>` (was `· model <m>` only), so a review's backend is identifiable at a glance.
2. **Per-provider idempotency marker** — `RestGitHubGateway` gains a `marker_key`; the hidden marker becomes `<\!-- lgtmaybe:<provider>/<model> -->` when keyed (legacy `<\!-- lgtmaybe -->` otherwise). `post_review`/`_find_existing_review` use it, so a gateway only updates *its own* provider's review instead of last-writer-wins clobbering. This makes multi-provider runs on one PR (e.g. the e2e matrix) coexist.
3. **Wiring** — `cli.build_review_context` passes `marker_key=f"{cfg.provider}/{cfg.model}"`. The frozen `post_review` port signature is unchanged — identity rides on the constructor.

## Tests (TDD, red → green)

- `test_summary_names_provider_and_model`
- `test_post_review_uses_provider_scoped_marker`
- `test_post_review_with_distinct_marker_keys_coexist`

Full suite (418) + ruff + mypy green.

## Note

A pre-existing review with the old bare `<\!-- lgtmaybe -->` marker won't match a now-keyed gateway, so the first post after upgrade creates a fresh keyed comment and orphans the old one — a one-time cosmetic transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)