### PR TITLE
Add openai-compatible provider for custom OpenAI /v1 endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,10 @@ variants:
 
 **The wedge:** first-class **Bedrock + Vertex + Azure with keyless OIDC/WIF**.
 Six hosted providers (plus local ollama), one flag, no keys in secrets for
-cloud. We win on auth + simplicity.
+cloud. We win on auth + simplicity. An `openai-compatible` provider is the escape
+hatch for anything else that speaks the OpenAI `/v1` wire format (DeepSeek's API,
+llama.cpp, LM Studio, vLLM) — you bring the `--api-base`, the key is optional —
+so the provider list is never a cage.
 
 ## Non-negotiables
 
@@ -52,10 +55,12 @@ cloud. We win on auth + simplicity.
 | vertex                 | ambient GCP creds (WIF, or local ADC)                            |
 | azure                  | needs the resource endpoint (`--api-base` / `AZURE_API_BASE`); ambient Entra creds (GitHub OIDC federation via `azure/login`, or local `az login` / managed identity) → else `AZURE_API_KEY` / `--api-key` |
 | ollama                 | none — just an `api_base` (localhost, host.docker.internal, tailscale host); fully local, zero cost |
+| openai-compatible      | requires the endpoint (`--api-base` / `OPENAI_COMPATIBLE_API_BASE`); key **optional** — `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, else a placeholder for keyless local servers (llama.cpp / LM Studio / vLLM). litellm `openai/` route to a custom base |
 
 Resolver order: chosen provider → try ambient cloud creds if that's its native
-mode → else API key → ollama needs neither → else **fail with a clear "how to
-auth this provider" message**.
+mode → else API key → ollama needs neither → openai-compatible needs an
+`api_base` (key optional, placeholder when absent) → else **fail with a clear
+"how to auth this provider" message**.
 
 ## Architecture — ports & adapters (hexagonal)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # lgtmaybe
 
-Provider-agnostic PR reviewer. Six hosted providers plus local ollama, one
-flag, no static keys for cloud providers. Posts inline review comments and a
-summary.
+Provider-agnostic PR reviewer. Six hosted providers, local ollama, and any
+OpenAI-compatible endpoint — one flag, no static keys for cloud providers. Posts
+inline review comments and a summary.
 
 📖 **Full documentation:** <https://mattjcoles.github.io/lgtmaybe/>
 
@@ -110,6 +110,7 @@ up the [GitHub Action](#use-as-a-github-action). See
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |
 | `ollama` | None — local only, zero cost |
+| `openai-compatible` | Any OpenAI `/v1` endpoint via `--api-base` (DeepSeek, llama.cpp, LM Studio, vLLM). Key optional — `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, or none for local servers |
 
 ## Documentation
 
@@ -123,6 +124,7 @@ Markdown sources below.
 **How-to guides** — task recipes
 
 - [Run locally with ollama](docs/how-to/run-locally-with-ollama.md)
+- [Use a custom OpenAI-compatible endpoint](docs/how-to/use-a-custom-openai-compatible-endpoint.md)
 - [Review with Bedrock OIDC](docs/how-to/review-with-bedrock-oidc.md)
 - [Review with Vertex WIF](docs/how-to/review-with-vertex-wif.md)
 - [Review with Azure OpenAI](docs/how-to/review-with-azure.md)

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: ""
   timeout:
-    description: "Per-request timeout in seconds for each model call. Leave empty for the provider default (ollama 300, cloud 60)."
+    description: "Per-request timeout in seconds for each model call. Leave empty for the provider default (ollama and openai-compatible 300, cloud 60)."
     required: false
     default: ""
   temperature:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: lgtmaybe
-description: Provider-agnostic PR reviewer — six providers, one flag, no static keys for cloud.
+description: Provider-agnostic PR reviewer — six hosted providers plus ollama and any OpenAI-compatible endpoint, one flag, no static keys for cloud.
 author: Matt Coles
 branding:
   icon: check-circle
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   provider:
-    description: "LLM provider: openai, anthropic, openrouter, bedrock, vertex, azure, or ollama."
+    description: "LLM provider: openai, anthropic, openrouter, bedrock, vertex, azure, ollama, or openai-compatible (any OpenAI /v1 endpoint via api_base — DeepSeek, llama.cpp, LM Studio, vLLM)."
     required: false
     default: ""
   model:
@@ -19,11 +19,11 @@ inputs:
     required: false
     default: ""
   api_key:
-    description: "API key for key-based providers (openai/anthropic/openrouter/azure). Leave empty for bedrock/vertex/ollama."
+    description: "API key for key-based providers (openai/anthropic/openrouter/azure, and openai-compatible hosted endpoints like DeepSeek). Leave empty for bedrock/vertex/ollama and keyless local openai-compatible servers."
     required: false
     default: ""
   api_base:
-    description: "Resource endpoint for azure (https://<resource>.openai.azure.com), or a custom base URL for other providers."
+    description: "Resource endpoint for azure (https://<resource>.openai.azure.com), the OpenAI /v1 base for openai-compatible (e.g. https://api.deepseek.com/v1), or a custom base URL for other providers."
     required: false
     default: ""
   timeout:

--- a/docs/explanation/auth-model.md
+++ b/docs/explanation/auth-model.md
@@ -1,11 +1,13 @@
 # Auth Model
 
-lgtmaybe supports six hosted providers plus local ollama. The design principle is **no static cloud
-credentials**: cloud providers use ambient, short-lived tokens; key-based SaaS
-providers (openai, anthropic, openrouter) require an API key that stays in
-secrets rather than being committed to config. Azure straddles both — it prefers
-ambient Azure AD (Entra) credentials but accepts a resource key — and always
-needs the resource endpoint (`AZURE_API_BASE`), since each Azure OpenAI
+lgtmaybe supports six hosted providers plus local ollama, and an
+`openai-compatible` escape hatch for any server speaking the OpenAI `/v1` wire
+format (DeepSeek's API, llama.cpp, LM Studio, vLLM). The design principle is **no
+static cloud credentials**: cloud providers use ambient, short-lived tokens;
+key-based SaaS providers (openai, anthropic, openrouter) require an API key that
+stays in secrets rather than being committed to config. Azure straddles both — it
+prefers ambient Azure AD (Entra) credentials but accepts a resource key — and
+always needs the resource endpoint (`AZURE_API_BASE`), since each Azure OpenAI
 deployment lives at its own URL.
 
 ## Why keyless for cloud
@@ -50,6 +52,12 @@ chain:
    available, lgtmaybe fails with a message naming both options.
 5. **None** — ollama requires no credentials. Only `--api-base` is needed
    to reach the local or remote server.
+6. **openai-compatible** — always needs the endpoint (`--api-base` or
+   `OPENAI_COMPATIBLE_API_BASE`), since the whole point is to choose your own.
+   The key is **optional**: hosted endpoints like DeepSeek take one
+   (`--api-key` / `OPENAI_COMPATIBLE_API_KEY`), while local servers (llama.cpp,
+   LM Studio, vLLM) need none — lgtmaybe sends a harmless placeholder key when
+   you supply none, because the underlying OpenAI client rejects an empty one.
 
 ## Provider auth summary
 
@@ -62,6 +70,7 @@ chain:
 | vertex | Ambient GCP creds | GitHub WIF or local ADC (`gcloud auth application-default login`) |
 | azure | Ambient Azure AD creds (keyless) or API key, + endpoint | GitHub OIDC → Entra federated credential, or local `az login` / managed identity; or `AZURE_API_KEY`. Always with `AZURE_API_BASE` / `--api-base` |
 | ollama | None | `--api-base` pointing to the local or remote server |
+| openai-compatible | Optional key, + endpoint | `--api-base` / `OPENAI_COMPATIBLE_API_BASE` (e.g. `https://api.deepseek.com/v1` or `http://localhost:8000/v1`); key via `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, or none for keyless local servers |
 
 ## Least-privilege IAM
 

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -136,7 +136,10 @@ def generate() -> str:
             "LLM backend selected by `--provider`. "
             "Cloud providers (`bedrock`, `vertex`, `azure`) use ambient "
             "credentials — `azure` also needs the resource endpoint "
-            "(`--api-base`) and accepts a key as an alternative.",
+            "(`--api-base`) and accepts a key as an alternative. "
+            "`openai-compatible` points at any server speaking the OpenAI `/v1` "
+            "wire format (DeepSeek, llama.cpp, LM Studio, vLLM) via `--api-base`; "
+            "the key is optional so keyless local servers work.",
         )
     )
     sections.append(

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -1,0 +1,100 @@
+# Use a Custom OpenAI-Compatible Endpoint
+
+Lots of model servers speak the OpenAI `/v1` wire format: [DeepSeek's API][deepseek],
+[llama.cpp][llamacpp]'s server, [LM Studio][lmstudio], [vLLM][vllm], and many
+hosted proxies. The `openai-compatible` provider points lgtmaybe at any of them —
+you supply the base URL, and (if the server wants one) a key.
+
+This is the answer to "I don't want to be limited to the built-in provider list":
+anything that exposes an OpenAI-compatible `/v1` endpoint works through one flag.
+
+## How it works
+
+`--provider openai-compatible` routes through litellm's OpenAI client, but sends
+your requests to the `--api-base` you give instead of `api.openai.com`. The
+**base URL is required** (that's the whole point); the **API key is optional**:
+
+- **Hosted endpoints** (DeepSeek, a paid proxy) need a key — pass `--api-key` or
+  set `OPENAI_COMPATIBLE_API_KEY`.
+- **Local servers** (llama.cpp, LM Studio, vLLM) usually need none. lgtmaybe
+  sends a harmless placeholder key in that case, because the OpenAI client rejects
+  an empty one.
+
+The API key, when you do supply one, is read from the environment or `--api-key`
+and is **never persisted** to config.
+
+## DeepSeek (hosted, keyed)
+
+```bash
+export OPENAI_COMPATIBLE_API_KEY=sk-...        # your DeepSeek key
+
+lgtmaybe review \
+  --provider openai-compatible \
+  --model deepseek-chat \
+  --api-base https://api.deepseek.com/v1
+```
+
+You can pass the key inline with `--api-key sk-...` instead of the env var.
+
+## llama.cpp (local, keyless)
+
+Start the server:
+
+```bash
+llama-server -m ./model.gguf --port 8000        # serves the OpenAI API at /v1
+```
+
+Then review against it — no key needed:
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model local-model \
+  --api-base http://localhost:8000/v1
+```
+
+## LM Studio (local, keyless)
+
+Enable the local server in LM Studio (it serves the OpenAI API, default port
+`1234`), then:
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model your-loaded-model \
+  --api-base http://localhost:1234/v1
+```
+
+## vLLM (local or self-hosted, keyless)
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
+```
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --api-base http://localhost:8000/v1
+```
+
+## Persist it in `.lgtmaybe.yml`
+
+The provider, model, and base URL are non-secret defaults, so they can live in
+config (the key stays in the environment):
+
+```yaml
+provider: openai-compatible
+model: deepseek-chat
+api_base: https://api.deepseek.com/v1
+```
+
+With that file in place, `lgtmaybe review` needs no flags. In the GitHub Action,
+set the same values as inputs (or in `.lgtmaybe.yml`) and pass `api_key` from a
+secret for hosted endpoints; leave it empty for keyless local servers reached at
+`http://host.docker.internal:<port>/v1`.
+
+[deepseek]: https://api-docs.deepseek.com/
+[llamacpp]: https://github.com/ggml-org/llama.cpp
+[lmstudio]: https://lmstudio.ai/
+[vllm]: https://docs.vllm.ai/

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -23,6 +23,10 @@ your requests to the `--api-base` you give instead of `api.openai.com`. The
 The API key, when you do supply one, is read from the environment or `--api-key`
 and is **never persisted** to config.
 
+Because the endpoint might be a slow local model, `openai-compatible` defaults to
+the same generous **300s** per-call timeout as ollama. For a fast hosted endpoint
+like DeepSeek you can dial it down with `--timeout` (or `timeout:` in config).
+
 ## DeepSeek (hosted, keyed)
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@
 
 </div>
 
-Provider-agnostic PR reviewer. Six hosted providers plus local ollama, one
-flag, and no static keys for cloud providers. It posts inline comments and a
-summary straight onto the pull request.
+Provider-agnostic PR reviewer. Six hosted providers, local ollama, and any
+OpenAI-compatible endpoint — one flag, and no static keys for cloud providers. It
+posts inline comments and a summary straight onto the pull request.
 
 lgtmaybe reviews the lines a change touches, and it runs in two places: as a
 GitHub Action on a pull request, or locally from the command line against your

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -22,7 +22,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `info` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
-| `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openrouter` / `vertex` | Yes | — |  |
+| `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` | Yes | — |  |
 | `reflect` | boolean | No | `True` | Reflect |
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `temperature` | number | No | `0.0` | Temperature |
@@ -32,13 +32,14 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 
 ### Provider
 
-LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`, `azure`) use ambient credentials — `azure` also needs the resource endpoint (`--api-base`) and accepts a key as an alternative.
+LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`, `azure`) use ambient credentials — `azure` also needs the resource endpoint (`--api-base`) and accepts a key as an alternative. `openai-compatible` points at any server speaking the OpenAI `/v1` wire format (DeepSeek, llama.cpp, LM Studio, vLLM) via `--api-base`; the key is optional so keyless local servers work.
 
 - `anthropic`
 - `azure`
 - `bedrock`
 - `ollama`
 - `openai`
+- `openai-compatible`
 - `openrouter`
 - `vertex`
 
@@ -111,7 +112,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "bedrock",
         "vertex",
         "azure",
-        "ollama"
+        "ollama",
+        "openai-compatible"
       ],
       "title": "Provider",
       "type": "string"

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -1,0 +1,44 @@
+# Copy into your repo at .github/workflows/lgtmaybe.yml
+#
+# OpenAI-compatible endpoint — any server speaking the OpenAI /v1 wire format
+# (DeepSeek's API, a self-hosted vLLM, an OpenAI-compatible proxy). Set api_base
+# to the endpoint. Add a key secret for hosted endpoints; leave api_key empty for
+# keyless self-hosted servers.
+name: lgtmaybe (openai-compatible)
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+# pull_request_target runs against the BASE repo (secrets available); the action
+# only ever reads the diff via the API and never checks out PR code.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only trusted authors (repo owner / org member / collaborator) can trigger a
+    # review, so fork PRs and drive-by /ask or /review comments from strangers
+    # cannot spend your provider budget. A maintainer can still opt-in to an
+    # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    if: >-
+      (github.event_name == 'pull_request_target' &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6 # base repo only — for .lgtmaybe.yml config
+      - uses: MattJColes/lgtmaybe@v0
+        with:
+          provider: openai-compatible
+          model: deepseek-chat
+          api_base: https://api.deepseek.com/v1
+          # Hosted endpoints need a key; omit api_key for keyless self-hosted servers.
+          api_key: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: lgtmaybe
-site_description: Provider-agnostic PR reviewer — six providers, one flag, no keys in secrets for cloud.
+site_description: Provider-agnostic PR reviewer — six hosted providers, ollama, and any OpenAI-compatible endpoint, one flag, no keys in secrets for cloud.
 site_url: https://mattjcoles.github.io/lgtmaybe/
 repo_url: https://github.com/MattJColes/lgtmaybe
 repo_name: MattJColes/lgtmaybe
@@ -61,6 +61,7 @@ nav:
       - Getting started: tutorial/getting-started.md
   - How-to:
       - Run locally with ollama: how-to/run-locally-with-ollama.md
+      - Use a custom OpenAI-compatible endpoint: how-to/use-a-custom-openai-compatible-endpoint.md
       - Fix findings with an AI agent: how-to/fix-findings-with-an-ai-agent.md
       - Review with Bedrock OIDC: how-to/review-with-bedrock-oidc.md
       - Review with Vertex WIF: how-to/review-with-vertex-wif.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lgtmaybe"
 version = "0.1.6"
-description = "Provider-agnostic PR reviewer — six providers, one flag, no keys in secrets for cloud."
+description = "Provider-agnostic PR reviewer — six hosted providers, ollama, and any OpenAI-compatible endpoint, one flag, no keys in secrets for cloud."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.12"

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -32,7 +32,8 @@ from lgtmaybe.config.loader import load_config
 @click.option(
     "--provider",
     default=None,
-    help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, openrouter)",
+    help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, "
+    "openrouter, openai-compatible)",
 )
 @click.option("--model", default=None, help="Model name understood by the chosen provider")
 @click.option(
@@ -50,7 +51,9 @@ from lgtmaybe.config.loader import load_config
     "--api-base",
     default=None,
     help="API base URL (ollama: http://localhost:11434; "
-    "azure: https://<resource>.openai.azure.com)",
+    "azure: https://<resource>.openai.azure.com; "
+    "openai-compatible: any OpenAI /v1 endpoint, e.g. https://api.deepseek.com/v1 "
+    "or http://localhost:8000/v1)",
 )
 @click.option(
     "--min-severity",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -71,6 +71,9 @@ class Provider(StrEnum):
     vertex = "vertex"
     azure = "azure"
     ollama = "ollama"
+    # Any server speaking the OpenAI /v1 wire format, reached via --api-base:
+    # DeepSeek's API, llama.cpp, LM Studio, vLLM, and other proxies. Key optional.
+    openai_compatible = "openai-compatible"
 
 
 class _Strict(BaseModel):

--- a/src/lgtmaybe/providers/constants.py
+++ b/src/lgtmaybe/providers/constants.py
@@ -6,3 +6,8 @@ from __future__ import annotations
 # resolver (to fill AuthConfig.api_base) and the factory (to configure the
 # litellm client) so the two never drift.
 DEFAULT_OLLAMA_BASE = "http://localhost:11434"
+
+# Sent as the api_key for an `openai-compatible` endpoint when the user supplies
+# none. Local servers (llama.cpp / LM Studio / vLLM) need no auth, but the OpenAI
+# client litellm uses rejects an empty key — so we pass this harmless placeholder.
+OPENAI_COMPATIBLE_PLACEHOLDER_KEY = "lgtmaybe-no-key"

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -13,7 +13,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from lgtmaybe.core.models import Provider
-from lgtmaybe.providers.constants import DEFAULT_OLLAMA_BASE
+from lgtmaybe.providers.constants import (
+    DEFAULT_OLLAMA_BASE,
+    OPENAI_COMPATIBLE_PLACEHOLDER_KEY,
+)
 
 
 @dataclass(frozen=True)
@@ -179,6 +182,26 @@ def resolve_credentials(
 
     if provider is Provider.ollama:
         return AuthConfig(api_base=api_base or DEFAULT_OLLAMA_BASE)
+
+    if provider is Provider.openai_compatible:
+        import os
+
+        base = api_base or os.environ.get("OPENAI_COMPATIBLE_API_BASE")
+        if not base:
+            raise ValueError(
+                "openai-compatible requires a base URL. Pass --api-base "
+                "(e.g. http://localhost:8000/v1 for llama.cpp / LM Studio / vLLM, "
+                "or https://api.deepseek.com/v1) or set OPENAI_COMPATIBLE_API_BASE."
+            )
+        # Key is optional: hosted endpoints (DeepSeek) need one, local servers
+        # don't. When absent we still send a placeholder — the OpenAI client
+        # litellm uses rejects an empty key.
+        key = (
+            api_key
+            or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
+            or OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+        )
+        return AuthConfig(api_key=key, api_base=base)
 
     # API-key providers: openai, anthropic, openrouter
     _ENV_VAR: dict[Provider, str] = {

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -33,10 +33,16 @@ _PREFIXES: dict[Provider, str] = {
 }
 
 # Default per-request timeout (seconds) when the caller doesn't set one. Local
-# models on ollama are slow — and the per-category fan-out runs them serially —
-# so ollama gets a generous default; cloud providers respond fast.
-_OLLAMA_TIMEOUT = 300
+# models are slow — and the per-category fan-out runs them serially — so the
+# providers that can front a local server (ollama, and openai-compatible pointing
+# at llama.cpp / LM Studio / vLLM) get a generous default; cloud providers respond
+# fast. An explicit --timeout always wins, so a fast cloud openai-compatible
+# endpoint (e.g. DeepSeek) can dial it down.
+_LOCAL_TIMEOUT = 300
 _CLOUD_TIMEOUT = 60
+
+# Providers whose endpoint may be a slow, locally hosted model.
+_LOCAL_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible})
 
 # Ollama context window. Big enough to hold a real review prompt + diff + the
 # emitted findings; ollama's own default (~4k) truncates the output to a stub.
@@ -47,7 +53,7 @@ _OLLAMA_NUM_CTX = 32768
 
 def default_timeout_for(provider: Provider) -> int:
     """The auto timeout (seconds) for a provider when none is given explicitly."""
-    return _OLLAMA_TIMEOUT if provider is Provider.ollama else _CLOUD_TIMEOUT
+    return _LOCAL_TIMEOUT if provider in _LOCAL_CAPABLE else _CLOUD_TIMEOUT
 
 
 def litellm_model_string(provider: Provider, model: str) -> str:

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -8,6 +8,7 @@ litellm model-string conventions:
   vertex     → vertex_ai/<model>
   azure      → azure/<model>   (+ api_base = resource endpoint)
   ollama     → ollama/<model>  (+ api_base)
+  openai-compatible → openai/<model>  (+ api_base = custom endpoint)
 """
 
 from __future__ import annotations
@@ -26,6 +27,9 @@ _PREFIXES: dict[Provider, str] = {
     Provider.vertex: "vertex_ai",
     Provider.azure: "azure",
     Provider.ollama: "ollama",
+    # OpenAI-compatible servers (DeepSeek, llama.cpp, LM Studio, vLLM) ride the
+    # openai route; the custom endpoint comes through api_base.
+    Provider.openai_compatible: "openai",
 }
 
 # Default per-request timeout (seconds) when the caller doesn't set one. Local

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -102,6 +102,15 @@ CASES = [
         True,
     ),
     ("ollama", "ollama", "llama3", [], {}, "ollama/llama3", False),
+    (
+        "openai-compatible",
+        "openai-compatible",
+        "deepseek-chat",
+        ["--api-key", "sk-x", "--api-base", "https://api.deepseek.com/v1"],
+        {},
+        "openai/deepseek-chat",
+        True,
+    ),
 ]
 
 
@@ -148,6 +157,56 @@ def test_ollama_call_carries_api_base(captured_completion: list[dict[str, Any]])
 
     assert result.exit_code == 0, result.output
     assert captured_completion[0].get("api_base")
+
+
+def test_openai_compatible_call_carries_custom_base(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """A custom OpenAI-compatible endpoint must reach litellm with its api_base."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openai-compatible",
+            "--model",
+            "deepseek-chat",
+            "--api-base",
+            "https://api.deepseek.com/v1",
+            "--api-key",
+            "sk-x",
+            "--no-reflect",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("api_base") == "https://api.deepseek.com/v1"
+
+
+def test_openai_compatible_keyless_local_server_sends_base_and_placeholder(
+    captured_completion: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local llama.cpp / LM Studio / vLLM server needs no key — the base reaches
+    litellm and a placeholder key is supplied (the OpenAI client demands one)."""
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openai-compatible",
+            "--model",
+            "local-model",
+            "--api-base",
+            "http://localhost:8000/v1",
+            "--no-reflect",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("api_base") == "http://localhost:8000/v1"
+    assert captured_completion[0].get("api_key")
 
 
 def test_num_ctx_flag_reaches_litellm_for_ollama(

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -178,6 +178,51 @@ class TestAzure:
         assert "OIDC" in msg or "keyless" in msg.lower()
 
 
+class TestOpenAICompatible:
+    """Custom OpenAI-compatible endpoints: DeepSeek, llama.cpp, LM Studio, vLLM."""
+
+    def test_requires_a_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_COMPATIBLE_API_BASE", raising=False)
+        with pytest.raises(ValueError, match="openai-compatible") as exc_info:
+            resolve_credentials(Provider.openai_compatible)
+        assert "api-base" in str(exc_info.value) or "base URL" in str(exc_info.value)
+
+    def test_with_api_key_and_base_resolves(self) -> None:
+        config = resolve_credentials(
+            Provider.openai_compatible,
+            api_key="sk-deepseek",
+            api_base="https://api.deepseek.com/v1",
+        )
+        assert config.api_key == "sk-deepseek"
+        assert config.api_base == "https://api.deepseek.com/v1"
+
+    def test_reads_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "sk-env")
+        config = resolve_credentials(
+            Provider.openai_compatible,
+            api_base="https://api.deepseek.com/v1",
+        )
+        assert config.api_key == "sk-env"
+
+    def test_reads_base_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_BASE", "http://localhost:8000/v1")
+        config = resolve_credentials(Provider.openai_compatible, api_key="sk-x")
+        assert config.api_base == "http://localhost:8000/v1"
+
+    def test_keyless_local_server_uses_placeholder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """llama.cpp / LM Studio / vLLM need no key — but the OpenAI client demands
+        a non-empty one, so a harmless placeholder is sent and the base preserved."""
+        from lgtmaybe.providers.constants import OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+
+        monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+        config = resolve_credentials(
+            Provider.openai_compatible,
+            api_base="http://localhost:8000/v1",
+        )
+        assert config.api_key == OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+        assert config.api_base == "http://localhost:8000/v1"
+
+
 class TestOllama:
     def test_ollama_resolves_with_no_key_or_creds(self) -> None:
         config = resolve_credentials(Provider.ollama)

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -40,6 +40,14 @@ class TestLiteLLMModelString:
     def test_azure_prefix(self) -> None:
         assert litellm_model_string(Provider.azure, "gpt-4o") == "azure/gpt-4o"
 
+    def test_openai_compatible_uses_openai_prefix(self) -> None:
+        # litellm routes any OpenAI-compatible server through the openai prefix +
+        # a custom api_base (DeepSeek, llama.cpp, LM Studio, vLLM).
+        assert (
+            litellm_model_string(Provider.openai_compatible, "deepseek-chat")
+            == "openai/deepseek-chat"
+        )
+
 
 class TestBuildProvider:
     def test_build_provider_returns_litellm_provider(self) -> None:
@@ -89,6 +97,29 @@ class TestBuildProvider:
         assert provider.default_opts.get("azure_ad_token") == "ad-token-xyz"
         assert provider.default_opts.get("api_base") == "https://my-resource.openai.azure.com"
         assert "api_key" not in provider.default_opts
+
+    def test_build_provider_openai_compatible_carries_key_and_base(self) -> None:
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        provider = build_provider(
+            Provider.openai_compatible,
+            "deepseek-chat",
+            api_key="sk-deepseek",
+            api_base="https://api.deepseek.com/v1",
+        )
+        assert isinstance(provider, LiteLLMProvider)
+        assert provider.default_opts.get("api_key") == "sk-deepseek"
+        assert provider.default_opts.get("api_base") == "https://api.deepseek.com/v1"
+        assert provider.model == "openai/deepseek-chat"
+
+    def test_build_provider_openai_compatible_gets_cloud_timeout(self) -> None:
+        provider = build_provider(
+            Provider.openai_compatible,
+            "deepseek-chat",
+            api_key="sk-x",
+            api_base="https://api.deepseek.com/v1",
+        )
+        assert provider.default_opts.get("timeout") == 60
 
     def test_build_provider_stores_resolved_model_string(self) -> None:
         provider = build_provider(Provider.bedrock, "anthropic.claude-3-haiku-20240307-v1:0")

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -112,14 +112,26 @@ class TestBuildProvider:
         assert provider.default_opts.get("api_base") == "https://api.deepseek.com/v1"
         assert provider.model == "openai/deepseek-chat"
 
-    def test_build_provider_openai_compatible_gets_cloud_timeout(self) -> None:
+    def test_build_provider_openai_compatible_gets_the_long_local_timeout(self) -> None:
+        # The endpoint may be a slow local server (llama.cpp / LM Studio / vLLM),
+        # so default to the generous timeout — overridable for fast cloud endpoints.
         provider = build_provider(
             Provider.openai_compatible,
             "deepseek-chat",
             api_key="sk-x",
             api_base="https://api.deepseek.com/v1",
         )
-        assert provider.default_opts.get("timeout") == 60
+        assert provider.default_opts.get("timeout") == 300
+
+    def test_openai_compatible_timeout_is_overridable(self) -> None:
+        provider = build_provider(
+            Provider.openai_compatible,
+            "deepseek-chat",
+            api_key="sk-x",
+            api_base="https://api.deepseek.com/v1",
+            timeout=30,
+        )
+        assert provider.default_opts.get("timeout") == 30
 
     def test_build_provider_stores_resolved_model_string(self) -> None:
         provider = build_provider(Provider.bedrock, "anthropic.claude-3-haiku-20240307-v1:0")
@@ -176,6 +188,14 @@ class TestDefaultTimeout:
         from lgtmaybe.providers.factory import default_timeout_for
 
         assert default_timeout_for(Provider.ollama) > default_timeout_for(Provider.openai)
+
+    def test_openai_compatible_default_matches_ollama(self) -> None:
+        # Both can front a slow local model, so they share the generous default.
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert default_timeout_for(Provider.openai_compatible) == default_timeout_for(
+            Provider.ollama
+        )
 
     def test_build_provider_threads_temperature_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", temperature=0.0)

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -30,6 +30,8 @@ EXPECTED_PREFIX: dict[Provider, str] = {
     Provider.vertex: "vertex_ai/",
     Provider.azure: "azure/",
     Provider.ollama: "ollama/",
+    # OpenAI-compatible servers ride the openai route with a custom api_base.
+    Provider.openai_compatible: "openai/",
 }
 
 # Providers that authenticate with an API key, and the env var that supplies it.
@@ -44,6 +46,9 @@ CLOUD_PROVIDERS = (Provider.bedrock, Provider.vertex)
 NO_AUTH_PROVIDERS = (Provider.ollama,)
 # Hybrid: always needs an endpoint, then EITHER a key OR an ambient AD token.
 HYBRID_PROVIDERS = (Provider.azure,)
+# Custom endpoint: always needs an api_base; the key is optional (placeholder
+# sent for keyless local servers).
+ENDPOINT_PROVIDERS = (Provider.openai_compatible,)
 
 
 def test_every_provider_is_classified_exactly_once() -> None:
@@ -58,6 +63,7 @@ def test_every_provider_is_classified_exactly_once() -> None:
         set(CLOUD_PROVIDERS),
         set(NO_AUTH_PROVIDERS),
         set(HYBRID_PROVIDERS),
+        set(ENDPOINT_PROVIDERS),
     ]
     union = set().union(*auth_classes)
     assert union == set(Provider)
@@ -155,3 +161,36 @@ class TestHybridProviderCredentials:
     def test_build_provider_threads_the_endpoint(self, provider: Provider) -> None:
         built = build_provider(provider, "gpt-4o", api_key="k", api_base=_AZURE_BASE)
         assert built.default_opts.get("api_base") == _AZURE_BASE
+
+
+_CUSTOM_BASE = "https://api.deepseek.com/v1"
+
+
+@pytest.mark.parametrize("provider", ENDPOINT_PROVIDERS)
+class TestEndpointProviderCredentials:
+    """openai-compatible: always needs an api_base; the key is optional.
+
+    Hosted endpoints (DeepSeek) take a key; local servers (llama.cpp / LM Studio /
+    vLLM) take none — and lgtmaybe supplies a placeholder so the OpenAI client,
+    which rejects an empty key, still works.
+    """
+
+    def test_requires_an_endpoint(self, provider: Provider) -> None:
+        with pytest.raises(ValueError, match=provider.value):
+            resolve_credentials(provider, api_key="k")
+
+    def test_explicit_key_and_base_resolve(self, provider: Provider) -> None:
+        cfg = resolve_credentials(provider, api_key="sk-x", api_base=_CUSTOM_BASE)
+        assert cfg.api_key == "sk-x"
+        assert cfg.api_base == _CUSTOM_BASE
+
+    def test_keyless_base_resolves_with_a_placeholder(self, provider: Provider) -> None:
+        from lgtmaybe.providers.constants import OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+
+        cfg = resolve_credentials(provider, api_base=_CUSTOM_BASE)
+        assert cfg.api_key == OPENAI_COMPATIBLE_PLACEHOLDER_KEY
+        assert cfg.api_base == _CUSTOM_BASE
+
+    def test_build_provider_threads_the_endpoint(self, provider: Provider) -> None:
+        built = build_provider(provider, "deepseek-chat", api_key="k", api_base=_CUSTOM_BASE)
+        assert built.default_opts.get("api_base") == _CUSTOM_BASE

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -9,7 +9,8 @@
         "bedrock",
         "vertex",
         "azure",
-        "ollama"
+        "ollama",
+        "openai-compatible"
       ],
       "title": "Provider",
       "type": "string"


### PR DESCRIPTION
## Summary

Adds support for any server speaking the OpenAI `/v1` wire format as a first-class provider. This includes DeepSeek's API, llama.cpp, LM Studio, vLLM, and other OpenAI-compatible proxies. Users supply `--api-base` to point at their endpoint; the API key is optional (hosted endpoints like DeepSeek take one, local servers don't).

## Key Changes

- **New provider enum:** `Provider.openai_compatible` in `core/models.py`
- **Credential resolution:** `resolve_credentials()` in `providers/credentials.py` handles the `openai-compatible` case:
  - Requires `--api-base` or `OPENAI_COMPATIBLE_API_BASE` env var (the whole point of the provider)
  - Key is optional: reads from `--api-key` or `OPENAI_COMPATIBLE_API_KEY` env var
  - When no key is supplied, sends a harmless placeholder (`OPENAI_COMPATIBLE_PLACEHOLDER_KEY = "lgtmaybe-no-key"`) because the underlying OpenAI client rejects an empty key
- **Factory support:** `litellm_model_string()` routes `openai-compatible` through the `openai/` prefix with a custom `api_base`
- **Provider classification:** Added `ENDPOINT_PROVIDERS` tuple in test matrix to distinguish providers that always need an endpoint
- **Documentation:**
  - New how-to guide: `docs/how-to/use-a-custom-openai-compatible-endpoint.md` with examples for DeepSeek, llama.cpp, LM Studio, and vLLM
  - Updated auth model docs to explain the optional-key behavior
  - Updated CLI help text and action.yml to mention the new provider
  - Example GitHub Actions workflow: `examples/workflows/review-openai-compatible.yml`
- **Tests:**
  - Credential resolution tests for keyed (DeepSeek) and keyless (local server) modes
  - CLI integration tests verifying `api_base` and placeholder key reach litellm
  - Provider matrix tests ensuring the endpoint is threaded through correctly

## Implementation Details

The `openai-compatible` provider is a thin escape hatch: it routes all requests through litellm's OpenAI client (using the `openai/` prefix) but overrides the `api_base` to point at the user's endpoint. This works because litellm's OpenAI adapter accepts a custom base URL, so any server that mimics the OpenAI `/v1` API surface (models, completions, etc.) works transparently.

The placeholder key design is intentional: local servers (llama.cpp, LM Studio, vLLM) typically don't authenticate, but the OpenAI Python client requires a non-empty key. Rather than special-case the client or ask users to pass a dummy value, we send a known placeholder and document it clearly.

Config (provider, model, api_base) can be persisted in `.lgtmaybe.yml`; the API key stays in the environment or `--api-key` flag and is never written to disk.

https://claude.ai/code/session_01TSxQLcwvb8c24HxkkaKVqW