### PR TITLE
fix: robustly parse findings JSON from gateways without JSON mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: "Walk a file whose diff exceeds max_input_tokens hunk-by-hunk (RLM-style) instead of sending it whole and letting the model drop the tail. On by default; set to false to disable."
     required: false
     default: ""
+  structured_output:
+    description: "Constrain model output to the findings JSON schema via the provider's response_format (JSON mode). On by default; set to false for an openai-compatible gateway/proxy that rejects response_format (the lenient parser still handles fenced/prose output either way)."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -142,6 +146,7 @@ runs:
         INPUT_MAX_INPUT_TOKENS: ${{ inputs.max_input_tokens }}
         INPUT_RESOLVE_FIXED: ${{ inputs.resolve_fixed }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}
+        INPUT_STRUCTURED_OUTPUT: ${{ inputs.structured_output }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -154,7 +159,7 @@ runs:
           -e INPUT_API_KEY -e INPUT_API_BASE -e INPUT_CONFIG_PATH \
           -e INPUT_TIMEOUT -e INPUT_TEMPERATURE \
           -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS -e INPUT_RESOLVE_FIXED \
-          -e INPUT_RECURSIVE \
+          -e INPUT_RECURSIVE -e INPUT_STRUCTURED_OUTPUT \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -163,14 +163,16 @@ Default: auto (ollama 300 s, cloud 60 s). See
 Constrain the model to emit the findings JSON schema using the provider's native
 JSON mode (litellm `response_format`). This keeps models — especially local ones —
 from returning prose or reasoning instead of findings. Leave it on unless a
-particular model/provider doesn't support structured output, in which case the
-lenient parser is the fallback.
+particular model/provider **rejects** `response_format` (some `openai-compatible`
+gateways return a `400`), in which case turn it off; the lenient parser still
+strips fences and pulls JSON out of any surrounding prose. CLI: `--no-structured-output`.
 
 ```yaml
-structured_output: false   # only if your model rejects JSON-schema mode
+structured_output: false   # only if your gateway rejects JSON-schema mode
 ```
 
-Default: `true`.
+Default: `true`. See
+[Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
 
 ### resolve_fixed
 

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -98,6 +98,35 @@ set the same values as inputs (or in `.lgtmaybe.yml`) and pass `api_key` from a
 secret for hosted endpoints; leave it empty for keyless local servers reached at
 `http://host.docker.internal:<port>/v1`.
 
+## Gateways that don't support JSON mode (`response_format`)
+
+To keep models returning clean findings instead of prose, lgtmaybe asks for
+structured output via the OpenAI `response_format` parameter (JSON mode). Most
+endpoints honour it. Some enterprise gateways and custom proxies don't — they
+either **ignore** it (the model then answers with the JSON wrapped in a
+```` ```json ```` fence or surrounded by conversational prose) or **reject** the
+request outright with a `400 Bad Request`.
+
+lgtmaybe handles the first case for you: the parser strips fences and pulls the
+JSON out of surrounding prose, so a gateway that merely ignores `response_format`
+still produces a normal review. (Older versions could fail here with
+`unparseable model output` on every lens — that's fixed.)
+
+If your gateway **rejects** `response_format` with a `400`, turn it off so the
+request never carries the parameter — the prompt still asks for JSON and the
+lenient parser still does its job:
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model gemini-3.5-flash \
+  --api-base https://api.myllm.com/v1 \
+  --no-structured-output
+```
+
+Persist it as `structured_output: false` in `.lgtmaybe.yml`, or set the
+`structured_output` input to `false` in the GitHub Action.
+
 [deepseek]: https://api-docs.deepseek.com/
 [llamacpp]: https://github.com/ggml-org/llama.cpp
 [lmstudio]: https://lmstudio.ai/

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -124,7 +124,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 
 | Input | Default | Description |
 |---|---|---|
-| `provider` | — | One of: `openai`, `openrouter`, `anthropic`, `bedrock`, `vertex`, `azure`, `ollama` |
+| `provider` | — | One of: `openai`, `openrouter`, `anthropic`, `bedrock`, `vertex`, `azure`, `ollama`, `openai-compatible` |
 | `model` | — | Model identifier for the chosen provider |
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
@@ -134,6 +134,8 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `num_ctx` | `16384` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
+| `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
+| `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
 | `aws_role_arn` | — | IAM role ARN to assume via OIDC for bedrock (keyless) |
 | `aws_region` | `us-east-1` | AWS region for bedrock |
 | `gcp_wif_provider` | — | Workload Identity Federation provider resource name for vertex |

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -277,6 +277,7 @@ def action_inputs() -> dict[str, str | None]:
         "max_input_tokens": get("MAX_INPUT_TOKENS"),
         "resolve_fixed": get("RESOLVE_FIXED"),
         "recursive": get("RECURSIVE"),
+        "structured_output": get("STRUCTURED_OUTPUT"),
         "config_path": get("CONFIG_PATH"),
     }
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -142,6 +142,13 @@ from lgtmaybe.config.loader import load_config
     "instead of sending it whole and dropping the tail (--no-recursive disables)",
 )
 @click.option(
+    "--structured-output/--no-structured-output",
+    default=None,
+    help="Constrain output to the findings JSON schema via response_format "
+    "(--no-structured-output for a gateway/proxy that rejects it; the lenient "
+    "parser still handles fenced/prose output either way)",
+)
+@click.option(
     "--config",
     "config_path",
     default=".lgtmaybe.yml",
@@ -168,6 +175,7 @@ def review(
     temperature: float | None,
     reflect: bool | None,
     recursive: bool | None,
+    structured_output: bool | None,
     config_path: str,
 ) -> None:
     """Review local git changes and print findings — no GitHub needed."""
@@ -187,6 +195,7 @@ def review(
         temperature=temperature,
         reflect=reflect,
         recursive=recursive,
+        structured_output=structured_output,
     )
 
     runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
@@ -241,6 +250,7 @@ def action() -> None:
         max_input_tokens=inputs["max_input_tokens"],
         resolve_fixed=inputs["resolve_fixed"],
         recursive=inputs["recursive"],
+        structured_output=inputs["structured_output"],
     )
     runtime = RuntimeOptions(
         api_key=inputs["api_key"],

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -4,9 +4,17 @@ Tolerates:
 - The ``{"findings": [...]}`` structured-output envelope and a bare array alike
 - ``<think>...</think>`` reasoning blocks (qwen-style models) before the JSON
 - Markdown code fences (```json ... ```)
-- Leading/trailing prose
+- Leading/trailing prose — even when it carries stray brackets
 - Trailing commas in objects/arrays
 - A bare object instead of an array
+
+This matters most for ``openai-compatible`` gateways that don't honour the
+``response_format`` JSON-mode hint (see issue #104): the model then answers in
+conversational prose around the JSON, and that prose routinely contains brackets
+(``"reviewed 3 files [a, b, c]"``). Extraction therefore scans for *balanced*
+delimiters that respect JSON string literals, rather than greedily matching the
+first ``[`` to the last ``]`` — and never rewrites the bytes inside a string,
+so a code fence inside a ``suggestion`` survives intact.
 
 Raises ParseError for unrecoverable input.
 """
@@ -15,6 +23,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterator
 from typing import Any
 
 from lgtmaybe.core.models import ReviewFinding
@@ -31,11 +40,7 @@ _TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
 # we look for JSON so their contents can't be mistaken for the answer.
 _THINK_RE = re.compile(r"<think(?:ing)?>.*?</think(?:ing)?>", re.DOTALL | re.IGNORECASE)
 
-
-def strip_fences(text: str) -> str:
-    """Remove markdown code fences, keeping only the content."""
-    text = re.sub(r"```(?:json)?\s*", "", text)
-    return text.replace("```", "")
+_CLOSER = {"{": "}", "[": "]"}
 
 
 def _strip_think_blocks(text: str) -> str:
@@ -47,44 +52,96 @@ def _repair_trailing_commas(text: str) -> str:
     return _TRAILING_COMMA_RE.sub(r"\1", text)
 
 
-def _extract_json_blob(text: str) -> str:
-    """Extract the first JSON array or object from *text*."""
-    # Try to find a JSON array first
-    array_match = re.search(r"\[.*\]", text, re.DOTALL)
-    if array_match:
-        return array_match.group(0)
-    # Fall back to a JSON object
-    obj_match = re.search(r"\{.*\}", text, re.DOTALL)
-    if obj_match:
-        return obj_match.group(0)
-    return text
+def _balanced_span(text: str, start: int) -> str | None:
+    """Return the balanced ``{...}`` / ``[...]`` span beginning at *start*.
 
-
-def _loads_lenient(text: str) -> Any:
-    """Parse JSON from *text*: try it whole, then the first embedded JSON blob."""
-    for candidate in (text, _extract_json_blob(text)):
-        try:
-            return json.loads(_repair_trailing_commas(candidate))
-        except json.JSONDecodeError:
+    Walks forward tracking string state (so quotes, escapes, and brackets inside
+    string values don't affect nesting) and brace/bracket depth, returning the
+    substring once depth returns to zero. ``None`` if the delimiter never closes.
+    """
+    opener = text[start]
+    closer = _CLOSER[opener]
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
             continue
-    raise ParseError("Cannot parse JSON from response")
+        if ch == '"':
+            in_string = True
+        elif ch == opener:
+            depth += 1
+        elif ch == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
 
 
-def _unwrap(data: Any) -> Any:
-    """Turn the ``{"findings": [...]}`` envelope or a bare object into a list."""
+def iter_json_values(raw: str) -> Iterator[Any]:
+    """Yield every JSON value recoverable from *raw*, most-likely first.
+
+    Tries the whole think-stripped text first (clean JSON, no rewriting), then
+    each balanced ``{``/``[`` span in order. Trailing commas are repaired before
+    parsing. Spans that don't parse are skipped. The caller picks the value whose
+    *shape* it wants, so embedded prose JSON (a stray ``["a", "b"]``) can be
+    passed over in favour of the real payload.
+    """
+    text = _strip_think_blocks(raw).strip()
+    if not text:
+        return
+
+    seen: set[str] = set()
+
+    def _try(candidate: str) -> Iterator[Any]:
+        repaired = _repair_trailing_commas(candidate)
+        if repaired in seen:
+            return
+        seen.add(repaired)
+        try:
+            yield json.loads(repaired)
+        except json.JSONDecodeError:
+            return
+
+    yield from _try(text)
+    for i, ch in enumerate(text):
+        if ch in _CLOSER:
+            span = _balanced_span(text, i)
+            if span is not None:
+                yield from _try(span)
+
+
+def _as_findings_list(data: Any) -> list[Any] | None:
+    """Return *data* as a findings list if it is findings-shaped, else None.
+
+    Accepts the ``{"findings": [...]}`` envelope, a bare object (a single
+    finding), an empty list, or a list of objects. A list of non-objects (e.g. a
+    stray ``["security", "perf"]`` from the prose) is *not* findings-shaped.
+    """
     if isinstance(data, dict):
         findings = data.get("findings")
         if isinstance(findings, list):
             return findings
         return [data]  # a bare single finding object
-    return data
+    if isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            return data
+    return None
 
 
 def parse_findings(raw: str) -> list[ReviewFinding]:
     """Parse *raw* LLM text into a list of ReviewFinding objects.
 
     Accepts the ``{"findings": [...]}`` structured-output envelope or a bare
-    array, with reasoning blocks, fences, prose, and trailing commas tolerated.
+    array, with reasoning blocks, fences, prose (even bracket-bearing prose), and
+    trailing commas tolerated.
 
     Raises:
         ParseError: if the text cannot be recovered into valid findings.
@@ -92,15 +149,13 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
     if not raw or not raw.strip():
         raise ParseError("Empty response from provider")
 
-    text = _strip_think_blocks(raw).strip()
-    text = strip_fences(text).strip()
+    for value in iter_json_values(raw):
+        items = _as_findings_list(value)
+        if items is None:
+            continue
+        try:
+            return [ReviewFinding.model_validate(item) for item in items]
+        except Exception as exc:
+            raise ParseError(f"Finding validation failed: {exc}") from exc
 
-    data = _unwrap(_loads_lenient(text))
-
-    if not isinstance(data, list):
-        raise ParseError(f"Expected JSON array or {{'findings': [...]}}, got {type(data).__name__}")
-
-    try:
-        return [ReviewFinding.model_validate(item) for item in data]
-    except Exception as exc:
-        raise ParseError(f"Finding validation failed: {exc}") from exc
+    raise ParseError("Cannot parse JSON findings from response")

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -13,7 +13,7 @@ from typing import Any
 from lgtmaybe.core.models import PRContext, ReflectionResult, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ProviderClient
 
-from .parse import _strip_think_blocks, strip_fences
+from .parse import iter_json_values
 
 _REFLECT_SYSTEM = """\
 You are a senior code reviewer auditing another reviewer's findings for false positives.
@@ -81,20 +81,22 @@ def _parse_verdicts(raw: str) -> dict[int, bool]:
 
     Accepts the structured ``{"verdicts": [{"index": i, "keep": bool}, ...]}``
     envelope, and (as a fallback for models that ignore the schema) the legacy
-    ``{"0": true, "1": false}`` index-to-bool map. Reasoning blocks and code
-    fences are stripped first.
+    ``{"0": true, "1": false}`` index-to-bool map. Shares the findings parser's
+    lenient extraction (:func:`iter_json_values`), so reasoning blocks, code
+    fences, and surrounding prose — including the bracket-bearing prose that an
+    ``openai-compatible`` gateway without JSON mode emits — are tolerated.
     """
-    text = strip_fences(_strip_think_blocks(raw).strip()).strip()
-    data = json.loads(text)
+    for data in iter_json_values(raw):
+        if not isinstance(data, dict):
+            continue
+        if isinstance(data.get("verdicts"), list):
+            out: dict[int, bool] = {}
+            for v in data["verdicts"]:
+                if isinstance(v, dict) and "index" in v and "keep" in v:
+                    out[int(v["index"])] = bool(v["keep"])
+            return out
+        # legacy {"0": true, ...} — a dict of digit keys to bools.
+        if data and all(str(k).lstrip("-").isdigit() for k in data):
+            return {int(k): bool(val) for k, val in data.items()}
 
-    if isinstance(data, dict) and isinstance(data.get("verdicts"), list):
-        out: dict[int, bool] = {}
-        for v in data["verdicts"]:
-            if isinstance(v, dict) and "index" in v and "keep" in v:
-                out[int(v["index"])] = bool(v["keep"])
-        return out
-
-    if isinstance(data, dict):  # legacy {"0": true, ...}
-        return {int(k): bool(val) for k, val in data.items()}
-
-    raise ValueError(f"unrecognised verdict shape: {type(data).__name__}")
+    raise ValueError("unrecognised or unparseable verdict shape")

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -223,6 +223,17 @@ class TestActionRouting:
         monkeypatch.setenv("INPUT_CONFIG_PATH", "")
         assert action_inputs()["config_path"] is None
 
+    def test_structured_output_input_is_read(self, monkeypatch):
+        """INPUT_STRUCTURED_OUTPUT is the action's escape hatch for a gateway that
+        rejects response_format (issue #104); empty/unset normalises to None."""
+        from lgtmaybe.cli import action_inputs
+
+        monkeypatch.delenv("INPUT_STRUCTURED_OUTPUT", raising=False)
+        assert action_inputs()["structured_output"] is None
+
+        monkeypatch.setenv("INPUT_STRUCTURED_OUTPUT", "false")
+        assert action_inputs()["structured_output"] == "false"
+
     def test_azure_api_base_input_reaches_runtime(self, tmp_path, monkeypatch):
         """INPUT_API_BASE carries the azure resource endpoint into the run."""
         captured: dict[str, object] = {}

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -209,6 +209,44 @@ def test_openai_compatible_keyless_local_server_sends_base_and_placeholder(
     assert captured_completion[0].get("api_key")
 
 
+def test_structured_output_sends_response_format_by_default(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """By default the findings JSON schema reaches litellm as response_format."""
+    result = CliRunner().invoke(
+        main, ["review", "--provider", "ollama", "--model", "llama3", "--no-reflect"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("response_format") is not None
+
+
+def test_no_structured_output_omits_response_format(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """--no-structured-output is the escape hatch for a gateway that rejects
+    response_format: litellm must then be called without it (issue #104)."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openai-compatible",
+            "--model",
+            "gemini-3.5-flash",
+            "--api-base",
+            "https://api.myllm.com/v1",
+            "--api-key",
+            "sk-x",
+            "--no-reflect",
+            "--no-structured-output",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert all("response_format" not in call for call in captured_completion)
+
+
 def test_num_ctx_flag_reaches_litellm_for_ollama(
     captured_completion: list[dict[str, Any]],
 ) -> None:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -697,6 +697,36 @@ def test_all_categories_error_raises_incomplete_not_lgtm() -> None:
         engine.review(_CTX, cfg)
 
 
+def test_prose_wrapped_fenced_findings_review_succeeds() -> None:
+    """Issue #104: an openai-compatible gateway that ignores response_format
+    returns findings wrapped in conversational prose + a markdown fence. The
+    review must succeed rather than fail every lens as 'unparseable'."""
+
+    class _GatewayProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            if _REFLECT_MARKER in messages[0]["content"]:
+                return ProviderResult(
+                    text='{"verdicts": [{"index": 0, "keep": true}]}',
+                    input_tokens=5,
+                    output_tokens=5,
+                )
+            envelope = json.dumps({"findings": [_HIGH.model_dump(mode="json")]})
+            text = (
+                "I reviewed the 1 changed file [a.py] and here is what I found:\n\n"
+                f"```json\n{envelope}\n```\n\nHope this helps!"
+            )
+            return ProviderResult(text=text, input_tokens=10, output_tokens=20)
+
+    engine = LLMReviewEngine(_GatewayProvider())
+    cfg = ReviewConfig(provider=Provider.openai_compatible, model="gemini-3.5-flash")
+
+    findings, summary = engine.review(_CTX, cfg)
+
+    assert [f.title for f in findings] == ["real bug"]
+    assert "incomplete" not in summary.lower()
+
+
 def test_partial_failure_keeps_findings_with_a_notice_and_no_lgtm() -> None:
     # security returns a real finding; every other category is unparseable.
     class _MixedProvider(FakeProvider):

--- a/tests/engine/test_parse.py
+++ b/tests/engine/test_parse.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from lgtmaybe.core.models import ReviewFinding, Severity
@@ -51,6 +53,59 @@ def test_prose_wrapped_json_extracted() -> None:
     raw = "Here are my findings:\n\n" + _json_findings([_VALID_FINDING]) + "\n\nHope that helps!"
     result = parse_findings(raw)
     assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# gateway output without JSON mode (issue #104): conversational prose that
+# carries stray brackets, and JSON whose own string values contain code fences
+# ---------------------------------------------------------------------------
+
+
+def test_prose_with_brackets_before_json() -> None:
+    """Conversational lead-in with brackets must not derail extraction."""
+    raw = "I reviewed 3 files [app.py, db.py, util.py] and found:\n" + _json_findings(
+        [_VALID_FINDING]
+    )
+    result = parse_findings(raw)
+    assert len(result) == 1
+    assert result[0].path == "src/app.py"
+
+
+def test_valid_json_array_in_prose_before_findings_is_skipped() -> None:
+    """A real JSON array in the prose (e.g. a category list) is not mistaken
+    for the findings — the findings-shaped candidate is selected instead."""
+    raw = 'Categories checked: ["security", "perf"].\n' + json.dumps({"findings": [_VALID_FINDING]})
+    result = parse_findings(raw)
+    assert len(result) == 1
+    assert result[0].severity == Severity.high
+
+
+def test_trailing_prose_with_bracket() -> None:
+    """A closing remark with a bracket after the JSON must not derail extraction."""
+    raw = json.dumps({"findings": [_VALID_FINDING]}) + "\nThat is all [done]."
+    result = parse_findings(raw)
+    assert len(result) == 1
+
+
+def test_fenced_json_with_prose_on_both_sides() -> None:
+    raw = (
+        "Sure! Here are the issues I found:\n\n```json\n"
+        + json.dumps({"findings": [_VALID_FINDING]})
+        + "\n```\n\nLet me know if you need more detail."
+    )
+    result = parse_findings(raw)
+    assert len(result) == 1
+
+
+def test_suggestion_code_fence_survives_verbatim() -> None:
+    """A code fence inside a string value must not be stripped — the old global
+    backtick removal silently corrupted suggestions that contained code blocks."""
+    suggestion = "Use the stdlib instead:\n```python\nimport json\n```"
+    finding = dict(_VALID_FINDING, suggestion=suggestion)
+    raw = json.dumps({"findings": [finding]})
+    result = parse_findings(raw)
+    assert len(result) == 1
+    assert result[0].suggestion == suggestion
 
 
 def test_trailing_comma_tolerated() -> None:

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -153,3 +153,30 @@ def test_unparseable_verdict_keeps_all() -> None:
     survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
 
     assert survivors == [_HIGH, _LOW_CONF]  # safe default
+
+
+# ---------------------------------------------------------------------------
+# gateway output without JSON mode (issue #104): prose-wrapped verdicts
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_wrapped_in_conversational_prose_parses() -> None:
+    """A gateway that ignores response_format returns the verdict inside prose;
+    reflection must still parse it, not silently keep everything."""
+    text = "Sure, here are my verdicts:\n" + _envelope([(0, True), (1, False)]) + "\nDone."
+    provider = _fake_with_text(text)
+
+    survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
+
+    assert _HIGH in survivors
+    assert _LOW_CONF not in survivors
+
+
+def test_verdict_after_bracket_bearing_prose_parses() -> None:
+    """Prose with stray brackets before the JSON must not derail extraction."""
+    text = "I checked findings [0, 1] carefully:\n" + _envelope([(0, False)])
+    provider = _fake_with_text(text)
+
+    survivors = reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert survivors == []  # the keep=false verdict was parsed past the prose


### PR DESCRIPTION
OpenAI-compatible gateways that ignore (or strip) the response_format
parameter make models wrap findings in markdown fences or conversational
prose. The greedy-regex extractor in engine/parse.py grabbed the wrong span
whenever that prose carried stray brackets (e.g. "reviewed 3 files [a, b]"),
failing every lens with "unparseable model output", and it silently corrupted
suggestion/body values that contained code fences by globally stripping
backticks (issue #104).

Replace the greedy regex with a balanced-delimiter scanner that respects JSON
string literals/escapes and selects the first findings-shaped candidate, so
bracket-bearing prose is skipped and string contents are never rewritten.
Reflection (engine/reflect.py) now shares the same lenient extractor instead
of a bare json.loads, so prose-wrapped verdicts parse rather than always
falling back to keep-all.

Also expose the existing structured_output config as --structured-output/
--no-structured-output (CLI) and a structured_output Action input, the escape
hatch for gateways that reject response_format with a 400 — where no parser
fix can help because the call fails before any output exists.

Docs: troubleshooting section in the openai-compatible how-to, config
reference notes, and the Action inputs table (also backfilling the missing
recursive input and openai-compatible provider).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KVckGTnr3MacDk4cj3wE7L