### PR TITLE
ci: bump feat commits to minor pre-1.0 so features cut 0.2.x

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,7 @@
       "package-name": "lgtmaybe",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Drop bump-patch-for-minor-pre-major so release-please treats feat
commits as a minor bump (0.2.0) instead of a patch (0.1.x) while
the project is still pre-1.0. bump-minor-pre-major stays on so
breaking changes remain a minor bump rather than jumping to 1.0.0.

https://claude.ai/code/session_0176LmEBEde8ZRzcarCrwXoK