### PR TITLE
docs: align end-user docs with the codebase

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   provider:
-    description: "LLM provider: openai, anthropic, openrouter, bedrock, vertex, azure, ollama, or openai-compatible (any OpenAI /v1 endpoint via api_base — DeepSeek, llama.cpp, LM Studio, vLLM)."
+    description: "LLM provider: openai, anthropic, openrouter, zai, bedrock, vertex, azure, ollama, or openai-compatible (any OpenAI /v1 endpoint via api_base — DeepSeek, llama.cpp, LM Studio, vLLM)."
     required: false
     default: ""
   model:

--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -26,8 +26,8 @@ run:
 
 - **ollama is free** — it runs the model on your own hardware, so trigger it for
   whoever you like; there's no per-run cost.
-- **Hosted providers** (OpenAI, Anthropic, OpenRouter, Bedrock, Vertex, Azure)
-  charge for the tokens each review uses.
+- **Hosted providers** (OpenAI, Anthropic, OpenRouter, z.ai, Bedrock, Vertex,
+  Azure) charge for the tokens each review uses.
 
 So if you're on a hosted provider and your repo is public, "everyone" means
 anyone can start a run. That's perfectly fine for plenty of projects — just pick

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -276,7 +276,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `categories` | all nine | Which review lenses to run; each runs as its own model call. Narrowing the list means fewer calls. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
-| `min_severity` | `info` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`). |
+| `min_severity` | `low` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`); `low` keeps everything except pure-`info` narration. |
 | `include_paths` / `exclude_paths` | — | Glob filters to focus the review. |
 
 > These bound a **single run**, not the number of runs. On a public repo, anyone

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -18,6 +18,7 @@ provides defaults for all runs.
   - [context_lines](#context_lines)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
+  - [reflect](#reflect)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -195,6 +196,22 @@ structured_output: false   # only if your gateway rejects JSON-schema mode
 
 Default: `true`. See
 [Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
+
+### reflect
+
+Run the **self-reflection pass** that audits the merged findings and drops the
+ones the model marks low-confidence, before anything is posted. This trims false
+positives, so leave it on for most models. Turn it **off** for a weaker or local
+model that over-prunes and drops valid findings during the audit. CLI:
+`--no-reflect`.
+
+```yaml
+reflect: false   # keep every finding; skip the false-positive audit
+```
+
+Default: `true`. To audit a weak reviewer's findings with a stronger model
+instead of disabling the pass, set `reflect_model` to that model id (it uses the
+same provider and credentials as `model`).
 
 ### resolve_fixed
 


### PR DESCRIPTION
- what-gets-reviewed: min_severity default is `low`, not `info`
  (matches ReviewConfig and the generated config reference)
- trust-and-cost: include z.ai in the hosted-provider list
- action.yml: list `zai` in the provider input description (was the
  only provider surface still omitting it)
- configure-lgtmaybe-yml: document the `reflect` knob (and reflect_model),
  the main tuning option for weaker/local models that over-prune

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DiB51dEzMPraimJWQuVeVu