### PR TITLE
feat: cut weak-model false positives with confidence gates

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -20,7 +20,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
-| `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `info` |  |
+| `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` | Yes | — |  |
@@ -30,6 +30,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `temperature` | number | No | `0.0` | Temperature |
 | `timeout` | integer / null | No | `null` | Timeout |
+| `unanchored_min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `high` |  |
 
 ## Enums
 
@@ -343,7 +344,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
     },
     "min_severity": {
       "$ref": "#/$defs/Severity",
-      "default": "info"
+      "default": "low"
     },
     "model": {
       "title": "Model",
@@ -400,6 +401,10 @@ The canonical machine-readable schemas. These are the source of truth for provid
       ],
       "default": null,
       "title": "Timeout"
+    },
+    "unanchored_min_severity": {
+      "$ref": "#/$defs/Severity",
+      "default": "high"
     }
   },
   "required": [

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -61,6 +61,13 @@ from lgtmaybe.config.loader import load_config
     type=click.Choice(["info", "low", "medium", "high", "critical"]),
     help="Minimum severity to report",
 )
+@click.option(
+    "--unanchored-min-severity",
+    default=None,
+    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    help="Minimum severity for a finding the engine could not anchor to a changed "
+    "line (default high; raise/lower to control how many low-confidence guesses surface)",
+)
 @click.option("--max-files", default=None, type=int, help="Maximum number of files to review")
 @click.option(
     "--max-input-tokens",
@@ -162,6 +169,7 @@ def review(
     api_key: str | None,
     api_base: str | None,
     min_severity: str | None,
+    unanchored_min_severity: str | None,
     max_files: int | None,
     max_input_tokens: int | None,
     num_ctx: int | None,
@@ -187,6 +195,7 @@ def review(
         provider=provider,
         model=model,
         min_severity=min_severity,
+        unanchored_min_severity=unanchored_min_severity,
         max_files=max_files,
         max_input_tokens=max_input_tokens,
         num_ctx=num_ctx,

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -207,7 +207,17 @@ class ReviewConfig(_Strict):
     provider: Provider
     model: str
     api_base: str | None = None
-    min_severity: Severity = Severity.info
+    # Severity floor: findings below this are dropped before posting. Defaults to
+    # `low` (not `info`) so pure-info narration — a finding that merely restates
+    # the diff ("X was removed") — never reaches the PR. Raise it to `medium` for
+    # a weak/fast model that still over-reports.
+    min_severity: Severity = Severity.low
+    # Stricter floor applied only to UNANCHORED findings — ones whose verbatim
+    # anchor matched no changed line, so the engine could not place them. A failed
+    # anchor is a low-confidence signal (a weak model miscounting), so only a
+    # high/critical guess is worth surfacing (demoted to the review body, never
+    # posted on a line we can't stand behind); anything weaker is dropped.
+    unanchored_min_severity: Severity = Severity.high
     include_paths: list[str] = Field(default_factory=list)
     exclude_paths: list[str] = Field(default_factory=list)
     max_files: int = 50

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -213,8 +213,15 @@ class LLMReviewEngine(ReviewEngine):
             clean_ctx = ctx.model_copy(update={"diff": reviewed_diff})
             all_findings = reflect_findings(all_findings, clean_ctx, cfg, self._provider)
 
-        # 9. Filter by min_severity.
-        filtered = [f for f in all_findings if f.severity >= cfg.min_severity]
+        # 9. Filter: drop findings below the severity floor, and apply the
+        #    stricter unanchored floor — a finding the engine could not anchor is a
+        #    low-confidence guess, so surface it only when it's high/critical.
+        filtered = [
+            f
+            for f in all_findings
+            if f.severity >= cfg.min_severity
+            and (f.anchored or f.severity >= cfg.unanchored_min_severity)
+        ]
 
         plural = "s" if len(filtered) != 1 else ""
         summary_line = (

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -534,6 +534,11 @@ _SHARED_RULES = """\
   findings about the diff itself — a changed code path the diff leaves untested, a new
   public surface left undocumented, a stale comment next to changed code — those are real;
   raise them as usual.
+- Report a finding only when there is a concrete problem, risk, or gap with a clear
+  recommended action. Do NOT raise a finding that merely DESCRIBES what the change does
+  ("X was removed", "Y now takes a new parameter", "this method is now async") — narration
+  that restates the diff is not a finding. If the content is only a restatement of the
+  change with no problem attached, omit it entirely.
 - Return `{"findings": []}` only when there are genuinely no issues.
 - Never output anything other than the JSON object."""
 

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -25,6 +25,12 @@ one per finding.
 Keep a finding only if you are confident it is a real issue in the actual changed code.
 Drop it if it is speculative, out of scope, or referring to unchanged lines.
 
+Also drop a finding that merely DESCRIBES the change without naming a concrete problem \
+("X was removed", "Y now takes a new parameter", "this method is now async") — narration \
+that restates the diff is not a finding, only a changelog. Be especially strict with \
+low-severity (info/low) findings: keep one only when it names a specific, actionable issue, \
+not just an observation about what changed.
+
 Also drop a finding whose validity depends on an assumption about code NOT shown in the \
 diff. The diff is only a slice of the codebase: base classes, guards, validators, \
 idempotency checks, callers, and config may live in files you cannot see. A finding that \

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -200,6 +200,61 @@ def test_all_findings_returned_when_min_severity_info() -> None:
 
 
 # ---------------------------------------------------------------------------
+# unanchored confidence gate: a finding whose anchor matched nothing is a guess.
+# Below unanchored_min_severity it is dropped, not demoted to the body.
+# ---------------------------------------------------------------------------
+
+_UNANCHORED_MEDIUM = ReviewFinding(
+    path="a.py",
+    line=2,
+    severity=Severity.medium,
+    title="guessed bug",
+    body="line is a guess",
+    anchor="this text is nowhere in the diff",
+)
+_UNANCHORED_HIGH = ReviewFinding(
+    path="a.py",
+    line=2,
+    severity=Severity.high,
+    title="serious guessed bug",
+    body="line is a guess",
+    anchor="this text is nowhere in the diff",
+)
+
+
+def test_unanchored_finding_below_threshold_dropped() -> None:
+    provider = _provider_for([_UNANCHORED_MEDIUM], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_severity=Severity.info)
+
+    findings, _ = engine.review(_CTX, cfg)
+
+    assert findings == []  # medium < unanchored floor (high) → dropped
+
+
+def test_unanchored_high_finding_survives() -> None:
+    provider = _provider_for([_UNANCHORED_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_severity=Severity.info)
+
+    findings, _ = engine.review(_CTX, cfg)
+
+    assert len(findings) == 1
+    assert findings[0].anchored is False  # kept for the body, never posted inline
+
+
+def test_anchored_finding_unaffected_by_unanchored_gate() -> None:
+    provider = _provider_for([_INFO], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_severity=Severity.info)
+
+    findings, _ = engine.review(_CTX, cfg)
+
+    # _INFO carries no anchor → anchored, so the unanchored gate ignores it.
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
 # secret redaction in outbound messages
 # ---------------------------------------------------------------------------
 

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -94,6 +94,14 @@ def test_prompt_is_nonempty_string() -> None:
     assert len(prompt) > 200
 
 
+def test_prompt_forbids_narration_only_findings() -> None:
+    # The weak-model failure mode is INFO-level narration that just restates the
+    # diff ("X was removed"). The contract must tell the model that's not a finding.
+    prompt = build_system_prompt().lower()
+    assert "narrat" in prompt or "describe" in prompt
+    assert "restate" in prompt or "merely" in prompt
+
+
 # ---------------------------------------------------------------------------
 # Security-review coverage (the reviewer should actually hunt for vulns)
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -160,6 +160,17 @@ def test_reflect_prompt_drops_unseen_code_assumptions() -> None:
     assert "missing" in system
 
 
+def test_reflect_prompt_drops_narration_only_findings() -> None:
+    """The auditor must drop findings that merely describe the change without
+    naming a concrete problem — the INFO-level narration a weak model emits."""
+    provider = _fake_with_verdict({0: True})
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    system = provider.calls[0]["messages"][0]["content"].lower()
+    assert "narrat" in system or "describe" in system
+
+
 def test_unparseable_verdict_keeps_all() -> None:
     provider = _fake_with_text("I'm not really sure about these.")
 

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -235,7 +235,7 @@
     },
     "min_severity": {
       "$ref": "#/$defs/Severity",
-      "default": "info"
+      "default": "low"
     },
     "model": {
       "title": "Model",
@@ -292,6 +292,10 @@
       ],
       "default": null,
       "title": "Timeout"
+    },
+    "unanchored_min_severity": {
+      "$ref": "#/$defs/Severity",
+      "default": "high"
     }
   },
   "required": [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,6 +107,20 @@ def test_review_config_structured_output_defaults_true() -> None:
     assert cfg.structured_output is True
 
 
+def test_review_config_min_severity_defaults_to_low() -> None:
+    # The floor sits at `low`, not `info`: pure-info narration ("X was removed")
+    # is the weak-model noise tier and is dropped by default.
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+    assert cfg.min_severity is Severity.low
+
+
+def test_review_config_unanchored_min_severity_defaults_to_high() -> None:
+    # A failed anchor is a low-confidence signal: only a high/critical guess is
+    # worth surfacing without a precise line.
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+    assert cfg.unanchored_min_severity is Severity.high
+
+
 def test_review_config_temperature_defaults_to_zero() -> None:
     cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
     assert cfg.temperature == 0.0


### PR DESCRIPTION
## Why

Running lgtmaybe with a fast/weak model (e.g. **Bedrock Claude Haiku 4.5**) floods PRs with low-value findings. Inspecting live reviews on a real repo, the noise was three patterns:

1. **Pure narration as "findings"** — INFO/LOW items that just restate the diff (*"Procore login methods removed"*, *"tenant_id now passed to admin_create_user"*). Not problems.
2. **Anchor-failed guesses dumped into "Additional findings"** — Haiku miscounts diff line numbers, so findings fail to re-anchor and get demoted to the review body instead of dropped.
3. **Plausible-but-wrong claims** — e.g. *"duplicate class defined at lines 1001/1005"*.

The review prompt **already** forbade some of these (e.g. the "defined twice" case) and the model ignored them — so the fix is **structural confidence gates**, not more prompt nuance. Every change is **runtime-neutral**: no extra LLM calls, same per-lens fan-out.

## What

- **Anti-narration rule** (`engine/prompt.py`) — narration that restates the diff is not a finding; omit it.
- **Severity-aware reflection** (`engine/reflect.py`) — the existing single audit pass also drops description-only findings and is stricter on info/low.
- **Unanchored confidence gate** (`core/models.py`, `engine/engine.py`) — new `unanchored_min_severity` (default `high`). A finding the engine couldn't anchor is a low-confidence guess, surfaced only when high/critical (still demoted to the body, never posted on a wrong line); weaker unanchored findings are dropped.
- **Gentle floor bump** (`core/models.py`) — default `min_severity` `info → low`, dropping pure-info narration while keeping legitimate low-severity test/doc findings for strong-model users.
- **CLI/config** — `--unanchored-min-severity` flag; both knobs also settable in `.lgtmaybe.yml`.

For an even quieter weak-model setup, `min_severity: medium` and trimming `categories` in `.lgtmaybe.yml` cut noise further (and trimming lenses also speeds the review).

## Tests

TDD (red → green). Added coverage for the new prompt rule, the reflection rule, the unanchored gate (medium dropped, high retained, anchored findings unaffected), and the new config defaults. Regenerated the `ReviewConfig` schema snapshot and the generated config reference. Full suite: **655 passed**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)