### PR TITLE
ci: add lint-fix workflow to auto-fix ruff violations on PRs

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -1,0 +1,50 @@
+name: lint-fix
+
+# Auto-fix lint + formatting on a PR instead of only failing it: run ruff's
+# autofixes and formatter, then commit the result straight back to the PR branch.
+# The strict, fail-on-violation gate still lives in ci.yml for anything ruff
+# can't fix automatically.
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  ruff-fix:
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN is read-only for PRs opened from forks, so we can't push the
+    # fix back there. Only run for same-repo PRs; fork PRs fall back to the
+    # ci.yml check, which still reports the violations.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Check out the PR branch itself (not the merge ref) so the commit
+          # lands on the contributor's branch.
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync (with dev deps)
+        run: uv sync --dev
+
+      - name: Ruff autofix + format
+        run: |
+          uv run ruff check --fix .
+          uv run ruff format .
+
+      - name: Commit and push fixes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "style: apply ruff lint and format fixes"
+            git push
+          else
+            echo "No lint or format changes to commit."
+          fi

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "lgtmaybe"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Add a new GitHub Actions workflow that automatically fixes lint and formatting violations on pull requests using ruff, rather than only failing the build. This improves the contributor experience by applying fixes directly to PR branches.

## Changes

- **New workflow:** `.github/workflows/lint-fix.yml`
  - Runs on `pull_request` events
  - Checks out the PR branch (not the merge ref) to land commits on the contributor's branch
  - Installs dependencies via `uv` with dev tools
  - Runs `ruff check --fix` and `ruff format` to auto-fix violations
  - Commits and pushes fixes back to the PR branch if changes were made
  - Skips execution for fork PRs (where `GITHUB_TOKEN` is read-only), allowing the strict gate in `ci.yml` to report violations instead
  - Uses GitHub Actions bot identity for commits

## Implementation Details

- **Fork safety:** The workflow includes a guard (`if: github.event.pull_request.head.repo.full_name == github.repository`) to only run on same-repo PRs, respecting the fork-safety principle in CLAUDE.md by not attempting to write to forks
- **Idempotent:** Only commits if there are actual changes (`git status --porcelain` check)
- **Complementary:** Works alongside the existing strict lint gate in `ci.yml`, which continues to fail on violations that ruff cannot auto-fix
- **Python 3.12:** Uses the same Python version as other CI workflows for consistency

https://claude.ai/code/session_01THSKLAVZ85uLN1emzDVBDs