### PR TITLE
Replace deprecated `position` with `line`+`side` for GitHub review comments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,7 +69,7 @@ lgtmaybe/
 │   │
 │   ├── github/              # GitHub adapter (the GitHubGateway side)
 │   │   ├── rest_gateway.py  #   fetch PR context · post review · in-thread replies
-│   │   └── diff.py          #   diff→position map · is_reviewable() skip filter
+│   │   └── diff.py          #   commentable-line index · is_reviewable() skip filter
 │   │
 │   ├── local/               # local-mode adapter: build a PRContext from `git`
 │   ├── config/              # layered config: defaults < user file < repo file < flags
@@ -140,8 +140,9 @@ long one, cloud short).
 **GitHub adapter (`github/`)** — `RestGitHubGateway` reads PR context (diff,
 files, head-revision file text — all read-only API, never a checkout) and posts a
 single batched review, updated idempotently via a hidden per-provider marker
-comment. `diff.py` builds the line→position map and the `is_reviewable` skip
-filter (lockfiles, minified, vendored, generated, binary).
+comment. `diff.py` builds the commentable-line index (the `line`+`side` anchors a
+review comment can attach to) and the `is_reviewable` skip filter (lockfiles,
+minified, vendored, generated, binary).
 
 **Local adapter (`local/`)** — builds a `PRContext` by shelling out to `git`, so
 `lgtmaybe review` works on a branch or working tree with no GitHub at all.

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -139,7 +139,7 @@ def run_review(
     if not dry_run:
         # Pass the diff we already fetched so post_review doesn't re-fetch the
         # whole PR context (diff + file list + every file's contents) just to
-        # rebuild the position map.
+        # rebuild the commentable-line index.
         github.post_review(findings, summary, diff=ctx.diff)
 
     return findings, summary

--- a/src/lgtmaybe/core/diffparse.py
+++ b/src/lgtmaybe/core/diffparse.py
@@ -2,7 +2,7 @@
 
 One home for the regexes and helpers that read a ``git diff``: splitting a diff
 into per-file patches and parsing hunk headers. Shared by the engine (batching,
-hunk expansion) and the github adapter (position map) so the patterns and their
+hunk expansion) and the github adapter (commentable-line index) so the patterns and their
 off-by-one rules live in exactly one place.
 """
 

--- a/src/lgtmaybe/github/__init__.py
+++ b/src/lgtmaybe/github/__init__.py
@@ -2,11 +2,12 @@
 
 Public surface:
 - RestGitHubGateway: implements GitHubGateway against the GitHub REST API.
-- build_position_map: parse a unified diff into a (file, line) → position map.
+- build_commentable_lines: parse a unified diff into the set of (file, line, side)
+  tuples a review comment can anchor to.
 - is_reviewable: predicate that rejects lockfiles, minified, vendored, binary paths.
 """
 
-from .diff import build_position_map, is_reviewable
+from .diff import build_commentable_lines, is_reviewable
 from .rest_gateway import RestGitHubGateway
 
-__all__ = ["RestGitHubGateway", "build_position_map", "is_reviewable"]
+__all__ = ["RestGitHubGateway", "build_commentable_lines", "is_reviewable"]

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -1,9 +1,12 @@
-"""Diff utilities: position map and skip filter.
+"""Diff utilities: commentable-line index and skip filter.
 
-Position map: GitHub review comments need a 1-based `position` that counts
-lines in the patch (hunk headers count as 0, context/add/remove lines count
-sequentially). We build a mapping of (filename, new_file_line) → position so
-the gateway can anchor findings to the right spot.
+Commentable-line index: GitHub anchors a review comment with `line` + `side`
+(`side="RIGHT"` → the new-file line number, `side="LEFT"` → the old-file line
+number) rather than the deprecated, fragile `position` count. We build the set
+of (filename, line, side) tuples a comment can legally attach to — every added,
+deleted, or context line in the diff — so the gateway can post findings on real
+diff lines and silently drop anything that isn't (e.g. a finding the model put
+on an expanded-context-only line).
 
 Skip filter: lockfiles, minified bundles, vendored/generated paths and binary
 files are dropped before review to save tokens and avoid noise.
@@ -16,37 +19,43 @@ from fnmatch import fnmatch
 from lgtmaybe.core.diffparse import FILE_HEADER_RE, parse_hunk_header
 
 # ---------------------------------------------------------------------------
-# Position map
+# Commentable-line index
 # ---------------------------------------------------------------------------
 
-# Maps (filename, new_file_line_number) → 1-based diff position within that file's hunks.
-PositionMap = dict[tuple[str, int], int]
+# The set of (filename, line, side) tuples a review comment can attach to, where
+# `line` is the new-file line for side "RIGHT" and the old-file line for "LEFT".
+CommentableLines = set[tuple[str, int, str]]
 
 
-def build_position_map(diff: str) -> PositionMap:
-    """Parse a unified diff and build a (file, new_line) → diff_position mapping.
+def build_commentable_lines(diff: str) -> CommentableLines:
+    """Parse a unified diff into the set of commentable (file, line, side) tuples.
 
-    `diff_position` is the 1-based offset of that line within the file's patch
-    block (hunk headers do not count as a position themselves; the first content
-    line after the first hunk header is position 1).
+    GitHub anchors a review comment by file line and side, not by a running
+    position count, so this avoids the off-by-N drift the `position` count
+    suffered across multiple hunks. A line is commentable when it appears in the
+    diff:
 
-    Deleted lines ("-") advance the diff position counter but do not produce a
-    new-file line entry. Context lines (no prefix or " " prefix) and added lines
-    ("+") both advance the new-file line counter.
+    - added ("+") lines → commentable on the **new** file (RIGHT) at new_line;
+    - deleted ("-") lines → commentable on the **old** file (LEFT) at old_line;
+    - context lines (no prefix or " " prefix) → commentable on **both** sides,
+      at their new_line (RIGHT) and old_line (LEFT).
+
+    Anything not in the returned set (out-of-diff or expanded-context-only
+    lines) has no anchor and is dropped by the gateway rather than mis-posted.
     """
-    pos_map: PositionMap = {}
+    commentable: CommentableLines = set()
 
     current_file: str | None = None
-    diff_pos = 0  # 1-based position within this file's hunks
     new_line = 0  # current new-file line number
+    old_line = 0  # current old-file line number
     in_hunk = False
 
     for raw_line in diff.splitlines():
         file_match = FILE_HEADER_RE.match(raw_line)
         if file_match:
             current_file = file_match.group(1)
-            diff_pos = 0
             new_line = 0
+            old_line = 0
             in_hunk = False
             continue
 
@@ -55,12 +64,10 @@ def build_position_map(diff: str) -> PositionMap:
 
         hunk = parse_hunk_header(raw_line)
         if hunk is not None:
-            # Hunk header resets the new-file line counter; diff_pos keeps counting
-            # across hunks within a file. The hunk header line does NOT occupy a
-            # position itself — the first content line after it is position 1 (or
-            # position N+1 if prior hunks exist). GitHub's position is a 1-based
-            # count of content lines only.
+            # Hunk header resets both line counters to the hunk's starts. No
+            # position arithmetic — line/side bind directly to file lines.
             new_line = hunk.new_start
+            old_line = hunk.old_start
             in_hunk = True
             continue
 
@@ -68,20 +75,21 @@ def build_position_map(diff: str) -> PositionMap:
             continue
 
         if raw_line.startswith("-"):
-            # Deleted line: advances diff_pos but NOT new_line.
-            diff_pos += 1
+            # Deleted line: present on the old side only.
+            commentable.add((current_file, old_line, "LEFT"))
+            old_line += 1
         elif raw_line.startswith("+"):
-            # Added line: advances both.
-            diff_pos += 1
-            pos_map[(current_file, new_line)] = diff_pos
+            # Added line: present on the new side only.
+            commentable.add((current_file, new_line, "RIGHT"))
             new_line += 1
         else:
-            # Context line (leading " " or empty).
-            diff_pos += 1
-            pos_map[(current_file, new_line)] = diff_pos
+            # Context line (leading " " or empty): present on both sides.
+            commentable.add((current_file, new_line, "RIGHT"))
+            commentable.add((current_file, old_line, "LEFT"))
             new_line += 1
+            old_line += 1
 
-    return pos_map
+    return commentable
 
 
 # ---------------------------------------------------------------------------

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -21,7 +21,7 @@ from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import PRContext, ReviewFinding
 from lgtmaybe.core.ports import GitHubGateway
 
-from .diff import PositionMap, build_position_map, is_reviewable
+from .diff import CommentableLines, build_commentable_lines, is_reviewable
 
 _log = get_logger(__name__)
 
@@ -165,14 +165,14 @@ class RestGitHubGateway(GitHubGateway):
         the body), it is updated in-place rather than creating a duplicate.
 
         The ``diff`` parameter is optional; when omitted the method fetches the
-        PR diff to build the position map.
+        PR diff to build the commentable-line index.
         """
         if diff is None:
             ctx = self.get_pr_context()
             diff = ctx.diff
 
-        pos_map: PositionMap = build_position_map(diff)
-        comments = self._build_comments(findings, pos_map)
+        commentable: CommentableLines = build_commentable_lines(diff)
+        comments = self._build_comments(findings, commentable)
 
         body = f"{summary}\n\n{self._marker}"
         existing_id = self._find_existing_review()
@@ -435,17 +435,22 @@ class RestGitHubGateway(GitHubGateway):
     @staticmethod
     def _build_comments(
         findings: list[ReviewFinding],
-        pos_map: PositionMap,
+        commentable: CommentableLines,
     ) -> list[dict[str, Any]]:
-        """Map findings to GitHub review comment dicts, skipping unmapped lines."""
+        """Map findings to GitHub review comment dicts, skipping out-of-diff lines.
+
+        Anchors each comment with `line` + `side` (GitHub's recommended params),
+        not the deprecated `position` count, so a finding binds directly to its
+        file line regardless of how many hunks precede it.
+        """
         comments: list[dict[str, Any]] = []
         for f in findings:
-            position = pos_map.get((f.path, f.line))
-            if position is None:
+            if (f.path, f.line, f.side) not in commentable:
                 continue
             comment: dict[str, Any] = {
                 "path": f.path,
-                "position": position,
+                "line": f.line,
+                "side": f.side,
                 "body": f"**[{f.severity.upper()}] {f.title}**\n\n{f.body}",
             }
             if f.suggestion is not None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -80,7 +80,7 @@ class TestRunReview:
 
     def test_non_dry_run_passes_fetched_diff_to_post_review(self):
         """post_review must receive the already-fetched diff so it doesn't
-        re-fetch the entire PR context just to rebuild the position map."""
+        re-fetch the entire PR context just to rebuild the commentable-line index."""
         github = FakeGitHub()
         engine = FakeEngine(FakeProvider())
         cfg = _default_cfg()

--- a/tests/cli/test_integration_e2e.py
+++ b/tests/cli/test_integration_e2e.py
@@ -35,7 +35,7 @@ PR_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}"
 FILES_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}/files"
 REVIEWS_URL = f"{PR_URL}/reviews"
 
-# src/app.py line 2 ("+import sys") sits at diff position 2.
+# src/app.py new-file line 2 ("+import sys") is an added line (RIGHT side).
 SAMPLE_DIFF = """\
 diff --git a/src/app.py b/src/app.py
 index 0000001..0000002 100644
@@ -123,7 +123,8 @@ def test_e2e_posts_inline_comment_at_correct_position_and_summary() -> None:
     comments = body["comments"]
     assert len(comments) == 1
     assert comments[0]["path"] == "src/app.py"
-    assert comments[0]["position"] == 2  # correct diff position
+    assert comments[0]["line"] == 2  # anchored by new-file line + side
+    assert comments[0]["side"] == "RIGHT"
 
     # The review body carries the summary + the idempotency marker.
     assert "<!-- lgtmaybe -->" in str(body["body"])

--- a/tests/github/test_diff.py
+++ b/tests/github/test_diff.py
@@ -1,11 +1,11 @@
-"""Tests for diff position map and skip filter."""
+"""Tests for the diff commentable-line index and skip filter."""
 
 from __future__ import annotations
 
-from lgtmaybe.github import build_position_map, is_reviewable
+from lgtmaybe.github import build_commentable_lines, is_reviewable
 
 # ---------------------------------------------------------------------------
-# Diff position map
+# Commentable-line index
 # ---------------------------------------------------------------------------
 
 SAMPLE_DIFF = """\
@@ -33,51 +33,52 @@ index 0000003..0000004 100644
 """
 
 
-def test_position_map_context_line() -> None:
-    """A context line (unchanged) maps to a position within the hunk."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    # Line 1 of src/app.py is "import os" — a context line at new-file line 1.
-    # It is diff position 1 within the first file's hunk.
-    assert pos_map.get(("src/app.py", 1)) == 1
+def test_added_line_is_commentable_on_right() -> None:
+    """An added line is commentable on RIGHT at its new-file line number."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    # "+import sys" is the first added line in src/app.py, at new-file line 2.
+    assert ("src/app.py", 2, "RIGHT") in index
+    # "+    print(...)" / "+    return 0" land at new-file lines 5 and 6.
+    assert ("src/app.py", 5, "RIGHT") in index
+    assert ("src/app.py", 6, "RIGHT") in index
 
 
-def test_position_map_added_line() -> None:
-    """An added line maps to its correct 1-based diff position."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    # "import sys" is the first added line in src/app.py, at new-file line 2.
-    # Hunk header is position 0 (not counted); context "import os" is pos 1;
-    # "+import sys" is pos 2.
-    assert pos_map.get(("src/app.py", 2)) == 2
+def test_context_line_is_commentable_on_both_sides() -> None:
+    """A context line is commentable on RIGHT (new line) and LEFT (old line)."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    # "import os" is context at new-file line 1 / old-file line 1.
+    assert ("src/app.py", 1, "RIGHT") in index
+    assert ("src/app.py", 1, "LEFT") in index
 
 
-def test_position_map_line_not_in_diff_returns_none() -> None:
-    """A line number outside any hunk maps to None."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    assert pos_map.get(("src/app.py", 999)) is None
+def test_deleted_line_is_commentable_on_left() -> None:
+    """A deleted line is commentable on LEFT at its old-file line number."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    # "-    pass" was old-file line 4 (context "import os", blank, "def main():"
+    # are old lines 1-3); it is anchored on the LEFT side only.
+    assert ("src/app.py", 4, "LEFT") in index
 
 
-def test_position_map_unknown_file_returns_none() -> None:
-    """A file not present in the diff maps to None for any line."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    assert pos_map.get(("totally_absent.py", 1)) is None
+def test_line_not_in_diff_is_absent() -> None:
+    """A line number outside any hunk is not commentable on either side."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    assert ("src/app.py", 999, "RIGHT") not in index
+    assert ("src/app.py", 999, "LEFT") not in index
 
 
-def test_position_map_second_file() -> None:
-    """Position counting resets per file, not globally."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    # src/utils.py: hunk @@ -10,3 +10,4 @@
-    # new-file line 10 → "    x = 1" → diff position 1 (first line after hunk header)
-    assert pos_map.get(("src/utils.py", 10)) == 1
+def test_unknown_file_is_absent() -> None:
+    """A file not present in the diff is never commentable."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    assert ("totally_absent.py", 1, "RIGHT") not in index
 
 
-def test_position_map_deleted_line_not_in_new_file() -> None:
-    """Deleted lines do not advance the new-file line counter, so they have no position."""
-    pos_map = build_position_map(SAMPLE_DIFF)
-    # src/app.py original line 4 was "    pass" (deleted).
-    # After deletion the new file jumps from line 3 to line 4 being "    print(...)".
-    # There is no new-file line corresponding to the deleted line itself.
-    # The test just verifies the map contains known good entries and not junk.
-    assert ("src/app.py", 5) in pos_map or ("src/app.py", 4) in pos_map  # either is fine
+def test_line_counting_resets_per_file() -> None:
+    """Line tracking resets per file, not globally."""
+    index = build_commentable_lines(SAMPLE_DIFF)
+    # src/utils.py: hunk @@ -10,3 +10,4 @@ → "    x = 1" is new-file line 10.
+    assert ("src/utils.py", 10, "RIGHT") in index
+    # The trailing "+    # comment added" is the added line at new-file line 13.
+    assert ("src/utils.py", 13, "RIGHT") in index
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +175,7 @@ def test_is_reviewable_accepts_dotfiles_and_configs() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Position map — multi-hunk and add-after-delete anchoring
+# Commentable lines — multi-hunk and add-after-delete anchoring
 # ---------------------------------------------------------------------------
 
 _MULTI_HUNK_DIFF = """\
@@ -193,20 +194,27 @@ index 0000001..0000002 100644
 """
 
 
-def test_position_counts_continue_across_hunks_within_a_file() -> None:
-    """diff_position keeps counting across a file's hunks; new-line resets per hunk."""
-    pos_map = build_position_map(_MULTI_HUNK_DIFF)
-    # Second hunk starts at new-file line 21 ("    run()" is context, position 6:
-    # hunk1 has context(1) + del(2) + add(3) + add(4) = 4 positions, then hunk2
-    # context "    run()" is position 5, "+    cleanup()" is position 6.
-    assert pos_map.get(("src/svc.py", 21)) == 5
-    assert pos_map.get(("src/svc.py", 22)) == 6
+def test_second_hunk_line_anchors_to_its_real_new_file_line() -> None:
+    """Findings in the 2nd hunk anchor to their true new-file line, not an
+    off-by-N diff position.
+
+    Regression for the multi-hunk bug: the old `position` math did not count the
+    intervening "@@" hunk header, so a finding on the 2nd hunk's "+    cleanup()"
+    (new-file line 22) was posted one line too high. With line+side the anchor is
+    simply the new-file line, independent of any earlier hunk.
+    """
+    index = build_commentable_lines(_MULTI_HUNK_DIFF)
+    # Second hunk @@ -20,2 +21,3 @@: "    run()" is context at new-file line 21,
+    # "+    cleanup()" is added at new-file line 22.
+    assert ("src/svc.py", 21, "RIGHT") in index
+    assert ("src/svc.py", 22, "RIGHT") in index
 
 
 def test_added_line_after_deletion_anchors_correctly() -> None:
-    pos_map = build_position_map(_MULTI_HUNK_DIFF)
-    # "import os" context = new-line 1, pos 1; "-import sys" del = pos 2 (no new line);
-    # "+import sys" add = new-line 2, pos 3; "+import json" add = new-line 3, pos 4.
-    assert pos_map.get(("src/svc.py", 1)) == 1
-    assert pos_map.get(("src/svc.py", 2)) == 3
-    assert pos_map.get(("src/svc.py", 3)) == 4
+    index = build_commentable_lines(_MULTI_HUNK_DIFF)
+    # First hunk: "import os" context = new-line 1; "-import sys" del = old-line 2
+    # (LEFT, no new line); "+import sys" add = new-line 2; "+import json" = new-line 3.
+    assert ("src/svc.py", 1, "RIGHT") in index
+    assert ("src/svc.py", 2, "LEFT") in index
+    assert ("src/svc.py", 2, "RIGHT") in index
+    assert ("src/svc.py", 3, "RIGHT") in index

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -23,7 +23,8 @@ GRAPHQL_URL = f"{BASE_URL}/graphql"
 
 MARKER = "<!-- lgtmaybe -->"
 
-# A minimal diff that puts src/app.py line 2 at diff position 2.
+# A minimal diff in which src/app.py new-file line 2 ("+import sys") is an
+# added line, so a RIGHT-side finding on line 2 anchors there.
 SAMPLE_DIFF = """\
 diff --git a/src/app.py b/src/app.py
 index 0000001..0000002 100644
@@ -81,7 +82,9 @@ def test_post_review_creates_review_with_marker_and_batched_comments() -> None:
     comments = review_body.get("comments", [])
     assert len(comments) == 1
     assert comments[0]["path"] == "src/app.py"
-    assert comments[0]["position"] == 2
+    assert comments[0]["line"] == 2
+    assert comments[0]["side"] == "RIGHT"
+    assert "position" not in comments[0]
 
 
 @respx.mock
@@ -185,7 +188,7 @@ def test_post_issue_comment_posts_to_issues_endpoint() -> None:
 
 @respx.mock
 def test_post_review_skips_findings_outside_diff() -> None:
-    """Findings whose line has no diff position are omitted from the review comments."""
+    """Findings whose line is not in the diff are omitted from the review comments."""
     respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
 
     out_of_diff_findings = [
@@ -221,9 +224,9 @@ def test_post_review_skips_findings_outside_diff() -> None:
 def test_post_review_drops_finding_on_expanded_context_line() -> None:
     """A finding on a surrounding-context line (not in the real diff) is never posted.
 
-    The engine pads hunks with extra lines for the model, but the position map is
-    built from the real diff — so a finding landing on an expanded-only line maps
-    to nothing and is dropped, never producing a bogus inline comment.
+    The engine pads hunks with extra lines for the model, but the commentable-line
+    index is built from the real diff — so a finding landing on an expanded-only
+    line has no anchor and is dropped, never producing a bogus inline comment.
     """
     respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
 


### PR DESCRIPTION
## Summary

Migrate from GitHub's deprecated `position`-based comment anchoring to the modern `line`+`side` approach. This eliminates off-by-N drift across multiple hunks and aligns with GitHub's current API recommendations.

## Changes

- **Renamed core function:** `build_position_map()` → `build_commentable_lines()`
  - Returns `set[tuple[str, int, str]]` (filename, line, side) instead of `dict[tuple[str, int], int]`
  - Tracks both new-file and old-file line numbers independently
  
- **Updated diff parsing logic:**
  - Maintains separate `new_line` and `old_line` counters (previously only `new_line` + `diff_pos`)
  - Added lines anchor to `(file, new_line, "RIGHT")`
  - Deleted lines anchor to `(file, old_line, "LEFT")`
  - Context lines anchor to both `(file, new_line, "RIGHT")` and `(file, old_line, "LEFT")`
  
- **Updated comment building:**
  - `_build_comments()` now checks membership in the commentable set instead of dict lookup
  - Replaced `"position": position` with `"line": f.line, "side": f.side` in comment dicts
  
- **Updated all tests:**
  - Rewrote test assertions to check for `(file, line, side)` tuples in the index
  - Clarified test names and docstrings to reflect the new semantics
  - Added regression test for multi-hunk anchoring correctness

## Implementation Details

The old `position` count was fragile across multiple hunks because it accumulated a running total that could drift if hunk headers weren't counted consistently. The new approach is simpler: a comment anchors directly to its file line and side, independent of any prior hunks or position arithmetic.

This also fixes a latent bug where findings in the 2nd+ hunk of a multi-hunk diff could be posted one or more lines too high due to position miscounting.

The `ReviewFinding` model now carries a `side` field (already present in the codebase) that indicates which side of the diff the finding applies to.

https://claude.ai/code/session_01WFwRu4Ca15ac8KiXaqDtDM