### PR TITLE
Enable litellm.drop_params to handle unsupported model parameters

### DIFF
--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -17,6 +17,16 @@ from lgtmaybe.core.ports import Message, ProviderClient
 _DEFAULT_TIMEOUT = 60  # seconds
 _MAX_ATTEMPTS = 4
 
+# We always send ``temperature`` (for determinism) and ``response_format`` (for
+# structured JSON output), but not every model accepts them: some bedrock-hosted
+# models (e.g. ``openai.gpt-5.5``) reject both and litellm raises
+# ``UnsupportedParamsError``, which would fail the entire review. Enabling
+# drop_params makes litellm consult its per-model capability map and silently
+# drop only the params a given model can't take — keeping them for the local
+# (ollama) and cloud models that do support them. The prompt also asks for JSON,
+# and the parser is lenient, so a dropped ``response_format`` still parses.
+litellm.drop_params = True
+
 
 class LiteLLMProvider(ProviderClient):
     """ProviderClient backed by litellm with retry and optional fallback."""

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -10,6 +10,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+import litellm
+
 from lgtmaybe.core.models import ProviderResult
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
@@ -91,3 +93,10 @@ class TestLiteLLMProvider:
             result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
 
         assert isinstance(result, ProviderResult)
+
+    def test_drop_params_is_enabled_for_unsupported_provider_params(self) -> None:
+        """Importing the provider enables litellm.drop_params so a model that
+        rejects ``temperature``/``response_format`` (e.g. bedrock
+        ``openai.gpt-5.5``) drops them instead of failing the whole review,
+        while models that support them keep them."""
+        assert litellm.drop_params is True


### PR DESCRIPTION
## Summary

Enable `litellm.drop_params` to gracefully handle models that don't support `temperature` and `response_format` parameters (e.g., some Bedrock-hosted models). This prevents `UnsupportedParamsError` from failing the entire review while preserving these parameters for models that do support them.

## Changes

- **src/lgtmaybe/providers/litellm_provider.py**: Set `litellm.drop_params = True` at module initialization with detailed documentation explaining the rationale:
  - We always send `temperature` (for determinism) and `response_format` (for structured JSON output)
  - Some Bedrock-hosted models reject these parameters, causing litellm to raise `UnsupportedParamsError`
  - Enabling `drop_params` makes litellm consult its per-model capability map and silently drop unsupported parameters
  - Local (ollama) and cloud models that support these parameters retain them
  - The prompt requests JSON and the parser is lenient, so a dropped `response_format` still parses correctly

- **tests/providers/test_litellm_provider.py**: Added test to verify `litellm.drop_params` is enabled when the provider module is imported, ensuring the feature is active and won't regress

## Implementation Details

The change is minimal and non-invasive: a single module-level assignment with comprehensive documentation. This leverages litellm's built-in capability to handle model-specific parameter support, eliminating the need for custom parameter filtering logic in the provider wrapper.

https://claude.ai/code/session_013xqGm9Zi3NWwDCeSZS9tRo