### PR TITLE
Add --fixture flag to run subset of eval fixtures in CI

### DIFF
--- a/.github/workflows/e2e-ollama.yml
+++ b/.github/workflows/e2e-ollama.yml
@@ -2,17 +2,23 @@
 #
 # Unlike action-e2e.yml (hosted providers, real spend, label-gated), this runs a
 # genuinely local model on the runner — free, no secrets — so it can run on every
-# PR. It pulls a tiny model (qwen3:1.7b) and reviews the eval fixtures through the
-# full pipeline (redact → batch → per-category fan-out → parse → reflect), with a
-# generous timeout and a large ollama context window so a big multi-file diff
-# ("vibe-coded" commit) isn't truncated. The fixtures plant security and
-# correctness bugs alongside blatant performance (N+1 / quadratic) and complexity
-# (deep nesting / duplication) issues, so every review lens is exercised live.
+# PR. It reviews an eval fixture through the full pipeline (redact → batch →
+# per-category fan-out → parse), proving the ollama path works on a real model.
 #
-# This is the proof the ollama path actually works on a large change without
-# hand-holding — the pytest suite only ever mocks ollama. The eval runner exits
-# non-zero if any fixture fails to parse or falls below --min-recall, so a broken
-# pipeline (timeout, truncated context, unparseable output) fails the job.
+# Speed: a single ollama instance serves one model serially, and a GitHub runner
+# is CPU-only, so wall-clock scales with the number of model calls (fixtures ×
+# review lenses). To keep this fast enough to run on every PR with a real 9B-class
+# model we:
+#   - run ONE fixture (badcode) — small diff, but its manifest plants a bug for
+#     every one of the seven code lenses, so a single fixture still exercises the
+#     whole fan-out live (the larger multi-file fixture stays in-repo for on-demand
+#     `python -m evals.run` runs);
+#   - cache the pulled model so a multi-GB download doesn't repeat every run;
+#   - size num_ctx to the small diff instead of the big-multifile default.
+#
+# The eval runner exits non-zero if the fixture fails to parse or falls below
+# --min-recall, so a broken pipeline (timeout, truncated context, unparseable
+# output) fails the job.
 #
 # Kept out of the ci.yml pytest gate on purpose (it needs a live model), but it
 # IS a per-PR check here.
@@ -33,11 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      # Small but capable local model — big enough to actually catch the planted
-      # bugs (so the recall bar is a real signal), still CPU-friendly for CI. It's
-      # a qwen3 thinking model, so the factory's tested think=False handling applies
-      # (a 0.6b model parsed the diff fine but caught nothing, failing the bar).
-      OLLAMA_MODEL: qwen3:1.7b
+      # One local model for the e2e. A 9B-class model is far more capable than the
+      # old 1.7B (so the recall bar is a real signal), and still CPU-runnable on a
+      # standard runner once the call matrix is trimmed to a single fixture. It's a
+      # qwen3 thinking model, so the factory's tested think=False handling applies.
+      OLLAMA_MODEL: qwen3.5:9b
+      # Pin the model store to a known path so the pull, the cache, and `ollama
+      # serve` all agree on where blobs live.
+      OLLAMA_MODELS: /home/runner/.ollama/models
     steps:
       - uses: actions/checkout@v6
 
@@ -53,6 +62,15 @@ jobs:
       - name: Install ollama
         run: curl -fsSL https://ollama.com/install.sh | sh
 
+      # Cache the pulled model blobs (content-addressed) so re-runs skip the
+      # multi-GB download — the biggest fixed cost of a 9B model in CI. `ollama
+      # pull` verifies the digest and no-ops when the blobs are already present.
+      - name: Cache ollama model
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.OLLAMA_MODELS }}
+          key: ollama-${{ runner.os }}-${{ env.OLLAMA_MODEL }}
+
       - name: Start ollama and wait until ready
         run: |
           ollama serve &
@@ -66,26 +84,23 @@ jobs:
           echo "ollama did not become ready in time" >&2
           exit 1
 
-      - name: Pull the tiny model
+      - name: Pull the model
         run: ollama pull "$OLLAMA_MODEL"
 
-      # Review every fixture (incl. the large multi-file one) with a long timeout
-      # and a big context window. min-recall 0.3: every fixture must PARSE, and the
-      # model must catch at least ~a third of the planted bugs *pooled across
-      # fixtures* (total caught / total planted) — not per-fixture. A 1.7b model on
-      # CPU isn't bit-reproducible even at temperature 0, so a single missed finding
-      # on one short fixture (e.g. badcode at 2/7) shouldn't flip the job; pooling
-      # over ~18 samples keeps the bar a real regression signal without flaking on
-      # that one-finding margin. Reflection is off: on a small local model the
-      # self-reflection pass over-prunes its own valid findings (CLAUDE.md notes
-      # --no-reflect for weaker models).
+      # Review the single small fixture. min-recall 0.3: it must PARSE and the
+      # model must catch at least ~a third of the planted bugs. A 9B model on CPU
+      # isn't bit-reproducible even at temperature 0, so the floor is kept modest
+      # to stay a regression signal without flaking on a one-finding margin.
+      # num_ctx is sized to the small diff (the big-multifile default isn't needed
+      # here), which keeps prompt eval and memory light on the larger model.
       - name: End-to-end review via ollama
         run: |
           uv run python -m evals.run \
             --provider ollama \
             --model "$OLLAMA_MODEL" \
             --api-base http://localhost:11434 \
+            --fixture badcode \
             --min-recall 0.3 \
             --timeout 900 \
-            --num-ctx 32768 \
+            --num-ctx 16384 \
             --no-reflect

--- a/evals/run.py
+++ b/evals/run.py
@@ -33,6 +33,27 @@ def _load_fixtures() -> list[tuple[str, Fixture]]:
     return out
 
 
+def _select_fixtures(
+    fixtures: list[tuple[str, Fixture]], names: list[str] | None
+) -> list[tuple[str, Fixture]]:
+    """Keep only the fixtures whose name is in *names* (all when *names* is empty).
+
+    An unknown name is a hard error, not a silent skip: running zero fixtures would
+    pool to 100% recall and pass vacuously, hiding a typo'd CI invocation.
+    """
+    if not names:
+        return fixtures
+    wanted = set(names)
+    available = {m.name for _, m in fixtures}
+    missing = wanted - available
+    if missing:
+        raise SystemExit(
+            f"unknown fixture(s): {', '.join(sorted(missing))}. "
+            f"Available: {', '.join(sorted(available))}"
+        )
+    return [(diff, m) for diff, m in fixtures if m.name in wanted]
+
+
 def _review(
     diff: str,
     manifest: Fixture,
@@ -141,9 +162,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_false",
         help="skip the self-reflection pass (weak local models over-prune their own findings)",
     )
+    ap.add_argument(
+        "--fixture",
+        action="append",
+        dest="fixtures",
+        metavar="NAME",
+        help="only run the named fixture(s); repeatable. Default: all. Lets CI run a fast "
+        "single-fixture subset while the full set stays available on demand.",
+    )
     args = ap.parse_args(argv)
 
     provider = Provider(args.provider)
+    fixtures = _select_fixtures(_load_fixtures(), args.fixtures)
     scores = [
         _review(
             diff,
@@ -156,7 +186,7 @@ def main(argv: list[str] | None = None) -> int:
             max_input_tokens=args.max_input_tokens,
             reflect=args.reflect,
         )
-        for diff, m in _load_fixtures()
+        for diff, m in fixtures
     ]
     for score in scores:
         _print(score)

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -162,6 +162,50 @@ def test_max_input_tokens_threads_to_review_config(monkeypatch: pytest.MonkeyPat
     assert seen and all(v == 250000 for v in seen)
 
 
+def test_fixture_flag_selects_only_the_named_fixtures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--fixture scopes the run to the named fixture(s) so CI can run a fast subset."""
+    seen: list[str] = []
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        seen.append(manifest.name)
+        return _score(manifest.name, 1, 1)
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+
+    run_mod.main(
+        ["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--fixture", "badcode"]
+    )
+    assert seen == ["badcode"]
+
+
+def test_no_fixture_flag_runs_every_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --fixture the runner reviews all fixtures, as before."""
+    seen: list[str] = []
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        seen.append(manifest.name)
+        return _score(manifest.name, 1, 1)
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+
+    run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"])
+    assert set(seen) == {"badcode", "vibe-multifile"}
+
+
+def test_unknown_fixture_name_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo'd --fixture must error, never vacuously pass by running zero fixtures."""
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        return _score(manifest.name, 1, 1)
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+
+    with pytest.raises(SystemExit):
+        run_mod.main(
+            ["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--fixture", "nope"]
+        )
+
+
 def test_reflect_defaults_on_and_no_reflect_disables_it(monkeypatch: pytest.MonkeyPatch) -> None:
     """--no-reflect turns off the reflection pass (weak CI models over-prune otherwise)."""
     seen: list[bool] = []


### PR DESCRIPTION
## Summary

Optimize the e2e ollama CI workflow to run faster by introducing a `--fixture` flag that scopes the eval runner to a single fixture, while keeping the full fixture suite available for on-demand local runs. Upgrade the model from qwen3:1.7b to qwen3.5:9b (more capable, still CPU-runnable with the reduced fixture set) and add model caching to skip multi-GB downloads on re-runs.

## Key Changes

- **New `--fixture` flag** (`evals/run.py`): 
  - Accepts one or more fixture names to run; defaults to all fixtures when omitted
  - Validates fixture names at startup (fails loudly on typos rather than silently passing with zero fixtures)
  - Enables CI to run a fast single-fixture subset while preserving the full suite for local development

- **Model upgrade & context tuning** (`.github/workflows/e2e-ollama.yml`):
  - Upgraded from qwen3:1.7b to qwen3.5:9b (9B-class model is far more capable, recall bar becomes a real signal)
  - Reduced `num_ctx` from 32768 to 16384 (sized to the small "badcode" fixture instead of the large multi-file default)
  - Added `OLLAMA_MODELS` env var to pin model store path for consistency across pull, cache, and serve

- **Model caching** (`.github/workflows/e2e-ollama.yml`):
  - New cache step using `actions/cache@v4` to persist pulled model blobs
  - Eliminates multi-GB download on every run (biggest fixed cost of a 9B model in CI)
  - `ollama pull` verifies digest and no-ops when blobs are already present

- **Workflow simplification** (`.github/workflows/e2e-ollama.yml`):
  - Now runs only the "badcode" fixture (small diff, but its manifest plants a bug for all seven code lenses)
  - Single fixture still exercises the full fan-out live; larger multi-file fixture stays in-repo for `python -m evals.run` runs
  - Updated comments to explain the speed/capability tradeoff

## Tests

Added three new test cases in `tests/evals/test_run.py`:
- `test_fixture_flag_selects_only_the_named_fixtures`: verifies `--fixture badcode` runs only that fixture
- `test_no_fixture_flag_runs_every_fixture`: verifies default behavior (all fixtures) is unchanged
- `test_unknown_fixture_name_fails_loudly`: ensures typos in fixture names exit non-zero

## Implementation Details

The `_select_fixtures()` function in `evals/run.py` implements the filtering logic with explicit error handling: if a requested fixture name doesn't exist, it raises `SystemExit` with a helpful message listing available fixtures. This prevents the silent failure mode where running zero fixtures would pool to 100% recall and pass vacuously.

https://claude.ai/code/session_01MtWnyq7xMfGEYxna7sYE4V