### PR TITLE
feat: add Homebrew install support

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,72 @@
+name: homebrew
+
+# Keeps the Homebrew tap formula (MattJColes/homebrew-lgtmaybe) in sync with the
+# latest PyPI release. Fires when a GitHub release is published (release-please
+# cuts it) and can be re-run manually for any version. It regenerates the whole
+# formula — including every PyPI resource stanza — so a dependency bump is picked
+# up too, not just the lgtmaybe version.
+#
+# One-time setup (see docs/how-to/releasing.md):
+#   - Create the tap repo MattJColes/homebrew-lgtmaybe.
+#   - Add a repo secret HOMEBREW_TAP_TOKEN: a PAT with `contents: write` on the
+#     tap repo (GITHUB_TOKEN cannot push to a different repository).
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish to the tap, e.g. 0.7.2 (no leading v)."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  formula:
+    # macOS so `brew` and `brew update-python-resources` are available.
+    runs-on: macos-latest
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            v="${{ inputs.version }}"
+          else
+            v="${{ github.event.release.tag_name }}"
+          fi
+          v="${v#lgtmaybe-v}"
+          v="${v#v}"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout lgtmaybe (for the generator script)
+        uses: actions/checkout@v7
+        with:
+          path: lgtmaybe
+
+      - name: Checkout the tap
+        uses: actions/checkout@v7
+        with:
+          repository: MattJColes/homebrew-lgtmaybe
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Regenerate the formula
+        run: |
+          lgtmaybe/scripts/update-homebrew-formula.sh \
+            "${{ steps.ver.outputs.version }}" \
+            "tap/Formula/lgtmaybe.rb"
+
+      - name: Commit and push
+        working-directory: tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- Formula/lgtmaybe.rb; then
+            echo "Formula already up to date for ${{ steps.ver.outputs.version }}."
+            exit 0
+          fi
+          git add Formula/lgtmaybe.rb
+          git commit -m "lgtmaybe ${{ steps.ver.outputs.version }}"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,17 @@ Read this before writing code. It encodes decisions that are **made, not options
 
 A PR reviewer that posts inline review comments + a summary. The user picks the
 LLM backend with a `--provider` flag, drops a key into GitHub secrets (or wires
-OIDC/WIF for cloud providers), and gets a review. One core, two distribution
+OIDC/WIF for cloud providers), and gets a review. One core, three distribution
 variants:
 
 - **PyPI CLI** — `pip install lgtmaybe`
+- **Homebrew CLI** — `brew install MattJColes/lgtmaybe/lgtmaybe`, from the
+  `MattJColes/homebrew-lgtmaybe` tap. The formula installs the core deps (covers
+  the API-key + local providers; keyless cloud needs the `pip` extras), and is
+  regenerated from the published PyPI release on each release by
+  `.github/workflows/homebrew.yml` + `scripts/update-homebrew-formula.sh` (full
+  resource stanzas via `brew update-python-resources`, so dep bumps are picked
+  up — never hand-maintained)
 - **GitHub Action** — composite action (`action.yml`) that does keyless OIDC/WIF
   auth, then runs a GHCR image via the `action` entrypoint
 
@@ -245,6 +252,13 @@ pattern, event bus, plugin framework.
      pushes the GHCR image (`{version}`, `v{major}`, `latest`) + moves the floating
      `v1`. `.github/workflows/commitlint.yml` (`commitlint.config.cjs`) gates PR
      titles/commits to conventional-commit format so the automation can version.
+   - **Homebrew tap** — `.github/workflows/homebrew.yml` fires on the published
+     release and regenerates the formula in the `MattJColes/homebrew-lgtmaybe`
+     tap via `scripts/update-homebrew-formula.sh` (resolves the PyPI sdist
+     url/sha, then `brew update-python-resources` fills the full dependency tree;
+     pushes with the `HOMEBREW_TAP_TOKEN` PAT). Regenerated wholesale each release
+     so dep bumps flow through — never hand-edited. Maintainer setup (tap repo +
+     PAT) is in `docs/how-to/releasing.md`.
    - **`examples/workflows/`** — one per posting provider (cloud + API-key);
      `id-token: write` for cloud. ollama is local-only (CLI), not a workflow.
    - **Model IDs in docs are kept current** per platform (litellm-native form).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ From inside a git repo, on a branch with changes, review your diff against the
 remote primary branch and print the findings:
 
 ```bash
-pip install lgtmaybe
+pip install lgtmaybe        # or: brew install MattJColes/lgtmaybe/lgtmaybe
 
 lgtmaybe review \
   --provider ollama \
@@ -211,7 +211,9 @@ only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instea
 
 ## Distribution
 
-- **CLI** — `pip install lgtmaybe`
+- **CLI (PyPI)** — `pip install lgtmaybe`
+- **CLI (Homebrew)** — `brew install MattJColes/lgtmaybe/lgtmaybe`
+  ([details](docs/how-to/install-with-homebrew.md))
 - **GitHub Action** — `uses: MattJColes/lgtmaybe@v0`
 
 ## Contributing

--- a/docs/how-to/install-with-homebrew.md
+++ b/docs/how-to/install-with-homebrew.md
@@ -1,0 +1,59 @@
+# Install with Homebrew
+
+On macOS (and Linuxbrew), you can install the `lgtmaybe` CLI from the project's
+[Homebrew tap](https://github.com/MattJColes/homebrew-lgtmaybe) instead of `pip`.
+
+```bash
+brew install MattJColes/lgtmaybe/lgtmaybe
+```
+
+That one command taps the repository and installs the formula. If you prefer to
+tap first:
+
+```bash
+brew tap MattJColes/lgtmaybe
+brew install lgtmaybe
+```
+
+Verify it:
+
+```bash
+lgtmaybe --help
+```
+
+Upgrade later with:
+
+```bash
+brew upgrade lgtmaybe
+```
+
+Homebrew installs lgtmaybe into its own isolated virtualenv, so it never touches
+your system or project Python. The first install builds a few native
+dependencies from source (pydantic-core, tiktoken, tokenizers), which can take a
+minute. It also pulls the `ast-grep` formula, which lgtmaybe uses for cross-file
+symbol resolution during review.
+
+## Which providers does the Homebrew build cover?
+
+The formula installs the core dependencies, which covers every **API-key** and
+**local** provider:
+
+- `openai`, `anthropic`, `openrouter`, `zai` — set the provider's API key in your
+  environment.
+- `ollama` and `openai-compatible` — fully local, point `--api-base` at the server.
+
+The **keyless cloud** providers — `bedrock`, `vertex`, `azure` — need extra cloud
+SDKs that the Homebrew formula does not bundle. For those, install the CLI from
+PyPI with the matching extra, e.g.:
+
+```bash
+pip install 'lgtmaybe[bedrock]'   # or [vertex] / [azure]
+```
+
+or run them through the [GitHub Action](use-as-github-action.md), where the image
+bundles all three and wires up the OIDC/WIF auth for you.
+
+## Next steps
+
+- Run your first local review: [Getting started](../tutorial/getting-started.md).
+- Post reviews on real pull requests: [Use as a GitHub Action](use-as-github-action.md).

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -8,6 +8,13 @@ the release: it cuts the tag and the GitHub release, then the same run publishes
 tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml`
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
+A third workflow, `.github/workflows/homebrew.yml`, fires on the published
+release and regenerates the **Homebrew formula** in the tap repo
+(`MattJColes/homebrew-lgtmaybe`) so `brew install MattJColes/lgtmaybe/lgtmaybe`
+tracks the latest version. It regenerates the whole formula — including every
+PyPI resource stanza via `scripts/update-homebrew-formula.sh` — so a dependency
+bump is picked up too.
+
 Commit messages must follow conventional-commit format — `.github/workflows/commitlint.yml`
 enforces it on PRs so release-please can compute the next version.
 
@@ -31,6 +38,12 @@ The only human-only pieces:
 - First release only: from the GitHub release page, tick **"Publish this Action
   to the GitHub Marketplace"**, accept the terms, and pick the categories
   `code-review` and `continuous-integration`.
+- **Homebrew tap:** create the repo **`MattJColes/homebrew-lgtmaybe`** with a
+  `Formula/` directory (it can start empty — the workflow writes the formula).
+  Add a repo secret **`HOMEBREW_TAP_TOKEN`** to *this* repo: a fine-grained PAT
+  with `contents: write` on the tap repo (the default `GITHUB_TOKEN` cannot push
+  to another repository). To seed or verify the formula by hand on a Mac, run
+  `scripts/update-homebrew-formula.sh <version> path/to/homebrew-lgtmaybe/Formula/lgtmaybe.rb`.
 
 ## Each release
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -17,6 +17,16 @@ and no pull request required.
 pip install lgtmaybe
 ```
 
+On macOS you can install from the Homebrew tap instead:
+
+```bash
+brew install MattJColes/lgtmaybe/lgtmaybe
+```
+
+See [Install with Homebrew](../how-to/install-with-homebrew.md) for details (the
+Homebrew build covers the API-key and local providers; keyless cloud providers
+need the `pip` extras).
+
 Verify the install:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - Tutorial:
       - Getting started: tutorial/getting-started.md
   - How-to:
+      - Install with Homebrew: how-to/install-with-homebrew.md
       - Review with OpenAI: how-to/review-with-openai.md
       - Review with Claude (Anthropic): how-to/review-with-anthropic.md
       - Review with OpenRouter: how-to/review-with-openrouter.md

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regenerate the Homebrew formula for lgtmaybe with up-to-date PyPI resources.
+#
+# litellm pulls a large transitive dependency tree, so a source-install formula
+# needs every transitive dependency as a `resource` stanza. Hand-maintaining that
+# is infeasible — this script regenerates the whole formula from the published
+# PyPI release instead, so a dependency bump is picked up automatically. The CI
+# job (.github/workflows/homebrew.yml) runs it on each release; a maintainer can
+# also run it locally on a Mac to seed or verify the tap before the first release.
+#
+# Requires macOS with Homebrew installed (for `brew update-python-resources`) and
+# python3 on PATH.
+#
+# Usage:
+#   scripts/update-homebrew-formula.sh <version> <output-formula-path>
+# e.g.
+#   scripts/update-homebrew-formula.sh 0.7.2 ../homebrew-lgtmaybe/Formula/lgtmaybe.rb
+set -euo pipefail
+
+VERSION="${1:?usage: update-homebrew-formula.sh <version> <output-formula-path>}"
+OUT="${2:?usage: update-homebrew-formula.sh <version> <output-formula-path>}"
+
+# Strip any leading tag noise so callers can pass either "0.7.2" or "lgtmaybe-v0.7.2".
+VERSION="${VERSION#lgtmaybe-v}"
+VERSION="${VERSION#v}"
+
+# 1. Resolve the sdist URL + sha256 for this version from PyPI. The release
+#    workflow can fire before PyPI's trusted-publishing job has finished, so poll
+#    until the version is available (up to ~10 minutes) rather than racing it.
+pypi_json=""
+for attempt in $(seq 1 60); do
+  if pypi_json="$(curl -fsSL "https://pypi.org/pypi/lgtmaybe/${VERSION}/json" 2>/dev/null)"; then
+    break
+  fi
+  echo "lgtmaybe ${VERSION} not on PyPI yet (attempt ${attempt}); waiting 10s…" >&2
+  sleep 10
+done
+if [ -z "$pypi_json" ]; then
+  echo "error: lgtmaybe ${VERSION} never appeared on PyPI" >&2
+  exit 1
+fi
+
+read -r SDIST_URL SDIST_SHA <<EOF
+$(printf '%s' "$pypi_json" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+sdist = next(u for u in data["urls"] if u["packagetype"] == "sdist")
+print(sdist["url"], sdist["digests"]["sha256"])
+')
+EOF
+
+echo "lgtmaybe ${VERSION}: ${SDIST_URL}" >&2
+
+# 2. Write the formula skeleton into a throwaway local tap. brew commands resolve
+#    formulae by tap-qualified NAME (local/lgtmaybe/lgtmaybe), not by file path, so
+#    update-python-resources only works on a formula that lives inside a tap.
+#    The heredoc is unquoted so ${SDIST_URL} / ${SDIST_SHA} expand — keep its body
+#    free of backticks and stray $ so nothing else is evaluated.
+TAP_DIR="$(brew --repository)/Library/Taps/local/homebrew-lgtmaybe"
+FORMULA="${TAP_DIR}/Formula/lgtmaybe.rb"
+rm -rf "$TAP_DIR"
+mkdir -p "${TAP_DIR}/Formula"
+git -C "$TAP_DIR" init -q
+
+cat > "$FORMULA" <<RUBY
+class Lgtmaybe < Formula
+  include Language::Python::Virtualenv
+
+  desc "Provider-agnostic pull request reviewer with keyless cloud auth"
+  homepage "https://mattjcoles.github.io/lgtmaybe/"
+  url "${SDIST_URL}"
+  sha256 "${SDIST_SHA}"
+  license "MIT"
+
+  # ast-grep-cli ships a prebuilt binary via platform wheels, but Homebrew
+  # installs resources from sdists (--no-binary), so we install the binary from
+  # the core ast-grep formula and exclude ast-grep-cli from the venv (see
+  # --exclude-packages below). lgtmaybe locates it on PATH via shutil.which.
+  depends_on "ast-grep"
+  depends_on "python@3.12"
+  # litellm pulls pydantic-core / tiktoken / tokenizers, whose sdists build with
+  # a Rust toolchain. Build-time only -- not a runtime dependency.
+  depends_on "rust" => :build
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/lgtmaybe --help")
+  end
+end
+RUBY
+
+# 3. Populate (or refresh) the resource stanzas for the full dependency tree.
+#    ast-grep-cli is excluded: its sdist would try to build/fetch a Rust binary
+#    inside Homebrew's network-sandboxed build and break `brew install`. The
+#    ast-grep dependency above supplies that binary instead.
+brew update-python-resources --exclude-packages=ast-grep-cli local/lgtmaybe/lgtmaybe
+
+# 4. Copy the generated formula into the caller's output path (the checked-out
+#    tap repo), then clean up the throwaway tap.
+mkdir -p "$(dirname "$OUT")"
+cp "$FORMULA" "$OUT"
+rm -rf "$TAP_DIR"
+
+echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2


### PR DESCRIPTION
Distribute the lgtmaybe CLI via a Homebrew tap
(MattJColes/homebrew-lgtmaybe) so `brew install MattJColes/lgtmaybe/lgtmaybe` works alongside `pip install`.

Because litellm pulls a large transitive dependency tree, the formula's resource stanzas are generated from the published PyPI release rather than hand-maintained:

- scripts/update-homebrew-formula.sh resolves the sdist url/sha from PyPI (polling until trusted-publishing finishes) and runs `brew update-python-resources` to fill the full dependency tree.
- .github/workflows/homebrew.yml runs it on each published release and pushes the regenerated formula to the tap, so dependency bumps flow through too.

Docs: new how-to/install-with-homebrew.md, getting-started + README install notes, and the one-time tap/PAT setup in how-to/releasing.md. CLAUDE.md now records the third distribution variant.


Claude-Session: https://claude.ai/code/session_01DJP2ZwatDbHEea2sE4YZpy