### PR TITLE
fix(homebrew): make the tap publish reliably on release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,24 +1,47 @@
 name: homebrew
 
 # Keeps the Homebrew tap formula (MattJColes/homebrew-lgtmaybe) in sync with the
-# latest PyPI release. Fires when a GitHub release is published (release-please
-# cuts it) and can be re-run manually for any version. It regenerates the whole
-# formula — including every PyPI resource stanza — so a dependency bump is picked
-# up too, not just the lgtmaybe version.
+# latest PyPI release. It regenerates the whole formula — including every PyPI
+# resource stanza — so a dependency bump is picked up too, not just the lgtmaybe
+# version.
+#
+# How it gets invoked (belt and braces, because no single trigger is reliable):
+#   - workflow_call — release-please.yml calls this right after it cuts a release
+#     (a `release: published` event is NOT delivered when release-please creates
+#     the release with the built-in GITHUB_TOKEN, so we cannot rely on it).
+#   - schedule — a daily run is the workhorse. Homebrew's `update-python-resources`
+#     refuses to resolve a PyPI version published in the last 24h (its hardcoded
+#     RELEASE_COOLDOWN_SECONDS supply-chain guard), so a brand-new release cannot
+#     be turned into a formula immediately. The scheduled run picks the version up
+#     once it has aged past that cooldown. It is idempotent: it no-ops when the tap
+#     is already on the latest version.
+#   - workflow_dispatch — manual re-run for any version.
+#   - release: published — still honoured for a release published by a human (a
+#     real user token DOES trigger downstream workflows); a no-op for the
+#     release-please flow.
 #
 # One-time setup (see docs/how-to/releasing.md):
 #   - Create the tap repo MattJColes/homebrew-lgtmaybe.
 #   - Add a repo secret HOMEBREW_TAP_TOKEN: a PAT with `contents: write` on the
 #     tap repo (GITHUB_TOKEN cannot push to a different repository).
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: "Version (or tag) to publish to the tap, e.g. 0.7.2 or lgtmaybe-v0.7.2."
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
         description: "Version to publish to the tap, e.g. 0.7.2 (no leading v)."
         required: true
         type: string
+  schedule:
+    # Daily — catches a release once it has aged past Homebrew's 24h PyPI cooldown.
+    - cron: "17 7 * * *"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -31,12 +54,17 @@ jobs:
       - name: Resolve version
         id: ver
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            v="${{ inputs.version }}"
-          else
-            v="${{ github.event.release.tag_name }}"
+          raw="${{ inputs.version }}"
+          if [ -z "$raw" ] && [ "${{ github.event_name }}" = "release" ]; then
+            raw="${{ github.event.release.tag_name }}"
           fi
-          v="${v#lgtmaybe-v}"
+          if [ -z "$raw" ]; then
+            # schedule (or anything without an explicit version): take the latest
+            # published version straight from PyPI.
+            raw="$(curl -fsSL https://pypi.org/pypi/lgtmaybe/json \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["info"]["version"])')"
+          fi
+          v="${raw#lgtmaybe-v}"
           v="${v#v}"
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
@@ -52,13 +80,43 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 
-      - name: Regenerate the formula
+      - name: Skip if the tap is already on this version
+        id: idem
         run: |
+          f="tap/Formula/lgtmaybe.rb"
+          cur=""
+          if [ -f "$f" ]; then
+            # Pull the version out of the sdist filename in the formula's url line,
+            # e.g. .../lgtmaybe-0.8.0.tar.gz -> 0.8.0
+            cur="$(grep -oE '/lgtmaybe-[0-9][^/]*\.tar\.gz' "$f" | head -n1 | sed -E 's#/lgtmaybe-##; s#\.tar\.gz$##')"
+          fi
+          echo "Current formula version: '${cur}', target: '${{ steps.ver.outputs.version }}'"
+          if [ "$cur" = "${{ steps.ver.outputs.version }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Tap already at ${cur}; nothing to do."
+          fi
+
+      - name: Regenerate the formula
+        id: gen
+        if: steps.idem.outputs.skip != 'true'
+        run: |
+          set +e
           lgtmaybe/scripts/update-homebrew-formula.sh \
             "${{ steps.ver.outputs.version }}" \
             "tap/Formula/lgtmaybe.rb"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 75 ]; then
+            # Within Homebrew's 24h PyPI cooldown — not an error. The next
+            # scheduled run will publish it once it has aged past the cooldown.
+            echo "deferred=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::lgtmaybe ${{ steps.ver.outputs.version }} is within Homebrew's 24h PyPI cooldown; deferring to a later scheduled run."
+            exit 0
+          fi
+          exit "$rc"
 
       - name: Commit and push
+        if: steps.idem.outputs.skip != 'true' && steps.gen.outputs.deferred != 'true'
         working-directory: tap
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,3 +71,16 @@ jobs:
       contents: write # move floating major tag
       packages: write # GHCR push
     secrets: inherit
+
+  # Homebrew tap — call it directly, because a `release: published` event is NOT
+  # delivered for a release that release-please cuts with the built-in
+  # GITHUB_TOKEN. The freshly-published version is still inside Homebrew's 24h
+  # PyPI cooldown, so this call usually defers (no-op); homebrew.yml's daily
+  # schedule then publishes the formula once the version ages past the cooldown.
+  homebrew:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/homebrew.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,18 @@ variants:
 - **Homebrew CLI** — `brew install MattJColes/lgtmaybe/lgtmaybe`, from the
   `MattJColes/homebrew-lgtmaybe` tap. The formula installs the core deps (covers
   the API-key + local providers; keyless cloud needs the `pip` extras), and is
-  regenerated from the published PyPI release on each release by
-  `.github/workflows/homebrew.yml` + `scripts/update-homebrew-formula.sh` (full
-  resource stanzas via `brew update-python-resources`, so dep bumps are picked
-  up — never hand-maintained)
+  regenerated from the published PyPI release by `.github/workflows/homebrew.yml`
+  + `scripts/update-homebrew-formula.sh` (full resource stanzas via
+  `brew update-python-resources`, so dep bumps are picked up — never
+  hand-maintained). Two wrinkles shape how it runs: (1) `release-please.yml`
+  **calls** `homebrew.yml` directly (`workflow_call`) because a `release:
+  published` event isn't delivered for a release cut by the built-in
+  `GITHUB_TOKEN`; (2) `brew update-python-resources` hardcodes a 24h PyPI
+  cooldown (`RELEASE_COOLDOWN_SECONDS`, no opt-out) so a just-published version
+  can't be resolved yet — the release-time call defers (script exits `75`) and a
+  **daily scheduled run** publishes once the version ages past the cooldown
+  (idempotent, no-ops when the tap is current). A new version lands in the tap
+  within ~a day, not instantly
 - **GitHub Action** — composite action (`action.yml`) that does keyless OIDC/WIF
   auth, then runs a GHCR image via the `action` entrypoint
 

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -14,12 +14,31 @@ the release: it cuts the tag and the GitHub release, then the same run publishes
 tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml`
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
-A third workflow, `.github/workflows/homebrew.yml`, fires on the published
-release and regenerates the **Homebrew formula** in the tap repo
-(`MattJColes/homebrew-lgtmaybe`) so `brew install MattJColes/lgtmaybe/lgtmaybe`
-tracks the latest version. It regenerates the whole formula — including every
-PyPI resource stanza via `scripts/update-homebrew-formula.sh` — so a dependency
-bump is picked up too.
+A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
+formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
+`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version. It
+regenerates the whole formula — including every PyPI resource stanza via
+`scripts/update-homebrew-formula.sh` — so a dependency bump is picked up too.
+
+Two things make the Homebrew publish less direct than PyPI/GHCR, and the
+workflow is built around both:
+
+- A `release: published` event is **not** delivered for a release that
+  release-please cuts, because it is created with the built-in `GITHUB_TOKEN`
+  (GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN` to prevent
+  recursion). So `release-please.yml` **calls** `homebrew.yml` directly
+  (`workflow_call`) instead of relying on the event.
+- Homebrew's `brew update-python-resources` hardcodes a 24-hour PyPI cooldown
+  (`RELEASE_COOLDOWN_SECONDS`) and refuses to resolve a version published in the
+  last day — a supply-chain guard with no opt-out. A brand-new release therefore
+  **cannot** be turned into a formula immediately. The release-time call detects
+  this and defers; a **daily scheduled run** in `homebrew.yml` is the workhorse
+  that publishes the formula once the version has aged past the cooldown
+  (idempotent — a no-op when the tap is already current). Net effect: a new
+  version lands in the tap within roughly a day of release, not instantly. To
+  publish sooner, re-run `homebrew.yml` via **workflow_dispatch** with the
+  version once it is >24h old, or run `scripts/update-homebrew-formula.sh`
+  locally on a Mac.
 
 Commit messages must follow conventional-commit format — `.github/workflows/commitlint.yml`
 enforces it on PRs so release-please can compute the next version.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2217,12 +2217,31 @@ the release: it cuts the tag and the GitHub release, then the same run publishes
 tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml`
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
-A third workflow, `.github/workflows/homebrew.yml`, fires on the published
-release and regenerates the **Homebrew formula** in the tap repo
-(`MattJColes/homebrew-lgtmaybe`) so `brew install MattJColes/lgtmaybe/lgtmaybe`
-tracks the latest version. It regenerates the whole formula — including every
-PyPI resource stanza via `scripts/update-homebrew-formula.sh` — so a dependency
-bump is picked up too.
+A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
+formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
+`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version. It
+regenerates the whole formula — including every PyPI resource stanza via
+`scripts/update-homebrew-formula.sh` — so a dependency bump is picked up too.
+
+Two things make the Homebrew publish less direct than PyPI/GHCR, and the
+workflow is built around both:
+
+- A `release: published` event is **not** delivered for a release that
+  release-please cuts, because it is created with the built-in `GITHUB_TOKEN`
+  (GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN` to prevent
+  recursion). So `release-please.yml` **calls** `homebrew.yml` directly
+  (`workflow_call`) instead of relying on the event.
+- Homebrew's `brew update-python-resources` hardcodes a 24-hour PyPI cooldown
+  (`RELEASE_COOLDOWN_SECONDS`) and refuses to resolve a version published in the
+  last day — a supply-chain guard with no opt-out. A brand-new release therefore
+  **cannot** be turned into a formula immediately. The release-time call detects
+  this and defers; a **daily scheduled run** in `homebrew.yml` is the workhorse
+  that publishes the formula once the version has aged past the cooldown
+  (idempotent — a no-op when the tap is already current). Net effect: a new
+  version lands in the tap within roughly a day of release, not instantly. To
+  publish sooner, re-run `homebrew.yml` via **workflow_dispatch** with the
+  version once it is >24h old, or run `scripts/update-homebrew-formula.sh`
+  locally on a Mac.
 
 Commit messages must follow conventional-commit format — `.github/workflows/commitlint.yml`
 enforces it on PRs so release-please can compute the next version.

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -40,16 +40,25 @@ if [ -z "$pypi_json" ]; then
   exit 1
 fi
 
-read -r SDIST_URL SDIST_SHA <<EOF
+read -r SDIST_URL SDIST_SHA AGE_SECONDS <<EOF
 $(printf '%s' "$pypi_json" | python3 -c '
 import json, sys
+from datetime import datetime, timezone
 data = json.load(sys.stdin)
 sdist = next(u for u in data["urls"] if u["packagetype"] == "sdist")
-print(sdist["url"], sdist["digests"]["sha256"])
+uploaded = sdist.get("upload_time_iso_8601") or sdist.get("upload_time") or ""
+try:
+    dt = datetime.fromisoformat(uploaded.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    age = int((datetime.now(timezone.utc) - dt).total_seconds())
+except ValueError:
+    age = 10**9  # unknown upload time — assume old, let brew decide
+print(sdist["url"], sdist["digests"]["sha256"], age)
 ')
 EOF
 
-echo "lgtmaybe ${VERSION}: ${SDIST_URL}" >&2
+echo "lgtmaybe ${VERSION}: ${SDIST_URL} (uploaded ${AGE_SECONDS}s ago)" >&2
 
 # 2. Write the formula skeleton. `brew update-python-resources` fills in the
 #    `resource` stanzas below the `depends_on` lines.
@@ -89,6 +98,22 @@ RUBY
 #    ast-grep-cli is excluded: its sdist would try to build/fetch a Rust binary
 #    inside Homebrew's network-sandboxed build and break `brew install`. The
 #    `depends_on "ast-grep"` above supplies that binary instead.
-brew update-python-resources --exclude-packages=ast-grep-cli "$OUT"
-
-echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2
+#
+#    Homebrew hardcodes a `--uploaded-prior-to = now - RELEASE_COOLDOWN_SECONDS`
+#    (24h) pip cutoff to avoid resolving a freshly-compromised PyPI release. There
+#    is no flag to disable it, so a version published less than ~24h ago cannot be
+#    resolved yet. Distinguish that expected "too fresh" failure (exit 75, the
+#    caller defers to a later scheduled run) from a genuine resolution failure
+#    (propagate the real exit code so CI goes red).
+COOLDOWN_WITH_MARGIN=$((25 * 3600))  # 24h cooldown + 1h margin for clock skew
+if brew update-python-resources --exclude-packages=ast-grep-cli "$OUT"; then
+  echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2
+else
+  rc=$?
+  if [ "$AGE_SECONDS" -lt "$COOLDOWN_WITH_MARGIN" ]; then
+    echo "note: lgtmaybe ${VERSION} was published ${AGE_SECONDS}s ago, within Homebrew's 24h PyPI cooldown; brew cannot resolve its resources yet. Deferring — a later run will publish it once it ages past the cooldown." >&2
+    exit 75
+  fi
+  echo "error: brew update-python-resources failed for lgtmaybe ${VERSION} (exit ${rc}); the version is past the PyPI cooldown, so this is a real resolution failure." >&2
+  exit "$rc"
+fi


### PR DESCRIPTION
The Homebrew tap never received new versions because of two distinct,
compounding failures:

1. The release never triggered the workflow. release-please cuts the
   GitHub release with the built-in GITHUB_TOKEN, and GitHub suppresses
   downstream workflow runs triggered by GITHUB_TOKEN (anti-recursion).
   So homebrew.yml's `release: published` trigger never fired — every
   homebrew run on record was a manual workflow_dispatch.

2. Even when run manually, `brew update-python-resources` failed. Homebrew
   hardcodes a 24h PyPI cooldown (`--uploaded-prior-to = now - 24h`,
   RELEASE_COOLDOWN_SECONDS) with no opt-out, so it refuses to resolve a
   version published in the last day. A freshly released version can never
   be turned into a formula immediately.

Fixes:

- release-please.yml now calls homebrew.yml directly via workflow_call
  after a release is created, instead of relying on the undelivered
  `release: published` event.
- homebrew.yml gains a daily schedule (the workhorse) plus workflow_call,
  and is now idempotent: it parses the tap's current formula version and
  no-ops when already current.
- update-homebrew-formula.sh reads each version's PyPI upload age and, when
  `brew update-python-resources` fails within the 24h cooldown window,
  exits 75 ("deferred") instead of failing; a genuine resolution failure
  past the cooldown still propagates and goes red. The release-time call
  defers; the daily schedule publishes once the version ages out.

Net effect: a new version lands in the tap within ~a day of release,
automatically, with no hand-maintained formula. Docs (CLAUDE.md,
releasing.md) updated to describe the cooldown/schedule reality.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QvNCXRNJJ2ZGfRSpVPXrKa