### PR TITLE
fix(github): paginate the existing-review lookup, plus code-quality pass fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: ""
   num_ctx:
-    description: "Ollama context window (ollama only; ignored for hosted providers). Raise it so a large multi-file diff isn't truncated. Leave empty for the default (16384)."
+    description: "Ollama context window (ollama only; ignored for hosted providers). Raise it so a large multi-file diff isn't truncated. Leave empty for the default (32768)."
     required: false
     default: ""
   max_input_tokens:

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -243,7 +243,9 @@ def _post_failure(github: GitHubGateway, exc: Exception) -> None:
 def pr_url_from_event(event: dict[str, Any]) -> str:
     """Build the PR URL from a pull_request(_target) event payload.
 
-    Uses ``GITHUB_SERVER_URL`` so it works on GitHub Enterprise too.
+    Honours ``GITHUB_SERVER_URL`` for the link, though only github.com is
+    supported end to end — the URL parser and the REST gateway both speak to
+    api.github.com.
     """
     server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
     repo = event["repository"]["full_name"]
@@ -272,7 +274,7 @@ def action_inputs() -> dict[str, str | None]:
         "temperature": get("TEMPERATURE"),
         "num_ctx": get("NUM_CTX"),
         "max_input_tokens": get("MAX_INPUT_TOKENS"),
-        "config_path": os.environ.get("INPUT_CONFIG_PATH") or ".lgtmaybe.yml",
+        "config_path": get("CONFIG_PATH"),
     }
 
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -71,7 +71,7 @@ from lgtmaybe.config.loader import load_config
     default=None,
     type=int,
     help="ollama context window (ollama only; ignored for hosted providers). "
-    "Raise it so a large multi-file diff isn't truncated; default 16384",
+    "Raise it so a large multi-file diff isn't truncated; default 32768",
 )
 @click.option(
     "--base",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -160,7 +160,7 @@ class ReviewConfig(_Strict):
     max_input_tokens: int = 100_000
     # Ollama's context window (num_ctx). Ollama only — hosted providers manage
     # their own context window server-side and litellm won't forward this, so it
-    # is ignored for them. None keeps the factory default (16384); raise it so a
+    # is ignored for them. None keeps the factory default (32768); raise it so a
     # large multi-file diff plus the emitted findings isn't truncated.
     num_ctx: int | None = None
     # Ceiling on surrounding context lines added around each hunk. The engine

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -179,7 +179,9 @@ class ReviewConfig(_Strict):
     reflect: bool = True
     # Review lenses to run. Each is asked in its own concurrent LLM call and the
     # findings are merged + deduped. Defaults to all of them; narrow it to trade
-    # thoroughness for fewer calls.
+    # thoroughness for fewer calls. `default=` (not default_factory) on purpose:
+    # pydantic copies it per instance, and only a plain default reaches the JSON
+    # schema that docs/generate_reference.py renders.
     categories: list[ReviewCategory] = Field(default=list(ReviewCategory))
     # Constrain model output to the findings JSON schema via litellm
     # response_format (provider-native JSON mode). Keeps models from returning

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -278,14 +278,28 @@ class RestGitHubGateway(GitHubGateway):
         return m.group(1) if m else None
 
     def _find_existing_review(self) -> int | None:
-        """Return the ID of the first review whose body contains the marker, or None."""
-        reviews_url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
-        reviews = self._get_json(reviews_url)
-        for review in reviews:
-            body: str = review.get("body", "") or ""
-            if self._marker in body:
-                review_id: int = review["id"]
-                return review_id
+        """Return the ID of the first review whose body contains the marker, or None.
+
+        Follows Link rel=next pagination — a busy PR can hold more than one page
+        of reviews, and missing the marker there would duplicate the review
+        instead of updating it.
+        """
+        url: str | None = (
+            f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
+        )
+        while url is not None:
+            resp = self._client.get(
+                url,
+                headers={**self._headers, "Accept": "application/vnd.github+json"},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            for review in resp.json():
+                body: str = review.get("body", "") or ""
+                if self._marker in body:
+                    review_id: int = review["id"]
+                    return review_id
+            url = self._next_link(resp)
         return None
 
     @staticmethod

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -183,6 +183,46 @@ class TestActionRouting:
         assert result.exit_code == 0, result.output
         assert captured == {"num_ctx": 32768, "max_input_tokens": 250000}
 
+    def test_config_path_input_selects_the_repo_config(self, tmp_path, monkeypatch):
+        """INPUT_CONFIG_PATH points the run at a custom repo config file."""
+        cfg_file = tmp_path / "custom.yml"
+        cfg_file.write_text("min_severity: high\n")
+        captured: dict[str, object] = {}
+
+        import lgtmaybe.cli as cli_module
+
+        def fake_build(cfg, runtime):
+            captured["min_severity"] = cfg.min_severity.value
+            return FakeGitHub(), FakeEngine(FakeProvider())
+
+        monkeypatch.setattr(cli_module, "build_adapters", fake_build)
+
+        event = _write_event(
+            tmp_path,
+            {"repository": {"full_name": "org/repo"}, "pull_request": {"number": 1}},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "ollama")
+        monkeypatch.setenv("INPUT_MODEL", "llama3")
+        monkeypatch.setenv("INPUT_CONFIG_PATH", str(cfg_file))
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert captured == {"min_severity": "high"}
+
+    def test_config_path_input_defaults_when_empty(self, monkeypatch):
+        """An unset or empty INPUT_CONFIG_PATH normalises to None like every
+        other input; the action falls back to .lgtmaybe.yml."""
+        from lgtmaybe.cli import action_inputs
+
+        monkeypatch.delenv("INPUT_CONFIG_PATH", raising=False)
+        assert action_inputs()["config_path"] is None
+
+        monkeypatch.setenv("INPUT_CONFIG_PATH", "")
+        assert action_inputs()["config_path"] is None
+
     def test_azure_api_base_input_reaches_runtime(self, tmp_path, monkeypatch):
         """INPUT_API_BASE carries the azure resource endpoint into the run."""
         captured: dict[str, object] = {}

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -119,6 +119,50 @@ def test_post_review_updates_existing_review_on_second_call() -> None:
 
 
 @respx.mock
+def test_post_review_finds_existing_review_past_first_page() -> None:
+    """The marker review is found even when it sits beyond the first page of
+    reviews (GitHub returns 30 per page), so a busy PR still gets its review
+    updated in place rather than duplicated."""
+    existing_review_id = 99
+    page1 = [{"id": i, "body": f"human review {i}"} for i in range(30)]
+    page2 = [{"id": existing_review_id, "body": f"Old summary {MARKER}"}]
+    page2_url = f"{REVIEWS_URL}?page=2"
+
+    # One route serves both pages in order: a respx URL pattern without a query
+    # string matches any query, so registering page 2 separately would be
+    # shadowed by the page-1 route.
+    respx.route(method="GET", url=REVIEWS_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=page1, headers={"Link": f'<{page2_url}>; rel="next"'}),
+            httpx.Response(200, json=page2),
+        ]
+    )
+
+    update_url = f"{REVIEWS_URL}/{existing_review_id}"
+    updated_bodies: list[dict[object, object]] = []
+
+    def capture_update(request: httpx.Request) -> httpx.Response:
+        updated_bodies.append(json.loads(request.content))
+        return httpx.Response(200, json={"id": existing_review_id})
+
+    create_calls: list[httpx.Request] = []
+
+    def capture_create(request: httpx.Request) -> httpx.Response:
+        create_calls.append(request)
+        return httpx.Response(201, json={"id": 100})
+
+    respx.route(method="PUT", url=update_url).mock(side_effect=capture_update)
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert len(create_calls) == 0, "must not duplicate a review that exists on a later page"
+    assert len(updated_bodies) == 1
+    assert MARKER in str(updated_bodies[0].get("body", ""))
+
+
+@respx.mock
 def test_post_issue_comment_posts_to_issues_endpoint() -> None:
     """post_issue_comment posts a standalone comment to the PR conversation."""
     posted: list[dict[object, object]] = []


### PR DESCRIPTION
Full code-quality pass over the codebase: every layer reviewed (engine/core, CLI/local/config, providers/GitHub/packaging), all gates run, and the findings fixed.

## Fixes

- **Review-update idempotency bug** (`rest_gateway.py`): `_find_existing_review` only read the first page of PR reviews (GitHub returns 30/page) and never followed the `Link` header — on a PR with more than 30 reviews the marker comment was missed and every run posted a **duplicate review** instead of updating in place. Now follows `Link rel=next` like the files/commits fetches already did. TDD: the new test failed red (duplicate created) before the fix.
- **Stale `num_ctx` default**: CLI help, the `action.yml` input description, and the `ReviewConfig` comment all said 16384; the factory default is 32768 (docs/tests/e2e already agreed).
- **`INPUT_CONFIG_PATH` normalisation**: it was the one action input read outside the `get()` helper, with its `.lgtmaybe.yml` default applied twice (the second unreachable). Now empty → `None` like every other input, fallback in one place, pinned by two new tests (incl. end-to-end: a custom config file's `min_severity` reaches the run).
- **Honest GHES docstring**: `pr_url_from_event` claimed GitHub Enterprise support, but the URL parser and REST gateway only speak github.com. The docstring now says so; real GHES support is left as a deliberate feature decision.
- Documented why `ReviewConfig.categories` uses `Field(default=...)` rather than `default_factory`: only a plain default reaches the JSON schema that `docs/generate_reference.py` renders (a factory would make the docs show `[]` instead of the real all-lenses default), and pydantic copies it per instance.

## Verification

- 497/497 tests pass (3 added); `ruff check`, `ruff format --check`, `mypy --strict`, `uv lock --check` all clean
- `uv build` (sdist + wheel) and `mkdocs build --strict` both succeed
- Reviewed and dismissed as false positives: the `categories` mutable-default concern (verified pydantic copies per instance) and the `--working` mode `git diff &lt;merge-base&gt;` spec (correct by design)

https://claude.ai/code/session_01BbQMy4PVVGB7ingsjwMcFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbQMy4PVVGB7ingsjwMcFb)_