### PR TITLE
Add sampling params and category filtering to eval runner

### DIFF
--- a/.github/workflows/e2e-ollama.yml
+++ b/.github/workflows/e2e-ollama.yml
@@ -7,18 +7,22 @@
 #
 # Speed: a single ollama instance serves one model serially, and a GitHub runner
 # is CPU-only, so wall-clock scales with the number of model calls (fixtures ×
-# review lenses). To keep this fast enough to run on every PR with a real 9B-class
-# model we:
-#   - run ONE fixture (badcode) — small diff, but its manifest plants a bug for
-#     every one of the seven code lenses, so a single fixture still exercises the
-#     whole fan-out live (the larger multi-file fixture stays in-repo for on-demand
-#     `python -m evals.run` runs);
+# review lenses). A 9B model running all seven lenses took ~25 min and timed out,
+# so this is a deliberately CUT-DOWN smoke — it proves the live ollama path picks
+# up critical issues, not that a small model is thorough. To keep it fast we:
+#   - use a small (qwen3.5:2b) model with THINKING OFF (the factory forces
+#     think=False for ollama) — no reasoning tokens to grind through on CPU;
+#   - run ONE fixture (badcode, small diff) through only the two CRITICAL lenses
+#     (security + correctness) instead of the full seven-lens fan-out — fewer
+#     serial model calls. The larger multi-file fixture and the full lens set stay
+#     in-repo for on-demand `python -m evals.run` / nightly runs;
 #   - cache the pulled model so a multi-GB download doesn't repeat every run;
 #   - size num_ctx to the small diff instead of the big-multifile default.
 #
 # The eval runner exits non-zero if the fixture fails to parse or falls below
 # --min-recall, so a broken pipeline (timeout, truncated context, unparseable
-# output) fails the job.
+# output) fails the job. The recall floor is low (0.2) on purpose: a small model
+# need only catch a fraction of the planted critical bugs to prove the path works.
 #
 # Kept out of the ci.yml pytest gate on purpose (it needs a live model), but it
 # IS a per-PR check here.
@@ -39,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      # One local model for the e2e. A 9B-class model is far more capable than the
-      # old 1.7B (so the recall bar is a real signal), and still CPU-runnable on a
-      # standard runner once the call matrix is trimmed to a single fixture. It's a
-      # qwen3 thinking model, so the factory's tested think=False handling applies.
-      OLLAMA_MODEL: qwen3.5:9b
+      # One small local model for the smoke. qwen3.5:2b is CPU-friendly and, with
+      # thinking off + the fan-out cut to two lenses, finishes in minutes instead
+      # of the ~25 min a 9B all-lens run took. It's a qwen3.x thinking model, so the
+      # factory's tested think=False handling applies (no reasoning tokens on CPU).
+      OLLAMA_MODEL: qwen3.5:2b
       # Pin the model store to a known path so the pull, the cache, and `ollama
       # serve` all agree on where blobs live.
       OLLAMA_MODELS: /home/runner/.ollama/models
@@ -87,12 +91,13 @@ jobs:
       - name: Pull the model
         run: ollama pull "$OLLAMA_MODEL"
 
-      # Review the single small fixture. min-recall 0.3: it must PARSE and the
-      # model must catch at least ~a third of the planted bugs. A 9B model on CPU
-      # isn't bit-reproducible even at temperature 0, so the floor is kept modest
-      # to stay a regression signal without flaking on a one-finding margin.
-      # num_ctx is sized to the small diff (the big-multifile default isn't needed
-      # here), which keeps prompt eval and memory light on the larger model.
+      # Review the single small fixture through only the security + correctness
+      # lenses. min-recall 0.2: it must PARSE and the model must catch at least ~a
+      # fifth of the planted critical bugs — a low bar on purpose, since a 2B model
+      # on CPU isn't bit-reproducible and the point is "the path works", not depth.
+      # Sampling: qwen3.x's recommended non-thinking settings (temp 0.6, top_p 0.8,
+      # top_k 20); thinking itself is forced off by the factory. num_ctx is sized to
+      # the small diff, keeping prompt eval and memory light.
       - name: End-to-end review via ollama
         run: |
           uv run python -m evals.run \
@@ -100,7 +105,11 @@ jobs:
             --model "$OLLAMA_MODEL" \
             --api-base http://localhost:11434 \
             --fixture badcode \
-            --min-recall 0.3 \
+            --categories security,correctness \
+            --min-recall 0.2 \
             --timeout 900 \
             --num-ctx 16384 \
+            --temperature 0.6 \
+            --top-p 0.8 \
+            --top-k 20 \
             --no-reflect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,22 +288,26 @@ Split by whether it can be deterministic, because that decides where it lives:
   with a real provider and reports **parse-rate + recall**, exiting non-zero below
   `--min-recall` so it can gate a model/prompt change when run deliberately
   (`python -m evals.run --provider … --model …`; `--timeout` / `--num-ctx` /
-  `--max-input-tokens` tune it for a big diff on a slow local model). Its plumbing
+  `--max-input-tokens` tune it for a big diff on a slow local model;
+  `--temperature` / `--top-p` / `--top-k` set the model's sampling; `--categories`
+  cuts the per-category fan-out to a subset). Its plumbing
   is unit-tested in `tests/evals/`. The **hosted** providers stay out of the pytest
   gate, but a real **local ollama** run *is* wired into CI as its own workflow —
-  `.github/workflows/e2e-ollama.yml` pulls a small model (`qwen3:1.7b`) and runs the
-  eval over the fixtures (incl. the large multi-file `vibe-multifile` one) on every
-  PR with a long timeout + big `num_ctx` and `--no-reflect` (the reflection pass
-  over-prunes on a small model), proving the pipeline survives a real local model
-  on a large "vibe-coded" diff and still catches the planted bugs (`--min-recall
-  0.3`, pooled across fixtures — every fixture must parse, and total caught /
-  total planted must clear the floor, so a single missed finding on one short
-  fixture can't flake the job). The fixtures plant security + correctness bugs **and** blatant performance
-  (N+1 / quadratic) + complexity (deep nesting / duplication) issues, so the live
-  run exercises all seven code lenses, not just security/correctness — the
-  per-lens coverage is guarded in `tests/evals/test_fixtures.py`. (The eighth
-  lens, intent, needs a stated intent the fixtures don't carry, so the engine
-  skips it there by design.) Real-spend hosted-provider e2e remains label-gated
-  in `action-e2e.yml`.
+  `.github/workflows/e2e-ollama.yml` is a deliberately **cut-down smoke**: it pulls
+  a small model (`qwen3.5:2b`, thinking forced off) and reviews the single small
+  `badcode` fixture through only the two **critical** lenses (`--categories
+  security,correctness`) on every PR with `--no-reflect` (the reflection pass
+  over-prunes on a small model) and qwen3.x's recommended non-thinking sampling
+  (`--temperature 0.6 --top-p 0.8 --top-k 20`). It proves the live ollama path
+  parses and picks up critical issues — not that a small model is thorough — so the
+  floor is low (`--min-recall 0.2`, pooled across fixtures — every fixture must
+  parse, and total caught / total planted must clear the floor). The full lens set
+  and the large multi-file `vibe-multifile` fixture stay in-repo for on-demand
+  `python -m evals.run` runs: the fixtures plant security + correctness bugs **and**
+  blatant performance (N+1 / quadratic) + complexity (deep nesting / duplication)
+  issues so a full run exercises all seven code lenses, with the per-lens coverage
+  guarded in `tests/evals/test_fixtures.py`. (The eighth lens, intent, needs a
+  stated intent the fixtures don't carry, so the engine skips it there by design.)
+  Real-spend hosted-provider e2e remains label-gated in `action-e2e.yml`.
 
 [litellm]: https://github.com/BerriAI/litellm

--- a/evals/run.py
+++ b/evals/run.py
@@ -68,8 +68,7 @@ def _parse_categories(value: str | None) -> list[ReviewCategory] | None:
     unknown = [n for n in names if n not in valid]
     if unknown:
         raise SystemExit(
-            f"unknown categor(y/ies): {', '.join(unknown)}. "
-            f"Available: {', '.join(sorted(valid))}"
+            f"unknown categor(y/ies): {', '.join(unknown)}. Available: {', '.join(sorted(valid))}"
         )
     return [ReviewCategory(n) for n in names]
 

--- a/evals/run.py
+++ b/evals/run.py
@@ -15,7 +15,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from lgtmaybe.core.models import PRContext, Provider, ReviewConfig
+from lgtmaybe.core.models import PRContext, Provider, ReviewCategory, ReviewConfig
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
 from lgtmaybe.providers.factory import build_provider
 
@@ -54,6 +54,26 @@ def _select_fixtures(
     return [(diff, m) for diff, m in fixtures if m.name in wanted]
 
 
+def _parse_categories(value: str | None) -> list[ReviewCategory] | None:
+    """Parse a comma-separated --categories value into review lenses (None = all).
+
+    An unknown name is a hard error, not a silent skip: a typo'd lens would quietly
+    run a different (or empty) fan-out and the recall bar would no longer mean what
+    the CI invocation thinks it does.
+    """
+    if not value:
+        return None
+    valid = {c.value for c in ReviewCategory}
+    names = [n.strip() for n in value.split(",") if n.strip()]
+    unknown = [n for n in names if n not in valid]
+    if unknown:
+        raise SystemExit(
+            f"unknown categor(y/ies): {', '.join(unknown)}. "
+            f"Available: {', '.join(sorted(valid))}"
+        )
+    return [ReviewCategory(n) for n in names]
+
+
 def _review(
     diff: str,
     manifest: Fixture,
@@ -65,6 +85,10 @@ def _review(
     num_ctx: int | None = None,
     max_input_tokens: int | None = None,
     reflect: bool = True,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    top_k: int | None = None,
+    categories: list[ReviewCategory] | None = None,
 ):
     ctx = PRContext(
         diff=diff,
@@ -74,7 +98,11 @@ def _review(
         repo="eval/eval",
         pr_number=0,
     )
-    cfg_overrides = {"max_input_tokens": max_input_tokens} if max_input_tokens is not None else {}
+    cfg_overrides: dict[str, object] = {}
+    if max_input_tokens is not None:
+        cfg_overrides["max_input_tokens"] = max_input_tokens
+    if categories is not None:
+        cfg_overrides["categories"] = categories
     cfg = ReviewConfig(
         provider=provider,
         model=model,
@@ -85,7 +113,19 @@ def _review(
     )
     # num_ctx is ollama's context window — litellm rejects it for hosted providers,
     # so only forward it on the ollama path.
-    extra = {"num_ctx": num_ctx} if (num_ctx is not None and provider is Provider.ollama) else {}
+    extra: dict[str, object] = (
+        {"num_ctx": num_ctx} if (num_ctx is not None and provider is Provider.ollama) else {}
+    )
+    # Sampling params reach the model via the provider's default_opts → litellm.
+    # Only forward the ones explicitly given so an unset flag keeps the model's own
+    # default rather than pinning it to something. litellm.drop_params handles a
+    # param a given provider can't take (e.g. top_k on an OpenAI-compat endpoint).
+    if temperature is not None:
+        extra["temperature"] = temperature
+    if top_p is not None:
+        extra["top_p"] = top_p
+    if top_k is not None:
+        extra["top_k"] = top_k
     engine = LLMReviewEngine(
         build_provider(provider, model, api_base=api_base, timeout=timeout, **extra)
     )
@@ -163,6 +203,30 @@ def main(argv: list[str] | None = None) -> int:
         help="skip the self-reflection pass (weak local models over-prune their own findings)",
     )
     ap.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="sampling temperature forwarded to the model (default: the model's own)",
+    )
+    ap.add_argument(
+        "--top-p",
+        type=float,
+        default=None,
+        help="nucleus-sampling top_p forwarded to the model",
+    )
+    ap.add_argument(
+        "--top-k",
+        type=int,
+        default=None,
+        help="top_k forwarded to the model (ollama/qwen3.x recommend 20 with thinking off)",
+    )
+    ap.add_argument(
+        "--categories",
+        default=None,
+        help="comma-separated review lenses to run (default: all). Cuts the per-category "
+        "fan-out for a fast CI smoke, e.g. 'security,correctness'.",
+    )
+    ap.add_argument(
         "--fixture",
         action="append",
         dest="fixtures",
@@ -173,6 +237,7 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     provider = Provider(args.provider)
+    categories = _parse_categories(args.categories)
     fixtures = _select_fixtures(_load_fixtures(), args.fixtures)
     scores = [
         _review(
@@ -185,6 +250,10 @@ def main(argv: list[str] | None = None) -> int:
             num_ctx=args.num_ctx,
             max_input_tokens=args.max_input_tokens,
             reflect=args.reflect,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            top_k=args.top_k,
+            categories=categories,
         )
         for diff, m in fixtures
     ]

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -8,7 +8,7 @@ import pytest
 
 from evals import run as run_mod
 from evals.scorer import FixtureScore
-from lgtmaybe.core.models import ProviderResult, ReviewFinding, Severity
+from lgtmaybe.core.models import ProviderResult, ReviewCategory, ReviewFinding, Severity
 from tests.fakes import FakeProvider
 
 
@@ -203,6 +203,89 @@ def test_unknown_fixture_name_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.raises(SystemExit):
         run_mod.main(
             ["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--fixture", "nope"]
+        )
+
+
+def test_sampling_params_thread_to_build_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--temperature/--top-p/--top-k reach build_provider so they steer the model.
+
+    They land in the provider's default_opts and litellm forwards them to ollama —
+    the recommended non-thinking sampling for qwen3.x (temp 0.6, top_p 0.8, top_k 20).
+    """
+    calls = _capture_build_provider(monkeypatch)
+
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "x",
+            "--min-recall",
+            "0.0",
+            "--temperature",
+            "0.6",
+            "--top-p",
+            "0.8",
+            "--top-k",
+            "20",
+        ]
+    )
+
+    assert calls, "build_provider was never called"
+    assert calls[0]["temperature"] == pytest.approx(0.6)
+    assert calls[0]["top_p"] == pytest.approx(0.8)
+    assert calls[0]["top_k"] == 20
+
+
+def test_sampling_params_omitted_when_not_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the flags, no sampling kwargs are forced — the model keeps its defaults."""
+    calls = _capture_build_provider(monkeypatch)
+
+    run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"])
+
+    assert calls
+    assert "temperature" not in calls[0]
+    assert "top_p" not in calls[0]
+    assert "top_k" not in calls[0]
+
+
+def test_categories_flag_scopes_review_lenses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--categories cuts the fan-out to a subset so a CI smoke runs fewer model calls."""
+    seen: list[list[ReviewCategory]] = []
+
+    real_review = run_mod.LLMReviewEngine.review
+
+    def spy_review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+        seen.append(list(cfg.categories))
+        return real_review(self, ctx, cfg)
+
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    monkeypatch.setattr(run_mod.LLMReviewEngine, "review", spy_review)
+
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "x",
+            "--min-recall",
+            "0.0",
+            "--categories",
+            "security,correctness",
+        ]
+    )
+
+    assert seen
+    assert all(c == [ReviewCategory.security, ReviewCategory.correctness] for c in seen)
+
+
+def test_unknown_category_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo'd --categories must error, not silently run a different/empty lens set."""
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+
+    with pytest.raises(SystemExit):
+        run_mod.main(
+            ["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--categories", "bogus"]
         )
 
 


### PR DESCRIPTION
## Summary

Extends the eval runner (`evals.run`) with fine-grained control over model sampling behavior and review scope, enabling faster CI smoke tests on small models and on-demand tuning for local runs.

## Changes

- **Sampling parameter flags** (`--temperature`, `--top-p`, `--top-k`): Forward to the provider's `default_opts` → litellm → model, allowing users to steer sampling without code changes. Only explicitly-set flags are forwarded, preserving the model's own defaults when omitted. Supports qwen3.x's recommended non-thinking settings (temp 0.6, top_p 0.8, top_k 20).

- **Category filtering** (`--categories`): Accept a comma-separated list of review lenses (e.g., `security,correctness`) to cut the per-category fan-out. Reduces model calls for fast CI smoke tests. Unknown category names raise `SystemExit` with a helpful error message rather than silently running a different lens set, preventing typos from masking test failures.

- **Test coverage**: Added four new tests:
  - `test_sampling_params_thread_to_build_provider`: Verifies sampling params reach `build_provider`
  - `test_sampling_params_omitted_when_not_given`: Confirms unset flags don't force defaults
  - `test_categories_flag_scopes_review_lenses`: Validates category filtering in the review engine
  - `test_unknown_category_fails_loudly`: Ensures typos in `--categories` fail fast

- **E2E workflow update** (`.github/workflows/e2e-ollama.yml`): Downscaled from a full 9B all-lens run (~25 min, timeout) to a deliberate smoke test:
  - Switched model from `qwen3.5:9b` to `qwen3.5:2b` (CPU-friendly)
  - Runs only the `badcode` fixture through `--categories security,correctness` (two critical lenses instead of seven)
  - Lowered `--min-recall` from 0.3 to 0.2 (a low bar on purpose: proves the path works, not depth)
  - Added qwen3.x recommended sampling flags (`--temperature 0.6 --top-p 0.8 --top-k 20`)
  - Finishes in minutes instead of timing out, unblocking per-PR CI

- **Documentation** (CLAUDE.md): Updated to reflect new flags and the intentionally cut-down smoke-test strategy.

## Implementation details

- `_parse_categories()` validates category names against `ReviewCategory` enum values and raises `SystemExit` on unknown names, preventing silent test failures from typos.
- Sampling params are conditionally added to the `extra` dict passed to `build_provider`, so unset flags don't override model defaults.
- Category overrides are injected into `ReviewConfig` via `cfg_overrides`, scoping the engine's lens fan-out.
- The import of `ReviewCategory` was added to both `evals/run.py` and `tests/evals/test_run.py`.

https://claude.ai/code/session_01P5XwzFVBtE65f2jfF2B5oA