### PR TITLE
fix(evals): run the eval harness against keyless local endpoints

### DIFF
--- a/evals/run.py
+++ b/evals/run.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from lgtmaybe.core.models import PRContext, Provider, ReviewCategory, ReviewConfig
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
+from lgtmaybe.providers.credentials import resolve_credentials
 from lgtmaybe.providers.factory import build_provider
 
 from .scorer import Fixture, FixtureScore, score_fixture
@@ -80,6 +81,7 @@ def _review(
     model: str,
     api_base: str | None,
     *,
+    api_key: str | None = None,
     timeout: int | None = None,
     num_ctx: int | None = None,
     max_input_tokens: int | None = None,
@@ -127,8 +129,21 @@ def _review(
         extra["top_p"] = top_p
     if top_k is not None:
         extra["top_k"] = top_k
+    # Resolve credentials the same way the CLI does, so the harness works against
+    # a keyless openai-compatible endpoint (LM Studio / llama.cpp / vLLM) — which
+    # needs the placeholder key the OpenAI client demands — and reads provider env
+    # vars (OPENAI_API_KEY, OPENAI_COMPATIBLE_API_KEY, …) for hosted endpoints.
+    auth = resolve_credentials(provider, api_key=api_key, api_base=api_base)
     engine = LLMReviewEngine(
-        build_provider(provider, model, api_base=api_base, timeout=timeout, **extra)
+        build_provider(
+            provider,
+            model,
+            api_key=auth.api_key,
+            api_base=auth.api_base,
+            azure_ad_token=auth.azure_ad_token,
+            timeout=timeout,
+            **extra,
+        )
     )
     try:
         findings, _summary = engine.review(ctx, cfg)
@@ -188,6 +203,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--provider", required=True, choices=[p.value for p in Provider])
     ap.add_argument("--model", required=True)
     ap.add_argument("--api-base", default=None)
+    ap.add_argument(
+        "--api-key",
+        default=None,
+        help="API key for a hosted endpoint (else read from the provider's env var); "
+        "omit for keyless local servers (ollama, LM Studio / llama.cpp / vLLM)",
+    )
     ap.add_argument(
         "--min-recall",
         type=float,
@@ -270,6 +291,7 @@ def main(argv: list[str] | None = None) -> int:
             provider,
             args.model,
             args.api_base,
+            api_key=args.api_key,
             timeout=args.timeout,
             num_ctx=args.num_ctx,
             max_input_tokens=args.max_input_tokens,

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -142,11 +142,47 @@ def test_num_ctx_is_omitted_for_hosted_provider(monkeypatch: pytest.MonkeyPatch)
     calls = _capture_build_provider(monkeypatch)
 
     run_mod.main(
-        ["--provider", "openai", "--model", "x", "--min-recall", "0.0", "--num-ctx", "9000"]
+        [
+            "--provider",
+            "openai",
+            "--model",
+            "x",
+            "--api-key",
+            "sk-test",
+            "--min-recall",
+            "0.0",
+            "--num-ctx",
+            "9000",
+        ]
     )
 
     assert calls
     assert "num_ctx" not in calls[0]
+
+
+def test_keyless_openai_compatible_gets_placeholder_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A keyless local endpoint (LM Studio / llama.cpp / vLLM) must still reach
+    build_provider with a key — the OpenAI client litellm uses rejects an empty
+    one — so the harness resolves credentials like the CLI does."""
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    calls = _capture_build_provider(monkeypatch)
+
+    run_mod.main(
+        [
+            "--provider",
+            "openai-compatible",
+            "--model",
+            "qwen",
+            "--api-base",
+            "http://localhost:1234/v1",
+            "--min-recall",
+            "0.0",
+        ]
+    )
+
+    assert calls
+    assert calls[0]["api_key"]  # a placeholder, not None/empty
+    assert calls[0]["api_base"] == "http://localhost:1234/v1"
 
 
 def test_max_input_tokens_threads_to_review_config(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

The eval runner built its provider with `build_provider(provider, model, api_base=...)` **directly**, skipping the credential resolution the CLI performs in `build_provider_engine`. So pointing the harness at a **keyless openai-compatible** endpoint (LM Studio / llama.cpp / vLLM) died at call time:

```
OpenAIException - Missing credentials. Please pass an `api_key` ...
```

The OpenAI client litellm uses rejects an empty key; the CLI supplies a placeholder for keyless local servers, but the eval harness never did. Benchmarking a small local model on LM Studio — exactly what `evals/` exists for, and what the ollama how-to points users to — was impossible.

Found while running `python -m evals.run --provider openai-compatible --model qwen/qwen3.5-9b --api-base http://localhost:1234/v1 --fixture badcode`.

## Fix

`evals/run.py` now resolves credentials via `resolve_credentials` (same as the CLI) before building the provider:

- keyless openai-compatible → placeholder key,
- hosted endpoints → read the provider env var (`OPENAI_API_KEY`, `OPENAI_COMPATIBLE_API_KEY`, …),
- new optional `--api-key` to pass one inline,
- Azure AD tokens thread through too.

## Validation

- New test: a keyless openai-compatible run reaches `build_provider` with a (placeholder) key and the given base.
- Updated the hosted-provider test to pass `--api-key` (credential resolution now runs for it).
- Eval unit tests green (20 passed).
- Manually confirmed `python -m evals.run --provider openai-compatible --api-base http://localhost:1234/v1 ...` now runs end-to-end against LM Studio instead of erroring on missing credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)