### PR TITLE
fix: retry without temperature when a model rejects the value

### DIFF
--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -17,6 +17,18 @@ from lgtmaybe.core.ports import Message, ProviderClient
 _DEFAULT_TIMEOUT = 60  # seconds
 _MAX_ATTEMPTS = 4
 
+
+def _rejects_temperature(exc: Exception) -> bool:
+    """True when an API error means the model accepts the ``temperature`` param
+    but not the value we sent (e.g. OpenAI's gpt-5.x: "'temperature' does not
+    support 0 ... Only the default (1) value is supported"). ``drop_params`` does
+    not catch this — the param is supported, only the value is rejected."""
+    msg = str(exc).lower()
+    return "temperature" in msg and (
+        "does not support" in msg or "unsupported value" in msg or "only the default" in msg
+    )
+
+
 # We always send ``temperature`` (for determinism) and ``response_format`` (for
 # structured JSON output), but not every model accepts them: some bedrock-hosted
 # models (e.g. ``openai.gpt-5.5``) reject both and litellm raises
@@ -64,7 +76,15 @@ class LiteLLMProvider(ProviderClient):
             reraise=True,
         )
         def _call() -> ProviderResult:
-            response = litellm.completion(model=model, messages=messages, **kwargs)
+            try:
+                response = litellm.completion(model=model, messages=messages, **kwargs)
+            except Exception as exc:
+                if "temperature" not in kwargs or not _rejects_temperature(exc):
+                    raise
+                # Drop temperature for this and every subsequent retry, letting the
+                # model use its only supported value (its default).
+                kwargs.pop("temperature")
+                response = litellm.completion(model=model, messages=messages, **kwargs)
             return self._map_response(response, model)
 
         return _call()

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -46,6 +46,42 @@ class TestRetry:
                 provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
 
 
+class TestTemperatureRejection:
+    def test_retries_without_temperature_when_model_rejects_the_value(self) -> None:
+        """Models like gpt-5.5 accept the temperature param but only the default
+        value; on that rejection the provider retries without temperature."""
+        good = _fake_response("ok without temperature")
+        seen_temperatures: list[Any] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen_temperatures.append(kwargs.get("temperature", "absent"))
+            if "temperature" in kwargs:
+                raise RuntimeError(
+                    "litellm.BadRequestError: OpenAIException - Unsupported value: "
+                    "'temperature' does not support 0 with this model. Only the "
+                    "default (1) value is supported."
+                )
+            return good
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
+            )
+
+        assert result.text == "ok without temperature"
+        assert seen_temperatures == [0.0, "absent"]
+
+    def test_unrelated_bad_request_is_not_swallowed(self) -> None:
+        """A non-temperature error must still propagate, not be retried bare."""
+        with patch("litellm.completion", side_effect=RuntimeError("invalid api key")):
+            provider = LiteLLMProvider()
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
+                )
+
+
 class TestFallback:
     def test_primary_fails_hard_fallback_model_is_used(self) -> None:
         """After primary exhausts retries, fallback model is tried."""


### PR DESCRIPTION
## Problem

The new self-review workflow (#82) failed on its first run against **gpt-5.5**:

```
OpenAIException - Unsupported value: 'temperature' does not support 0 with this model.
Only the default (1) value is supported.
```

lgtmaybe sends `temperature=0` by default (for deterministic reviews), but OpenAI's gpt-5.x line accepts the `temperature` *param* yet only its default *value* of `1`. So every per-lens call 400'd and the whole review failed. litellm's `drop_params` doesn't catch this — the parameter is supported, only the value is rejected.

## Fix

Detect that specific rejection in `LiteLLMProvider` and retry the call once **without** `temperature`, letting the model fall back to its default. The drop persists across tenacity retries. Unrelated `BadRequestError`s (bad key, bad model, etc.) still propagate untouched.

## Tests

- `test_retries_without_temperature_when_model_rejects_the_value` — first call (with `temperature`) 400s, retry without it succeeds; asserts the second call omitted the param.
- `test_unrelated_bad_request_is_not_swallowed` — a non-temperature error still raises.

132 provider tests pass; ruff clean.

> Note: the merged `lgtmaybe.yml` runs the released GHCR image, so this fix takes effect there only after the next release. Setting `temperature: "1"` in the workflow is an optional bridge until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)