### PR TITLE
feat(providers): add first-class zai (GLM / Zhipu AI) provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ variants:
   auth, then runs a GHCR image via the `action` entrypoint
 
 **The wedge:** first-class **Bedrock + Vertex + Azure with keyless OIDC/WIF**.
-Six hosted providers (plus local ollama), one flag, no keys in secrets for
+Seven hosted providers (plus local ollama), one flag, no keys in secrets for
 cloud. We win on auth + simplicity. An `openai-compatible` provider is the escape
 hatch for anything else that speaks the OpenAI `/v1` wire format (DeepSeek's API,
 llama.cpp, LM Studio, vLLM) — you bring the `--api-base`, the key is optional —
@@ -57,6 +57,7 @@ so the provider list is never a cage.
 | Provider               | Auth                                                              |
 |------------------------|------------------------------------------------------------------|
 | openai / openrouter / anthropic | API key from `secrets.*` / env / `--api-key`            |
+| zai (GLM / Zhipu AI)   | API key (`ZAI_API_KEY` / `--api-key`); litellm-native `zai/` route. Optional `--api-base` / `ZAI_API_BASE` override for the China / coding-plan endpoint |
 | bedrock                | ambient AWS creds (GitHub OIDC role, or local `~/.aws`); IAM `bedrock:InvokeModel*` only |
 | vertex                 | ambient GCP creds (WIF, or local ADC)                            |
 | azure                  | needs the resource endpoint (`--api-base` / `AZURE_API_BASE`); ambient Entra creds (GitHub OIDC federation via `azure/login`, or local `az login` / managed identity) → else `AZURE_API_KEY` / `--api-key` |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # lgtmaybe
 
-Provider-agnostic PR reviewer. Six hosted providers, local ollama, and any
+Provider-agnostic PR reviewer. Seven hosted providers, local ollama, and any
 OpenAI-compatible endpoint — one flag, no static keys for cloud providers. Posts
 inline review comments and a summary.
 
@@ -123,6 +123,7 @@ up the [GitHub Action](#use-as-a-github-action). See
 | `openai` | `OPENAI_API_KEY` |
 | `anthropic` | `ANTHROPIC_API_KEY` |
 | `openrouter` | `OPENROUTER_API_KEY` |
+| `zai` | `ZAI_API_KEY` — GLM / Zhipu AI (`glm-4.6`, `glm-4.7`, `glm-4.5-air`, …; newer `glm-5.x` too). Optional `--api-base` for the China / coding-plan endpoint |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: lgtmaybe
-description: Provider-agnostic PR reviewer — six hosted providers plus ollama and any OpenAI-compatible endpoint, one flag, no static keys for cloud.
+description: Provider-agnostic PR reviewer — seven hosted providers plus ollama and any OpenAI-compatible endpoint, one flag, no static keys for cloud.
 author: Matt Coles
 branding:
   icon: check-circle

--- a/docs/explanation/auth-model.md
+++ b/docs/explanation/auth-model.md
@@ -1,10 +1,10 @@
 # Auth Model
 
-lgtmaybe supports six hosted providers plus local ollama, and an
+lgtmaybe supports seven hosted providers plus local ollama, and an
 `openai-compatible` escape hatch for any server speaking the OpenAI `/v1` wire
 format (DeepSeek's API, llama.cpp, LM Studio, vLLM). The design principle is **no
 static cloud credentials**: cloud providers use ambient, short-lived tokens;
-key-based SaaS providers (openai, anthropic, openrouter) require an API key that
+key-based SaaS providers (openai, anthropic, openrouter, zai) require an API key that
 stays in secrets rather than being committed to config. Azure straddles both — it
 prefers ambient Azure AD (Entra) credentials but accepts a resource key — and
 always needs the resource endpoint (`AZURE_API_BASE`), since each Azure OpenAI
@@ -41,9 +41,12 @@ chain:
 2. **Ambient cloud creds** — for Bedrock and Vertex, the chain stops here.
    If no ambient creds exist, lgtmaybe fails immediately with a clear
    "how to auth this provider" message. It does not fall back to a key.
-3. **API key** — for openai, anthropic, and openrouter, lgtmaybe reads the
-   key from the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-   `OPENROUTER_API_KEY`). The `--api-key` flag can override this at the CLI.
+3. **API key** — for openai, anthropic, openrouter, and zai (GLM / Zhipu AI),
+   lgtmaybe reads the key from the environment (`OPENAI_API_KEY`,
+   `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`). The `--api-key` flag
+   can override this at the CLI. `zai` also accepts an optional `--api-base` /
+   `ZAI_API_BASE` override for the China / coding-plan GLM endpoint; without it
+   litellm's native `zai/` route targets the international endpoint.
 4. **Azure** — always needs the resource endpoint (`AZURE_API_BASE` or
    `--api-base`). For the credential it prefers a key when one is present
    (`AZURE_API_KEY` / `--api-key`); otherwise it goes **keyless**, minting an
@@ -66,6 +69,7 @@ chain:
 | openai | API key | `OPENAI_API_KEY` env var or `--api-key` |
 | anthropic | API key | `ANTHROPIC_API_KEY` env var or `--api-key` |
 | openrouter | API key | `OPENROUTER_API_KEY` env var or `--api-key` |
+| zai | API key (+ optional endpoint) | `ZAI_API_KEY` env var or `--api-key` (GLM / Zhipu AI); optional `ZAI_API_BASE` / `--api-base` for the China / coding-plan endpoint |
 | bedrock | Ambient AWS creds | GitHub OIDC role or local `~/.aws`; IAM requires only `bedrock:InvokeModel*` |
 | vertex | Ambient GCP creds | GitHub WIF or local ADC (`gcloud auth application-default login`) |
 | azure | Ambient Azure AD creds (keyless) or API key, + endpoint | GitHub OIDC → Entra federated credential, or local `az login` / managed identity; or `AZURE_API_KEY`. Always with `AZURE_API_BASE` / `--api-base` |

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -31,7 +31,7 @@ types and defaults.
 
 ### provider
 
-Which LLM backend to use. One of `openai`, `openrouter`, `anthropic`,
+Which LLM backend to use. One of `openai`, `openrouter`, `anthropic`, `zai`,
 `bedrock`, `vertex`, `azure`, `ollama`, `openai-compatible`.
 
 ```yaml
@@ -47,6 +47,7 @@ The model identifier for the chosen provider. Format varies by provider:
 | openai | `gpt-5.5` |
 | anthropic | `claude-sonnet-4-6`, `claude-haiku-4-5` |
 | openrouter | `anthropic/claude-sonnet-4-6` |
+| zai | `glm-4.6`, `glm-4.7`, `glm-4.5-air` (GLM / Zhipu AI; newer `glm-5.x` pass through too) |
 | bedrock | `us.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-haiku-4-5` (prefer the cross-region inference profile; a non-Bedrock id like `openai.gpt-5.5` is invalid — see [Review with Bedrock](review-with-bedrock-oidc.md)) |
 | vertex | `gemini-3-pro`, `gemini-3.5-flash` |
 | azure | your deployment name, e.g. `my-gpt-4o-deployment` (not the upstream model id — see [Review with Azure](review-with-azure.md)) |

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -103,6 +103,13 @@ Swap the `provider`, `model`, and `api_key` inputs:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
     api_key: ${{ secrets.OPENROUTER_API_KEY }}
+
+# zai (GLM / Zhipu AI)
+- uses: MattJColes/lgtmaybe@v0
+  with:
+    provider: zai
+    model: glm-4.6
+    api_key: ${{ secrets.ZAI_API_KEY }}
 ```
 
 For these, the one-time setup is just: generate an API key in the provider's
@@ -124,7 +131,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 
 | Input | Default | Description |
 |---|---|---|
-| `provider` | — | One of: `openai`, `openrouter`, `anthropic`, `bedrock`, `vertex`, `azure`, `ollama`, `openai-compatible` |
+| `provider` | — | One of: `openai`, `openrouter`, `anthropic`, `zai`, `bedrock`, `vertex`, `azure`, `ollama`, `openai-compatible` |
 | `model` | — | Model identifier for the chosen provider |
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 </div>
 
-Provider-agnostic PR reviewer. Six hosted providers, local ollama, and any
+Provider-agnostic PR reviewer. Seven hosted providers, local ollama, and any
 OpenAI-compatible endpoint — one flag, and no static keys for cloud providers. It
 posts inline comments and a summary straight onto the pull request.
 
@@ -54,6 +54,7 @@ before anything leaves for the model, and a clean PR just gets a 👍 **LGTM!**.
 | `openai` | `OPENAI_API_KEY` |
 | `anthropic` | `ANTHROPIC_API_KEY` |
 | `openrouter` | `OPENROUTER_API_KEY` |
+| `zai` | `ZAI_API_KEY` — GLM / Zhipu AI; optional `--api-base` for the China / coding-plan endpoint |
 | `bedrock` | Ambient AWS creds — GitHub OIDC, no static key |
 | `vertex` | Ambient GCP creds — Workload Identity Federation, no key |
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,7 +23,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
-| `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` | Yes | — |  |
+| `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `recursive` | boolean | No | `True` | Recursive |
 | `reflect` | boolean | No | `True` | Reflect |
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
@@ -46,6 +46,7 @@ LLM backend selected by `--provider`. Cloud providers (`bedrock`, `vertex`, `azu
 - `openai-compatible`
 - `openrouter`
 - `vertex`
+- `zai`
 
 ### Severity
 
@@ -167,7 +168,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "vertex",
         "azure",
         "ollama",
-        "openai-compatible"
+        "openai-compatible",
+        "zai"
       ],
       "title": "Provider",
       "type": "string"

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -1,0 +1,40 @@
+# Copy into your repo at .github/workflows/lgtmaybe.yml
+#
+# Z.AI / Zhipu AI GLM (key-based). Add a ZAI_API_KEY repo secret.
+name: lgtmaybe (zai)
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only trusted authors (repo owner / org member / collaborator) can trigger a
+    # review, so fork PRs and drive-by /ask or /review comments from strangers
+    # cannot spend your provider budget. A maintainer can still opt-in to an
+    # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    if: >-
+      (github.event_name == 'pull_request_target' &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: MattJColes/lgtmaybe@v0
+        with:
+          provider: zai
+          model: glm-4.6
+          api_key: ${{ secrets.ZAI_API_KEY }}
+          # Optional: point at the China / coding-plan endpoint instead of the
+          # international default.
+          # api_base: https://open.bigmodel.cn/api/paas/v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: lgtmaybe
-site_description: Provider-agnostic PR reviewer — six hosted providers, ollama, and any OpenAI-compatible endpoint, one flag, no keys in secrets for cloud.
+site_description: Provider-agnostic PR reviewer — seven hosted providers, ollama, and any OpenAI-compatible endpoint, one flag, no keys in secrets for cloud.
 site_url: https://mattjcoles.github.io/lgtmaybe/
 repo_url: https://github.com/MattJColes/lgtmaybe
 repo_name: MattJColes/lgtmaybe

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -33,7 +33,7 @@ from lgtmaybe.config.loader import load_config
     "--provider",
     default=None,
     help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, "
-    "openrouter, openai-compatible)",
+    "openrouter, zai, openai-compatible)",
 )
 @click.option("--model", default=None, help="Model name understood by the chosen provider")
 @click.option(
@@ -53,7 +53,9 @@ from lgtmaybe.config.loader import load_config
     help="API base URL (ollama: http://localhost:11434; "
     "azure: https://<resource>.openai.azure.com; "
     "openai-compatible: any OpenAI /v1 endpoint, e.g. https://api.deepseek.com/v1 "
-    "or http://localhost:8000/v1)",
+    "or http://localhost:8000/v1; "
+    "zai: optional override for the China / coding-plan GLM endpoint, "
+    "e.g. https://open.bigmodel.cn/api/paas/v4)",
 )
 @click.option(
     "--min-severity",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -78,6 +78,9 @@ class Provider(StrEnum):
     # Any server speaking the OpenAI /v1 wire format, reached via --api-base:
     # DeepSeek's API, llama.cpp, LM Studio, vLLM, and other proxies. Key optional.
     openai_compatible = "openai-compatible"
+    # GLM / Zhipu AI via litellm's native zai/ route; API-key auth (ZAI_API_KEY),
+    # optional --api-base override for the China / coding-plan endpoints.
+    zai = "zai"
 
 
 class _Strict(BaseModel):

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -183,6 +183,20 @@ def resolve_credentials(
     if provider is Provider.ollama:
         return AuthConfig(api_base=api_base or DEFAULT_OLLAMA_BASE)
 
+    if provider is Provider.zai:
+        import os
+
+        key = api_key or os.environ.get("ZAI_API_KEY")
+        if not key:
+            raise ValueError(
+                "zai (GLM / Zhipu AI) requires an API key. Set the ZAI_API_KEY "
+                "environment variable or pass --api-key."
+            )
+        # Key-only by default (litellm's native zai/ route targets the international
+        # endpoint). An explicit base overrides it for the China / coding-plan
+        # endpoints (e.g. https://open.bigmodel.cn/api/paas/v4).
+        return AuthConfig(api_key=key, api_base=api_base or os.environ.get("ZAI_API_BASE"))
+
     if provider is Provider.openai_compatible:
         import os
 

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -9,6 +9,7 @@ litellm model-string conventions:
   azure      → azure/<model>   (+ api_base = resource endpoint)
   ollama     → ollama/<model>  (+ api_base)
   openai-compatible → openai/<model>  (+ api_base = custom endpoint)
+  zai        → zai/<model>     (GLM / Zhipu AI; optional api_base override)
 """
 
 from __future__ import annotations
@@ -30,6 +31,8 @@ _PREFIXES: dict[Provider, str] = {
     # OpenAI-compatible servers (DeepSeek, llama.cpp, LM Studio, vLLM) ride the
     # openai route; the custom endpoint comes through api_base.
     Provider.openai_compatible: "openai",
+    # GLM / Zhipu AI on litellm's native zai/ route (e.g. zai/glm-4.6).
+    Provider.zai: "zai",
 }
 
 # Default per-request timeout (seconds) when the caller doesn't set one. Local

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ _PROVIDER_CRED_ENV = (
     "ANTHROPIC_API_KEY",
     "OPENROUTER_API_KEY",
     "LGTMAYBE_API_KEY",
+    # GLM / Zhipu AI (zai)
+    "ZAI_API_KEY",
+    "ZAI_API_BASE",
     # Ambient AWS creds (bedrock)
     "AWS_ACCESS_KEY_ID",
     "AWS_SECRET_ACCESS_KEY",

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -110,6 +110,43 @@ class TestOpenRouter:
         assert "OPENROUTER_API_KEY" in str(exc_info.value)
 
 
+class TestZai:
+    """GLM / Zhipu AI: a pure API-key provider with an optional endpoint override."""
+
+    def test_zai_with_api_key_resolves(self) -> None:
+        config = resolve_credentials(Provider.zai, api_key="zai-secret")
+        assert config.api_key == "zai-secret"
+
+    def test_zai_reads_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ZAI_API_KEY", "zai-env")
+        config = resolve_credentials(Provider.zai)
+        assert config.api_key == "zai-env"
+
+    def test_zai_without_key_raises_naming_the_env_var(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            resolve_credentials(Provider.zai)
+        assert "ZAI_API_KEY" in str(exc_info.value)
+
+    def test_zai_threads_optional_api_base_override(self) -> None:
+        """The China / coding-plan endpoint flows through instead of being dropped."""
+        config = resolve_credentials(
+            Provider.zai,
+            api_key="zai-secret",
+            api_base="https://open.bigmodel.cn/api/paas/v4",
+        )
+        assert config.api_base == "https://open.bigmodel.cn/api/paas/v4"
+
+    def test_zai_reads_api_base_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ZAI_API_BASE", "https://open.bigmodel.cn/api/paas/v4")
+        config = resolve_credentials(Provider.zai, api_key="zai-secret")
+        assert config.api_base == "https://open.bigmodel.cn/api/paas/v4"
+
+    def test_zai_without_override_leaves_base_unset(self) -> None:
+        """No override → litellm's native zai/ default endpoint is used."""
+        config = resolve_credentials(Provider.zai, api_key="zai-secret")
+        assert config.api_base is None
+
+
 class TestAzure:
     def test_azure_with_api_key_and_base_resolves(self) -> None:
         config = resolve_credentials(

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -32,6 +32,8 @@ EXPECTED_PREFIX: dict[Provider, str] = {
     Provider.ollama: "ollama/",
     # OpenAI-compatible servers ride the openai route with a custom api_base.
     Provider.openai_compatible: "openai/",
+    # GLM / Zhipu AI rides litellm's native zai/ route.
+    Provider.zai: "zai/",
 }
 
 # Providers that authenticate with an API key, and the env var that supplies it.
@@ -39,6 +41,7 @@ KEY_PROVIDERS: dict[Provider, str] = {
     Provider.openai: "OPENAI_API_KEY",
     Provider.anthropic: "ANTHROPIC_API_KEY",
     Provider.openrouter: "OPENROUTER_API_KEY",
+    Provider.zai: "ZAI_API_KEY",
 }
 # Providers that authenticate with ambient cloud creds (keyless).
 CLOUD_PROVIDERS = (Provider.bedrock, Provider.vertex)

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -58,7 +58,8 @@
         "vertex",
         "azure",
         "ollama",
-        "openai-compatible"
+        "openai-compatible",
+        "zai"
       ],
       "title": "Provider",
       "type": "string"


### PR DESCRIPTION
## What

Adds **GLM / Zhipu AI** as a first-class provider (`--provider zai`) via litellm's native `zai/` route, so `--provider zai --model glm-4.6` works without reaching for the `openai-compatible` escape hatch.

## Why

GLM already worked today through `openai-compatible`, but litellm has *native* GLM support, so making it first-class is a small, well-bounded change following the existing pure-API-key pattern (`openai`/`anthropic`). It gives the clean `--provider zai --model glm-4.6` UX with no `--api-base` fiddling, and fits the "hosted providers, one flag" wedge.

## Auth

Pure API-key (`ZAI_API_KEY` / `--api-key`), with an **optional** `--api-base` / `ZAI_API_BASE` override threaded through its own resolver branch for the China / coding-plan GLM endpoint (`https://open.bigmodel.cn/api/paas/v4`). Without it, litellm's `zai/` route targets the international endpoint. No keyless/OIDC path (GLM is key-only), so no new `action.yml` cloud inputs.

## Changes

**Code**
- `core/models.py` — `zai` added to the `Provider` enum
- `providers/factory.py` — `Provider.zai: "zai"` prefix (cloud 60s timeout)
- `providers/credentials.py` — dedicated `zai` resolver branch (`ZAI_API_KEY` + optional `api_base` override; the generic key branch drops `api_base`)
- `cli/commands.py` — `--provider` / `--api-base` help text

**Tests (TDD: red → green)**
- `tests/providers/test_provider_matrix.py` — `zai/` prefix + `ZAI_API_KEY` rows; the `test_every_provider_is_classified_exactly_once` guard forces classification
- `tests/providers/test_credentials.py` — focused `TestZai` (key resolution + endpoint override)
- `tests/conftest.py` — isolate `ZAI_API_KEY` / `ZAI_API_BASE`
- `tests/snapshots/ReviewConfig.json` — regenerated schema snapshot

**Docs / config**
- README, `docs/index.md`, `auth-model.md`, `configure-lgtmaybe-yml.md`, `use-as-github-action.md`, regenerated `docs/reference/config.md`, CLAUDE.md, mkdocs/action descriptions (six → seven hosted providers)
- New `examples/workflows/review-zai.yml`

## Verification

- `uv run pytest` — **677 passed**, ruff check + format clean
- Smoke: `--provider zai --model glm-4.6` resolves to `zai/glm-4.6`, cloud 60s timeout, `--api-base` override threads through
- Not verified locally (no key): a live review call against the GLM API

🤖 Generated with [Claude Code](https://claude.com/claude-code)