### PR TITLE
fix: recover empty structured-output responses from local gateways

### DIFF
--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -112,6 +112,13 @@ JSON out of surrounding prose, so a gateway that merely ignores `response_format
 still produces a normal review. (Older versions could fail here with
 `unparseable model output` on every lens — that's fixed.)
 
+There is a third case, common with **LM Studio fronting a "thinking" model**
+(e.g. qwen3.x): the server *accepts* `response_format` but the schema-constrained
+decoder returns **empty content** — every lens would otherwise fail with
+`unparseable model output`. lgtmaybe handles this for you too: when a structured
+call comes back empty, it drops the schema and retries once, and the model then
+emits the findings as normal (fenced) text the parser reads. No flag needed.
+
 If your gateway **rejects** `response_format` with a `400`, turn it off so the
 request never carries the parameter — the prompt still asks for JSON and the
 lenient parser still does its job:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -101,6 +101,11 @@ class LiteLLMProvider(ProviderClient):
         self.model = model
         self.fallback_model = fallback_model
         self.default_opts: dict[str, Any] = default_opts
+        # Set once a structured-output call comes back empty (see _call): the
+        # backend's JSON-schema decoder is broken for this model, so every
+        # subsequent call skips response_format up front instead of paying a
+        # wasted empty round-trip first. Sticky for the life of this provider.
+        self._skip_response_format = False
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
@@ -129,21 +134,44 @@ class LiteLLMProvider(ProviderClient):
             reraise=True,
         )
         def _call() -> ProviderResult:
-            try:
-                response = litellm.completion(model=model, messages=messages, **kwargs)
-            except Exception as exc:
-                if "temperature" not in kwargs or not _rejects_temperature(exc):
-                    raise
-                # Drop temperature for this and every subsequent retry, letting the
-                # model use its only supported value (its default).
-                kwargs.pop("temperature")
-                response = litellm.completion(model=model, messages=messages, **kwargs)
-            return self._map_response(response, model)
+            # A prior call already proved this model's JSON-schema mode returns
+            # empty, so don't pay the wasted round-trip again — drop it up front.
+            if self._skip_response_format:
+                kwargs.pop("response_format", None)
+            result = self._raw_completion(model, messages, kwargs)
+            # Some grammar-constrained backends (notably LM Studio fronting a
+            # "thinking" model like qwen3.x) return EMPTY content under a
+            # response_format JSON schema — the schema decoder yields nothing. The
+            # prompt already asks for JSON and the parser is lenient, so drop the
+            # schema and retry once: the model then emits the findings as normal
+            # (fenced) text we can parse. Remember it so later calls skip it too.
+            if not result.text.strip() and kwargs.get("response_format") is not None:
+                self._skip_response_format = True
+                kwargs.pop("response_format")
+                result = self._raw_completion(model, messages, kwargs)
+            return result
 
         return _call()
 
+    def _raw_completion(
+        self, model: str, messages: list[Message], kwargs: dict[str, Any]
+    ) -> ProviderResult:
+        """One litellm call, with the temperature-value-rejection fallback applied."""
+        try:
+            response = litellm.completion(model=model, messages=messages, **kwargs)
+        except Exception as exc:
+            if "temperature" not in kwargs or not _rejects_temperature(exc):
+                raise
+            # Drop temperature for this and every subsequent retry, letting the
+            # model use its only supported value (its default).
+            kwargs.pop("temperature")
+            response = litellm.completion(model=model, messages=messages, **kwargs)
+        return self._map_response(response, model)
+
     def _map_response(self, response: Any, model: str) -> ProviderResult:
-        text: str = response.choices[0].message.content
+        # Some providers return null content (e.g. a model that answered only via
+        # a reasoning channel under JSON mode); treat that as empty, not a crash.
+        text: str = response.choices[0].message.content or ""
         input_tokens: int = response.usage.prompt_tokens
         output_tokens: int = response.usage.completion_tokens
 

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -83,6 +83,94 @@ class TestTemperatureRejection:
                 )
 
 
+class TestEmptyStructuredOutputFallback:
+    """Some grammar-constrained backends (LM Studio fronting a thinking qwen
+    model) return empty content under a response_format JSON schema. The provider
+    drops the schema and retries once so the model can emit parseable text."""
+
+    def test_empty_content_under_response_format_retries_without_it(self) -> None:
+        seen_response_format: list[Any] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen_response_format.append("response_format" in kwargs)
+            if "response_format" in kwargs:
+                return _fake_response("")  # schema mode yields nothing
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "openai/qwen",
+                response_format={"type": "json_schema"},
+            )
+
+        assert result.text == '{"findings": []}'
+        assert seen_response_format == [True, False]
+
+    def test_non_empty_content_keeps_response_format(self) -> None:
+        calls = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "openai/gpt-4o",
+                response_format={"type": "json_schema"},
+            )
+
+        assert result.text == '{"findings": []}'
+        assert calls == 1  # good content first time → no retry
+
+    def test_empty_once_makes_later_calls_skip_response_format_up_front(self) -> None:
+        """After one empty structured response, the provider remembers the model's
+        schema mode is broken and drops response_format up front on later calls —
+        so a slow local model isn't billed a wasted empty round-trip every time."""
+        seen_response_format: list[bool] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            has_rf = "response_format" in kwargs
+            seen_response_format.append(has_rf)
+            if has_rf:
+                return _fake_response("")  # schema mode yields nothing
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "a"}], "openai/qwen", response_format={"x": 1}
+            )
+            provider.complete(
+                [{"role": "user", "content": "b"}], "openai/qwen", response_format={"x": 1}
+            )
+
+        # First call: with-rf (empty) then without (good). Second call: straight
+        # to without-rf — no wasted empty round-trip.
+        assert seen_response_format == [True, False, False]
+
+    def test_empty_content_without_response_format_is_not_retried(self) -> None:
+        """A genuinely empty answer with no schema to drop is returned as-is — no
+        infinite retry loop."""
+        calls = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            return _fake_response("")
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert result.text == ""
+        assert calls == 1
+
+
 class TestFailFastOnPermanentErrors:
     """Retrying a permanent error can't fix it — and stacked backoff over every
     lens turns an instant "out of credit" into many minutes of burned runner


### PR DESCRIPTION
## Problem

Running a local review against **LM Studio** (qwen3.5 9b, a "thinking" model) failed completely — **every** review lens returned `unparseable model output` and the review aborted with `review incomplete — every review call failed`.

Root cause, reproduced directly against litellm:

- With `response_format` (the findings JSON schema) → LM Studio returns **empty content** (`finish_reason: stop`, zero bytes). The schema-constrained decoder yields nothing for this model. Every `response_format` variant (`json_schema`, larger `max_tokens`, `enable_thinking:false`) returned empty.
- Without `response_format` → the model produces **perfect** `{"findings": [...]}` output that the lenient parser reads cleanly.

This is a third JSON-mode failure mode beyond the two already handled (gateway *ignores* it → parser copes; gateway *rejects* it with 400 → `--no-structured-output`). Here the gateway *accepts* it but the model returns nothing.

## Fix

The provider now detects an empty structured response, **drops `response_format`, and retries once** — mirroring the existing temperature-value rejection fallback. The prompt already asks for JSON and the parser is lenient, so the retry parses normally.

The detection is **sticky per provider instance**: after the first empty response it skips the schema up front on subsequent calls, so a slow local model isn't billed a wasted empty round-trip on every lens. Also coerces null message content to `""` rather than crashing in `_map_response`.

Documents the new behaviour in the openai-compatible how-to.

## Validation

- New unit tests cover the retry, the sticky skip, the no-regression path, and the no-infinite-loop guard.
- Full suite green (658 passed).
- **End-to-end against LM Studio qwen3.5-9b**: before the fix 0/9 lenses produced output; after the fix the lenses recover and produce findings (off-by-one, SQL injection, `datetime.utcnow()` deprecation, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)