### PR TITLE
Add component-prefixed floating major tag for Action consumers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # Publish clean v-prefixed git tags consumers can use in `uses:` — the exact
-  # alias (v0.1.0) and the floating major (v0) — pointing at the released commit.
-  # release-please owns the canonical lgtmaybe-v0.1.0 tag + GitHub release; these
-  # are the Action-friendly aliases (the image uses the same v0 / 0.1.0 scheme).
+  # alias (v0.1.0), the floating major (v0), and the component-prefixed floating
+  # major (lgtmaybe-v0) — all pointing at the released commit. release-please owns
+  # the canonical lgtmaybe-v0.1.0 tag + GitHub release; these are the
+  # Action-friendly aliases (the image uses the same v0 / 0.1.0 scheme).
   floating-tag:
     needs: [ghcr]
     runs-on: ubuntu-latest
@@ -91,4 +92,9 @@ jobs:
           git push -f origin "refs/tags/$ver"
           git tag -f "$major" "$tag"
           git push -f origin "refs/tags/$major"
-          echo "tagged $ver and moved $major -> $tag"
+          # Also keep the component-prefixed floating major (lgtmaybe-v0) in sync.
+          # Some consumers pin `uses: MattJColes/lgtmaybe@lgtmaybe-v0`; without this
+          # it stays frozen at an old commit whose action.yml points at a stale image.
+          git tag -f "lgtmaybe-$major" "$tag"
+          git push -f origin "refs/tags/lgtmaybe-$major"
+          echo "tagged $ver and moved $major / lgtmaybe-$major -> $tag"


### PR DESCRIPTION
## Summary

Extend the release workflow to publish a component-prefixed floating major tag (`lgtmaybe-v0`) alongside the existing floating major tag (`v0`). This ensures consumers pinning `uses: MattJColes/lgtmaybe@lgtmaybe-v0` receive updates to the latest patch within that major version, preventing them from staying frozen at stale commits whose `action.yml` points to outdated images.

## Changes

- **Updated release workflow comments** to document the three tag aliases now published: the exact version (`v0.1.0`), the floating major (`v0`), and the component-prefixed floating major (`lgtmaybe-v0`)
- **Added tag sync logic** to keep `lgtmaybe-v0` in sync with the released commit, matching the existing behavior for `v0`
- **Updated final log message** to reflect all tags being moved

## Implementation Details

The change follows the existing pattern for floating major tags:
- Creates/updates the `lgtmaybe-v0` tag to point at the released commit
- Force-pushes to origin to keep it current across releases
- Maintains consistency with how `v0` is handled, ensuring both tag families stay synchronized

This addresses a real use case where consumers explicitly pin the component-prefixed variant to avoid manual updates while staying within a major version.

https://claude.ai/code/session_011ZmkadE6z1cYUDARKyW76u