### PR TITLE
docs(homebrew): document the required `brew trust` step for the tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ From inside a git repo, on a branch with changes, review your diff against the
 remote primary branch and print the findings:
 
 ```bash
-pip install lgtmaybe        # or: brew install MattJColes/lgtmaybe/lgtmaybe
+pip install lgtmaybe        # or Homebrew — see docs/how-to/install-with-homebrew.md
 
 lgtmaybe review \
   --provider ollama \
@@ -215,8 +215,8 @@ only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instea
 ## Distribution
 
 - **CLI (PyPI)** — `pip install lgtmaybe`
-- **CLI (Homebrew)** — `brew install MattJColes/lgtmaybe/lgtmaybe`
-  ([details](docs/how-to/install-with-homebrew.md))
+- **CLI (Homebrew)** — `brew tap MattJColes/lgtmaybe && brew trust MattJColes/lgtmaybe && brew install lgtmaybe`
+  ([details](docs/how-to/install-with-homebrew.md) — the `brew trust` step is required for third-party taps)
 - **GitHub Action** — `uses: MattJColes/lgtmaybe@v0`
 
 ## Contributing

--- a/docs/how-to/install-with-homebrew.md
+++ b/docs/how-to/install-with-homebrew.md
@@ -8,16 +8,21 @@ On macOS (and Linuxbrew), you can install the `lgtmaybe` CLI from the project's
 [Homebrew tap](https://github.com/MattJColes/homebrew-lgtmaybe) instead of `pip`.
 
 ```bash
-brew install MattJColes/lgtmaybe/lgtmaybe
-```
-
-That one command taps the repository and installs the formula. If you prefer to
-tap first:
-
-```bash
 brew tap MattJColes/lgtmaybe
+brew trust MattJColes/lgtmaybe
 brew install lgtmaybe
 ```
+
+The middle step is required: current Homebrew refuses to load a formula from a
+third-party tap until you explicitly **trust** it (`Error: Refusing to load
+formula … from untrusted tap`). This is a one-time, per-machine decision that
+applies to every tap outside Homebrew's core — the tap author can't waive it for
+you, by design. To trust only this one formula instead of the whole tap, use
+`brew trust --formula MattJColes/lgtmaybe/lgtmaybe`.
+
+Tapping and installing in one line (`brew install MattJColes/lgtmaybe/lgtmaybe`)
+works too, but still needs the `brew trust …` step first — otherwise the install
+stops at the untrusted-tap error.
 
 Verify it:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -103,12 +103,14 @@ pip install lgtmaybe
 On macOS you can install from the Homebrew tap instead:
 
 ```bash
-brew install MattJColes/lgtmaybe/lgtmaybe
+brew tap MattJColes/lgtmaybe
+brew trust MattJColes/lgtmaybe   # current Homebrew requires trusting third-party taps
+brew install lgtmaybe
 ```
 
 See [Install with Homebrew](../how-to/install-with-homebrew.md) for details (the
-Homebrew build covers the API-key and local providers; keyless cloud providers
-need the `pip` extras).
+`brew trust` step, and that the Homebrew build covers the API-key and local
+providers while keyless cloud providers need the `pip` extras).
 
 Verify the install:
 
@@ -201,16 +203,21 @@ On macOS (and Linuxbrew), you can install the `lgtmaybe` CLI from the project's
 [Homebrew tap](https://github.com/MattJColes/homebrew-lgtmaybe) instead of `pip`.
 
 ```bash
-brew install MattJColes/lgtmaybe/lgtmaybe
-```
-
-That one command taps the repository and installs the formula. If you prefer to
-tap first:
-
-```bash
 brew tap MattJColes/lgtmaybe
+brew trust MattJColes/lgtmaybe
 brew install lgtmaybe
 ```
+
+The middle step is required: current Homebrew refuses to load a formula from a
+third-party tap until you explicitly **trust** it (`Error: Refusing to load
+formula … from untrusted tap`). This is a one-time, per-machine decision that
+applies to every tap outside Homebrew's core — the tap author can't waive it for
+you, by design. To trust only this one formula instead of the whole tap, use
+`brew trust --formula MattJColes/lgtmaybe/lgtmaybe`.
+
+Tapping and installing in one line (`brew install MattJColes/lgtmaybe/lgtmaybe`)
+works too, but still needs the `brew trust …` step first — otherwise the install
+stops at the untrusted-tap error.
 
 Verify it:
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -24,12 +24,14 @@ pip install lgtmaybe
 On macOS you can install from the Homebrew tap instead:
 
 ```bash
-brew install MattJColes/lgtmaybe/lgtmaybe
+brew tap MattJColes/lgtmaybe
+brew trust MattJColes/lgtmaybe   # current Homebrew requires trusting third-party taps
+brew install lgtmaybe
 ```
 
 See [Install with Homebrew](../how-to/install-with-homebrew.md) for details (the
-Homebrew build covers the API-key and local providers; keyless cloud providers
-need the `pip` extras).
+`brew trust` step, and that the Homebrew build covers the API-key and local
+providers while keyless cloud providers need the `pip` extras).
 
 Verify the install:
 


### PR DESCRIPTION
## Why

Current Homebrew refuses to load a formula from a third-party tap until the user
explicitly trusts it:

```
Error: Refusing to load formula mattjcoles/lgtmaybe/lgtmaybe from untrusted tap mattjcoles/lgtmaybe.
Run `brew trust --formula mattjcoles/lgtmaybe/lgtmaybe` or `brew trust mattjcoles/lgtmaybe` to trust it.
```

The install instructions omitted this step, so every user hit the error after
the tap went live (verified by an actual `brew tap` + `brew install` on a Mac).
The one-line `brew install MattJColes/lgtmaybe/lgtmaybe` form trips on it too —
it taps, then refuses to load.

## What

- **`docs/how-to/install-with-homebrew.md`** — lead with the
  tap → trust → install sequence and explain the trust gate (one-time,
  per-machine, can't be waived by the tap author; `--formula` variant to trust
  just the one formula).
- **`docs/tutorial/getting-started.md`** and **`README.md`** — show the
  `brew trust` step alongside the install command.
- Regenerate the `llms.txt` / `llms-full.txt` docs bundle.

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvNCXRNJJ2ZGfRSpVPXrKa)_