### PR TITLE
ci: add lgtmaybe self-review workflow (openai gpt-5.5)

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -1,0 +1,39 @@
+# Dogfood: lgtmaybe reviews its own PRs with OpenAI gpt-5.5.
+# Runs the in-repo action (./) so changes to action.yml are exercised too.
+# Add an OPENAI_API_KEY repo secret.
+name: lgtmaybe
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+# pull_request_target runs against the BASE repo (secrets available); the action
+# only ever reads the diff via the API and never checks out PR code.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only trusted authors (repo owner / org member / collaborator) can trigger a
+    # review, so fork PRs and drive-by /ask or /review comments from strangers
+    # cannot spend the provider budget. A maintainer can still opt-in to an
+    # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    if: >-
+      (github.event_name == 'pull_request_target' &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6 # base repo only — for action.yml + .lgtmaybe.yml config
+      - uses: ./
+        with:
+          provider: openai
+          model: gpt-5.5
+          api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Dogfood lgtmaybe on its own PRs using OpenAI **gpt-5.5**.

- Runs the in-repo action (`uses: ./`) so changes to `action.yml` are exercised too.
- Triggers on `pull_request_target` (full review) and `issue_comment` (slash commands).
- Gated to trusted authors (OWNER/MEMBER/COLLABORATOR) so fork PRs and stranger comments can't spend the provider budget.
- Minimal perms: `contents: read`, `pull-requests: write`. Never checks out PR code.

**Action required before this works:** add an `OPENAI_API_KEY` repo secret.

Because `pull_request_target` reads the workflow from the base branch, this must merge to `main` first — then it'll review subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)