### PR TITLE
Reframe demoted findings copy to avoid internal jargon

### DIFF
--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -83,10 +83,9 @@ def _render_demoted(demoted: list[ReviewFinding]) -> str:
     lines = [
         "",
         "",
-        "### Findings without a precise line",
+        "### Additional findings",
         "",
-        "_Couldn't anchor these to a specific diff line, so they're noted here "
-        "rather than risk an inline comment on the wrong line:_",
+        "_These relate to the changes but aren't tied to a single line:_",
         "",
     ]
     for f in demoted:

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -612,4 +612,10 @@ def test_unanchored_finding_demoted_to_body_not_inline() -> None:
     assert len(comments) == 1
     assert all("Unplaced finding" not in c for c in titles_inline)
     # The demoted finding survives in the review body instead.
-    assert "Unplaced finding" in str(body.get("body", ""))
+    rendered = str(body.get("body", ""))
+    assert "Unplaced finding" in rendered
+    # Framed as a feature for the reader, not an apology about our internals:
+    # no pipeline jargon ("anchor") leaks into customer-facing copy.
+    assert "### Additional findings" in rendered
+    assert "anchor" not in rendered.lower()
+    assert "Couldn't anchor" not in rendered


### PR DESCRIPTION
## Summary

Improve customer-facing messaging for findings that couldn't be anchored to a specific diff line. Replace internal pipeline terminology ("anchor") with user-friendly language that frames the limitation as a feature benefit rather than an apology about our internals.

## Changes

- **Message reframing:** Changed section header from "Findings without a precise line" to "### Additional findings" — a more neutral, feature-focused framing
- **Explanation update:** Replaced technical jargon ("Couldn't anchor these to a specific diff line") with plain language ("These relate to the changes but aren't tied to a single line")
- **Test coverage:** Added assertions to verify:
  - The new section header appears in the review body
  - The word "anchor" does not leak into customer-facing copy (case-insensitive check)
  - The phrase "Couldn't anchor" is absent from rendered output

## Implementation details

The changes live in `_render_demoted()` in `rest_gateway.py`, which formats findings that failed line anchoring. By removing internal jargon, we ensure that users see a professional, user-centric explanation rather than implementation details about our re-anchoring algorithm.

The test additions in `test_post_review.py` enforce this boundary going forward, preventing accidental reintroduction of pipeline terminology into the review body.

https://claude.ai/code/session_01Wgq5dfRQU3B9xec5mEeYUR