### PR TITLE
feat(e2e): real ollama CI run on a large multi-file diff + tunable context/timeout knobs

### DIFF
--- a/.github/workflows/e2e-ollama.yml
+++ b/.github/workflows/e2e-ollama.yml
@@ -1,0 +1,79 @@
+# Real end-to-end review against a LOCAL ollama model.
+#
+# Unlike action-e2e.yml (hosted providers, real spend, label-gated), this runs a
+# genuinely local model on the runner — free, no secrets — so it can run on every
+# PR. It pulls a tiny model (qwen3:0.6b) and reviews the eval fixtures through the
+# full pipeline (redact → batch → per-category fan-out → parse → reflect), with a
+# generous timeout and a large ollama context window so a big multi-file diff
+# ("vibe-coded" commit) isn't truncated.
+#
+# This is the proof the ollama path actually works on a large change without
+# hand-holding — the pytest suite only ever mocks ollama. The eval runner exits
+# non-zero if any fixture fails to parse or falls below --min-recall, so a broken
+# pipeline (timeout, truncated context, unparseable output) fails the job.
+#
+# Kept out of the ci.yml pytest gate on purpose (it needs a live model), but it
+# IS a per-PR check here.
+name: e2e-ollama
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-ollama-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ollama:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Tiny local model — the point is to prove the plumbing on a large diff, not
+      # to grade model quality. The factory already sets think=False for qwen3.
+      OLLAMA_MODEL: qwen3:0.6b
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync (with dev deps)
+        run: uv sync --dev
+
+      - name: Install ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Start ollama and wait until ready
+        run: |
+          ollama serve &
+          for _ in $(seq 1 60); do
+            if curl -sf http://localhost:11434/api/tags >/dev/null; then
+              echo "ollama is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ollama did not become ready in time" >&2
+          exit 1
+
+      - name: Pull the tiny model
+        run: ollama pull "$OLLAMA_MODEL"
+
+      # Review every fixture (incl. the large multi-file one) with a long timeout
+      # and a big context window. min-recall 0.2: the parse must succeed AND the
+      # tiny model must catch at least a fifth of the planted bugs.
+      - name: End-to-end review via ollama
+        run: |
+          uv run python -m evals.run \
+            --provider ollama \
+            --model "$OLLAMA_MODEL" \
+            --api-base http://localhost:11434 \
+            --min-recall 0.2 \
+            --timeout 600 \
+            --num-ctx 32768

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,14 @@ Split by whether it can be deterministic, because that decides where it lives:
   `evals/` (`run.py` + `scorer.py` over `evals/fixtures/`) reviews each fixture
   with a real provider and reports **parse-rate + recall**, exiting non-zero below
   `--min-recall` so it can gate a model/prompt change when run deliberately
-  (`python -m evals.run --provider … --model …`). Its plumbing is unit-tested in
-  `tests/evals/`, but the live run is never wired into CI.
+  (`python -m evals.run --provider … --model …`; `--timeout` / `--num-ctx` /
+  `--max-input-tokens` tune it for a big diff on a slow local model). Its plumbing
+  is unit-tested in `tests/evals/`. The **hosted** providers stay out of the pytest
+  gate, but a real **local ollama** run *is* wired into CI as its own workflow —
+  `.github/workflows/e2e-ollama.yml` pulls a tiny model (`qwen3:0.6b`) and runs the
+  eval over the fixtures (incl. the large multi-file `vibe-multifile` one) on every
+  PR with a long timeout + big `num_ctx`, proving the pipeline survives a real
+  local model on a large "vibe-coded" diff. Real-spend hosted-provider e2e remains
+  label-gated in `action-e2e.yml`.
 
 [litellm]: https://github.com/BerriAI/litellm

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Sampling temperature (default 0.0 for deterministic reviews)."
     required: false
     default: ""
+  num_ctx:
+    description: "Ollama context window (ollama only; ignored for hosted providers). Raise it so a large multi-file diff isn't truncated. Leave empty for the default (16384)."
+    required: false
+    default: ""
+  max_input_tokens:
+    description: "Token budget per model call before the diff is split into batches (any provider). Leave empty for the default (100000)."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -122,6 +130,8 @@ runs:
         INPUT_API_BASE: ${{ inputs.api_base }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_TEMPERATURE: ${{ inputs.temperature }}
+        INPUT_NUM_CTX: ${{ inputs.num_ctx }}
+        INPUT_MAX_INPUT_TOKENS: ${{ inputs.max_input_tokens }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -133,6 +143,7 @@ runs:
           -e INPUT_PROVIDER -e INPUT_MODEL -e INPUT_FALLBACK_MODEL \
           -e INPUT_API_KEY -e INPUT_API_BASE -e INPUT_CONFIG_PATH \
           -e INPUT_TIMEOUT -e INPUT_TEMPERATURE \
+          -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -134,9 +134,34 @@ For a **large diff** this can mean the prompt plus the findings don't fit in
 ollama's context window and the output gets truncated. lgtmaybe runs ollama with
 a generous context (`num_ctx` of 16384) and **structured JSON output** (it also
 disables "thinking" so reasoning models like qwen3.x emit the findings directly),
-which covers most reviews. If a very large diff still truncates, narrow it with
-`include_paths` / `exclude_paths` or a lower `max_files` in `.lgtmaybe.yml`, or run
-a model with a bigger context window.
+which covers most reviews.
+
+For a big multi-file change ("vibe-coded" commits across many files), raise the
+context window with `--num-ctx` so the whole diff and the findings fit — this is
+**ollama-only** (hosted providers manage their context window server-side and
+ignore it):
+
+```bash
+# A large multi-file diff on a local model — more time and more context:
+lgtmaybe review --provider ollama --model qwen3.6:35b \
+  --api-base http://localhost:11434 --timeout 900 --num-ctx 32768
+```
+
+```yaml
+# or in .lgtmaybe.yml (also how the GitHub Action picks it up):
+provider: ollama
+model: qwen3.6:35b
+timeout: 900
+num_ctx: 32768
+```
+
+`--num-ctx` needs enough RAM/VRAM on the ollama host — a bigger window costs
+memory, so size it to your machine. The token budget that decides when lgtmaybe
+splits a diff into separate model calls is `--max-input-tokens` (default 100000),
+which applies to **any** provider — raise it to send a large diff in fewer calls,
+lower it for a small-context model. If a very large diff still truncates, narrow
+it with `include_paths` / `exclude_paths` or a lower `max_files` in `.lgtmaybe.yml`,
+or run a model with a bigger context window.
 
 **Review is empty or truncated** — the diff may exceed the model's context
 window. Add a path filter in `.lgtmaybe.yml` to reduce diff size, or set

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,6 +21,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `info` |  |
 | `model` | string | Yes | — | Model |
+| `num_ctx` | integer / null | No | `null` | Num Ctx |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openrouter` / `vertex` | Yes | — |  |
 | `reflect` | boolean | No | `True` | Reflect |
 | `structured_output` | boolean | No | `True` | Structured Output |
@@ -202,6 +203,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "model": {
       "title": "Model",
       "type": "string"
+    },
+    "num_ctx": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Num Ctx"
     },
     "provider": {
       "$ref": "#/$defs/Provider"

--- a/evals/fixtures/vibe-multifile/diff.txt
+++ b/evals/fixtures/vibe-multifile/diff.txt
@@ -1,0 +1,119 @@
+diff --git a/src/api/handlers.py b/src/api/handlers.py
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/src/api/handlers.py
+@@ -0,0 +1,17 @@
++"""User API request handlers (new feature)."""
++import requests
++
++from src.db.queries import find_user
++
++API_TOKEN = "ghp_AbCdEf0123456789AbCdEf0123456789AbCd"
++
++
++def get_user(user_id):
++    # Fetch a user record from the internal service.
++    url = "http://internal.example.com/users/" + user_id
++    resp = requests.get(url, headers={"Authorization": "Bearer " + API_TOKEN})
++    return resp.json()
++
++
++def find(username):
++    return find_user(username)
+diff --git a/src/db/queries.py b/src/db/queries.py
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/src/db/queries.py
+@@ -0,0 +1,16 @@
++"""Database query helpers."""
++import sqlite3
++
++_DB = sqlite3.connect("app.db", check_same_thread=False)
++
++
++def find_user(username):
++    # Look up a user by name.
++    query = "SELECT * FROM users WHERE name = '" + username + "'"
++    cur = _DB.execute(query)
++    return cur.fetchone()
++
++
++def top_scores(limit):
++    rows = _DB.execute("SELECT score FROM scores ORDER BY score DESC").fetchall()
++    return [r[0] for r in rows[1:limit]]
+diff --git a/src/utils/shell.py b/src/utils/shell.py
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/src/utils/shell.py
+@@ -0,0 +1,12 @@
++"""Shell command helpers."""
++import subprocess
++
++
++def run_report(name):
++    # Generate a report by name.
++    cmd = "generate-report --name " + name
++    return subprocess.run(cmd, shell=True, capture_output=True)
++
++
++def archive(path):
++    subprocess.run("tar czf backup.tgz " + path, shell=True)
+diff --git a/src/auth/session.py b/src/auth/session.py
+new file mode 100644
+index 0000000..4444444
+--- /dev/null
++++ b/src/auth/session.py
+@@ -0,0 +1,17 @@
++"""Session and token handling."""
++import hashlib
++
++
++def make_token(user_id, secret):
++    raw = str(user_id) + secret
++    return hashlib.md5(raw.encode()).hexdigest()
++
++
++def verify(token, expected):
++    # Compare the provided token with the expected one.
++    return token == expected
++
++
++def parse_roles(raw):
++    roles = eval(raw)
++    return [r.strip() for r in roles]
+diff --git a/config/settings.py b/config/settings.py
+new file mode 100644
+index 0000000..5555555
+--- /dev/null
++++ b/config/settings.py
+@@ -0,0 +1,9 @@
++"""Application settings."""
++
++DEBUG = True
++
++DATABASE_PASSWORD = "sup3rs3cr3t-pa55word"
++
++ALLOWED_HOSTS = ["*"]
++
++SESSION_TIMEOUT = 0
+diff --git a/src/api/pagination.py b/src/api/pagination.py
+new file mode 100644
+index 0000000..6666666
+--- /dev/null
++++ b/src/api/pagination.py
+@@ -0,0 +1,12 @@
++"""Pagination helpers."""
++
++
++def paginate(items, page, per_page):
++    # Return the slice of items for the given 1-indexed page.
++    start = page * per_page
++    end = start + per_page
++    return items[start:end]
++
++
++def page_count(total, per_page):
++    return total // per_page

--- a/evals/fixtures/vibe-multifile/expected.json
+++ b/evals/fixtures/vibe-multifile/expected.json
@@ -1,0 +1,56 @@
+{
+  "name": "vibe-multifile",
+  "changed_file": "src/api/handlers.py",
+  "expected": [
+    {
+      "label": "hardcoded API token in handlers.py (API_TOKEN)",
+      "line": 6,
+      "keywords": ["secret", "token", "hardcoded", "credential", "api key", "api_token"],
+      "severity_at_least": "low"
+    },
+    {
+      "label": "insecure HTTP request without timeout / SSRF in get_user",
+      "line": 12,
+      "keywords": ["http", "timeout", "insecure", "ssrf", "tls", "verify"]
+    },
+    {
+      "label": "SQL injection via string concatenation in find_user",
+      "line": 9,
+      "keywords": ["sql", "injection", "parameter", "concatenat", "sanitiz"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "off-by-one slice rows[1:limit] skips the first row in top_scores",
+      "line": 16,
+      "keywords": ["off-by-one", "slice", "index", "first", "boundary", "range"]
+    },
+    {
+      "label": "command injection via shell=True in run_report",
+      "line": 8,
+      "keywords": ["injection", "shell", "command", "subprocess"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "weak hash (MD5) used to derive a token in make_token",
+      "line": 7,
+      "keywords": ["md5", "weak", "crypto", "hash", "insecure"]
+    },
+    {
+      "label": "eval() on untrusted input in parse_roles",
+      "line": 16,
+      "keywords": ["eval", "injection", "untrusted", "code execution", "rce", "arbitrary"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "hardcoded database password in settings.py",
+      "line": 5,
+      "keywords": ["password", "hardcoded", "secret", "credential"],
+      "severity_at_least": "low"
+    },
+    {
+      "label": "off-by-one in paginate(): 1-indexed page should subtract one",
+      "line": 6,
+      "keywords": ["off-by-one", "index", "page", "start", "boundary", "1-indexed"]
+    }
+  ]
+}

--- a/evals/run.py
+++ b/evals/run.py
@@ -32,7 +32,17 @@ def _load_fixtures() -> list[tuple[str, Fixture]]:
     return out
 
 
-def _review(diff: str, manifest: Fixture, provider: Provider, model: str, api_base: str | None):
+def _review(
+    diff: str,
+    manifest: Fixture,
+    provider: Provider,
+    model: str,
+    api_base: str | None,
+    *,
+    timeout: int | None = None,
+    num_ctx: int | None = None,
+    max_input_tokens: int | None = None,
+):
     ctx = PRContext(
         diff=diff,
         changed_files=[manifest.changed_file],
@@ -41,8 +51,16 @@ def _review(diff: str, manifest: Fixture, provider: Provider, model: str, api_ba
         repo="eval/eval",
         pr_number=0,
     )
-    cfg = ReviewConfig(provider=provider, model=model, api_base=api_base)
-    engine = LLMReviewEngine(build_provider(provider, model, api_base=api_base))
+    cfg_overrides = {"max_input_tokens": max_input_tokens} if max_input_tokens is not None else {}
+    cfg = ReviewConfig(
+        provider=provider, model=model, api_base=api_base, timeout=timeout, **cfg_overrides
+    )
+    # num_ctx is ollama's context window — litellm rejects it for hosted providers,
+    # so only forward it on the ollama path.
+    extra = {"num_ctx": num_ctx} if (num_ctx is not None and provider is Provider.ollama) else {}
+    engine = LLMReviewEngine(
+        build_provider(provider, model, api_base=api_base, timeout=timeout, **extra)
+    )
     try:
         findings, _summary = engine.review(ctx, cfg)
         return score_fixture(manifest.name, findings, manifest.expected, parsed_ok=True)
@@ -67,10 +85,40 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--model", required=True)
     ap.add_argument("--api-base", default=None)
     ap.add_argument("--min-recall", type=float, default=0.6, help="fail below this recall")
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="per-request timeout (seconds); raise for slow local models on big diffs",
+    )
+    ap.add_argument(
+        "--num-ctx",
+        type=int,
+        default=None,
+        help="ollama context window; raise so a large multi-file diff isn't truncated",
+    )
+    ap.add_argument(
+        "--max-input-tokens",
+        type=int,
+        default=None,
+        help="token budget per model call before the diff is split into batches",
+    )
     args = ap.parse_args(argv)
 
     provider = Provider(args.provider)
-    scores = [_review(diff, m, provider, args.model, args.api_base) for diff, m in _load_fixtures()]
+    scores = [
+        _review(
+            diff,
+            m,
+            provider,
+            args.model,
+            args.api_base,
+            timeout=args.timeout,
+            num_ctx=args.num_ctx,
+            max_input_tokens=args.max_input_tokens,
+        )
+        for diff, m in _load_fixtures()
+    ]
     for score in scores:
         _print(score)
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -22,7 +22,7 @@ import click
 
 from lgtmaybe.cli.render import render_findings
 from lgtmaybe.cli.runtime import RuntimeOptions
-from lgtmaybe.core.models import ReviewConfig, ReviewFinding
+from lgtmaybe.core.models import Provider, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
 from lgtmaybe.engine import LLMReviewEngine
 from lgtmaybe.github import RestGitHubGateway
@@ -62,6 +62,11 @@ def build_provider_engine(
         api_key=runtime.api_key,
         api_base=runtime.api_base or cfg.api_base,
     )
+    # num_ctx is ollama's context window — hosted providers manage theirs
+    # server-side and litellm rejects the option, so only forward it for ollama.
+    extra: dict[str, Any] = {}
+    if cfg.provider is Provider.ollama and cfg.num_ctx is not None:
+        extra["num_ctx"] = cfg.num_ctx
     provider = build_provider(
         cfg.provider,
         cfg.model,
@@ -71,6 +76,7 @@ def build_provider_engine(
         fallback_model=runtime.fallback_model,
         timeout=cfg.timeout,
         temperature=cfg.temperature,
+        **extra,
     )
     return LLMReviewEngine(provider), provider
 
@@ -260,6 +266,8 @@ def action_inputs() -> dict[str, str | None]:
         "api_base": get("API_BASE"),
         "timeout": get("TIMEOUT"),
         "temperature": get("TEMPERATURE"),
+        "num_ctx": get("NUM_CTX"),
+        "max_input_tokens": get("MAX_INPUT_TOKENS"),
         "config_path": os.environ.get("INPUT_CONFIG_PATH") or ".lgtmaybe.yml",
     }
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -60,6 +60,20 @@ from lgtmaybe.config.loader import load_config
 )
 @click.option("--max-files", default=None, type=int, help="Maximum number of files to review")
 @click.option(
+    "--max-input-tokens",
+    default=None,
+    type=int,
+    help="Token budget per model call before the diff is split into batches "
+    "(any provider; raise it to send a big diff in fewer calls)",
+)
+@click.option(
+    "--num-ctx",
+    default=None,
+    type=int,
+    help="ollama context window (ollama only; ignored for hosted providers). "
+    "Raise it so a large multi-file diff isn't truncated; default 16384",
+)
+@click.option(
     "--base",
     default=None,
     help="Base ref to diff the current branch against "
@@ -125,6 +139,8 @@ def review(
     api_base: str | None,
     min_severity: str | None,
     max_files: int | None,
+    max_input_tokens: int | None,
+    num_ctx: int | None,
     base: str | None,
     working: bool,
     output_format: str | None,
@@ -143,6 +159,8 @@ def review(
         model=model,
         min_severity=min_severity,
         max_files=max_files,
+        max_input_tokens=max_input_tokens,
+        num_ctx=num_ctx,
         context_lines=context_lines,
         timeout=timeout,
         temperature=temperature,
@@ -197,6 +215,8 @@ def action() -> None:
         model=inputs["model"],
         timeout=inputs["timeout"],
         temperature=inputs["temperature"],
+        num_ctx=inputs["num_ctx"],
+        max_input_tokens=inputs["max_input_tokens"],
     )
     runtime = RuntimeOptions(
         api_key=inputs["api_key"],

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -144,6 +144,11 @@ class ReviewConfig(_Strict):
     exclude_paths: list[str] = Field(default_factory=list)
     max_files: int = 50
     max_input_tokens: int = 100_000
+    # Ollama's context window (num_ctx). Ollama only — hosted providers manage
+    # their own context window server-side and litellm won't forward this, so it
+    # is ignored for them. None keeps the factory default (16384); raise it so a
+    # large multi-file diff plus the emitted findings isn't truncated.
+    num_ctx: int | None = None
     # Ceiling on surrounding context lines added around each hunk. The engine
     # uses min(context_lines, what the token budget allows); 0 disables it.
     context_lines: int = 20

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -154,6 +154,35 @@ class TestActionRouting:
         assert result.exit_code == 0, result.output
         assert captured == {"timeout": 900, "temperature": 0.2}
 
+    def test_num_ctx_and_max_input_tokens_inputs_reach_config(self, tmp_path, monkeypatch):
+        """INPUT_NUM_CTX / INPUT_MAX_INPUT_TOKENS tune a big-diff run from the Action."""
+        captured: dict[str, object] = {}
+
+        import lgtmaybe.cli as cli_module
+
+        def fake_build(cfg, runtime):
+            captured["num_ctx"] = cfg.num_ctx
+            captured["max_input_tokens"] = cfg.max_input_tokens
+            return FakeGitHub(), FakeEngine(FakeProvider())
+
+        monkeypatch.setattr(cli_module, "build_adapters", fake_build)
+
+        event = _write_event(
+            tmp_path,
+            {"repository": {"full_name": "org/repo"}, "pull_request": {"number": 1}},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "ollama")
+        monkeypatch.setenv("INPUT_MODEL", "llama3")
+        monkeypatch.setenv("INPUT_NUM_CTX", "32768")
+        monkeypatch.setenv("INPUT_MAX_INPUT_TOKENS", "250000")
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert captured == {"num_ctx": 32768, "max_input_tokens": 250000}
+
     def test_azure_api_base_input_reaches_runtime(self, tmp_path, monkeypatch):
         """INPUT_API_BASE carries the azure resource endpoint into the run."""
         captured: dict[str, object] = {}

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -148,3 +148,49 @@ def test_ollama_call_carries_api_base(captured_completion: list[dict[str, Any]])
 
     assert result.exit_code == 0, result.output
     assert captured_completion[0].get("api_base")
+
+
+def test_num_ctx_flag_reaches_litellm_for_ollama(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """--num-ctx raises ollama's context window so big diffs aren't truncated."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "ollama",
+            "--model",
+            "llama3",
+            "--no-reflect",
+            "--num-ctx",
+            "32768",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("num_ctx") == 32768
+
+
+def test_num_ctx_flag_is_ignored_for_hosted_provider(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """num_ctx is ollama-only — a hosted provider must never receive it (litellm rejects it)."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o",
+            "--api-key",
+            "sk-x",
+            "--no-reflect",
+            "--num-ctx",
+            "32768",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "num_ctx" not in captured_completion[0]

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -77,6 +77,23 @@ def test_context_lines_defaults_and_overrides():
     assert overridden.context_lines == 0
 
 
+def test_max_input_tokens_and_num_ctx_defaults_and_overrides():
+    """max_input_tokens (any provider) and num_ctx (ollama) load from file and CLI."""
+    import io
+
+    base = load_config(config_stream=io.StringIO("provider: ollama\nmodel: llama3\n"))
+    assert base.max_input_tokens == 100_000
+    assert base.num_ctx is None
+
+    overridden = load_config(
+        config_stream=io.StringIO("provider: ollama\nmodel: llama3\n"),
+        max_input_tokens=250_000,
+        num_ctx=32768,
+    )
+    assert overridden.max_input_tokens == 250_000
+    assert overridden.num_ctx == 32768
+
+
 def test_cli_input_overrides_provider():
     """A CLI --provider overrides the file's provider."""
     import io

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -1,0 +1,61 @@
+"""Structural checks on the eval fixtures — they load and parse as expected.
+
+These are pure (no model): they guard that a fixture's diff is well-formed and
+that the large multi-file fixture really exercises the multi-file path, so a
+broken fixture fails fast in the pytest gate rather than only in the live
+ollama e2e run.
+"""
+
+from __future__ import annotations
+
+from evals import run as run_mod
+from lgtmaybe.core.diffparse import split_by_file
+from lgtmaybe.github import is_reviewable
+
+_VIBE_FILES = {
+    "src/api/handlers.py",
+    "src/db/queries.py",
+    "src/utils/shell.py",
+    "src/auth/session.py",
+    "config/settings.py",
+    "src/api/pagination.py",
+}
+
+
+def _fixture(name: str):
+    for diff, manifest in run_mod._load_fixtures():
+        if manifest.name == name:
+            return diff, manifest
+    raise AssertionError(f"fixture {name!r} not found")
+
+
+def test_all_fixtures_load() -> None:
+    """Every fixture dir parses into a (diff, manifest) pair with expected findings."""
+    fixtures = run_mod._load_fixtures()
+    assert fixtures, "no fixtures discovered"
+    for diff, manifest in fixtures:
+        assert diff.strip()
+        assert manifest.expected, f"{manifest.name} has no expected findings"
+
+
+def test_vibe_multifile_spans_all_reviewable_files() -> None:
+    """The large fixture splits into all six files and none is filtered as generated."""
+    diff, manifest = _fixture("vibe-multifile")
+
+    paths = {path for path, _ in split_by_file(diff, [manifest.changed_file])}
+    assert paths == _VIBE_FILES
+
+    # All of them must survive the reviewable filter (no lockfiles/vendored noise).
+    assert all(is_reviewable(p) for p in paths)
+
+
+def test_vibe_multifile_has_high_signal_and_subtle_findings() -> None:
+    """The manifest mixes easy security catches with subtler correctness bugs."""
+    _diff, manifest = _fixture("vibe-multifile")
+    labels = " ".join(e.label.lower() for e in manifest.expected)
+    # A 0.6B CI model should be able to clear the 0.2 recall bar on these.
+    assert "sql injection" in labels
+    assert "shell=true" in labels
+    assert "eval()" in labels
+    # ...and the subtler bugs that prove depth.
+    assert "off-by-one" in labels

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -45,3 +45,80 @@ def test_runner_fails_when_review_incomplete(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _Unparseable())
     assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"]) == 1
+
+
+def _capture_build_provider(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Patch build_provider to record its kwargs and serve the catch-one provider."""
+    calls: list[dict[str, object]] = []
+
+    def fake_build(*_args: object, **kwargs: object) -> _ShellInjectionProvider:
+        calls.append(kwargs)
+        return _ShellInjectionProvider()
+
+    monkeypatch.setattr(run_mod, "build_provider", fake_build)
+    return calls
+
+
+def test_timeout_and_num_ctx_thread_to_build_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--timeout and --num-ctx reach build_provider so big ollama diffs get more room."""
+    calls = _capture_build_provider(monkeypatch)
+
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "x",
+            "--min-recall",
+            "0.0",
+            "--timeout",
+            "600",
+            "--num-ctx",
+            "32768",
+        ]
+    )
+
+    assert calls, "build_provider was never called"
+    assert calls[0]["timeout"] == 600
+    assert calls[0]["num_ctx"] == 32768
+
+
+def test_num_ctx_is_omitted_for_hosted_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """num_ctx is ollama-only — litellm rejects it for hosted providers, so don't send it."""
+    calls = _capture_build_provider(monkeypatch)
+
+    run_mod.main(
+        ["--provider", "openai", "--model", "x", "--min-recall", "0.0", "--num-ctx", "9000"]
+    )
+
+    assert calls
+    assert "num_ctx" not in calls[0]
+
+
+def test_max_input_tokens_threads_to_review_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--max-input-tokens reaches the ReviewConfig the engine batches against."""
+    seen: list[int] = []
+
+    real_review = run_mod.LLMReviewEngine.review
+
+    def spy_review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+        seen.append(cfg.max_input_tokens)
+        return real_review(self, ctx, cfg)
+
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    monkeypatch.setattr(run_mod.LLMReviewEngine, "review", spy_review)
+
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "x",
+            "--min-recall",
+            "0.0",
+            "--max-input-tokens",
+            "250000",
+        ]
+    )
+
+    assert seen and all(v == 250000 for v in seen)

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -105,6 +105,18 @@
       "title": "Model",
       "type": "string"
     },
+    "num_ctx": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Num Ctx"
+    },
     "provider": {
       "$ref": "#/$defs/Provider"
     },


### PR DESCRIPTION
Add a per-PR end-to-end test that runs a genuinely local ollama model
(qwen3:0.6b) over the eval fixtures through the full review pipeline, so the
ollama path is proven on a large "vibe-coded" change instead of only ever being
mocked in the pytest suite.

- .github/workflows/e2e-ollama.yml: install ollama, pull a tiny model, run the
  eval harness with a long timeout and a big context window; fails if any
  fixture can't be parsed or falls below --min-recall 0.2. Runs on every PR +
  push to main (kept out of the pytest gate, which can't use a live model).
- evals/fixtures/vibe-multifile: a ~6-file diff simulating an AI-generated
  feature, planting textbook security bugs (SQL injection, shell=True, eval) plus
  subtler correctness bugs (off-by-one, weak hash, missing timeout) so a tiny
  model can clear the low recall bar while still exercising the multi-file path.
- evals/run.py: --timeout / --num-ctx / --max-input-tokens so the big-diff run
  can be given more room (num_ctx only forwarded for ollama).
- Promote the same knobs to first-class end-user params: --num-ctx (ollama-only)
  and --max-input-tokens on the review CLI, num_ctx ReviewConfig field, and
  num_ctx / max_input_tokens Action inputs; regenerate the config reference and
  document tuning large diffs in the ollama how-to.

https://claude.ai/code/session_01QCf9SaqBuwj14rTcHgjiGC