### PR TITLE
fix(e2e): use qwen3:1.7b + --no-reflect so the ollama recall bar is reachable

### DIFF
--- a/.github/workflows/e2e-ollama.yml
+++ b/.github/workflows/e2e-ollama.yml
@@ -29,11 +29,13 @@ concurrency:
 jobs:
   ollama:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
-      # Tiny local model — the point is to prove the plumbing on a large diff, not
-      # to grade model quality. The factory already sets think=False for qwen3.
-      OLLAMA_MODEL: qwen3:0.6b
+      # Small but capable local model — big enough to actually catch the planted
+      # bugs (so the recall bar is a real signal), still CPU-friendly for CI. It's
+      # a qwen3 thinking model, so the factory's tested think=False handling applies
+      # (a 0.6b model parsed the diff fine but caught nothing, failing the bar).
+      OLLAMA_MODEL: qwen3:1.7b
     steps:
       - uses: actions/checkout@v6
 
@@ -67,7 +69,9 @@ jobs:
 
       # Review every fixture (incl. the large multi-file one) with a long timeout
       # and a big context window. min-recall 0.2: the parse must succeed AND the
-      # tiny model must catch at least a fifth of the planted bugs.
+      # model must catch at least a fifth of the planted bugs. Reflection is off:
+      # on a small local model the self-reflection pass over-prunes its own valid
+      # findings (CLAUDE.md notes --no-reflect for weaker models).
       - name: End-to-end review via ollama
         run: |
           uv run python -m evals.run \
@@ -75,5 +79,6 @@ jobs:
             --model "$OLLAMA_MODEL" \
             --api-base http://localhost:11434 \
             --min-recall 0.2 \
-            --timeout 600 \
-            --num-ctx 32768
+            --timeout 900 \
+            --num-ctx 32768 \
+            --no-reflect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,10 +255,11 @@ Split by whether it can be deterministic, because that decides where it lives:
   `--max-input-tokens` tune it for a big diff on a slow local model). Its plumbing
   is unit-tested in `tests/evals/`. The **hosted** providers stay out of the pytest
   gate, but a real **local ollama** run *is* wired into CI as its own workflow —
-  `.github/workflows/e2e-ollama.yml` pulls a tiny model (`qwen3:0.6b`) and runs the
+  `.github/workflows/e2e-ollama.yml` pulls a small model (`qwen3:1.7b`) and runs the
   eval over the fixtures (incl. the large multi-file `vibe-multifile` one) on every
-  PR with a long timeout + big `num_ctx`, proving the pipeline survives a real
-  local model on a large "vibe-coded" diff. Real-spend hosted-provider e2e remains
-  label-gated in `action-e2e.yml`.
+  PR with a long timeout + big `num_ctx` and `--no-reflect` (the reflection pass
+  over-prunes on a small model), proving the pipeline survives a real local model
+  on a large "vibe-coded" diff and still catches the planted bugs (`--min-recall
+  0.2`). Real-spend hosted-provider e2e remains label-gated in `action-e2e.yml`.
 
 [litellm]: https://github.com/BerriAI/litellm

--- a/evals/run.py
+++ b/evals/run.py
@@ -42,6 +42,7 @@ def _review(
     timeout: int | None = None,
     num_ctx: int | None = None,
     max_input_tokens: int | None = None,
+    reflect: bool = True,
 ):
     ctx = PRContext(
         diff=diff,
@@ -53,7 +54,12 @@ def _review(
     )
     cfg_overrides = {"max_input_tokens": max_input_tokens} if max_input_tokens is not None else {}
     cfg = ReviewConfig(
-        provider=provider, model=model, api_base=api_base, timeout=timeout, **cfg_overrides
+        provider=provider,
+        model=model,
+        api_base=api_base,
+        timeout=timeout,
+        reflect=reflect,
+        **cfg_overrides,
     )
     # num_ctx is ollama's context window — litellm rejects it for hosted providers,
     # so only forward it on the ollama path.
@@ -103,6 +109,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="token budget per model call before the diff is split into batches",
     )
+    ap.add_argument(
+        "--no-reflect",
+        dest="reflect",
+        action="store_false",
+        help="skip the self-reflection pass (weak local models over-prune their own findings)",
+    )
     args = ap.parse_args(argv)
 
     provider = Provider(args.provider)
@@ -116,6 +128,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout=args.timeout,
             num_ctx=args.num_ctx,
             max_input_tokens=args.max_input_tokens,
+            reflect=args.reflect,
         )
         for diff, m in _load_fixtures()
     ]

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -122,3 +122,24 @@ def test_max_input_tokens_threads_to_review_config(monkeypatch: pytest.MonkeyPat
     )
 
     assert seen and all(v == 250000 for v in seen)
+
+
+def test_reflect_defaults_on_and_no_reflect_disables_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--no-reflect turns off the reflection pass (weak CI models over-prune otherwise)."""
+    seen: list[bool] = []
+
+    real_review = run_mod.LLMReviewEngine.review
+
+    def spy_review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+        seen.append(cfg.reflect)
+        return real_review(self, ctx, cfg)
+
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    monkeypatch.setattr(run_mod.LLMReviewEngine, "review", spy_review)
+
+    run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"])
+    assert seen and all(v is True for v in seen)
+
+    seen.clear()
+    run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--no-reflect"])
+    assert seen and all(v is False for v in seen)


### PR DESCRIPTION
## Why

Merging #52 put the `e2e-ollama` workflow on `main` with **qwen3:0.6b** and a
**0.2 recall bar**. That run proved the pipeline (both fixtures `parsed=ok` on the
large multi-file diff at `num_ctx 32768`, no timeout) but scored **0% recall** — a
0.6B model catches nothing, and the default reflection pass prunes the little it
finds. So `e2e-ollama` now fails on every PR and push to `main`. This fixes it.

## What

- **`evals/run.py`**: add `--no-reflect` so the self-reflection pass can be skipped
  for weak local models that over-prune their own findings (CLAUDE.md already
  prescribes this for weaker models).
- **`.github/workflows/e2e-ollama.yml`**: bump the CI model to **`qwen3:1.7b`** (a
  qwen3 *thinking* model, so the factory's tested `think=False` path applies —
  unlike non-thinking gemma3), add `--no-reflect`, raise the per-call timeout to
  900s and the job budget to 45m. Keeps **`--min-recall 0.2`** as a real signal —
  the textbook bugs (SQL injection, `shell=True`, `eval`) are well within a 1.7B
  model's reach with reflection off.

## Validation

`e2e-ollama` on this PR is the validation: it should now go green (parse + ≥20%
recall on both fixtures). If qwen3:1.7b still falls short, the fallback is gemma3:4b
with a longer budget, or trimming the eval to the security+correctness lenses.

https://claude.ai/code/session_01QCf9SaqBuwj14rTcHgjiGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCf9SaqBuwj14rTcHgjiGC)_