### PR TITLE
Add validation, logging, and redaction improvements

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -225,6 +225,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "type": "boolean"
         },
         "line": {
+          "minimum": 1,
           "title": "Line",
           "type": "integer"
         },
@@ -499,6 +500,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "boolean"
     },
     "line": {
+      "minimum": 1,
       "title": "Line",
       "type": "integer"
     },

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -91,7 +91,11 @@ class ReviewFinding(_Strict):
     """A single inline review comment the model wants to post."""
 
     path: str
-    line: int
+    # 1-based diff line. A 0/negative value is degenerate model output that maps to
+    # no real changed line (re-anchoring finds nothing) or mis-posts on GitHub, so
+    # reject it at the boundary — like a non-integer line, this fails the lens
+    # loudly rather than posting a comment on a nonsensical line.
+    line: int = Field(ge=1)
     side: Side = "RIGHT"
     severity: Severity
     title: str

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -240,7 +240,11 @@ class LLMReviewEngine(ReviewEngine):
         #     fingerprint (cfg.ignore_fingerprints) or an inline `# lgtmaybe:
         #     ignore` pragma on/above the flagged line. Done before reflection so a
         #     suppressed finding costs no reflection tokens and never posts.
+        before_suppress = len(all_findings)
         all_findings = apply_suppressions(all_findings, cfg, ctx.file_contents)
+        suppressed = before_suppress - len(all_findings)
+        if suppressed:
+            _log.info("suppressed findings", extra={"count": suppressed})
 
         # 8. Self-reflection: filter out low-confidence findings. Reflect against
         #    only the reviewed diff — redacted, and free of skipped/over-cap files.

--- a/src/lgtmaybe/engine/redact.py
+++ b/src/lgtmaybe/engine/redact.py
@@ -28,6 +28,12 @@ _SIMPLE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"AIza[0-9A-Za-z\-_]{35}"),
     # Stripe live/test secret keys
     re.compile(r"sk_(?:live|test)_[A-Za-z0-9]{16,}"),
+    # JSON Web Encryption (compact): header.encrypted_key.iv.ciphertext.tag —
+    # five base64url segments. The second segment is an encrypted key, NOT a
+    # base64url JSON header, so the three-part JWT pattern below never matches a
+    # JWE; without this it would egress whole. Listed first so the 5-segment form
+    # is consumed before the 3-segment pattern can claim a prefix of it.
+    re.compile(r"eyJ[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,}){4}"),
     # JSON Web Tokens: header.payload.signature, each base64url. The payload
     # carries claims/PII, so the whole token must go — not just up to a dot.
     re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -142,8 +142,15 @@ def _reflect_pass(
     try:
         verdicts = _audit(findings, ctx, cfg, provider, fetched_paths=fetched_paths)
     except Exception:
-        # If reflection fails to parse, keep all findings (safe default), each
-        # non-broad — never silently drop a real finding, nor tier it as broad.
+        # If reflection fails (provider error, quota, unparseable output), keep all
+        # findings (safe default), each non-broad — never silently drop a real
+        # finding, nor tier it as broad. Log the cause: an always-failing reflection
+        # pass otherwise looks identical to "nothing to prune".
+        _log.warning(
+            "reflection pass failed; keeping all findings",
+            extra={"findings": len(findings)},
+            exc_info=True,
+        )
         return findings
 
     survivors: list[ReviewFinding] = []

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1027,6 +1027,38 @@ def test_review_logs_a_heartbeat_as_each_lens_runs(engine_logs) -> None:
     assert all(getattr(r, "lens", None) for r in completed)
 
 
+def test_suppressed_findings_are_logged_with_a_count(engine_logs) -> None:
+    """A suppression silently dropping findings is invisible; log how many went, so
+    a team can tell a too-broad fingerprint/pragma from a genuinely clean review."""
+    from lgtmaybe.github.rest_gateway import finding_fingerprint
+
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        ignore_fingerprints=[finding_fingerprint(_HIGH.path, _HIGH.title)],
+    )
+
+    findings, _ = engine.review(_CTX, cfg)
+
+    assert findings == []  # the only finding was suppressed
+    suppressed = [r for r in engine_logs if "suppress" in r.getMessage().lower()]
+    assert suppressed, "expected a log noting suppressed findings"
+    assert getattr(suppressed[0], "count", None) == 1
+
+
+def test_no_suppression_log_when_nothing_suppressed(engine_logs) -> None:
+    """Don't add noise: with no suppressions configured, emit no suppression log."""
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+
+    engine.review(_CTX, cfg)
+
+    assert not [r for r in engine_logs if "suppress" in r.getMessage().lower()]
+
+
 def test_custom_lens_runs_as_an_extra_review_call() -> None:
     """A configured extra lens fans out as its own focused review call, and its
     findings flow through the same merge/dedupe/reflect pipeline."""

--- a/tests/engine/test_redact.py
+++ b/tests/engine/test_redact.py
@@ -177,6 +177,40 @@ def test_jwt_redacted() -> None:
     assert REDACTED_PLACEHOLDER in result
 
 
+_JWE = (
+    "eyJ" + "hbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ"  # protected header (eyJ…)
+    ".OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGe"  # encrypted key
+    ".48V1_ALb6US04U3b"  # iv
+    ".5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji"  # ciphertext
+    ".XFBoMYUZodetZdvTiFvSkQ"  # auth tag
+)
+
+
+def test_jwe_compact_token_redacted() -> None:
+    """A five-segment compact JWE (common with cloud OIDC/Entra) must be scrubbed.
+
+    The three-segment JWT pattern can't match a JWE — its second segment is an
+    encrypted key, not a base64url JSON header (`eyJ…`) — so without a dedicated
+    pattern the whole token would egress. Framed without an assignment keyword so
+    the generic value pattern can't take credit by scrubbing only the first
+    segment; the middle (ciphertext) segment must be gone for this to pass.
+    """
+    result = redact(f"+  cookie {_JWE}\n")
+    assert _JWE not in result
+    # A middle segment — not just the leading header — must be scrubbed.
+    assert "5eym8TW_c8SuK0lt" not in result
+    assert REDACTED_PLACEHOLDER in result
+
+
+def test_jwt_still_redacted_alongside_jwe_pattern() -> None:
+    """The new JWE pattern must not stop a plain three-segment JWT being scrubbed."""
+    result = redact(f"+  cookie {_JWT}\n")
+    assert _JWT not in result
+    # The payload segment carries claims/PII — none of it may survive.
+    assert "zdWIiOiIxMjM0" not in result
+    assert REDACTED_PLACEHOLDER in result
+
+
 def test_npm_token_redacted() -> None:
     result = redact(f"+//registry.npmjs.org/:_authToken={_NPM_TOKEN}\n")
     assert _NPM_TOKEN not in result

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 from lgtmaybe.core.models import (
     PRContext,
@@ -178,6 +179,48 @@ def test_unparseable_verdict_keeps_all() -> None:
     survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, provider)
 
     assert survivors == [_HIGH, _LOW_CONF]  # safe default
+
+
+class _RaisingProvider(ProviderClient):
+    """A ProviderClient whose complete() always raises (quota/auth/network)."""
+
+    def complete(self, messages: list[dict[str, str]], model: str, **opts: object):
+        raise RuntimeError("provider exploded")
+
+
+class _ListHandler(logging.Handler):
+    """Collects emitted LogRecords for assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def test_reflection_failure_keeps_all_and_logs() -> None:
+    """When the audit call raises, keep every finding (safe default) AND warn.
+
+    Swallowing the cause silently makes an always-failing reflection pass look
+    identical to "nothing to prune" — the repo convention is errors must surface.
+    The reflect logger does not propagate to root, so attach a handler directly.
+    """
+    from lgtmaybe.engine import reflect as reflect_mod
+
+    handler = _ListHandler()
+    reflect_mod._log.addHandler(handler)
+    try:
+        survivors = reflect_findings([_HIGH, _LOW_CONF], _CTX, _CFG, _RaisingProvider())
+    finally:
+        reflect_mod._log.removeHandler(handler)
+
+    assert survivors == [_HIGH, _LOW_CONF]  # safe default — nothing dropped
+    warnings = [r for r in handler.records if r.levelno >= logging.WARNING]
+    assert warnings, "expected a warning when the reflection pass fails"
+    assert any("reflection" in r.getMessage().lower() for r in warnings)
+    # The cause must be attached so logs name why it failed, not just that it did.
+    assert any(r.exc_info for r in warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -111,6 +111,7 @@
           "type": "boolean"
         },
         "line": {
+          "minimum": 1,
           "title": "Line",
           "type": "integer"
         },

--- a/tests/snapshots/ReviewFinding.json
+++ b/tests/snapshots/ReviewFinding.json
@@ -43,6 +43,7 @@
       "type": "boolean"
     },
     "line": {
+      "minimum": 1,
       "title": "Line",
       "type": "integer"
     },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -322,3 +322,14 @@ def test_review_finding_anchored_defaults_true() -> None:
         f.model_copy(update={"anchored": False}).model_dump_json()
     )
     assert restored.anchored is False
+
+
+def test_review_finding_line_must_be_positive() -> None:
+    """Line numbers are 1-based; a 0/negative line is bogus model output and would
+    map to no real diff line (or worse, a wrong one) — reject it at the boundary."""
+    for bad in (0, -1):
+        with pytest.raises(ValidationError):
+            ReviewFinding(path="a.py", line=bad, severity=Severity.low, title="t", body="b")
+    # The first valid line is accepted.
+    f = ReviewFinding(path="a.py", line=1, severity=Severity.low, title="t", body="b")
+    assert f.line == 1


### PR DESCRIPTION
## Summary

This PR hardens the review engine with input validation, improved error observability, and expanded secret redaction patterns. It adds validation to reject degenerate line numbers, logs suppressed findings and reflection failures, detects JWE tokens alongside JWTs, and ensures reflection errors surface rather than silently degrade.

## Key changes

- **Line number validation:** `ReviewFinding.line` now requires `ge=1` (1-based diff lines). Rejects 0/negative values that would map to no real changed line or mis-post on GitHub, failing loudly at the boundary like a non-integer would.

- **Reflection failure logging:** When the audit call raises (provider error, quota, unparseable output), the engine now logs a warning with `exc_info=True` so the cause surfaces. An always-failing reflection pass no longer looks identical to "nothing to prune" — errors must surface per convention.

- **Suppression count logging:** When findings are suppressed via fingerprint or pragma, the engine logs how many were dropped with a `count` attribute. Prevents a too-broad fingerprint from being invisible; a team can now tell a genuinely clean review from one where suppressions are hiding findings.

- **JWE token redaction:** Added pattern to detect five-segment compact JWE tokens (header.encrypted_key.iv.ciphertext.tag), which the existing three-segment JWT pattern cannot match. Listed first so the 5-segment form is consumed before the 3-segment pattern claims a prefix. Plain JWTs continue to be redacted.

- **Test coverage:** Added tests for reflection failure with logging, JWE redaction alongside JWT redaction, suppression logging with and without suppressions configured, and line number validation.

## Implementation details

- Reflection logging uses the module-level `_log` logger (does not propagate to root), so tests attach a handler directly to verify warnings are emitted.
- Suppression logging only emits when `suppressed > 0`, avoiding noise when no suppressions are configured.
- JWE pattern uses `(?:\.[A-Za-z0-9_-]{8,}){4}` to match exactly four additional segments after the header, ensuring the 5-segment form is matched before the 3-segment JWT pattern can claim a prefix.
- Line validation is enforced at the Pydantic model boundary via `Field(ge=1)`, so invalid output fails the lens loudly rather than posting a comment on a nonsensical line.

https://claude.ai/code/session_0177Q8JS9VTiaTasgcihgA3c