### PR TITLE
Prompt model to hedge claims about unseen code

### DIFF
--- a/evals/fixtures/cross-file-fp/diff.txt
+++ b/evals/fixtures/cross-file-fp/diff.txt
@@ -1,0 +1,23 @@
+diff --git a/migrations/0003_backfill.py b/migrations/0003_backfill.py
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/migrations/0003_backfill.py
+@@ -0,0 +1,17 @@
++import logging
++
++from .ledger import already_applied, mark_applied, pending
++from .models import SavedSubmittalSetV2
++
++log = logging.getLogger(__name__)
++
++
++def backfill(run_id: str) -> list[SavedSubmittalSetV2]:
++    """Copy every pending row into its V2 shape. Idempotent via the ledger."""
++    copied = []
++    for row in pending(run_id):
++        new = SavedSubmittalSetV2(**row.model_dump())
++        log.info("backfilled %s api_token=%s", row.id, row.api_token)
++        copied.append(new)
++    mark_applied(run_id)
++    return copied

--- a/evals/fixtures/cross-file-fp/expected.json
+++ b/evals/fixtures/cross-file-fp/expected.json
@@ -1,0 +1,29 @@
+{
+  "name": "cross-file-fp",
+  "changed_file": "migrations/0003_backfill.py",
+  "expected": [
+    {
+      "label": "secret logged: api_token written to the log line",
+      "line": 14,
+      "keywords": ["token", "secret", "api_token", "credential", "sensitive"],
+      "severity_at_least": "high"
+    }
+  ],
+  "forbidden": [
+    {
+      "label": "FP: model_dump may pass fields absent from V2 (shared base is unshown)",
+      "line": 13,
+      "keywords": ["model_dump", "absent", "extra field"]
+    },
+    {
+      "label": "FP: no idempotency guard, backfill could re-run (ledger guard is unshown)",
+      "line": 12,
+      "keywords": ["idempoten", "re-run", "rerun", "run twice"]
+    },
+    {
+      "label": "FP: tenant_id may be None, missing null check (pending() filters upstream)",
+      "line": 13,
+      "keywords": ["tenant_id"]
+    }
+  ]
+}

--- a/evals/run.py
+++ b/evals/run.py
@@ -132,9 +132,17 @@ def _review(
     )
     try:
         findings, _summary = engine.review(ctx, cfg)
-        return score_fixture(manifest.name, findings, manifest.expected, parsed_ok=True)
+        return score_fixture(
+            manifest.name,
+            findings,
+            manifest.expected,
+            forbidden=manifest.forbidden,
+            parsed_ok=True,
+        )
     except ReviewIncompleteError:
-        return score_fixture(manifest.name, [], manifest.expected, parsed_ok=False)
+        return score_fixture(
+            manifest.name, [], manifest.expected, forbidden=manifest.forbidden, parsed_ok=False
+        )
 
 
 def _print(score: FixtureScore) -> None:
@@ -147,6 +155,8 @@ def _print(score: FixtureScore) -> None:
     )
     for miss in score.missed:
         print(f"    missed: {miss}")
+    for fp in score.false_positives:
+        print(f"    FALSE POSITIVE: {fp}")
 
 
 def _gate(scores: list[FixtureScore], min_recall: float) -> tuple[bool, float]:
@@ -161,12 +171,16 @@ def _gate(scores: list[FixtureScore], min_recall: float) -> tuple[bool, float]:
       temperature 0, so a single missed finding on one short fixture shouldn't
       flip the whole job — pooling over more samples keeps the bar a real
       regression signal without flaking on that one-finding margin.
+    - Every fixture must be *clean*: a forbidden (cross-file false-positive)
+      finding firing is a humility regression, so any one fails the run. Only
+      fixtures that declare `forbidden` can trip this — the rest are always clean.
     """
     total_expected = sum(s.expected_count for s in scores)
     total_matched = sum(s.matched_count for s in scores)
     aggregate = total_matched / total_expected if total_expected else 1.0
     parsed = all(s.parsed_ok for s in scores)
-    return (parsed and aggregate >= min_recall), aggregate
+    clean = all(s.clean for s in scores)
+    return (parsed and clean and aggregate >= min_recall), aggregate
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/evals/scorer.py
+++ b/evals/scorer.py
@@ -36,6 +36,11 @@ class Fixture(BaseModel):
     name: str
     changed_file: str
     expected: list[ExpectedFinding]
+    # Findings that must NOT appear: cross-file false-positive traps. The diff
+    # looks like it omits a guard/field/check, but the handling lives in an
+    # unshown file, so a correct reviewer stays silent. A produced finding that
+    # matches one of these is a regression (see engine codebase-humility rules).
+    forbidden: list[ExpectedFinding] = []
 
 
 class FixtureScore(BaseModel):
@@ -48,12 +53,18 @@ class FixtureScore(BaseModel):
     findings_count: int
     missed: list[str]
     anchored_count: int = 0
+    false_positives: list[str] = []
 
     @property
     def recall(self) -> float:
         if self.expected_count == 0:
             return 1.0
         return self.matched_count / self.expected_count
+
+    @property
+    def clean(self) -> bool:
+        """True when no forbidden (cross-file false-positive) finding fired."""
+        return not self.false_positives
 
     @property
     def anchored_rate(self) -> float:
@@ -87,9 +98,15 @@ def score_fixture(
     findings: list[ReviewFinding],
     expected: list[ExpectedFinding],
     *,
+    forbidden: list[ExpectedFinding] | None = None,
     parsed_ok: bool = True,
 ) -> FixtureScore:
-    """Score *findings* against the *expected* manifest for one fixture."""
+    """Score *findings* against the *expected* manifest for one fixture.
+
+    Recall counts how many *expected* issues were caught. *forbidden* findings are
+    the inverse: any produced finding matching one is a false positive (a cross-file
+    claim the reviewer should not have made), recorded in ``false_positives``.
+    """
     matched = 0
     missed: list[str] = []
     for exp in expected:
@@ -97,6 +114,9 @@ def score_fixture(
             matched += 1
         else:
             missed.append(exp.label)
+    false_positives = [
+        fb.label for fb in (forbidden or []) if any(_matches(f, fb) for f in findings)
+    ]
     return FixtureScore(
         name=name,
         parsed_ok=parsed_ok,
@@ -105,4 +125,5 @@ def score_fixture(
         findings_count=len(findings),
         missed=missed,
         anchored_count=sum(1 for f in findings if f.anchored),
+        false_positives=false_positives,
     )

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -522,6 +522,18 @@ _SHARED_RULES = """\
   line followed by a similar `+` line is ONE modified line, not two copies — never report
   such a pair as duplicated code or as something "defined twice"/"declared twice".
 - Do NOT comment on lines outside the diff hunk.
+- The diff and its surrounding context are only a SLICE of the codebase. Base classes,
+  helpers, guards, validators, idempotency checks, callers, config, and schemas you rely
+  on may live in files you CANNOT see. Before claiming something is "missing", "never
+  handled", "unguarded", "not validated", or "will break X", ask: could that handling
+  exist in code that is not shown to me? If so, do NOT assert the absence — hedge the
+  wording ("if there is no X elsewhere…"), lower the severity, and raise it only as a
+  question worth checking. If the finding has no value once that handling might exist,
+  omit it entirely.
+- That restraint applies ONLY to claims about code outside the diff. It does NOT apply to
+  findings about the diff itself — a changed code path the diff leaves untested, a new
+  public surface left undocumented, a stale comment next to changed code — those are real;
+  raise them as usual.
 - Return `{"findings": []}` only when there are genuinely no issues.
 - Never output anything other than the JSON object."""
 

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -25,6 +25,14 @@ one per finding.
 Keep a finding only if you are confident it is a real issue in the actual changed code.
 Drop it if it is speculative, out of scope, or referring to unchanged lines.
 
+Also drop a finding whose validity depends on an assumption about code NOT shown in the \
+diff. The diff is only a slice of the codebase: base classes, guards, validators, \
+idempotency checks, callers, and config may live in files you cannot see. A finding that \
+asserts something is "missing", "unguarded", "never handled", or "will break" — when that \
+handling could plausibly exist elsewhere — is a likely false positive; drop it unless the \
+diff itself shows the absence. A finding that already hedges this ("if there is no X \
+elsewhere…") may be kept at low severity.
+
 Gap findings are valid types, not false positives: a missing test, a missing or stale \
 docstring, a performance or complexity concern, or a mismatch with the PR's stated intent. \
 For those, judge whether the gap or mismatch is real — not whether the changed line \

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -395,3 +395,22 @@ def test_prompt_warns_minus_lines_are_removed_not_duplicates() -> None:
     assert "removed" in prompt
     # A modify pair must not be read as a redefinition / duplication.
     assert "defined twice" in prompt or "duplicat" in prompt
+
+
+def test_prompt_demands_codebase_humility_about_unseen_code() -> None:
+    """The diff is only a slice of the codebase. A finding that asserts a
+    guard/field/handler is "missing" may be wrong because that thing lives in an
+    unshown file — so every lens must be told to hedge such claims, not assert
+    them. The rule lives in shared rules, so it appears in every focused prompt."""
+    for category in ReviewCategory:
+        prompt = build_system_prompt(category).lower()
+        assert "cannot see" in prompt or "not shown" in prompt
+        assert "missing" in prompt
+        # tells the model to hedge + lower severity rather than assert absence
+        assert "hedge" in prompt
+        assert "severity" in prompt
+
+
+def test_humility_rule_present_in_custom_lens_prompt() -> None:
+    lens = CustomLens(id="x", instructions="flag foo")
+    assert "cannot see" in build_lens_prompt(lens).lower()

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -147,6 +147,19 @@ def test_reflect_prompt_names_gap_findings_as_valid_types() -> None:
     assert "intent" in system
 
 
+def test_reflect_prompt_drops_unseen_code_assumptions() -> None:
+    """The auditor must drop findings whose validity hinges on an assumption about
+    code not shown in the diff (e.g. a guard/field that may exist elsewhere) — the
+    exact shape of the cross-file false positives we keep seeing."""
+    provider = _fake_with_verdict({0: True})
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    system = provider.calls[0]["messages"][0]["content"].lower()
+    assert "cannot see" in system or "not shown" in system
+    assert "missing" in system
+
+
 def test_unparseable_verdict_keeps_all() -> None:
     provider = _fake_with_text("I'm not really sure about these.")
 

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -78,6 +78,16 @@ def test_rlm_fixture_is_one_multi_hunk_file(name: str) -> None:
     assert len(split_patch_into_hunks(patch)) >= 3, f"{name} needs several hunks"
 
 
+def test_cross_file_fp_fixture_has_expected_and_forbidden() -> None:
+    """The cross-file fixture loads with a genuine in-diff catch plus forbidden traps —
+    the diff alone (no sibling file_contents) so the guard is genuinely unseen, which is
+    the real-world shape that produced the invalid findings."""
+    diff, manifest = _fixture("cross-file-fp")
+    assert diff.strip()
+    assert manifest.expected, "needs a real in-diff finding so recall stays meaningful"
+    assert manifest.forbidden, "needs forbidden (cross-file false-positive) traps"
+
+
 def test_fixtures_cover_performance_and_complexity_lenses() -> None:
     """Both fixtures plant a performance and a complexity issue so the e2e exercises
     all seven code lenses, not just security + correctness. (The intent lens needs a

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -49,6 +49,22 @@ def test_gate_fails_on_any_parse_failure_regardless_of_recall() -> None:
     assert not ok
 
 
+def test_gate_fails_on_false_positive() -> None:
+    """A forbidden (cross-file) finding firing fails the run even at full recall —
+    the humility regression signal the cross-file-fp fixture exists to catch."""
+    fp = FixtureScore(
+        name="cross-file-fp",
+        parsed_ok=True,
+        expected_count=1,
+        matched_count=1,
+        findings_count=2,
+        missed=[],
+        false_positives=["FP: model_dump may pass fields absent from V2"],
+    )
+    ok, _ = run_mod._gate([fp], 0.0)
+    assert not ok
+
+
 class _ShellInjectionProvider(FakeProvider):
     """Returns the badcode shell-injection finding for every review call."""
 
@@ -232,7 +248,13 @@ def test_no_fixture_flag_runs_every_fixture(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(run_mod, "_review", fake_review)
 
     run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0"])
-    assert set(seen) == {"badcode", "vibe-multifile", "rlm-bigfile", "rlm-pipeline"}
+    assert set(seen) == {
+        "badcode",
+        "vibe-multifile",
+        "rlm-bigfile",
+        "rlm-pipeline",
+        "cross-file-fp",
+    }
 
 
 def test_unknown_fixture_name_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/evals/test_scorer.py
+++ b/tests/evals/test_scorer.py
@@ -82,6 +82,44 @@ def test_parse_fail_recorded_with_zero_findings() -> None:
     assert score.recall == 0.0
 
 
+def test_forbidden_finding_flagged_as_false_positive() -> None:
+    """A produced finding matching a forbidden entry is a cross-file false positive."""
+    findings = [_finding(13, "model_dump may pass fields absent from V2")]
+    forbidden = [_expected(13, ["model_dump", "absent"])]
+    score = score_fixture("f", findings, [], forbidden=forbidden)
+    assert score.false_positives == ["line 13"]
+    assert score.clean is False
+
+
+def test_no_false_positive_when_forbidden_not_triggered() -> None:
+    """A clean review (no finding matches a forbidden trap) records no false positive."""
+    findings = [_finding(14, "secret api_token logged")]
+    forbidden = [_expected(13, ["model_dump", "absent"])]
+    score = score_fixture("f", findings, [], forbidden=forbidden)
+    assert score.false_positives == []
+    assert score.clean is True
+
+
+def test_forbidden_respects_line_and_keyword() -> None:
+    """A forbidden keyword on a far-off line is not a false positive (precision)."""
+    findings = [_finding(40, "model_dump may pass fields absent from V2")]  # far from line 13
+    forbidden = [_expected(13, ["model_dump", "absent"])]
+    score = score_fixture("f", findings, [], forbidden=forbidden)
+    assert score.false_positives == []
+    assert score.clean is True
+
+
+def test_committed_cross_file_fp_fixture_manifest_is_valid() -> None:
+    """The cross-file FP fixture parses and carries both expected and forbidden."""
+    fixtures = Path(__file__).resolve().parents[2] / "evals" / "fixtures" / "cross-file-fp"
+    manifest = Fixture.model_validate_json((fixtures / "expected.json").read_text())
+    assert manifest.changed_file == "migrations/0003_backfill.py"
+    assert manifest.expected, "fixture needs a genuine in-diff finding"
+    assert manifest.forbidden, "fixture needs forbidden (cross-file FP) traps"
+    assert all(e.keywords for e in manifest.expected)
+    assert all(f.keywords for f in manifest.forbidden)
+
+
 def test_committed_badcode_fixture_manifest_is_valid() -> None:
     """The shipped fixture parses and its expected lines fall within the diff."""
     fixtures = Path(__file__).resolve().parents[2] / "evals" / "fixtures" / "badcode"


### PR DESCRIPTION
## Summary

Adds explicit guidance to the review prompts (both the main lens and reflection stage) instructing the model to hedge claims about code that may exist outside the diff. This addresses a recurring class of false positives where the model asserts something is "missing", "unguarded", or "will break" when that handling could plausibly exist in files not shown in the diff.

## Key Changes

- **Main prompt (`prompt.py`):** Added a new rule in the shared instructions that:
  - Acknowledges the diff is only a slice of the codebase
  - Instructs the model to hedge wording when claiming something is missing ("if there is no X elsewhere…")
  - Directs the model to lower severity for such findings
  - Clarifies that this restraint applies *only* to claims about code outside the diff, not to real issues within the changed code itself

- **Reflection prompt (`reflect.py`):** Added guidance to the reflection stage to:
  - Drop findings whose validity depends on assumptions about unseen code
  - Identify likely false positives (assertions about missing guards, handlers, etc. that could exist elsewhere)
  - Allow hedged findings ("if there is no X elsewhere…") at low severity

- **Tests (`test_prompt.py`, `test_reflect.py`):** Added two new test cases:
  - `test_prompt_demands_codebase_humility_about_unseen_code()` — verifies the humility rule appears in all review category prompts and includes hedging/severity language
  - `test_humility_rule_present_in_custom_lens_prompt()` — verifies custom lenses also receive the unseen-code guidance
  - `test_reflect_prompt_drops_unseen_code_assumptions()` — verifies the reflection stage includes the same guidance

## Implementation Details

The rule is placed in the shared instructions block (not category-specific), ensuring it appears in every focused prompt. The language distinguishes between:
- **Speculative claims** (about code outside the diff) → hedge or omit
- **Real issues** (within the diff itself) → raise as usual

This targets the exact shape of cross-file false positives observed in practice: guards/fields/handlers that may exist in unshown files but are asserted as missing.

https://claude.ai/code/session_01H1xyLu7MVMPAm3vwn3rMbq