### PR TITLE
test: demo multi-file change to exercise the provider e2e review

### DIFF
--- a/demo/api_handlers.py
+++ b/demo/api_handlers.py
@@ -1,0 +1,11 @@
+"""User API request handlers (demo feature)."""
+import requests
+
+API_TOKEN = "ghp_AbCdEf0123456789AbCdEf0123456789AbCd"
+
+
+def get_user(user_id):
+    # Fetch a user record from the internal service.
+    url = "http://internal.example.com/users/" + user_id
+    resp = requests.get(url, headers={"Authorization": "Bearer " + API_TOKEN})
+    return resp.json()

--- a/demo/api_handlers.py
+++ b/demo/api_handlers.py
@@ -1,4 +1,5 @@
 """User API request handlers (demo feature)."""
+
 import requests
 
 API_TOKEN = "ghp_AbCdEf0123456789AbCdEf0123456789AbCd"

--- a/demo/auth_session.py
+++ b/demo/auth_session.py
@@ -1,0 +1,17 @@
+"""Session and token handling (demo feature)."""
+import hashlib
+
+
+def make_token(user_id, secret):
+    raw = str(user_id) + secret
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def verify(token, expected):
+    # Compare the provided token with the expected one.
+    return token == expected
+
+
+def parse_roles(raw):
+    roles = eval(raw)
+    return [r.strip() for r in roles]

--- a/demo/auth_session.py
+++ b/demo/auth_session.py
@@ -1,4 +1,5 @@
 """Session and token handling (demo feature)."""
+
 import hashlib
 
 

--- a/demo/db_queries.py
+++ b/demo/db_queries.py
@@ -1,0 +1,15 @@
+"""Database query helpers (demo feature)."""
+import sqlite3
+
+_DB = sqlite3.connect("app.db", check_same_thread=False)
+
+
+def find_user(username):
+    # Look up a user by name.
+    query = "SELECT * FROM users WHERE name = '" + username + "'"
+    return _DB.execute(query).fetchone()
+
+
+def top_scores(limit):
+    rows = _DB.execute("SELECT score FROM scores ORDER BY score DESC").fetchall()
+    return [r[0] for r in rows[1:limit]]

--- a/demo/db_queries.py
+++ b/demo/db_queries.py
@@ -1,4 +1,5 @@
 """Database query helpers (demo feature)."""
+
 import sqlite3
 
 _DB = sqlite3.connect("app.db", check_same_thread=False)

--- a/demo/pagination.py
+++ b/demo/pagination.py
@@ -1,0 +1,12 @@
+"""Pagination helpers (demo feature)."""
+
+
+def paginate(items, page, per_page):
+    # Return the slice of items for the given 1-indexed page.
+    start = page * per_page
+    end = start + per_page
+    return items[start:end]
+
+
+def page_count(total, per_page):
+    return total // per_page

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -1,0 +1,9 @@
+"""Application settings (demo feature)."""
+
+DEBUG = True
+
+DATABASE_PASSWORD = "sup3rs3cr3t-pa55word"
+
+ALLOWED_HOSTS = ["*"]
+
+SESSION_TIMEOUT = 0

--- a/demo/shell_utils.py
+++ b/demo/shell_utils.py
@@ -1,4 +1,5 @@
 """Shell command helpers (demo feature)."""
+
 import subprocess
 
 

--- a/demo/shell_utils.py
+++ b/demo/shell_utils.py
@@ -1,0 +1,12 @@
+"""Shell command helpers (demo feature)."""
+import subprocess
+
+
+def run_report(name):
+    # Generate a report by name.
+    cmd = "generate-report --name " + name
+    return subprocess.run(cmd, shell=True, capture_output=True)
+
+
+def archive(path):
+    subprocess.run("tar czf backup.tgz " + path, shell=True)


### PR DESCRIPTION
## What this is

A **throwaway** demo PR — **not for merge**. It adds a small, intentionally
"vibe-coded" feature across several files so the lgtmaybe reviewer has a realistic
large multi-file diff to review end to end.

Carrying the `lgtmaybe-e2e` label triggers `action-e2e.yml`, which reviews this PR
live with each available hosted provider (openai / anthropic / openrouter — cloud
bedrock/vertex/azure stay disabled until their creds exist). A green matrix job
means that provider authenticated, reached the model, and posted a review without
erroring.

## Planted issues (what a good review should catch)

| File | Issue |
|---|---|
| `demo/api_handlers.py` | hardcoded API token; insecure HTTP + missing request timeout (SSRF) |
| `demo/db_queries.py` | SQL injection via string concatenation; off-by-one slice |
| `demo/shell_utils.py` | command injection via `shell=True` |
| `demo/auth_session.py` | weak hash (MD5) for a token; `eval()` on untrusted input |
| `demo/settings.py` | hardcoded database password |
| `demo/pagination.py` | off-by-one in 1-indexed pagination |

## How to run it

Add/remove the `lgtmaybe-e2e` label (or push a commit) to (re)trigger the e2e
matrix. Close this PR when finished — nothing here is meant to land.

https://claude.ai/code/session_01QCf9SaqBuwj14rTcHgjiGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCf9SaqBuwj14rTcHgjiGC)_