### PR TITLE
fix: keep parsing past a non-finding JSON object in model output

### DIFF
--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -149,6 +149,12 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
     if not raw or not raw.strip():
         raise ParseError("Empty response from provider")
 
+    # A findings-shaped candidate can still fail validation — e.g. a small model
+    # emits a chatter object ({"note": "found 1 issue"}) before the real envelope,
+    # and `_as_findings_list` treats any bare dict as a single finding. Keep trying
+    # later candidates instead of aborting on the first that doesn't validate, so
+    # the real `{"findings": [...]}` that follows is still recovered.
+    last_error: Exception | None = None
     for value in iter_json_values(raw):
         items = _as_findings_list(value)
         if items is None:
@@ -156,6 +162,8 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
         try:
             return [ReviewFinding.model_validate(item) for item in items]
         except Exception as exc:
-            raise ParseError(f"Finding validation failed: {exc}") from exc
+            last_error = exc
 
+    if last_error is not None:
+        raise ParseError(f"Finding validation failed: {last_error}") from last_error
     raise ParseError("Cannot parse JSON findings from response")

--- a/tests/engine/test_parse.py
+++ b/tests/engine/test_parse.py
@@ -80,6 +80,23 @@ def test_valid_json_array_in_prose_before_findings_is_skipped() -> None:
     assert result[0].severity == Severity.high
 
 
+def test_leading_non_finding_object_is_skipped() -> None:
+    """A small model that emits a chatter object before the real envelope must
+    not abort parsing — any bare dict is treated as a candidate finding, so the
+    parser has to keep going past one that fails validation."""
+    raw = '{"note": "found 1 issue"}\n' + json.dumps({"findings": [_VALID_FINDING]})
+    result = parse_findings(raw)
+    assert len(result) == 1
+    assert result[0].path == "src/app.py"
+
+
+def test_only_non_finding_object_raises_with_validation_detail() -> None:
+    """When nothing findings-shaped validates, the error names the validation
+    failure (not a generic 'cannot parse'), so the cause is debuggable."""
+    with pytest.raises(ParseError, match="Finding validation failed"):
+        parse_findings('{"note": "no findings here"}')
+
+
 def test_trailing_prose_with_bracket() -> None:
     """A closing remark with a bracket after the JSON must not derail extraction."""
     raw = json.dumps({"findings": [_VALID_FINDING]}) + "\nThat is all [done]."


### PR DESCRIPTION
## Problem

`parse_findings` treats any bare JSON object as a candidate finding (so a model can return a single un-enveloped finding). But that makes it abort when a small model emits a **chatter object before** the real envelope:

```
{"note": "found 1 issue"}
{"findings": [{...real finding...}]}
```

The first object is fed to `ReviewFinding.model_validate`, fails (missing required fields / `extra=forbid`), and the parser **raises immediately** — throwing away the genuine findings that came right after. Reproduced: this raises `ParseError` today even though valid findings are present.

Small local models (the ones we most want to support) are exactly the ones prone to emitting a stray status/reasoning object alongside the JSON.

## Fix

`parse_findings` now keeps trying later candidates when one fails validation, recovering the real `{"findings": [...]}`. If nothing findings-shaped validates it still raises `ParseError`, now carrying the **last validation detail** so the cause is debuggable rather than a generic "cannot parse".

## Validation

- New tests: a leading non-finding object is skipped and the real findings parse; an output with *only* a non-finding object still raises with the validation detail.
- Full suite green (657 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)