### PR TITLE
feat: add performance and complexity review lenses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,7 +157,7 @@ to the same engine/provider.
 
 ## Features
 
-**Review intelligence** — per-category fan-out across five lenses (each its own
+**Review intelligence** — per-category fan-out across seven lenses (each its own
 concurrent model call, merged & de-duped):
 - **Security** — OWASP-aligned checklist: injection, XSS, hardcoded secrets,
   broken authn/authz, path traversal, SSRF, insecure deserialization, weak
@@ -169,6 +169,11 @@ concurrent model call, merged & de-duped):
 - **Test coverage** — missing tests for changed paths, with a runnable test in
   the suggestion.
 - **Documentation** — undocumented or mis-described public surfaces only.
+- **Performance** — N+1 queries, accidentally quadratic work, redundant
+  computation, hot-path allocations/blocking I/O, unbounded queries (graded by
+  impact).
+- **Complexity** — high cyclomatic complexity / deep nesting, over-long
+  functions, duplicated logic, dead code (restrained, `info`/`medium`).
 
 **Output & posting** — structured findings (path, line, severity, title, body,
 optional suggestion). On GitHub: inline comments on the exact changed line + one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,12 +125,13 @@ pattern, event bus, plugin framework.
    - **Error surfacing:** any failure posts a short "review failed" comment and
      the CLI exits non-zero (`ClickException`) — never fails silently.
    - **Per-category fan-out:** the system prompt is composed per `ReviewCategory`
-     (security, correctness, deprecation, tests, documentation; `engine/prompt.py`)
+     (security, correctness, deprecation, tests, documentation, performance,
+     complexity; `engine/prompt.py`)
      and the engine runs each category as its own **concurrent** `provider.complete`
      call per batch (a `ThreadPoolExecutor` over the sync port — concurrent for
      cloud, serial for ollama), then **merges and de-dupes** the findings
      (`engine._dedupe`, keyed on path/line/side/title) before reflection.
-     `ReviewConfig.categories` selects the lenses (default: all five).
+     `ReviewConfig.categories` selects the lenses (default: all seven).
    - **Self-reflection:** after merge/dedupe, `engine/reflect.py` asks the
      provider to audit its own findings for false positives and drops the ones it
      marks low-confidence. The verdict is structured (`ReflectionResult` —
@@ -211,8 +212,13 @@ Two distinct concerns, kept separate:
   boundary errors, mismatched/inverted ranges, unhandled error paths;
   "Correctness & logic" section), **missing tests** for changed code paths
   (flagged `low`/`medium`, with a runnable test in the finding's `suggestion`
-  field; "Test coverage" section), and **documentation gaps** on public APIs
-  (`info`/`low`, restrained to public surfaces; "Documentation" section).
+  field; "Test coverage" section), **documentation gaps** on public APIs
+  (`info`/`low`, restrained to public surfaces; "Documentation" section),
+  **performance regressions** (N+1 queries, accidentally quadratic work, redundant
+  computation, hot-path allocations/blocking I/O, unbounded queries; graded by
+  impact up to `high`; "Performance" section), and needless **complexity** (deep
+  nesting / high cyclomatic complexity, over-long low-cohesion functions,
+  duplicated logic, dead code; `info`/`medium`, restrained; "Complexity" section).
 
 Both are covered by tests in `tests/engine/` (`test_redact.py`, `test_injection.py`,
 `test_prompt.py`, `test_parse.py`, `test_engine.py`) and `tests/github/test_diff.py`.
@@ -224,7 +230,8 @@ dependencies** in the PRs it reviews (prompt section "Deprecation & dependency
 health"; covered by `test_prompt.py`). Every scan category is asserted in
 `test_prompt.py` (`test_prompt_asks_for_logic_and_edge_case_review`,
 `test_prompt_asks_for_test_coverage`, `test_prompt_asks_for_documentation_review`,
-`test_prompt_names_pii_and_secrets_in_logs`) — extend those when you change the
+`test_prompt_names_pii_and_secrets_in_logs`, `test_prompt_asks_for_performance_review`,
+`test_prompt_asks_for_complexity_review`) — extend those when you change the
 prompt's checklist.
 
 ## Code-quality & dependency hygiene

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,11 +55,12 @@ fetch → redact → split + skip generated → file cap → expand hunks → ba
 ```
 
 The fan-out is the key non-obvious bit: the system prompt is composed per
-`ReviewCategory` (security, correctness, deprecation, tests, documentation), and
+`ReviewCategory` (security, correctness, deprecation, tests, documentation,
+performance, complexity), and
 the engine issues **one concurrent model call per category per batch** (a
 `ThreadPoolExecutor` over the synchronous provider port), then merges and
 de-duplicates the findings before the reflection pass. `ReviewConfig.categories`
-selects which lenses run (default: all five) — it's a `.lgtmaybe.yml` knob, not a
+selects which lenses run (default: all seven) — it's a `.lgtmaybe.yml` knob, not a
 CLI flag. Narrowing it means fewer model calls.
 
 ## Running locally

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ authn/authz, path traversal, SSRF, insecure deserialization, weak crypto,
 resource/DoS safety, and secrets or PII (passwords, tokens, SSNs, card data)
 leaking into logs — so security findings are first-class, not an afterthought. It
 also flags **factually outdated** code — deprecated APIs and end-of-life or
-vulnerable dependencies — when the diff shows them. Generated and non-reviewable
+vulnerable dependencies — when the diff shows them, **performance regressions**
+(N+1 queries, accidentally quadratic work, redundant computation, allocations or
+blocking I/O on hot paths, unbounded queries), and needless **complexity** (deep
+nesting / high cyclomatic complexity, over-long functions, duplicated logic).
+Generated and non-reviewable
 files (lockfiles, minified bundles, vendored directories, binaries) are skipped
 automatically, and secrets are redacted from the diff before it is sent to the
 model.
@@ -43,7 +47,7 @@ latency:
 
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
-- `categories` (default all five) — which review lenses to run; each is a concurrent model call, so narrowing the list means fewer calls.
+- `categories` (default all seven) — which review lenses to run; each is a concurrent model call, so narrowing the list means fewer calls.
 - `min_severity` (default `info`) plus `include_paths` / `exclude_paths` — focus the review on what you care about.
 
 See [Configure .lgtmaybe.yml](docs/how-to/configure-lgtmaybe-yml.md) for every knob.

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -96,6 +96,45 @@ Two lighter-weight checks round out a review:
   `info`/`low`. This is deliberately restrained: private helpers and self-evident
   code are not nagged about, so well-named code is left to document itself.
 
+## Performance
+
+The reviewer also watches for performance regressions the change introduces,
+graded by impact (`low` up to `high` when the cost scales with input size or sits
+in a hot path):
+
+- **N+1 queries / calls in a loop** — a query, request, or other expensive call
+  issued once per iteration that could be batched or hoisted out.
+- **Inefficient algorithms** — accidentally quadratic (`O(n²)`) work where linear
+  is feasible, or a linear scan where a set/dict lookup would do.
+- **Redundant computation** — recomputing the same value inside a loop instead of
+  hoisting or memoising it.
+- **Unnecessary allocations & copies** — building large intermediates or copying
+  big buffers on a hot path when streaming or in-place work suffices.
+- **Blocking I/O on a hot path** — synchronous I/O, sleeps, or lock contention
+  where non-blocking handling is expected.
+- **Unbounded / over-fetching queries** — loading whole tables into memory or
+  missing pagination/limits.
+
+It sticks to changes the diff actually shows and avoids micro-optimisations with
+no measurable impact.
+
+## Complexity
+
+A lighter, restrained lens that flags code harder to read, test, or maintain than
+it needs to be (`info`/`medium`), preferring a concrete simplification in the
+`suggestion` field:
+
+- **High cyclomatic complexity / deep nesting** — many branches or deeply nested
+  conditionals and loops that would read better with early returns.
+- **Over-long, low-cohesion functions** — a function doing several unrelated
+  things that should be split apart.
+- **Duplicated logic** — non-trivial logic repeated in the diff that should be
+  extracted into a shared helper.
+- **Excessive parameters / boolean-flag arguments**, **convoluted expressions**,
+  and **dead / unreachable code**.
+
+Like the documentation lens, it stays quiet on self-evident, already-simple code.
+
 ## How the scope is bounded
 
 Every run is bounded so a large PR can't run away on latency. All of these are
@@ -106,7 +145,7 @@ configurable in `.lgtmaybe.yml` (see
 |---|---|---|
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
-| `categories` | all five | Which review lenses to run; each runs as its own model call. Narrowing the list means fewer calls. |
+| `categories` | all seven | Which review lenses to run; each runs as its own model call. Narrowing the list means fewer calls. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
 | `min_severity` | `info` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`). |
 | `include_paths` / `exclude_paths` | — | Glob filters to focus the review. |
@@ -131,7 +170,8 @@ Each finding has:
 | `body` | The explanation |
 | `suggestion` | Optional suggested replacement code |
 
-Each review category (security, correctness, deprecation, tests, documentation)
+Each review category (security, correctness, deprecation, tests, documentation,
+performance, complexity)
 runs as its own concurrent model call with a focused prompt; their findings are
 merged and de-duplicated. A self-reflection pass then runs over the merged set
 and drops low-confidence findings, so the model's first guesses are filtered

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -104,8 +104,8 @@ Default: `100000`.
 Which review lenses to run. The reviewer asks for each category in its own
 concurrent model call and merges the findings, so a focused prompt concentrates
 on one concern at a time. One or more of `security`, `correctness`,
-`deprecation`, `tests`, `documentation`. Narrowing the list trades thoroughness
-for fewer model calls (and lower token usage).
+`deprecation`, `tests`, `documentation`, `performance`, `complexity`. Narrowing
+the list trades thoroughness for fewer model calls (and lower token usage).
 
 ```yaml
 categories:
@@ -113,7 +113,7 @@ categories:
   - correctness
 ```
 
-Default: all five categories.
+Default: all seven categories.
 
 ### context_lines
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -13,7 +13,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `api_base` | string / null | No | `null` | Api Base |
-| `categories` | list[`correctness` / `deprecation` / `documentation` / `security` / `tests`] | No | `['security', 'correctness', 'deprecation', 'tests', 'documentation']` | Categories |
+| `categories` | list[`complexity` / `correctness` / `deprecation` / `documentation` / `performance` / `security` / `tests`] | No | `['security', 'correctness', 'deprecation', 'tests', 'documentation', 'performance', 'complexity']` | Categories |
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
@@ -119,7 +119,9 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "correctness",
         "deprecation",
         "tests",
-        "documentation"
+        "documentation",
+        "performance",
+        "complexity"
       ],
       "title": "ReviewCategory",
       "type": "string"
@@ -158,7 +160,9 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "correctness",
         "deprecation",
         "tests",
-        "documentation"
+        "documentation",
+        "performance",
+        "complexity"
       ],
       "items": {
         "$ref": "#/$defs/ReviewCategory"

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -52,6 +52,8 @@ class ReviewCategory(StrEnum):
     deprecation = "deprecation"
     tests = "tests"
     documentation = "documentation"
+    performance = "performance"
+    complexity = "complexity"
 
 
 class Provider(StrEnum):

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -2,9 +2,10 @@
 
 The prompt is composed, not monolithic: a shared header (role + severity rubric
 + output contract + example) and shared rules wrap one focused **category**
-section. The engine asks for each ``ReviewCategory`` in its own LLM call, so each
-call concentrates on a single lens. ``build_system_prompt()`` with no category
-returns the union of every section (the original monolithic prompt).
+section (security, correctness, deprecation, tests, documentation, performance,
+complexity). The engine asks for each ``ReviewCategory`` in its own LLM call, so
+each call concentrates on a single lens. ``build_system_prompt()`` with no
+category returns the union of every section (the original monolithic prompt).
 """
 
 from __future__ import annotations
@@ -150,12 +151,61 @@ doc comment, or whose name or signature contradicts what they actually do
 helpers, local variables, or self-evident code — well-named code documents
 itself, and noise here is unwelcome."""
 
+_PERFORMANCE_SECTION = """\
+## Performance
+
+Flag performance regressions the change introduces, graded by impact (`low` to
+`high` — higher when the cost scales with input size or runs in a hot path):
+
+- **N+1 queries / calls in a loop** — a database query, network request, or other
+  expensive call issued once per iteration where it could be batched or hoisted.
+- **Inefficient algorithms** — accidentally quadratic (`O(n²)`) work where linear
+  is feasible, nested scans over the same collection, or a linear search where a
+  set/dict lookup would do.
+- **Redundant or repeated computation** — recomputing the same value inside a loop
+  instead of hoisting it out, or work that could be memoised/cached.
+- **Unnecessary allocations & copies** — building large intermediate collections
+  or copying big buffers on a hot path when streaming or in-place work suffices.
+- **Blocking I/O on a hot or latency-sensitive path** — synchronous I/O, sleeps,
+  or lock contention where async/non-blocking handling is expected.
+- **Unbounded or over-fetching queries** — loading an entire table/collection into
+  memory, missing pagination/limits, or selecting far more data than is used.
+
+Reason about the surrounding context, but only raise findings on changed lines.
+Do not speculate about micro-optimisations with no measurable impact."""
+
+_COMPLEXITY_SECTION = """\
+## Complexity
+
+Flag code that is harder to read, test, or maintain than it needs to be (grade
+`info` to `medium`). Be restrained — only raise a finding when the complexity is
+genuine, and prefer a concrete simplification in the `suggestion` field:
+
+- **High cyclomatic complexity / deep nesting** — many branches in one function,
+  or deeply nested conditionals and loops that would read better with early
+  returns or guard clauses.
+- **Over-long, low-cohesion functions** — a function doing several unrelated
+  things that should be split into well-named smaller pieces.
+- **Duplicated logic** — the same non-trivial logic repeated in the diff that
+  should be extracted into a shared helper.
+- **Excessive parameters / boolean-flag arguments** — long parameter lists or
+  flag arguments that toggle behaviour and would be clearer split apart.
+- **Convoluted expressions** — clever one-liners or tangled boolean/ternary
+  expressions that obscure intent.
+- **Dead or unreachable code** — branches that can never run, unused locals, or
+  code left behind after a change.
+
+Do NOT nag about self-evident or already-simple code — well-structured code needs
+no comment, and noise here is unwelcome."""
+
 _CATEGORY_SECTIONS: dict[ReviewCategory, str] = {
     ReviewCategory.security: _SECURITY_SECTION,
     ReviewCategory.correctness: _CORRECTNESS_SECTION,
     ReviewCategory.deprecation: _DEPRECATION_SECTION,
     ReviewCategory.tests: _TESTS_SECTION,
     ReviewCategory.documentation: _DOCUMENTATION_SECTION,
+    ReviewCategory.performance: _PERFORMANCE_SECTION,
+    ReviewCategory.complexity: _COMPLEXITY_SECTION,
 }
 
 _SHARED_RULES = """\

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -356,6 +356,8 @@ _CATEGORY_BY_MARKER = {
     "end-of-life": ("deprecation finding", 30),
     "accompanying test": ("tests finding", 40),
     "docstring": ("documentation finding", 50),
+    "n+1": ("performance finding", 60),
+    "cyclomatic": ("complexity finding", 70),
 }
 
 
@@ -401,7 +403,7 @@ def test_duplicate_findings_across_categories_are_deduped() -> None:
 
     findings, _ = engine.review(_CTX, cfg)
 
-    assert len(findings) == 1  # five identical copies collapse to one
+    assert len(findings) == 1  # seven identical copies collapse to one
 
 
 def test_dedupe_keeps_the_highest_severity_for_a_shared_location() -> None:

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -15,6 +15,8 @@ _SIGNATURE = {
     ReviewCategory.deprecation: "end-of-life",
     ReviewCategory.tests: "accompanying test",
     ReviewCategory.documentation: "docstring",
+    ReviewCategory.performance: "n+1",
+    ReviewCategory.complexity: "cyclomatic",
 }
 
 
@@ -125,6 +127,23 @@ def test_prompt_names_pii_and_secrets_in_logs() -> None:
     assert "pii" in prompt
     assert "ssn" in prompt  # SSNs
     assert "password" in prompt
+
+
+def test_prompt_asks_for_performance_review() -> None:
+    """The reviewer should flag performance regressions, graded by impact."""
+    prompt = build_system_prompt().lower()
+    assert "performance" in prompt
+    assert "n+1" in prompt  # N+1 queries / repeated calls in a loop
+    assert "quadratic" in prompt
+
+
+def test_prompt_asks_for_complexity_review() -> None:
+    """The reviewer should flag needless complexity, restrained and low severity."""
+    prompt = build_system_prompt().lower()
+    assert "complexity" in prompt
+    assert "cyclomatic" in prompt
+    assert "nest" in prompt  # deep nesting
+    assert "duplicat" in prompt  # duplicated logic to extract
 
 
 # ---------------------------------------------------------------------------

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -21,7 +21,9 @@
         "correctness",
         "deprecation",
         "tests",
-        "documentation"
+        "documentation",
+        "performance",
+        "complexity"
       ],
       "title": "ReviewCategory",
       "type": "string"
@@ -60,7 +62,9 @@
         "correctness",
         "deprecation",
         "tests",
-        "documentation"
+        "documentation",
+        "performance",
+        "complexity"
       ],
       "items": {
         "$ref": "#/$defs/ReviewCategory"


### PR DESCRIPTION
Introduce two new ReviewCategory scan lenses, on by default, following the
existing per-category fan-out pattern:

- performance: N+1 queries, accidentally quadratic work, redundant
  computation, hot-path allocations/blocking I/O, unbounded queries
  (graded by impact, up to high).
- complexity: high cyclomatic complexity / deep nesting, over-long
  functions, duplicated logic, dead code (restrained, info/medium).

Adds the enum members, focused prompt sections, and tests (red→green).
The engine, concurrency, dedupe, reflection, and config default need no
logic changes since they key off list(ReviewCategory) / cfg.categories.

Regenerates docs/reference/config.md and the ReviewConfig schema snapshot,
and updates README, CLAUDE.md, ARCHITECTURE.md, DEVELOPMENT.md, and the
docs (what-gets-reviewed, configure-lgtmaybe-yml).

https://claude.ai/code/session_01X7qWY8gATrys23gTM9tfmz