### PR TITLE
chore: relax commitlint rules for dependabot commits

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,34 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Dependabot's auto-generated bodies (and humans pasting changelog/compare
+    // URLs or dependency metadata) routinely exceed 100 chars per line. We can't
+    // control that text, and release-please only reads the subject + footers to
+    // compute the next version, so the body line-length cap adds no value while
+    // breaking every dependency bump — disable it. Subject/type enforcement,
+    // which the release automation actually relies on, stays on.
+    "body-max-line-length": [0, "always", Infinity],
+    // `.github/dependabot.yml` labels python dependency bumps with the `deps`
+    // prefix, which isn't one of the default conventional types. Add it so those
+    // auto-generated commits pass. release-please ignores unknown types, so
+    // `deps` bumps correctly don't cut a release on their own.
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "deps",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Updated commitlint configuration to accommodate Dependabot's auto-generated commits and the project's dependency-bump workflow.

## Changes

- **Disabled `body-max-line-length` rule:** Dependabot's auto-generated commit bodies (and changelog/compare URLs) routinely exceed 100 characters per line. Since release-please only reads the subject and footers to compute the next version, this rule adds no value while breaking every dependency bump.

- **Added `deps` to `type-enum`:** `.github/dependabot.yml` labels Python dependency bumps with the `deps` prefix, which isn't a default conventional commit type. Added it to the allowed types so auto-generated commits pass linting. Release-please ignores unknown types, so `deps` bumps correctly don't trigger a release on their own.

## Implementation Details

- Subject/type enforcement remains enabled — the rules that release automation actually relies on stay in place.
- The changes are backward-compatible; existing commit types continue to work as before.

https://claude.ai/code/session_01AaD36hsa1kerLh4LFXH3ns