### PR TITLE
docs(bedrock): clarify valid model ids and inference profiles

### DIFF
--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -47,7 +47,7 @@ The model identifier for the chosen provider. Format varies by provider:
 | openai | `gpt-5.5` |
 | anthropic | `claude-sonnet-4-6`, `claude-haiku-4-5` |
 | openrouter | `anthropic/claude-sonnet-4-6` |
-| bedrock | `anthropic.claude-sonnet-4-6`, `anthropic.claude-haiku-4-5` |
+| bedrock | `us.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-haiku-4-5` (prefer the cross-region inference profile; a non-Bedrock id like `openai.gpt-5.5` is invalid — see [Review with Bedrock](review-with-bedrock-oidc.md)) |
 | vertex | `gemini-3-pro`, `gemini-3.5-flash` |
 | azure | your deployment name, e.g. `my-gpt-4o-deployment` (not the upstream model id — see [Review with Azure](review-with-azure.md)) |
 | ollama | `qwen3.6:27b`, `gemma4:e4b` |

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -37,7 +37,12 @@ The role needs only:
 }
 ```
 
-Scope `Resource` to specific model ARNs for tighter least-privilege.
+Scope `Resource` to specific model ARNs for tighter least-privilege. If you use a
+cross-region inference profile (the `us.`/`eu.`/`apac.`-prefixed ids below — the
+recommended form), the role also needs `bedrock:InvokeModel*` on the
+inference-profile ARN, e.g.
+`arn:aws:bedrock:*:<account-id>:inference-profile/*`, otherwise the call fails
+with `AccessDeniedException`.
 
 ## Workflow example
 
@@ -66,22 +71,32 @@ jobs:
       - uses: MattJColes/lgtmaybe@v0
         with:
           provider: bedrock
-          model: anthropic.claude-sonnet-4-6
+          model: us.anthropic.claude-sonnet-4-6
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: us-east-1
 ```
 
 ## Choosing a Bedrock model ID
 
-| Model | Bedrock model ID |
-|---|---|
-| Claude Opus 4.8 | `anthropic.claude-opus-4-8` |
-| Claude Sonnet 4.6 | `anthropic.claude-sonnet-4-6` |
-| Claude Haiku 4.5 | `anthropic.claude-haiku-4-5` |
+The `model` must be a **Bedrock** model identifier. Bedrock hosts Anthropic
+Claude, Amazon Nova/Titan, Meta Llama, Mistral, Cohere and others — it does
+**not** host OpenAI's GPT models, so an id like `openai.gpt-5.5` is rejected with
+`The provided model identifier is invalid`. Use one of the Claude ids below
+(prefixed with a cross-region inference profile — see the note):
 
-For tighter availability across regions, prefix with a cross-region inference
-profile (e.g. `us.anthropic.claude-sonnet-4-6`) where one is enabled for your
-account.
+| Model | Inference-profile ID (recommended) | Base model ID |
+|---|---|---|
+| Claude Opus 4.8 | `us.anthropic.claude-opus-4-8` | `anthropic.claude-opus-4-8` |
+| Claude Sonnet 4.6 | `us.anthropic.claude-sonnet-4-6` | `anthropic.claude-sonnet-4-6` |
+| Claude Haiku 4.5 | `us.anthropic.claude-haiku-4-5` | `anthropic.claude-haiku-4-5` |
+
+**Prefer the inference-profile form.** Most current Claude models on Bedrock are
+invocable only through a cross-region inference profile, not via on-demand
+throughput on the bare model id — so a bare id often fails with the same
+`invalid model identifier` (or `on-demand throughput isn't supported`) error.
+Prefix with your geography: `us.` (US), `eu.` (Europe) or `apac.` (Asia
+Pacific), matching `aws_region`. Use the bare `anthropic.…` id only where
+on-demand access to that model is enabled in your region.
 
 ## Running locally with ambient AWS credentials
 
@@ -94,7 +109,7 @@ pip install 'lgtmaybe[bedrock]'
 
 lgtmaybe review \
   --provider bedrock \
-  --model anthropic.claude-haiku-4-5
+  --model us.anthropic.claude-haiku-4-5
 ```
 
 lgtmaybe does not require or accept a static API key for Bedrock.
@@ -107,4 +122,13 @@ that the IAM trust policy references the correct GitHub repository.
 
 **`AccessDeniedException`** — the role lacks `bedrock:InvokeModel` for the
 selected model, or the model is not enabled in the Bedrock console for your
-account and region.
+account and region. For an inference-profile id (`us.`/`eu.`/`apac.`-prefixed),
+the policy must also allow the `inference-profile/*` ARN, not just
+`foundation-model/*`.
+
+**`The provided model identifier is invalid`** — the `model` is not a Bedrock
+model id. Two common causes: (1) it's a non-Bedrock id such as `openai.gpt-5.5`
+or another provider's name — Bedrock hosts Claude / Nova / Llama / Mistral /
+Cohere, not OpenAI GPT, so pick a Claude id from the table above; (2) the model
+needs a cross-region inference profile — prefix with `us.`/`eu.`/`apac.` (e.g.
+`us.anthropic.claude-sonnet-4-6`) rather than the bare `anthropic.…` id.

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -37,6 +37,10 @@ jobs:
       - uses: MattJColes/lgtmaybe@v0
         with:
           provider: bedrock
-          model: anthropic.claude-sonnet-4-6
+          # Bedrock needs a Bedrock model id (Claude/Nova/Llama/…), not an
+          # OpenAI/GPT id. Prefer the cross-region inference profile (us./eu./
+          # apac.) — most current Claude models aren't available on-demand on the
+          # bare id. See docs/how-to/review-with-bedrock-oidc.md.
+          model: us.anthropic.claude-sonnet-4-6
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: us-east-1


### PR DESCRIPTION
## Why

A Bedrock review failed with:

```
BedrockException - {"message":"The provided model identifier is invalid."}
```

The configured model was `openai.gpt-5.5` — a non-Bedrock id. Bedrock hosts Anthropic Claude, Amazon Nova/Titan, Llama, Mistral, Cohere, etc. (not OpenAI's GPT), and most current Claude models on Bedrock are invocable **only through a cross-region inference profile** (`us.`/`eu.`/`apac.`-prefixed), not on-demand on the bare `anthropic.…` id — so even a valid Claude id can hit the same error without the prefix.

## What changed (docs only)

- **`docs/how-to/review-with-bedrock-oidc.md`**
  - "Choosing a Bedrock model ID": explain that non-Bedrock ids (e.g. `openai.gpt-5.5`) are invalid, and recommend the inference-profile form; the table now shows both the recommended `us.…` id and the base id.
  - Workflow + local-CLI examples use `us.anthropic.claude-*`.
  - IAM note: inference profiles need `bedrock:InvokeModel*` on the `inference-profile/*` ARN, not just `foundation-model/*`.
  - New troubleshooting entry for `The provided model identifier is invalid` covering both causes.
- **`examples/workflows/review-bedrock.yml`** — default model switched to `us.anthropic.claude-sonnet-4-6` with an explanatory comment.
- **`docs/how-to/configure-lgtmaybe-yml.md`** — bedrock row updated to the inference-profile form with a pointer to the how-to.

Verified with `mkdocs build --strict` (clean).

https://claude.ai/code/session_01P7ZaUawxtCsk2AVR6UMPY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7ZaUawxtCsk2AVR6UMPY1)_