### PR TITLE
docs: add Trust and Cost explanation and README security/cost callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Markdown sources below.
 - [Architecture](docs/explanation/architecture.md) — ports and adapters, the review pipeline
 - [Auth Model](docs/explanation/auth-model.md) — why keyless cloud, how credential resolution works
 - [Data and Privacy](docs/explanation/data-and-privacy.md) — what is sent where, secret redaction, ollama local mode
+- [Trust and Cost](docs/explanation/trust-and-cost.md) — who can trigger a review, why it costs money, and how the default workflows gate strangers out
 
 ## Use as a GitHub Action
 
@@ -153,6 +154,15 @@ Azure) are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` /
 `id-token: write`). See
 [Use as a GitHub Action](docs/how-to/use-as-github-action.md). ollama is local
 only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instead.
+
+> **💸 Security & cost.** Every review spends your provider tokens, so on a
+> public repo you don't want strangers triggering one. The example workflows
+> gate the `review` job on author association — only `OWNER`, `MEMBER`, and
+> `COLLABORATOR` can start a review, so a fork PR or drive-by `/review` comment
+> from a stranger never spends your budget. See
+> [Who can trigger a review](docs/how-to/use-as-github-action.md#who-can-trigger-a-review)
+> for how to tune the gate, and [Trust and Cost](docs/explanation/trust-and-cost.md)
+> for the full model.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Markdown sources below.
 - [Architecture](docs/explanation/architecture.md) — ports and adapters, the review pipeline
 - [Auth Model](docs/explanation/auth-model.md) — why keyless cloud, how credential resolution works
 - [Data and Privacy](docs/explanation/data-and-privacy.md) — what is sent where, secret redaction, ollama local mode
-- [Trust and Cost](docs/explanation/trust-and-cost.md) — who can trigger a review, why it costs money, and how the default workflows gate strangers out
+- [Trust and Cost](docs/explanation/trust-and-cost.md) — choosing who reviews run for (everyone, trusted contributors, or admins) and the small cost angle
 
 ## Use as a GitHub Action
 
@@ -155,14 +155,13 @@ Azure) are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` /
 [Use as a GitHub Action](docs/how-to/use-as-github-action.md). ollama is local
 only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instead.
 
-> **💸 Security & cost.** Every review spends your provider tokens, so on a
-> public repo you don't want strangers triggering one. The example workflows
-> gate the `review` job on author association — only `OWNER`, `MEMBER`, and
-> `COLLABORATOR` can start a review, so a fork PR or drive-by `/review` comment
-> from a stranger never spends your budget. See
+> **🔧 Choose who can trigger reviews.** You decide who reviews run for —
+> everyone, trusted contributors, or just admins. The example workflows default
+> to trusted contributors (`OWNER`, `MEMBER`, `COLLABORATOR`), and it's a
+> one-line change to open it up or tighten it. With ollama this is free; on a
+> hosted provider it also keeps token spend predictable. See
 > [Who can trigger a review](docs/how-to/use-as-github-action.md#who-can-trigger-a-review)
-> for how to tune the gate, and [Trust and Cost](docs/explanation/trust-and-cost.md)
-> for the full model.
+> and [Trust and Cost](docs/explanation/trust-and-cost.md).
 
 ## Distribution
 

--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -1,0 +1,90 @@
+# Trust and Cost
+
+This document explains lgtmaybe's trust and cost model: who can cause a review
+to run, why that matters financially, and how the default workflows keep a
+stranger from spending your provider budget. It is background for the
+step-by-step setup in
+[Use as a GitHub Action](../how-to/use-as-github-action.md).
+
+## Every review costs money
+
+A review is a call to your chosen LLM provider, and **you pay for the tokens it
+uses**. ollama is the exception — it runs the model on your own machine at zero
+marginal cost — but every hosted provider (OpenAI, Anthropic, OpenRouter,
+Bedrock, Vertex, Azure) bills you per run.
+
+That makes "who can start a review" a spending question, not just a permissions
+question. On a public repository the raw triggers — `pull_request_target` and
+`issue_comment` — fire for *anyone*: a stranger opening a fork PR, or a drive-by
+`/ask` / `/review` comment, would each cost you tokens, and every push to an open
+PR triggers another run. Without a gate, your provider bill is open to the
+internet.
+
+## Two kinds of bound
+
+It helps to separate the two limits, because they protect against different
+things:
+
+- **Per-run caps bound the size of one review.** `max_files` (default 50) and
+  `max_input_tokens` (default 100k) keep a single large PR from ballooning into
+  a huge request. See [What gets reviewed](what-gets-reviewed.md) for how the
+  diff is capped and batched.
+- **The trigger gate bounds how many runs happen at all.** The caps above do
+  nothing about a thousand drive-by comments; only restricting *who* can trigger
+  a review does that.
+
+You need both. The caps are on by default in the engine; the gate lives in the
+workflow.
+
+## The trust gate: author association
+
+The example workflows in
+[`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows)
+gate the `review` job on the triggering user's
+[author association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)
+— GitHub's classification of a user's relationship to the repository. The job
+only runs when that association is `OWNER`, `MEMBER`, or `COLLABORATOR`:
+
+```yaml
+if: >-
+  (github.event_name == 'pull_request_target' &&
+   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+  (github.event.issue.pull_request &&
+   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+```
+
+The consequence: a fork PR from a stranger has association `NONE`, so the job is
+skipped and **no tokens are spent**. The same gate covers slash commands — a
+`/review` or `/ask` from a non-member never runs. A maintainer can still review
+an outside contributor's PR by commenting `/review` on it themselves, because
+*their* association passes the gate. This is a deliberate opt-in: trust is
+asserted by someone who already has it.
+
+Because the gate lives in the workflow YAML rather than in the action's code,
+it is yours to tune. Widen it by adding `CONTRIBUTOR` (auto-review anyone whose
+PR has merged before), or narrow it by dropping `COLLABORATOR`. The trade-off is
+purely yours to make — the action runs whatever the workflow lets through.
+
+## Defence in depth
+
+The author gate is the primary control, but it is a single line of YAML. For
+anything spending real money, layer more underneath it:
+
+- **Require approval for fork-PR workflow runs** in
+  **Settings → Actions → General → Fork pull request workflows**, so a human
+  okays the run even if the gate is ever weakened.
+- **Move the provider key behind a protected `environment`**, so the secret is
+  only available to runs that clear the environment's rules.
+- **Set a spending limit in your provider console** as the financial backstop —
+  the only control that holds no matter what the workflow does.
+
+## Why this is safe to expose at all
+
+Restricting *who* triggers a review is about cost. A separate mechanism keeps a
+malicious PR from doing harm even when a review does run: lgtmaybe triggers on
+`pull_request_target` (so it has the base-branch secrets it needs) but **never
+checks out or executes PR code** — it fetches the diff through the GitHub API and
+treats every byte of it as untrusted input. So an outside PR cannot exfiltrate
+your secrets through the build, regardless of the gate. The full treatment of
+that boundary — secret redaction, prompt-injection defence, and fork safety —
+is in [Data and Privacy](data-and-privacy.md).

--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -1,49 +1,50 @@
 # Trust and Cost
 
-This document explains lgtmaybe's trust and cost model: who can cause a review
-to run, why that matters financially, and how the default workflows keep a
-stranger from spending your provider budget. It is background for the
-step-by-step setup in
+lgtmaybe lets you decide **who can trigger a review**. This document explains that
+choice and the small cost angle behind it, so you can pick the setting that fits
+your repo. The step-by-step setup is in
 [Use as a GitHub Action](../how-to/use-as-github-action.md).
 
-## Every review costs money
+## Who do you want reviews to run for?
 
-A review is a call to your chosen LLM provider, and **you pay for the tokens it
-uses**. ollama is the exception — it runs the model on your own machine at zero
-marginal cost — but every hosted provider (OpenAI, Anthropic, OpenRouter,
-Bedrock, Vertex, Azure) bills you per run.
+There's no single right answer — it depends on your repo and provider:
 
-That makes "who can start a review" a spending question, not just a permissions
-question. On a public repository the raw triggers — `pull_request_target` and
-`issue_comment` — fire for *anyone*: a stranger opening a fork PR, or a drive-by
-`/ask` / `/review` comment, would each cost you tokens, and every push to an open
-PR triggers another run. Without a gate, your provider bill is open to the
-internet.
+- **Everyone**, including strangers opening fork PRs — great for a welcoming
+  open-source project where you want every contributor to get feedback.
+- **Trusted contributors** — members and collaborators, the people who already
+  have a relationship with the repo. This is the default.
+- **Admins / owners only** — the tightest setting, handy while you're trying
+  lgtmaybe out.
 
-## Two kinds of bound
+The example workflows ship with the **trusted contributors** setting, and it's a
+one-line change to widen or narrow it.
 
-It helps to separate the two limits, because they protect against different
-things:
+## The small cost angle
 
-- **Per-run caps bound the size of one review.** `max_files` (default 50) and
-  `max_input_tokens` (default 100k) keep a single large PR from ballooning into
-  a huge request. See [What gets reviewed](what-gets-reviewed.md) for how the
-  diff is capped and batched.
-- **The trigger gate bounds how many runs happen at all.** The caps above do
-  nothing about a thousand drive-by comments; only restricting *who* can trigger
-  a review does that.
+The only reason this is worth a thought at all is that hosted providers bill per
+run:
 
-You need both. The caps are on by default in the engine; the gate lives in the
-workflow.
+- **ollama is free** — it runs the model on your own hardware, so trigger it for
+  whoever you like; there's no per-run cost.
+- **Hosted providers** (OpenAI, Anthropic, OpenRouter, Bedrock, Vertex, Azure)
+  charge for the tokens each review uses.
 
-## The trust gate: author association
+So if you're on a hosted provider and your repo is public, "everyone" means
+anyone can start a run. That's perfectly fine for plenty of projects — just pick
+it deliberately rather than by accident. The default keeps reviews to people you
+already trust, which is a sensible starting point you can open up whenever you
+want.
 
-The example workflows in
-[`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows)
-gate the `review` job on the triggering user's
+Two built-in caps also keep any single run modest regardless of who starts it:
+`max_files` (default 50) and `max_input_tokens` (default 100k). See
+[What gets reviewed](what-gets-reviewed.md) for how the diff is bounded.
+
+## How the choice is expressed
+
+The example workflows gate the `review` job on the triggering user's
 [author association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)
-— GitHub's classification of a user's relationship to the repository. The job
-only runs when that association is `OWNER`, `MEMBER`, or `COLLABORATOR`:
+— GitHub's classification of a user's relationship to the repo. By default the
+job runs when that association is `OWNER`, `MEMBER`, or `COLLABORATOR`:
 
 ```yaml
 if: >-
@@ -53,38 +54,33 @@ if: >-
    contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
 ```
 
-The consequence: a fork PR from a stranger has association `NONE`, so the job is
-skipped and **no tokens are spent**. The same gate covers slash commands — a
-`/review` or `/ask` from a non-member never runs. A maintainer can still review
-an outside contributor's PR by commenting `/review` on it themselves, because
-*their* association passes the gate. This is a deliberate opt-in: trust is
-asserted by someone who already has it.
+A maintainer can still review an outside contributor's PR any time by commenting
+`/review` on it — their own association passes the gate. To change the policy,
+edit the list:
 
-Because the gate lives in the workflow YAML rather than in the action's code,
-it is yours to tune. Widen it by adding `CONTRIBUTOR` (auto-review anyone whose
-PR has merged before), or narrow it by dropping `COLLABORATOR`. The trade-off is
-purely yours to make — the action runs whatever the workflow lets through.
+- **Open it up to everyone** — drop the `if:` so any PR or `/review` comment runs
+  a review.
+- **Welcome returning contributors** — add `CONTRIBUTOR` to auto-review anyone
+  whose PR has merged before.
+- **Tighten to admins** — keep just `OWNER` (and `MEMBER` for your org).
 
-## Defence in depth
+Because the gate lives in the workflow YAML, not in the action's code, the policy
+is entirely yours.
 
-The author gate is the primary control, but it is a single line of YAML. For
-anything spending real money, layer more underneath it:
+## If you want extra guardrails
 
-- **Require approval for fork-PR workflow runs** in
-  **Settings → Actions → General → Fork pull request workflows**, so a human
-  okays the run even if the gate is ever weakened.
-- **Move the provider key behind a protected `environment`**, so the secret is
-  only available to runs that clear the environment's rules.
-- **Set a spending limit in your provider console** as the financial backstop —
-  the only control that holds no matter what the workflow does.
+Optional, for repos where you want belt-and-braces:
 
-## Why this is safe to expose at all
+- Require approval for fork-PR workflow runs in
+  **Settings → Actions → General → Fork pull request workflows**.
+- Put the provider key behind a protected `environment`.
+- Set a spending limit in your provider console.
 
-Restricting *who* triggers a review is about cost. A separate mechanism keeps a
-malicious PR from doing harm even when a review does run: lgtmaybe triggers on
-`pull_request_target` (so it has the base-branch secrets it needs) but **never
+## Reviews are safe to run for anyone
+
+Whoever triggers a review, a malicious PR can't use it to do harm: lgtmaybe
+triggers on `pull_request_target` (so it has the secrets it needs) but **never
 checks out or executes PR code** — it fetches the diff through the GitHub API and
-treats every byte of it as untrusted input. So an outside PR cannot exfiltrate
-your secrets through the build, regardless of the gate. The full treatment of
-that boundary — secret redaction, prompt-injection defence, and fork safety —
-is in [Data and Privacy](data-and-privacy.md).
+treats it as untrusted input. So opening the gate wide is a cost decision, not a
+security one. The full boundary — secret redaction, prompt-injection defence, and
+fork safety — is in [Data and Privacy](data-and-privacy.md).

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -23,29 +23,35 @@ The action derives the PR from the triggering event, so there is no `pr-url`
 input to set. On an `issue_comment` event it routes the slash command
 (`/review`, `/ask`, `/describe`, `/improve`) to the same engine.
 
-> **⚠️ Cost disclaimer.** Each run calls your chosen LLM provider and **you pay
-> for those tokens**. On a public repository the default triggers let *anyone* —
-> including strangers opening fork PRs or posting `/ask` / `/review` comments —
-> spend your provider budget, and every push to a PR triggers another run. The
-> built-in `max_files` and `max_input_tokens` settings bound a single run, but
-> not the number of runs. You are responsible for your provider
-> spend: gate the workflow to trusted authors, use a cheap model, and set
-> spending limits in your provider console.
+> **Note on cost.** With ollama the model runs on your own hardware, so reviews
+> are free. On a hosted provider each run uses tokens you pay for, so it's worth
+> a moment's thought about who can trigger one (next section) — the default keeps
+> that to people you trust, and `max_files` / `max_input_tokens` keep any single
+> run modest.
 
 ## Who can trigger a review
 
-The example workflows gate the `review` job on the triggering user's
-[author association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation):
-only `OWNER`, `MEMBER`, and `COLLABORATOR` can start a review. So a fork PR from a
-stranger — or a drive-by `/ask` / `/review` comment — never spends your provider
-budget. A maintainer can still review an external contributor's PR by commenting
-`/review` on it (the maintainer's own association passes the gate).
+You choose who reviews run for. The example workflows gate the `review` job on
+the triggering user's
+[author association](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation)
+and default to **trusted contributors** — `OWNER`, `MEMBER`, and `COLLABORATOR`.
+A maintainer can also review an outside contributor's PR any time by commenting
+`/review` on it (their own association passes the gate).
 
-To widen or narrow this, edit the `if:` on the `review` job — for example drop
-`COLLABORATOR`, or add `CONTRIBUTOR` to also auto-review anyone whose PR has been
-merged before. For defence in depth, also require approval for fork-PR workflow
-runs in **Settings → Actions → General → Fork pull request workflows**, or move
-the provider key behind a protected `environment`.
+To change the policy, edit the `if:` on the `review` job:
+
+- **Everyone** — drop the `if:` so any PR or `/ask` / `/review` comment runs a
+  review (a friendly choice for an open project; on a hosted provider it means
+  anyone can start a run, so pick it deliberately).
+- **Returning contributors too** — add `CONTRIBUTOR` to auto-review anyone whose
+  PR has merged before.
+- **Admins only** — keep just `OWNER` (plus `MEMBER` for your org).
+
+For extra guardrails, you can also require approval for fork-PR workflow runs in
+**Settings → Actions → General → Fork pull request workflows**, or move the
+provider key behind a protected `environment`. See
+[Trust and Cost](../explanation/trust-and-cost.md) for the reasoning behind these
+options.
 
 ## Minimal workflow — openai
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,3 +73,4 @@ nav:
       - Architecture: explanation/architecture.md
       - Auth model: explanation/auth-model.md
       - Data and privacy: explanation/data-and-privacy.md
+      - Trust and cost: explanation/trust-and-cost.md


### PR DESCRIPTION
Document the author-association trigger gate so others adopting lgtmaybe
understand who can spend their provider budget. Adds an explanation-tier
doc (trust-and-cost.md) covering the cost-per-run model, the
OWNER/MEMBER/COLLABORATOR gate, per-run vs per-count bounds, and
defence-in-depth options, plus a Security & cost callout in the README
linking to it and the how-to section.