### PR TITLE
test(evals): plant performance & complexity issues in e2e fixtures

### DIFF
--- a/.github/workflows/e2e-ollama.yml
+++ b/.github/workflows/e2e-ollama.yml
@@ -2,10 +2,12 @@
 #
 # Unlike action-e2e.yml (hosted providers, real spend, label-gated), this runs a
 # genuinely local model on the runner — free, no secrets — so it can run on every
-# PR. It pulls a tiny model (qwen3:0.6b) and reviews the eval fixtures through the
+# PR. It pulls a tiny model (qwen3:1.7b) and reviews the eval fixtures through the
 # full pipeline (redact → batch → per-category fan-out → parse → reflect), with a
 # generous timeout and a large ollama context window so a big multi-file diff
-# ("vibe-coded" commit) isn't truncated.
+# ("vibe-coded" commit) isn't truncated. The fixtures plant security and
+# correctness bugs alongside blatant performance (N+1 / quadratic) and complexity
+# (deep nesting / duplication) issues, so every review lens is exercised live.
 #
 # This is the proof the ollama path actually works on a large change without
 # hand-holding — the pytest suite only ever mocks ollama. The eval runner exits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,10 @@ Split by whether it can be deterministic, because that decides where it lives:
   PR with a long timeout + big `num_ctx` and `--no-reflect` (the reflection pass
   over-prunes on a small model), proving the pipeline survives a real local model
   on a large "vibe-coded" diff and still catches the planted bugs (`--min-recall
-  0.2`). Real-spend hosted-provider e2e remains label-gated in `action-e2e.yml`.
+  0.2`). The fixtures plant security + correctness bugs **and** blatant performance
+  (N+1 / quadratic) + complexity (deep nesting / duplication) issues, so the live
+  run exercises all seven review lenses, not just security/correctness — the
+  per-lens coverage is guarded in `tests/evals/test_fixtures.py`. Real-spend
+  hosted-provider e2e remains label-gated in `action-e2e.yml`.
 
 [litellm]: https://github.com/BerriAI/litellm

--- a/evals/fixtures/badcode/diff.txt
+++ b/evals/fixtures/badcode/diff.txt
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..1111111
 --- /dev/null
 +++ b/badcode.py
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,60 @@
 +"""Demo helpers — deliberately buggy, for the reviewer eval."""
 +import subprocess
 +import requests
@@ -34,3 +34,33 @@ index 0000000..1111111
 +def run_report(report_name):
 +    cmd = "generate-report --name " + report_name
 +    subprocess.run(cmd, shell=True)
++
++
++def count_shared_tags(items):
++    # For every pair of items, count how many tags they have in common.
++    total = 0
++    for a in items:
++        for b in items:
++            for tag in a["tags"]:
++                if tag in b["tags"]:
++                    total += 1
++    return total
++
++
++def classify_account(account):
++    if account is not None:
++        if account.get("status") == "active":
++            if account.get("balance", 0) > 0:
++                if account.get("verified"):
++                    if account.get("tier") == "gold":
++                        return "gold-active"
++                    else:
++                        return "active"
++                else:
++                    return "unverified"
++            else:
++                return "empty"
++        else:
++            return "inactive"
++    else:
++        return "missing"

--- a/evals/fixtures/badcode/expected.json
+++ b/evals/fixtures/badcode/expected.json
@@ -30,6 +30,16 @@
       "line": 30,
       "keywords": ["injection", "shell", "command"],
       "severity_at_least": "high"
+    },
+    {
+      "label": "quadratic nested loops in count_shared_tags (performance)",
+      "line": 36,
+      "keywords": ["quadratic", "o(n^2)", "o(n²)", "nested loop", "performance", "n+1", "inefficient"]
+    },
+    {
+      "label": "deeply nested classify_account begs for early returns (complexity)",
+      "line": 45,
+      "keywords": ["complexity", "nesting", "nested", "cyclomatic", "early return", "guard", "refactor"]
     }
   ]
 }

--- a/evals/fixtures/vibe-multifile/diff.txt
+++ b/evals/fixtures/vibe-multifile/diff.txt
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..1111111
 --- /dev/null
 +++ b/src/api/handlers.py
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,33 @@
 +"""User API request handlers (new feature)."""
 +import requests
 +
@@ -21,12 +21,28 @@ index 0000000..1111111
 +
 +def find(username):
 +    return find_user(username)
++
++
++def format_user_label(user):
++    if user is not None:
++        if user.get("name"):
++            if user.get("role") == "admin":
++                if user.get("active"):
++                    return "admin: " + user["name"].strip().lower()
++                else:
++                    return "inactive admin: " + user["name"].strip().lower()
++            else:
++                if user.get("active"):
++                    return "user: " + user["name"].strip().lower()
++                else:
++                    return "inactive user: " + user["name"].strip().lower()
++    return "unknown"
 diff --git a/src/db/queries.py b/src/db/queries.py
 new file mode 100644
 index 0000000..2222222
 --- /dev/null
 +++ b/src/db/queries.py
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,25 @@
 +"""Database query helpers."""
 +import sqlite3
 +
@@ -43,6 +59,15 @@ index 0000000..2222222
 +def top_scores(limit):
 +    rows = _DB.execute("SELECT score FROM scores ORDER BY score DESC").fetchall()
 +    return [r[0] for r in rows[1:limit]]
++
++
++def scores_for_users(usernames):
++    # Look up each user's score, one at a time.
++    results = []
++    for name in usernames:
++        row = _DB.execute("SELECT score FROM scores WHERE user = ?", (name,)).fetchone()
++        results.append(row[0] if row else 0)
++    return results
 diff --git a/src/utils/shell.py b/src/utils/shell.py
 new file mode 100644
 index 0000000..3333333

--- a/evals/fixtures/vibe-multifile/expected.json
+++ b/evals/fixtures/vibe-multifile/expected.json
@@ -51,6 +51,16 @@
       "label": "off-by-one in paginate(): 1-indexed page should subtract one",
       "line": 6,
       "keywords": ["off-by-one", "index", "page", "start", "boundary", "1-indexed"]
+    },
+    {
+      "label": "N+1 query in scores_for_users (one SELECT per user in a loop)",
+      "line": 22,
+      "keywords": ["n+1", "loop", "query", "per iteration", "batch", "performance", "round trip"]
+    },
+    {
+      "label": "deeply nested format_user_label with duplicated logic (complexity)",
+      "line": 22,
+      "keywords": ["complexity", "nesting", "nested", "cyclomatic", "early return", "duplicat", "refactor"]
     }
   ]
 }

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -59,3 +59,16 @@ def test_vibe_multifile_has_high_signal_and_subtle_findings() -> None:
     assert "eval()" in labels
     # ...and the subtler bugs that prove depth.
     assert "off-by-one" in labels
+
+
+def test_fixtures_cover_performance_and_complexity_lenses() -> None:
+    """Both fixtures plant a performance and a complexity issue so the e2e exercises
+    all seven review lenses, not just security + correctness. Guards against a future
+    edit silently dropping these lower-severity lenses from the live recall check."""
+    for name in ("badcode", "vibe-multifile"):
+        _diff, manifest = _fixture(name)
+        keywords = " ".join(k.lower() for e in manifest.expected for k in e.keywords)
+        assert "n+1" in keywords or "quadratic" in keywords, f"{name}: no performance finding"
+        assert "complexity" in keywords and "cyclomatic" in keywords, (
+            f"{name}: no complexity finding"
+        )

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -32,7 +32,7 @@ class _ShellInjectionProvider(FakeProvider):
 
 def test_runner_loads_fixtures_and_scores(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
-    # The provider catches 1 of the 5 planted issues — passes a low bar, fails a high one.
+    # The provider catches 1 of the planted issues — passes a low bar, fails a high one.
     assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"]) == 0
     assert run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.9"]) == 1
 


### PR DESCRIPTION
## Why

The live e2e harness (`e2e-ollama.yml`) scored recall only against **security** and **correctness** bugs, so the **performance** and **complexity** review lenses ran on every PR but were never actually validated end-to-end. This closes that blind spot.

(The `examples/workflows/` tree needs no change — it's provider-auth templates, category-agnostic, and all seven lenses are on by default.)

## What

- **Extended both eval fixtures** with blatant, single-concern issues, appended at the **end** of existing files so every existing line number (and `expected.json` entry) stays valid:
  - `badcode.py` — a quadratic nested loop (`count_shared_tags`) + a deeply-nested function (`classify_account`).
  - `vibe-multifile` — an N+1 query (`scores_for_users` in `queries.py`) + a deeply-nested/duplicated helper (`format_user_label` in `handlers.py`). Kept to the existing six files so `test_vibe_multifile_spans_all_reviewable_files` stays valid.
- **Annotated** the new findings in both `expected.json` (keywords + line numbers within the scorer's ±3 tolerance; each verified to land on the planted code).
- **Kept the global recall metric** and `--min-recall 0.2` (conservative for the tiny `qwen3:1.7b` CI model). Updated the workflow header comment and fixed a stale `qwen3:0.6b` mention.
- **Guarded the new coverage** with `test_fixtures_cover_performance_and_complexity_lenses` so a future edit can't silently drop these lenses; fixed a stale comment in `test_run.py`; added a one-liner to `CLAUDE.md`.

## Verification

- `uv run pytest tests/evals/` → 19 passed; full suite 434 passed.
  - The 4 errors in `tests/local/test_git_context.py` are a pre-existing sandbox commit-signing quirk, unrelated to this change (they fail on any branch in this environment).
- `ruff check` / `ruff format --check` clean.
- Reconstructed each fixture diff and confirmed the parser still yields the six vibe files and every expected line lands on the planted code.
- The real recall proof runs on this PR's `e2e-ollama` job. If the 1.7b model proves flaky on the lower-severity lenses, `--min-recall` may need a small downward nudge — but security catches alone keep 0.2 comfortably green.

https://claude.ai/code/session_01WarYV53H4bzxNbFrVuLdcC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WarYV53H4bzxNbFrVuLdcC)_