### PR TITLE
Clarify Bedrock inference-profile IAM requirements

### DIFF
--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -33,16 +33,26 @@ The role needs only:
     "bedrock:InvokeModel",
     "bedrock:InvokeModelWithResponseStream"
   ],
-  "Resource": "arn:aws:bedrock:*::foundation-model/*"
+  "Resource": [
+    "arn:aws:bedrock:*:<account-id>:inference-profile/*",
+    "arn:aws:bedrock:*::foundation-model/*"
+  ]
 }
 ```
 
-Scope `Resource` to specific model ARNs for tighter least-privilege. If you use a
-cross-region inference profile (the `us.`/`eu.`/`apac.`-prefixed ids below — the
-recommended form), the role also needs `bedrock:InvokeModel*` on the
-inference-profile ARN, e.g.
-`arn:aws:bedrock:*:<account-id>:inference-profile/*`, otherwise the call fails
-with `AccessDeniedException`.
+**Both ARNs are required for the recommended inference-profile model ids**
+(the `us.`/`eu.`/`apac.`-prefixed ids below). A cross-region inference profile
+fans the call out to the foundation model in several regions, so the role needs
+`bedrock:InvokeModel*` on **both** the `inference-profile/*` ARN **and** the
+underlying `foundation-model/*` ARN — granting only one of them still fails with
+`AccessDeniedException`. (A bare `anthropic.…` model id needs only the
+`foundation-model/*` ARN, but most current Claude models are invocable only
+through an inference profile — see the model table below.)
+
+Scope each `Resource` to specific model / inference-profile ARNs for tighter
+least-privilege once it works, e.g.
+`arn:aws:bedrock:*:<account-id>:inference-profile/us.anthropic.claude-opus-4-8*`
+and `arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-8*`.
 
 ## Workflow example
 


### PR DESCRIPTION
## Summary

Updated documentation to clarify that both `inference-profile/*` and `foundation-model/*` ARNs are required in the IAM policy when using cross-region inference profiles with Bedrock, and that attempting to grant only one results in `AccessDeniedException`.

## Changes

- **Updated IAM policy example** to show both required ARNs in a list format instead of a single `foundation-model/*` resource
- **Expanded explanation** of why both ARNs are necessary: cross-region inference profiles fan calls out to foundation models in multiple regions, requiring permissions on both the profile and underlying foundation model ARNs
- **Clarified model ID types**: distinguished between cross-region inference-profile IDs (recommended, `us.`/`eu.`/`apac.`-prefixed) which need both ARNs, and bare `anthropic.…` model IDs which need only the `foundation-model/*` ARN
- **Added note** that most current Claude models are invocable only through inference profiles
- **Provided concrete scoping examples** for least-privilege configuration once the policy works

## Implementation Details

The documentation now makes explicit that granting only one of the two ARNs will fail with `AccessDeniedException`, preventing users from debugging a subtle permission issue. The examples show both the broad wildcard form (for initial setup) and specific ARN patterns (for production least-privilege).

https://claude.ai/code/session_01F1qL8BJyxcBH8zMXqgk7WT