### PR TITLE
fix(homebrew): make the tap actually publish (path, tap registration, first-publish commit)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -121,10 +121,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- Formula/lgtmaybe.rb; then
+          # Stage first, then check the staged diff: `git diff` alone ignores a
+          # brand-new untracked formula (the first-publish case), so the index
+          # diff is what correctly detects "new or changed" vs "nothing to do".
+          git add Formula/lgtmaybe.rb
+          if git diff --cached --quiet; then
             echo "Formula already up to date for ${{ steps.ver.outputs.version }}."
             exit 0
           fi
-          git add Formula/lgtmaybe.rb
           git commit -m "lgtmaybe ${{ steps.ver.outputs.version }}"
           git push

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -99,7 +99,21 @@ class Lgtmaybe < Formula
 end
 RUBY
 
-# 3. Populate (or refresh) the resource stanzas for the full dependency tree.
+# 3. Register the formula's repo as a local Homebrew tap. `brew
+#    update-python-resources` refuses to operate on a loose .rb file ("Homebrew
+#    requires formulae to be in a tap") — the formula must live in a registered
+#    tap. The output path is a plain checkout of the tap repo, so symlink it into
+#    Homebrew's Library/Taps and address the formula by its tap NAME. brew then
+#    edits the same file we wrote (and that the caller commits + pushes).
+FORMULA_NAME="$(basename "$OUT" .rb)"
+REPO_DIR="$(cd "$(dirname "$(dirname "$OUT")")" && pwd -P)"
+TAP_LINK="$(brew --repository)/Library/Taps/local/homebrew-${FORMULA_NAME}"
+mkdir -p "$(dirname "$TAP_LINK")"
+ln -sfn "$REPO_DIR" "$TAP_LINK"
+export HOMEBREW_NO_REQUIRE_TAP_TRUST=1  # trust our own local tap
+TAP_FORMULA="local/${FORMULA_NAME}/${FORMULA_NAME}"
+
+# 4. Populate (or refresh) the resource stanzas for the full dependency tree.
 #    ast-grep-cli is excluded: its sdist would try to build/fetch a Rust binary
 #    inside Homebrew's network-sandboxed build and break `brew install`. The
 #    `depends_on "ast-grep"` above supplies that binary instead.
@@ -111,7 +125,7 @@ RUBY
 #    caller defers to a later scheduled run) from a genuine resolution failure
 #    (propagate the real exit code so CI goes red).
 COOLDOWN_WITH_MARGIN=$((25 * 3600))  # 24h cooldown + 1h margin for clock skew
-if brew update-python-resources --exclude-packages=ast-grep-cli "$OUT"; then
+if brew update-python-resources --exclude-packages=ast-grep-cli "$TAP_FORMULA"; then
   echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2
 else
   rc=$?

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -63,6 +63,11 @@ echo "lgtmaybe ${VERSION}: ${SDIST_URL} (uploaded ${AGE_SECONDS}s ago)" >&2
 # 2. Write the formula skeleton. `brew update-python-resources` fills in the
 #    `resource` stanzas below the `depends_on` lines.
 mkdir -p "$(dirname "$OUT")"
+# Resolve OUT to an absolute path. `brew update-python-resources` parses a
+# relative arg shaped like `tap/Formula/lgtmaybe.rb` as a tap-qualified formula
+# NAME (tap `tap/formula`, formula `lgtmaybe.rb`) rather than a file path, and
+# fails with "No available formula". An absolute path is unambiguous.
+OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
 cat > "$OUT" <<RUBY
 class Lgtmaybe < Formula
   include Language::Python::Virtualenv
@@ -75,7 +80,7 @@ class Lgtmaybe < Formula
 
   # The ast-grep-cli dependency ships a prebuilt binary via platform wheels, but
   # Homebrew installs resources from sdists (--no-binary), so we get the binary
-  # from the core `ast-grep` formula instead and exclude ast-grep-cli from the
+  # from the core \`ast-grep\` formula instead and exclude ast-grep-cli from the
   # venv (see --exclude-packages below). lgtmaybe finds it on PATH via
   # shutil.which("ast-grep").
   depends_on "ast-grep"


### PR DESCRIPTION
## Why

After #152 wired the trigger and cooldown handling, the Homebrew tap still
never received a formula. Driving a real publish end-to-end surfaced three more
latent bugs in the original Homebrew design (#143), each hidden behind the
previous — which is why the tap (`MattJColes/homebrew-lgtmaybe`) had always been
empty. This branch fixes all three; a live run on `0.7.0` now seeds the tap
successfully (formula present, 56 resource stanzas, full litellm dependency
tree resolved).

## What

1. **Pass `brew` an absolute formula path; escape heredoc backticks.**
   `brew update-python-resources` parses a relative arg like
   `tap/Formula/lgtmaybe.rb` (three slash-separated components) as a
   *tap-qualified formula name*, not a file → "No available formula". Resolve
   `OUT` to an absolute path. Also escape the backticks in the formula
   skeleton's unquoted heredoc so bash doesn't execute `ast-grep` (and can't
   inject its output into the generated formula).

2. **Register the checkout as a tap.** `brew update-python-resources` refuses to
   operate on a loose `.rb` ("Homebrew requires formulae to be in a tap"). The
   workflow only checked the tap repo out to a plain `tap/` directory, which
   Homebrew doesn't recognise. Symlink it into `Library/Taps` as a local tap and
   address the formula by its tap name; set `HOMEBREW_NO_REQUIRE_TAP_TRUST` so
   brew trusts our own local tap.

3. **Commit the formula on first publish.** The commit step ran
   `git diff --quiet` *before* `git add`, but `git diff` ignores untracked
   files. On the first publish the formula is brand-new, so the check saw "no
   changes" and skipped the commit/push — the run went green while pushing
   nothing. Stage first, then test the staged diff.

## Verification

Dispatched the `homebrew` workflow for `0.7.0` from this branch:
`Regenerate the formula` resolves the full tree (~30s) and `Commit and push`
lands a real commit. `Formula/lgtmaybe.rb` is now live in the tap (HTTP 200,
points at `lgtmaybe-0.7.0.tar.gz`, 56 `resource` stanzas), so
`brew install MattJColes/lgtmaybe/lgtmaybe` works.

Once merged, the daily schedule + the next release's publish run from `main`
with these fixes, and the tap will bump to the latest version (0.8.0) as soon
as it ages past Homebrew's 24h PyPI cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvNCXRNJJ2ZGfRSpVPXrKa)_