### PR TITLE
fix: fail fast on permanent provider errors and bound the lens fan-out

### DIFF
--- a/.github/workflows/action-e2e.yml
+++ b/.github/workflows/action-e2e.yml
@@ -41,6 +41,9 @@ jobs:
     # Only when the PR is opted-in via label, so real spend never runs by default.
     if: contains(github.event.pull_request.labels.*.name, 'lgtmaybe-e2e')
     runs-on: ubuntu-latest
+    # Each leg builds an image + runs one real review; cap it so a hung provider
+    # call can't hold the runner for GitHub's 6-hour default.
+    timeout-minutes: 20
     name: ${{ matrix.provider }}
     strategy:
       fail-fast: false

--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -40,5 +40,5 @@ jobs:
       - uses: ./
         with:
           provider: openai
-          model: gpt-5.5
+          model: gpt-5.4
           api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -30,6 +30,11 @@ jobs:
       (github.event.issue.pull_request &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+    # A healthy full review runs in a handful of minutes; cap it so a wedged
+    # model call can't sit on the runner for GitHub's 6-hour default. Fail-fast on
+    # permanent provider errors (quota/auth) means this only ever trips on a real
+    # hang, not on an out-of-credit key.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6 # base repo only — for action.yml + .lgtmaybe.yml config
       - uses: ./

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -87,6 +87,41 @@ Credential resolution uses a **chain of responsibility**: each provider knows
 how to locate its own credentials (ambient cloud creds, env var API key, or
 none for ollama). lgtmaybe never stores or logs credentials.
 
+## Reliability: retries, timeouts, and concurrency
+
+The provider wrapper (`LiteLLMProvider`) and the engine cooperate so a flaky
+network recovers but a dead-end failure surfaces fast:
+
+- **Retries are classified, not blanket.** Transient failures — capacity rate
+  limits (`429 rate_limit_exceeded`), timeouts, connection errors (e.g. an
+  ollama server still warming up), 5xx — are retried with **exponential backoff
+  and jitter** (up to four attempts). **Permanent** failures are *not* retried:
+  bad credentials (`AuthenticationError`), malformed/unsupported requests
+  (`BadRequestError`, including content-policy blocks), unknown models
+  (`NotFoundError`), denied permissions, and **quota/billing** rate limits
+  (`429 insufficient_quota` — "you exceeded your current quota"). Retrying a
+  quota error can never succeed; stacked across every lens it only turns an
+  instant "out of credit" into many minutes of wasted runner time, so lgtmaybe
+  raises it immediately. An optional `fallback_model` is still tried once.
+
+- **One retry layer.** litellm's own internal retry loop is disabled
+  (`num_retries=0`) so failures aren't ground through two stacked backoff layers
+  — lgtmaybe owns the retry policy in one place.
+
+- **Per-request timeout.** Every model call carries a timeout: 60s for hosted
+  providers, 300s for local ones (ollama, openai-compatible), overridable via
+  `timeout` / `--timeout`. The posting workflows additionally set a job-level
+  `timeout-minutes` so a wedged run can't hold a runner for GitHub's six-hour
+  default.
+
+- **Bounded fan-out.** The per-category lenses run concurrently for hosted
+  providers, but the pool is **capped (4 workers)** so a single batch doesn't
+  burst the whole lens set at the provider at once and trip a capacity 429 on a
+  lower-tier account — the lenses run in a couple of waves instead, and per-call
+  latency dominates so the wall-clock cost is small. ollama runs **serially**
+  (one worker): a single local instance serves a model one request at a time, so
+  concurrent calls would only queue up and time out.
+
 ## Dependency injection
 
 The engine receives its ports by injection. In production the CLI wires real

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -129,7 +129,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama 300s, cloud 60s) | Per-request timeout in seconds for each model call |
+| `timeout` | provider default (ollama 300s, cloud 60s) | Per-request timeout in seconds for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `16384` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -35,7 +35,11 @@ _log = get_logger(__name__)
 
 # A single ollama instance serves a model serially, so concurrent calls only
 # queue up and time out; every other provider parallelises across categories.
-_MAX_WORKERS = 8
+# The ceiling is kept modest so the per-batch fan-out doesn't burst the whole
+# lens set at a provider at once and trip a capacity rate-limit (429) on
+# lower-tier accounts — the lenses just run in a couple of waves instead, and
+# per-call latency dominates so the wall-clock cost is small.
+_MAX_WORKERS = 4
 
 
 @dataclass(frozen=True)

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -9,6 +9,17 @@ from __future__ import annotations
 from typing import Any
 
 import litellm
+
+# litellm re-exports the openai exception types but doesn't list them in __all__,
+# so mypy rejects litellm.AuthenticationError etc. as un-exported — import them
+# from litellm.exceptions, where they're defined directly.
+from litellm.exceptions import (
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 from lgtmaybe.core.models import ProviderResult
@@ -24,10 +35,10 @@ _MAX_ATTEMPTS = 4
 # turns an instant failure into many minutes of wasted runner time (the gpt-5.5
 # quota failure that ran ~13 min before surfacing). Fail fast instead.
 _PERMANENT_ERROR_TYPES: tuple[type[Exception], ...] = (
-    litellm.AuthenticationError,
-    litellm.BadRequestError,
-    litellm.NotFoundError,
-    litellm.PermissionDeniedError,
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    PermissionDeniedError,
 )
 
 # A 429 is overloaded: a *capacity* rate-limit is transient (back off and retry),
@@ -50,7 +61,7 @@ def _is_permanent(exc: BaseException) -> bool:
     """True when retrying *exc* cannot plausibly succeed, so we should not."""
     if isinstance(exc, _PERMANENT_ERROR_TYPES):
         return True
-    if isinstance(exc, litellm.RateLimitError):
+    if isinstance(exc, RateLimitError):
         return _is_quota_rate_limit(exc)
     return False
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -9,13 +9,50 @@ from __future__ import annotations
 from typing import Any
 
 import litellm
-from tenacity import retry, stop_after_attempt, wait_exponential_jitter
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 from lgtmaybe.core.models import ProviderResult
 from lgtmaybe.core.ports import Message, ProviderClient
 
 _DEFAULT_TIMEOUT = 60  # seconds
 _MAX_ATTEMPTS = 4
+
+# Errors that retrying cannot fix: bad credentials, a malformed/unsupported
+# request, an unknown model, a denied permission, and a content-policy block
+# (ContentPolicyViolationError subclasses BadRequestError, so it's covered).
+# Retrying these just burns the backoff budget — and, stacked across every lens,
+# turns an instant failure into many minutes of wasted runner time (the gpt-5.5
+# quota failure that ran ~13 min before surfacing). Fail fast instead.
+_PERMANENT_ERROR_TYPES: tuple[type[Exception], ...] = (
+    litellm.AuthenticationError,
+    litellm.BadRequestError,
+    litellm.NotFoundError,
+    litellm.PermissionDeniedError,
+)
+
+# A 429 is overloaded: a *capacity* rate-limit is transient (back off and retry),
+# but a *quota/billing* rate-limit is permanent (out of credit — retrying never
+# recovers). Both arrive as RateLimitError, so we tell them apart by message.
+_QUOTA_MARKERS = (
+    "insufficient_quota",
+    "exceeded your current quota",
+    "check your plan and billing",
+)
+
+
+def _is_quota_rate_limit(exc: BaseException) -> bool:
+    """True for a quota/billing 429 (permanent), False for a capacity 429."""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _QUOTA_MARKERS)
+
+
+def _is_permanent(exc: BaseException) -> bool:
+    """True when retrying *exc* cannot plausibly succeed, so we should not."""
+    if isinstance(exc, _PERMANENT_ERROR_TYPES):
+        return True
+    if isinstance(exc, litellm.RateLimitError):
+        return _is_quota_rate_limit(exc)
+    return False
 
 
 def _rejects_temperature(exc: Exception) -> bool:
@@ -57,6 +94,10 @@ class LiteLLMProvider(ProviderClient):
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
         merged.setdefault("timeout", _DEFAULT_TIMEOUT)
+        # We own retries (tenacity, below). Disable litellm's own retry loop so a
+        # failure isn't ground through two stacked backoff layers — the doubling
+        # that helped a quota error run ~13 min before it surfaced.
+        merged.setdefault("num_retries", 0)
         # A factory-built provider carries the resolved litellm model string
         # (e.g. "ollama/qwen3:27b"); prefer it over the caller's raw cfg.model.
         effective_model = self.model or model
@@ -71,6 +112,7 @@ class LiteLLMProvider(ProviderClient):
         self, messages: list[Message], model: str, **kwargs: Any
     ) -> ProviderResult:
         @retry(
+            retry=retry_if_exception(lambda exc: not _is_permanent(exc)),
             stop=stop_after_attempt(_MAX_ATTEMPTS),
             wait=wait_exponential_jitter(initial=0.1, max=5),
             reraise=True,

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -568,8 +568,11 @@ def test_cloud_fans_out_concurrently() -> None:
     from lgtmaybe.engine.engine import _worker_count
 
     cfg = ReviewConfig(provider=Provider.openai, model="gpt-4o")
-    # Capped at the worker ceiling, but covers the full lens count when small.
-    assert _worker_count(cfg, 5) == 5
+    # A small lens count runs fully concurrently...
+    assert _worker_count(cfg, 3) == 3
+    # ...but the fan-out is capped to bound the per-batch request burst, so the
+    # full nine-lens set doesn't hit the provider all at once (capacity 429s).
+    assert _worker_count(cfg, 9) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+import litellm
 import pytest
 
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
@@ -80,6 +81,136 @@ class TestTemperatureRejection:
                 provider.complete(
                     [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
                 )
+
+
+class TestFailFastOnPermanentErrors:
+    """Retrying a permanent error can't fix it — and stacked backoff over every
+    lens turns an instant "out of credit" into many minutes of burned runner
+    time (the gpt-5.5 quota failure that took ~13 min). Permanent errors must
+    fail fast; only genuinely transient ones get the exponential backoff."""
+
+    def test_quota_rate_limit_is_not_retried(self) -> None:
+        """OpenAI's insufficient_quota 429 ("exceeded your current quota") is a
+        billing dead-end — one attempt, then raise."""
+        calls = 0
+
+        def quota(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.RateLimitError(
+                message=(
+                    "litellm.RateLimitError: OpenAIException - You exceeded your "
+                    "current quota, please check your plan and billing details."
+                ),
+                model="gpt-5.5",
+                llm_provider="openai",
+            )
+
+        with patch("litellm.completion", side_effect=quota):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.RateLimitError):
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-5.5")
+
+        assert calls == 1
+
+    def test_transient_rate_limit_is_still_retried(self) -> None:
+        """A plain capacity rate-limit (not quota) is transient — keep the
+        exponential backoff and retry it."""
+        good = _fake_response("ok after backoff")
+        calls = 0
+
+        def flaky(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise litellm.RateLimitError(
+                    message="RateLimitError: OpenAIException - Rate limit reached for gpt-4o",
+                    model="gpt-4o",
+                    llm_provider="openai",
+                )
+            return good
+
+        with patch("litellm.completion", side_effect=flaky):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert result.text == "ok after backoff"
+        assert calls == 2
+
+    def test_authentication_error_is_not_retried(self) -> None:
+        """A bad key won't become good on a retry — fail fast."""
+        calls = 0
+
+        def bad_auth(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.AuthenticationError(
+                message="AuthenticationError: invalid api key",
+                model="gpt-4o",
+                llm_provider="openai",
+            )
+
+        with patch("litellm.completion", side_effect=bad_auth):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.AuthenticationError):
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert calls == 1
+
+    def test_quota_error_does_not_storm_the_fallback_either(self) -> None:
+        """Fail-fast applies to the fallback leg too: each model is tried once,
+        no per-model retry storm."""
+        calls = 0
+
+        def quota(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.RateLimitError(
+                message="OpenAIException - You exceeded your current quota",
+                model="m",
+                llm_provider="openai",
+            )
+
+        with patch("litellm.completion", side_effect=quota):
+            provider = LiteLLMProvider(fallback_model="openai/gpt-4o-mini")
+            with pytest.raises(litellm.RateLimitError):
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-5.5")
+
+        assert calls == 2  # primary once + fallback once
+
+    def test_ollama_connection_error_is_retried(self) -> None:
+        """ollama gets the same treatment: a transient connection error (the
+        local server still warming up) is retried, not failed fast."""
+        good = _fake_response("ok")
+        calls = 0
+
+        def flaky(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise litellm.APIConnectionError(
+                    message="Connection refused",
+                    model="ollama/qwen3",
+                    llm_provider="ollama",
+                )
+            return good
+
+        with patch("litellm.completion", side_effect=flaky):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "ollama/qwen3")
+
+        assert result.text == "ok"
+        assert calls == 2
+
+    def test_litellm_internal_retries_are_disabled(self) -> None:
+        """We own retries via tenacity; litellm's own retry loop is switched off
+        so a failure isn't ground through two stacked backoff layers."""
+        response = _fake_response()
+        with patch("litellm.completion", return_value=response) as mock_completion:
+            provider = LiteLLMProvider()
+            provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert mock_completion.call_args.kwargs.get("num_retries") == 0
 
 
 class TestFallback:


### PR DESCRIPTION
A gpt-5.5 dogfood review took ~13 min to fail on an OpenAI quota error: the
provider wrapper retried every exception (4 attempts) on top of litellm's own
retry loop, so a non-recoverable "exceeded your current quota" 429 was ground
through stacked backoff across every lens before surfacing.

- Classify retries: transient failures (capacity 429s, timeouts, connection
  errors, 5xx) keep exponential backoff; permanent ones (auth, bad request,
  unknown model, denied permission, quota/billing 429) fail fast.
- Disable litellm's internal retry loop (num_retries=0) so there's one retry
  layer, not two stacked.
- Cap the per-category fan-out to 4 workers so a batch doesn't burst the whole
  lens set at the provider at once and trip a capacity 429 (ollama stays serial).
- Add job-level timeout-minutes (20) to the lgtmaybe and action-e2e workflows so
  a wedged run can't hold a runner for GitHub's 6-hour default.
- Document the retry/timeout/concurrency behaviour in the architecture guide and
  the action input reference.