### PR TITLE
docs: correct the "review incomplete" error string in the ollama guide

### DIFF
--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -194,7 +194,7 @@ the `--api-base` URL is reachable.
 
 **Model not found** — run `ollama pull <model>` before using it.
 
-**`review incomplete — the model returned no usable output`** — every category
+**`review incomplete — every review call failed`** — every category
 call timed out or returned output that wasn't valid JSON. Raise `--timeout`, try a
 model that follows instructions more reliably, or check `LITELLM_LOG=DEBUG` output
 for the underlying error. lgtmaybe reports this (and exits non-zero) rather than


### PR DESCRIPTION
The ollama troubleshooting section quoted the error string `review incomplete — the model returned no usable output`, but the engine (`engine.py`) actually raises:

> `review incomplete — every review call failed (<detail>)`

So a user pasting the real error into a search would never land on the troubleshooting steps. This matches the doc heading to the actual message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)