### PR TITLE
Handle malformed event payloads with clear error messages

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -232,8 +232,11 @@ def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: RuntimeOp
         click.echo("Comment is not on a pull request; ignoring.")
         return
 
-    repo = event["repository"]["full_name"]
-    pr_number = issue["number"]
+    try:
+        repo = event["repository"]["full_name"]
+        pr_number = issue["number"]
+    except (KeyError, TypeError) as exc:
+        raise click.ClickException(f"event payload missing required field: {exc}") from exc
     runtime = runtime.with_pr_url(f"https://github.com/{repo}/pull/{pr_number}")
 
     try:
@@ -267,8 +270,11 @@ def pr_url_from_event(event: dict[str, Any]) -> str:
     api.github.com.
     """
     server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
-    repo = event["repository"]["full_name"]
-    number = event["pull_request"]["number"]
+    try:
+        repo = event["repository"]["full_name"]
+        number = event["pull_request"]["number"]
+    except (KeyError, TypeError) as exc:
+        raise click.ClickException(f"event payload missing required field: {exc}") from exc
     return f"{server}/{repo}/pull/{number}"
 
 

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -314,7 +314,12 @@ def _head_tail(text: str, max_tokens: int) -> str:
         return text
 
     marker = "… [truncated] …"
-    half = max(1, (max_tokens - count_tokens(marker)) // 2)
+    half = (max_tokens - count_tokens(marker)) // 2
+    if half <= 0:
+        # Budget too small to hold the marker plus any head/tail — flooring the
+        # per-end budget to 1 here would push the result over *max_tokens*, so
+        # attach nothing rather than overflow.
+        return ""
 
     head: list[str] = []
     used = 0

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -178,8 +178,14 @@ class RestGitHubGateway(GitHubGateway):
 
         # Fetch metadata (base/head SHAs)
         meta = self._get_json(pr_url)
-        base_sha: str = meta["base"]["sha"]
-        head_sha: str = meta["head"]["sha"]
+        try:
+            base_sha: str = meta["base"]["sha"]
+            head_sha: str = meta["head"]["sha"]
+        except (KeyError, TypeError) as exc:
+            raise RuntimeError(
+                f"PR metadata for {self._repo}#{self._pr_number} is missing the "
+                f"base/head SHA — unexpected GitHub API response ({exc})."
+            ) from exc
         self._head_sha = head_sha  # cache for on-demand get_file_contents fetches
 
         # Fetch unified diff

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -10,10 +10,26 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
-from lgtmaybe.cli import main, pr_url_from_event
+from lgtmaybe.cli import RuntimeOptions, execute_comment, main, pr_url_from_event
+from lgtmaybe.core.models import Provider, ReviewConfig
 from tests.fakes import FakeEngine, FakeGitHub, FakeProvider
+
+
+def test_execute_comment_missing_repository_raises_clean_error():
+    """An issue_comment payload missing ``repository`` surfaces a ClickException."""
+    import click
+
+    event = {
+        "comment": {"body": "/review"},
+        "issue": {"pull_request": {"url": "x"}, "number": 5},
+        # no "repository" key
+    }
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+    with pytest.raises(click.ClickException, match="missing required field"):
+        execute_comment(event, cfg, RuntimeOptions())
 
 
 class TestPrUrlFromEvent:
@@ -31,6 +47,13 @@ class TestPrUrlFromEvent:
             "pull_request": {"number": 7},
         }
         assert pr_url_from_event(event) == "https://ghe.example.com/org/repo/pull/7"
+
+    def test_missing_field_raises_clean_click_exception(self):
+        """A malformed event payload surfaces a clear ClickException, not KeyError."""
+        import click
+
+        with pytest.raises(click.ClickException, match="missing required field"):
+            pr_url_from_event({"pull_request": {"number": 7}})  # no "repository"
 
 
 def _write_event(tmp_path: Path, payload: dict) -> Path:

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -14,7 +14,8 @@ from lgtmaybe.core.models import (
     Severity,
 )
 from lgtmaybe.core.ports import ProviderClient
-from lgtmaybe.engine.reflect import reflect_findings
+from lgtmaybe.engine.compress import count_tokens
+from lgtmaybe.engine.reflect import _head_tail, reflect_findings
 from tests.fakes import FakeProvider
 
 # ---------------------------------------------------------------------------
@@ -520,3 +521,31 @@ def test_kept_and_deferred_findings_handled_together() -> None:
 
     assert _HIGH in survivors
     assert _LOW_CONF in survivors
+
+
+# ---------------------------------------------------------------------------
+# _head_tail — token-budget contract
+# ---------------------------------------------------------------------------
+
+
+def test_head_tail_respects_tiny_budget() -> None:
+    """A budget smaller than the truncation marker must not overflow.
+
+    Regression: ``half = max(1, ...)`` floored the per-end budget to 1 token, so
+    head + marker + tail could exceed *max_tokens* when the budget was smaller
+    than the marker itself. The function's contract is that the result fits
+    within *max_tokens*.
+    """
+    text = "alpha\nbravo\ncharlie\ndelta\necho"
+    for budget in range(1, 6):
+        result = _head_tail(text, max_tokens=budget)
+        assert count_tokens(result) <= budget, (budget, repr(result))
+
+
+def test_head_tail_truncates_within_budget() -> None:
+    """With room for the marker, the result keeps both ends and stays in budget."""
+    text = "\n".join(f"line{i}" for i in range(200))
+    result = _head_tail(text, max_tokens=40)
+    assert count_tokens(result) <= 40
+    assert "[truncated]" in result
+    assert result.startswith("line0")

--- a/tests/github/test_rest_gateway.py
+++ b/tests/github/test_rest_gateway.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import httpx
+import pytest
 import respx
 
 from lgtmaybe.github import RestGitHubGateway
@@ -65,6 +66,22 @@ def test_get_pr_context_returns_expected_shas_and_diff() -> None:
     assert ctx.repo == REPO
     assert ctx.pr_number == PR_NUMBER
     assert "src/app.py" in ctx.diff
+
+
+@respx.mock
+def test_get_pr_context_raises_clear_error_when_metadata_lacks_shas() -> None:
+    """A PR-detail response missing base/head must surface a clear error.
+
+    Regression: ``meta["base"]["sha"]`` raised a bare ``KeyError`` on a
+    malformed/partial GitHub response — an opaque traceback rather than the
+    clear, surfaced error the project requires. Should raise with a message that
+    names the missing base/head SHA, not a KeyError.
+    """
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(200, json={}))
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    with pytest.raises(RuntimeError, match="base/head"):
+        gw.get_pr_context()
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

Add defensive error handling for malformed GitHub webhook payloads and API responses. When required fields are missing, the code now raises clear `ClickException` or `RuntimeError` messages instead of letting bare `KeyError`/`TypeError` exceptions propagate.

## Key Changes

- **CLI event handling** (`cli/__init__.py`):
  - Wrap `event["repository"]["full_name"]` and `event["pull_request"]["number"]` access in try-catch blocks in both `execute_comment()` and `pr_url_from_event()`
  - Raise `click.ClickException` with a message naming the missing field instead of letting `KeyError` bubble up

- **GitHub REST gateway** (`github/rest_gateway.py`):
  - Wrap `meta["base"]["sha"]` and `meta["head"]["sha"]` access in try-catch in `get_pr_context()`
  - Raise `RuntimeError` with context (repo, PR number, the exception) when base/head SHAs are missing from the API response

- **Token budget fix** (`engine/reflect.py`):
  - Fix regression in `_head_tail()` where `half = max(1, ...)` could cause the result to exceed `max_tokens` when the budget was smaller than the truncation marker
  - Change to `half = (max_tokens - count_tokens(marker)) // 2` and return empty string if `half <= 0`, ensuring the contract that output always fits within the budget is honored

- **Test coverage**:
  - Add regression tests for `_head_tail()` with tiny budgets and normal truncation
  - Add tests for `execute_comment()` and `pr_url_from_event()` with missing repository field
  - Add test for `get_pr_context()` with malformed GitHub API response missing base/head SHAs

## Implementation Details

All error handling follows the pattern: catch `(KeyError, TypeError)` and re-raise as a domain-appropriate exception with a clear, user-facing message. This aligns with the project's non-negotiable principle of surfacing clear errors rather than opaque tracebacks, especially important when handling untrusted webhook payloads.

https://claude.ai/code/session_01Sf7wpF3ohZLPZZtieHpWr8