### PR TITLE
test: add live e2e suite for local providers (ollama, llama.cpp, vLLM)

### DIFF
--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -1,0 +1,64 @@
+# Live local-provider e2e (tests/e2e/) — drives the real `lgtmaybe` CLI against a
+# local model server and asserts a review round-trips end-to-end. This is a
+# COMPATIBILITY smoke, not a gate, and it needs a live model, so it never runs on
+# a normal PR: dispatch it manually.
+#
+# Only the ollama leg runs on a hosted runner (it installs + serves locally, like
+# rlm-bench). The llama.cpp and vLLM legs of the suite auto-skip here — they want
+# docker images / a GPU that a default runner doesn't have — so run those two
+# locally with `scripts/e2e-up.sh`. The pytest test is the SAME one a developer
+# runs locally, so CI and local can't drift.
+name: e2e-local
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "ollama model tag (a tiny qwen keeps it fast)"
+        required: false
+        default: "qwen3:0.6b"
+
+concurrency:
+  group: e2e-local-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      LGTMAYBE_E2E_OLLAMA_MODEL: ${{ github.event.inputs.model || 'qwen3:0.6b' }}
+      OLLAMA_MODELS: /home/runner/.ollama/models
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Sync (with dev deps)
+        run: uv sync --dev
+
+      - name: Install ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Cache ollama model
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.OLLAMA_MODELS }}
+          key: ollama-${{ runner.os }}-${{ env.LGTMAYBE_E2E_OLLAMA_MODEL }}
+
+      - name: Start ollama and pull the model
+        run: |
+          ollama serve &
+          for _ in $(seq 1 60); do
+            curl -sf http://localhost:11434/api/tags >/dev/null && break
+            sleep 1
+          done
+          ollama pull "$LGTMAYBE_E2E_OLLAMA_MODEL"
+
+      # llama.cpp + vLLM legs auto-skip (no server here); the ollama leg runs.
+      - name: Run the e2e suite
+        run: uv run pytest -m e2e -v

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -212,6 +212,43 @@ LLM or the GitHub API. Test layout mirrors `src/`:
 - `tests/core/`, `tests/local/` — diff parsing, local git context
 - `tests/docs/` + `tests/snapshots/` — committed schema snapshots and the
   generated-reference freshness check (see below)
+- `tests/e2e/` — live end-to-end against a local model server (deselected by
+  default; see below)
+
+### Live provider e2e (tests/e2e/)
+
+`tests/e2e/test_local_providers.py` drives the **real `lgtmaybe` CLI** against a
+local model server, proving the app round-trips end-to-end through each local
+serving stack — **ollama**, **llama.cpp**, and **vLLM** — on a tiny qwen model.
+It exercises the whole path (arg parsing, `.lgtmaybe.yml`, the local git diff,
+provider/credential resolution, the litellm wire format, structured-output
+parsing, rendering). This is a **compatibility** smoke, not a recall test — for
+recall use `evals/run.py` (below).
+
+The three backends cover both adapter routes: ollama hits litellm's native
+`ollama/` route; llama.cpp and vLLM both ride the `openai-compatible` route
+(`openai/` + a custom `--api-base`).
+
+These need a live server + a downloaded model, so they are **marked `e2e` and
+deselected from the default gate** (`addopts = -m 'not e2e'`). Stand the servers
+up, then opt in:
+
+```bash
+scripts/e2e-up.sh            # start every backend with a runner available + pull models
+uv run pytest -m e2e         # run every backend the suite finds reachable
+scripts/e2e-up.sh down       # stop the docker-run backends (llama.cpp, vLLM)
+```
+
+Each backend **auto-skips when its server isn't up**, so you can start only one
+(`scripts/e2e-up.sh ollama`) and just that leg runs. Endpoints and model tags are
+env-overridable (`LGTMAYBE_E2E_OLLAMA_BASE`, `LGTMAYBE_E2E_VLLM_MODEL`, …) so the
+suite fits whatever you have running.
+
+> **Context window is a launch-time setting for llama.cpp/vLLM.** Unlike ollama
+> (where lgtmaybe passes `num_ctx` per request), the OpenAI-compatible servers
+> fix their context at startup — llama.cpp `-c`, vLLM `--max-model-len`. The
+> client can't raise it later, so `scripts/e2e-up.sh` bakes the window in at
+> launch (`E2E_CTX`, default 8192); bump it if you point the suite at a bigger diff.
 
 ### Regenerating generated artifacts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,15 @@ testpaths = ["tests"]
 pythonpath = ["src", "."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+# Live e2e tests (tests/e2e/) drive the real CLI against a local model server, so
+# they need a running ollama/llama.cpp/vLLM and a downloaded model — never the
+# default gate. They are DESELECTED here and opted into with `pytest -m e2e`
+# (a command-line -m overrides this one). Markers are registered so the strict
+# warning filter below never trips on an unknown mark.
+addopts = "-m 'not e2e'"
+markers = [
+    "e2e: live end-to-end test against a local model server (deselected by default; run with -m e2e)",
+]
 # Code-quality gate: using a deprecated API (ours, the stdlib's, or a dependency's
 # triggered on our hot path) is a hard error, not silent noise. This is fully
 # deterministic given the lockfile. If a *third-party* deprecation we don't

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Stand up the local model servers the e2e suite (tests/e2e/) reviews against:
+# ollama, llama.cpp, and vLLM — each serving a tiny qwen model so a full review
+# finishes in seconds on CPU. Then run:
+#
+#     uv run pytest -m e2e
+#
+# Each backend the suite finds reachable runs; the rest auto-skip, so you can
+# start only the ones you have (e.g. just ollama) and the others sit out.
+#
+# Usage:
+#     scripts/e2e-up.sh            # start every backend that has a runner available
+#     scripts/e2e-up.sh ollama     # start only the named backend(s)
+#     scripts/e2e-up.sh down       # stop the docker-run backends (llama.cpp, vLLM)
+#
+# IMPORTANT — context window is a LAUNCH-TIME setting for llama.cpp/vLLM.
+# Unlike ollama (where lgtmaybe passes `num_ctx` per request), the OpenAI-compatible
+# servers fix their context at startup: llama.cpp `-c`, vLLM `--max-model-len`. The
+# client cannot raise it later, so we bake a window here that comfortably fits the
+# e2e fixture diff. Bump E2E_CTX if you point the suite at a bigger diff.
+set -euo pipefail
+
+# --- knobs (override via env) ----------------------------------------------
+E2E_CTX="${E2E_CTX:-8192}"  # context window baked into llama.cpp/vLLM at launch
+
+OLLAMA_MODEL="${LGTMAYBE_E2E_OLLAMA_MODEL:-qwen3:0.6b}"
+OLLAMA_BASE="${LGTMAYBE_E2E_OLLAMA_BASE:-http://localhost:11434}"
+
+# llama.cpp serves whatever GGUF it loads under any requested model id; this HF
+# repo is a tiny qwen the server image can pull on its own.
+LLAMACPP_PORT="${LLAMACPP_PORT:-8080}"
+LLAMACPP_HF_REPO="${LLAMACPP_HF_REPO:-Qwen/Qwen2.5-0.5B-Instruct-GGUF}"
+LLAMACPP_HF_FILE="${LLAMACPP_HF_FILE:-qwen2.5-0.5b-instruct-q4_k_m.gguf}"
+
+# vLLM is strict: the served id must equal the --model it was launched with, and
+# that id is what lgtmaybe must send (LGTMAYBE_E2E_VLLM_MODEL defaults to match).
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_MODEL="${LGTMAYBE_E2E_VLLM_MODEL:-Qwen/Qwen2.5-0.5B-Instruct}"
+
+LLAMACPP_CONTAINER="lgtmaybe-e2e-llamacpp"
+VLLM_CONTAINER="lgtmaybe-e2e-vllm"
+
+# --- helpers ----------------------------------------------------------------
+log() { printf '\033[1;34m[e2e-up]\033[0m %s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+wait_for() {  # wait_for <url> <name>
+  local url="$1" name="$2"
+  for _ in $(seq 1 120); do
+    if curl -sf "$url" >/dev/null 2>&1; then
+      log "$name is up ($url)"
+      return 0
+    fi
+    sleep 1
+  done
+  log "WARNING: $name did not become ready at $url"
+  return 1
+}
+
+start_ollama() {
+  if ! have ollama; then
+    log "ollama not installed — skipping (install: curl -fsSL https://ollama.com/install.sh | sh)"
+    return 0
+  fi
+  if ! curl -sf "$OLLAMA_BASE/api/tags" >/dev/null 2>&1; then
+    log "starting ollama serve in the background"
+    ollama serve >/tmp/lgtmaybe-e2e-ollama.log 2>&1 &
+    wait_for "$OLLAMA_BASE/api/tags" "ollama" || return 0
+  fi
+  log "pulling $OLLAMA_MODEL"
+  ollama pull "$OLLAMA_MODEL"
+}
+
+start_llamacpp() {
+  if ! have docker; then
+    log "docker not installed — skipping llama.cpp"
+    return 0
+  fi
+  docker rm -f "$LLAMACPP_CONTAINER" >/dev/null 2>&1 || true
+  log "starting llama.cpp server (ctx=$E2E_CTX) on :$LLAMACPP_PORT"
+  # -c bakes the context window at launch — the client cannot raise it later.
+  docker run -d --name "$LLAMACPP_CONTAINER" \
+    -p "$LLAMACPP_PORT:8080" \
+    ghcr.io/ggml-org/llama.cpp:server \
+    -hf "$LLAMACPP_HF_REPO:$LLAMACPP_HF_FILE" \
+    -c "$E2E_CTX" \
+    --host 0.0.0.0 --port 8080 >/dev/null
+  wait_for "http://localhost:$LLAMACPP_PORT/v1/models" "llama.cpp" || true
+}
+
+start_vllm() {
+  if ! have docker; then
+    log "docker not installed — skipping vLLM"
+    return 0
+  fi
+  docker rm -f "$VLLM_CONTAINER" >/dev/null 2>&1 || true
+  log "starting vLLM server (max-model-len=$E2E_CTX) on :$VLLM_PORT serving $VLLM_MODEL"
+  # --max-model-len bakes the context window at launch (vLLM's equivalent of -c).
+  docker run -d --name "$VLLM_CONTAINER" \
+    -p "$VLLM_PORT:8000" \
+    vllm/vllm-openai:latest \
+    --model "$VLLM_MODEL" \
+    --max-model-len "$E2E_CTX" >/dev/null
+  wait_for "http://localhost:$VLLM_PORT/v1/models" "vLLM" || true
+}
+
+down() {
+  log "stopping docker-run backends"
+  docker rm -f "$LLAMACPP_CONTAINER" "$VLLM_CONTAINER" >/dev/null 2>&1 || true
+  log "ollama (if started here) keeps running — stop it with: pkill -f 'ollama serve'"
+}
+
+# --- dispatch ---------------------------------------------------------------
+targets=("$@")
+[ ${#targets[@]} -eq 0 ] && targets=(ollama llamacpp vllm)
+
+for t in "${targets[@]}"; do
+  case "$t" in
+    ollama) start_ollama ;;
+    llamacpp|llama.cpp) start_llamacpp ;;
+    vllm) start_vllm ;;
+    down|stop) down; exit 0 ;;
+    *) log "unknown target: $t (expected: ollama, llamacpp, vllm, down)"; exit 2 ;;
+  esac
+done
+
+log "ready — run the suite with:  uv run pytest -m e2e"

--- a/tests/e2e/test_local_providers.py
+++ b/tests/e2e/test_local_providers.py
@@ -1,0 +1,239 @@
+"""Live e2e: drive the real ``lgtmaybe`` CLI against a local model server.
+
+This proves *compatibility* — that the app round-trips end-to-end through each
+local serving stack (ollama, llama.cpp, vLLM) — not recall (that is
+``evals/run.py``). It exercises the whole path a developer hits: arg parsing,
+``.lgtmaybe.yml`` loading, the local git-diff context, the provider/credential
+resolution, the litellm wire format, structured-output parsing, and rendering.
+
+The three backends split across exactly two adapters:
+
+  - ollama            → litellm's native ``ollama/`` route (api_base + ``num_ctx``)
+  - llama.cpp / vLLM  → the ``openai-compatible`` route (``openai/`` + custom base)
+
+so running all three covers both code paths plus each server's quirks (vLLM is
+strict about the model id and JSON schema; llama.cpp is lax; ollama strips
+qwen-style ``think`` blocks).
+
+These need a live server and a downloaded model, so they are marked ``e2e`` and
+DESELECTED from the default gate (``addopts = -m "not e2e"`` in pyproject). Run
+them deliberately::
+
+    scripts/e2e-up.sh            # stand up the servers + pull the tiny models
+    uv run pytest -m e2e         # run every backend that is reachable
+
+Each backend auto-skips when its server is not up, so starting only one (say
+ollama) runs just that leg. Endpoints and model tags are overridable via env
+(see ``Backend``) so the same test fits whatever you have running locally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+# A small module with blatant, security-lens-visible bugs: a hardcoded GitHub
+# token and a shell-injection sink. Even a 0.5B model should flag at least one,
+# which keeps the "got a finding" assertion meaningful without chasing recall.
+_BUGGY_MODULE = '''\
+"""Report helpers."""
+import subprocess
+
+API_TOKEN = "ghp_aB3xK9mP2qR7sT1vW4yZ6cD8eF0gH2jK4lM"
+
+
+def run_report(report_name):
+    cmd = "generate-report --name " + report_name
+    subprocess.run(cmd, shell=True)
+
+
+def average(values):
+    total = 0
+    for i in range(1, len(values)):
+        total += values[i]
+    return total / len(values)
+'''
+
+# One lens, not the full nine-way fan-out — a tiny local model is slow, and the
+# planted bugs are squarely security findings, so a single lens keeps a leg to
+# one model call while still proving the round-trip.
+_REPO_CONFIG = "categories:\n  - security\n"
+
+# Per-request model timeout (seconds). Generous: a 0.5B model on CPU is slow.
+_TIMEOUT = os.environ.get("LGTMAYBE_E2E_TIMEOUT", "600")
+
+
+@dataclass(frozen=True)
+class Backend:
+    """One local serving stack, with env-overridable endpoint + model tag."""
+
+    id: str
+    provider: str
+    base_env: str
+    base_default: str
+    model_env: str
+    model_default: str
+    health_path: str  # appended to the base to probe liveness
+
+    @property
+    def base(self) -> str:
+        return os.environ.get(self.base_env, self.base_default)
+
+    @property
+    def model(self) -> str:
+        return os.environ.get(self.model_env, self.model_default)
+
+
+# Defaults match scripts/e2e-up.sh. The openai-compatible bases end in /v1, so
+# the OpenAI-style /models probe lands on <base>/models.
+BACKENDS = [
+    Backend(
+        id="ollama",
+        provider="ollama",
+        base_env="LGTMAYBE_E2E_OLLAMA_BASE",
+        base_default="http://localhost:11434",
+        model_env="LGTMAYBE_E2E_OLLAMA_MODEL",
+        model_default="qwen3:0.6b",
+        health_path="/api/tags",
+    ),
+    Backend(
+        id="llamacpp",
+        provider="openai-compatible",
+        base_env="LGTMAYBE_E2E_LLAMACPP_BASE",
+        base_default="http://localhost:8080/v1",
+        model_env="LGTMAYBE_E2E_LLAMACPP_MODEL",
+        model_default="qwen2.5-0.5b-instruct",
+        health_path="/models",
+    ),
+    Backend(
+        id="vllm",
+        provider="openai-compatible",
+        base_env="LGTMAYBE_E2E_VLLM_BASE",
+        base_default="http://localhost:8000/v1",
+        model_env="LGTMAYBE_E2E_VLLM_MODEL",
+        model_default="Qwen/Qwen2.5-0.5B-Instruct",
+        health_path="/models",
+    ),
+]
+
+
+def _server_up(backend: Backend) -> bool:
+    """True when the backend answers its health endpoint (any non-5xx)."""
+    url = backend.base.rstrip("/") + backend.health_path
+    try:
+        return httpx.get(url, timeout=2.0).status_code < 500
+    except httpx.HTTPError:
+        return False
+
+
+def _extract_findings(stdout: str) -> list[dict[str, object]]:
+    """Pull the findings JSON array out of CLI stdout.
+
+    The ``review`` command echoes the rendered JSON; any stray logging is
+    tolerated by scanning lines bottom-up for the first that parses as a list.
+    """
+    for line in reversed([ln for ln in stdout.splitlines() if ln.strip()]):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, list):
+            return value
+    raise AssertionError(f"no JSON findings array found in CLI stdout:\n{stdout}")
+
+
+@pytest.fixture
+def review_repo(tmp_path: Path) -> tuple[Path, str]:
+    """A temp git repo: clean baseline commit, then a commit adding the buggy file.
+
+    Returns (repo_path, base_sha). The config lives in the BASELINE commit so it
+    is not itself part of the reviewed diff — only ``payments.py`` is.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    git("init", "-q")
+    git("config", "user.email", "e2e@example.com")
+    git("config", "user.name", "lgtmaybe-e2e")
+    git("config", "commit.gpgsign", "false")
+
+    (repo / "README.md").write_text("# demo\n")
+    (repo / ".lgtmaybe.yml").write_text(_REPO_CONFIG)
+    git("add", "README.md", ".lgtmaybe.yml")
+    git("commit", "-q", "-m", "chore: baseline")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    (repo / "payments.py").write_text(_BUGGY_MODULE)
+    git("add", "payments.py")
+    git("commit", "-q", "-m", "feat: add report helper")
+    return repo, base
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=[b.id for b in BACKENDS])
+def test_cli_review_against_local_provider(
+    backend: Backend, review_repo: tuple[Path, str]
+) -> None:
+    """`lgtmaybe review` round-trips through a live local model and emits findings."""
+    if not _server_up(backend):
+        pytest.skip(f"{backend.id} server not reachable at {backend.base}")
+
+    repo, base = review_repo
+    cmd = [
+        sys.executable,
+        "-m",
+        "lgtmaybe",
+        "review",
+        "--provider",
+        backend.provider,
+        "--model",
+        backend.model,
+        "--api-base",
+        backend.base,
+        "--base",
+        base,
+        "--no-reflect",  # a tiny model over-prunes its own findings
+        "--format",
+        "json",
+        "--timeout",
+        _TIMEOUT,
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=int(_TIMEOUT) + 120,
+    )
+
+    assert result.returncode == 0, (
+        f"{backend.id}: CLI exited {result.returncode}\n"
+        f"--- stderr ---\n{result.stderr}\n--- stdout ---\n{result.stdout}"
+    )
+
+    findings = _extract_findings(result.stdout)
+    # Every finding must carry the structured shape — proves schema enforcement
+    # survived the live round-trip, not just that *some* JSON came back.
+    required = {"path", "line", "severity", "title", "body"}
+    for finding in findings:
+        assert required <= set(finding), f"{backend.id}: malformed finding {finding}"
+
+    # The file plants a hardcoded token + a shell-injection sink under the security
+    # lens, so a working pipeline should surface at least one.
+    assert findings, (
+        f"{backend.id}: expected >=1 finding on a file with a hardcoded secret "
+        f"and shell injection, got none"
+    )

--- a/tests/e2e/test_local_providers.py
+++ b/tests/e2e/test_local_providers.py
@@ -184,9 +184,7 @@ def review_repo(tmp_path: Path) -> tuple[Path, str]:
 
 
 @pytest.mark.parametrize("backend", BACKENDS, ids=[b.id for b in BACKENDS])
-def test_cli_review_against_local_provider(
-    backend: Backend, review_repo: tuple[Path, str]
-) -> None:
+def test_cli_review_against_local_provider(backend: Backend, review_repo: tuple[Path, str]) -> None:
     """`lgtmaybe review` round-trips through a live local model and emits findings."""
     if not _server_up(backend):
         pytest.skip(f"{backend.id} server not reachable at {backend.base}")


### PR DESCRIPTION
Drive the real `lgtmaybe` CLI against a local model server and assert a
review round-trips end-to-end on a tiny qwen model. Covers both adapter
routes — ollama's native `ollama/` and the `openai-compatible` route shared
by llama.cpp and vLLM — proving wire-format compatibility (not recall; that
stays in evals/run.py).

- tests/e2e/test_local_providers.py: parametrized over the three backends,
  each auto-skipping when its server is unreachable. Builds a temp git repo
  with a planted secret + shell-injection sink and reviews it via the CLI,
  asserting exit 0 + a well-formed findings array.
- Marked `e2e` and deselected from the default gate (addopts = -m 'not e2e');
  run with `uv run pytest -m e2e`.
- scripts/e2e-up.sh: stand up all three servers with tiny qwen models. Bakes
  the context window into llama.cpp (-c) / vLLM (--max-model-len) at launch,
  since those fix context at startup (unlike ollama's per-request num_ctx).
- .github/workflows/e2e-local.yml: workflow_dispatch job running the ollama
  leg on a hosted runner (llama.cpp/vLLM legs auto-skip there).
- DEVELOPMENT.md: document the suite and the launch-time context-window note.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ggRvqtZSdPYDeXSnFQJSb