### PR TITLE
feat(homebrew): install lgtmaybe + deps from PyPI wheels (preserve_rpath)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,29 +1,21 @@
 name: homebrew
 
-# Keeps the Homebrew tap formula (MattJColes/homebrew-lgtmaybe) in sync with the
-# latest PyPI release. It regenerates the whole formula — including every PyPI
-# resource stanza — so a dependency bump is picked up too, not just the lgtmaybe
-# version.
+# Publishes lgtmaybe to the Homebrew tap (MattJColes/homebrew-lgtmaybe).
 #
-# How it gets invoked (belt and braces, because no single trigger is reliable):
-#   - workflow_call — release-please.yml calls this right after it cuts a release
-#     (a `release: published` event is NOT delivered when release-please creates
-#     the release with the built-in GITHUB_TOKEN, so we cannot rely on it).
-#   - schedule — a daily run is the workhorse. Homebrew's `update-python-resources`
-#     refuses to resolve a PyPI version published in the last 24h (its hardcoded
-#     RELEASE_COOLDOWN_SECONDS supply-chain guard), so a brand-new release cannot
-#     be turned into a formula immediately. The scheduled run picks the version up
-#     once it has aged past that cooldown. It is idempotent: it no-ops when the tap
-#     is already on the latest version.
-#   - workflow_dispatch — manual re-run for any version.
-#   - release: published — still honoured for a release published by a human (a
-#     real user token DOES trigger downstream workflows); a no-op for the
-#     release-please flow.
+# The formula installs lgtmaybe + its dependency tree from PyPI **wheels** into an
+# isolated virtualenv (see scripts/update-homebrew-formula.sh). Building every
+# dependency from source as `resource` stanzas does not work for this tree —
+# tokenizers/hf-xet are Rust sdists that can't build in Homebrew's sandbox — so we
+# use the upstream wheels instead. The CI install smoke-test below gates the
+# commit, so we never publish a formula that doesn't install.
 #
-# One-time setup (see docs/how-to/releasing.md):
-#   - Create the tap repo MattJColes/homebrew-lgtmaybe.
-#   - Add a repo secret HOMEBREW_TAP_TOKEN: a PAT with `contents: write` on the
-#     tap repo (GITHUB_TOKEN cannot push to a different repository).
+# Invocation: workflow_call (release-please calls it post-release, since a
+# `release: published` event isn't delivered for a GITHUB_TOKEN release),
+# workflow_dispatch (manual; `force` re-publishes the same version), a daily
+# schedule safety net, and release: published (for a human-cut release).
+#
+# One-time setup (see docs/how-to/releasing.md): create MattJColes/homebrew-lgtmaybe
+# and add repo secret HOMEBREW_TAP_TOKEN (a PAT with contents:write on the tap).
 on:
   workflow_call:
     inputs:
@@ -37,8 +29,12 @@ on:
         description: "Version to publish to the tap, e.g. 0.7.2 (no leading v)."
         required: true
         type: string
+      force:
+        description: "Regenerate even if the tap is already on this version."
+        required: false
+        default: false
+        type: boolean
   schedule:
-    # Daily — catches a release once it has aged past Homebrew's 24h PyPI cooldown.
     - cron: "17 7 * * *"
   release:
     types: [published]
@@ -48,7 +44,6 @@ permissions:
 
 jobs:
   formula:
-    # macOS so `brew` and `brew update-python-resources` are available.
     runs-on: macos-latest
     steps:
       - name: Resolve version
@@ -59,8 +54,6 @@ jobs:
             raw="${{ github.event.release.tag_name }}"
           fi
           if [ -z "$raw" ]; then
-            # schedule (or anything without an explicit version): take the latest
-            # published version straight from PyPI.
             raw="$(curl -fsSL https://pypi.org/pypi/lgtmaybe/json \
               | python3 -c 'import json,sys; print(json.load(sys.stdin)["info"]["version"])')"
           fi
@@ -86,12 +79,12 @@ jobs:
           f="tap/Formula/lgtmaybe.rb"
           cur=""
           if [ -f "$f" ]; then
-            # Pull the version out of the sdist filename in the formula's url line,
-            # e.g. .../lgtmaybe-0.8.0.tar.gz -> 0.8.0
             cur="$(grep -oE '/lgtmaybe-[0-9][^/]*\.tar\.gz' "$f" | head -n1 | sed -E 's#/lgtmaybe-##; s#\.tar\.gz$##')"
           fi
-          echo "Current formula version: '${cur}', target: '${{ steps.ver.outputs.version }}'"
-          if [ "$cur" = "${{ steps.ver.outputs.version }}" ]; then
+          echo "Current formula version: '${cur}', target: '${{ steps.ver.outputs.version }}', force: '${{ inputs.force }}'"
+          if [ "${{ inputs.force }}" = "true" ]; then
+            echo "force=true; regenerating regardless of the current version."
+          elif [ "$cur" = "${{ steps.ver.outputs.version }}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Tap already at ${cur}; nothing to do."
           fi
@@ -100,30 +93,32 @@ jobs:
         id: gen
         if: steps.idem.outputs.skip != 'true'
         run: |
-          set +e
           lgtmaybe/scripts/update-homebrew-formula.sh \
             "${{ steps.ver.outputs.version }}" \
             "tap/Formula/lgtmaybe.rb"
-          rc=$?
-          set -e
-          if [ "$rc" -eq 75 ]; then
-            # Within Homebrew's 24h PyPI cooldown — not an error. The next
-            # scheduled run will publish it once it has aged past the cooldown.
-            echo "deferred=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::lgtmaybe ${{ steps.ver.outputs.version }} is within Homebrew's 24h PyPI cooldown; deferring to a later scheduled run."
-            exit 0
-          fi
-          exit "$rc"
+
+      # Install the regenerated formula exactly as a user would (sandbox on, no
+      # build-bottle), so the commit is gated on a real, working install.
+      - name: Smoke-test that the formula installs and runs
+        if: steps.idem.outputs.skip != 'true'
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
+        run: |
+          tap_link="$(brew --repository)/Library/Taps/local/homebrew-lgtmaybe"
+          mkdir -p "$(dirname "$tap_link")"
+          ln -sfn "$GITHUB_WORKSPACE/tap" "$tap_link"
+          # Exactly what a user runs. With `preserve_rpath` the install must now
+          # exit cleanly AND link `lgtmaybe` onto the prefix bin.
+          brew install --formula "local/lgtmaybe/lgtmaybe"
+          "$(brew --prefix)/bin/lgtmaybe" --help | grep -qi usage
+          echo "smoke test passed: lgtmaybe installs cleanly and runs"
 
       - name: Commit and push
-        if: steps.idem.outputs.skip != 'true' && steps.gen.outputs.deferred != 'true'
+        if: ${{ success() && steps.idem.outputs.skip != 'true' }}
         working-directory: tap
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Stage first, then check the staged diff: `git diff` alone ignores a
-          # brand-new untracked formula (the first-publish case), so the index
-          # diff is what correctly detects "new or changed" vs "nothing to do".
           git add Formula/lgtmaybe.rb
           if git diff --cached --quiet; then
             echo "Formula already up to date for ${{ steps.ver.outputs.version }}."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,21 +11,23 @@ OIDC/WIF for cloud providers), and gets a review. One core, three distribution
 variants:
 
 - **PyPI CLI** — `pip install lgtmaybe`
-- **Homebrew CLI** — `brew install MattJColes/lgtmaybe/lgtmaybe`, from the
-  `MattJColes/homebrew-lgtmaybe` tap. The formula installs the core deps (covers
-  the API-key + local providers; keyless cloud needs the `pip` extras), and is
-  regenerated from the published PyPI release by `.github/workflows/homebrew.yml`
-  + `scripts/update-homebrew-formula.sh` (full resource stanzas via
-  `brew update-python-resources`, so dep bumps are picked up — never
-  hand-maintained). Two wrinkles shape how it runs: (1) `release-please.yml`
-  **calls** `homebrew.yml` directly (`workflow_call`) because a `release:
-  published` event isn't delivered for a release cut by the built-in
-  `GITHUB_TOKEN`; (2) `brew update-python-resources` hardcodes a 24h PyPI
-  cooldown (`RELEASE_COOLDOWN_SECONDS`, no opt-out) so a just-published version
-  can't be resolved yet — the release-time call defers (script exits `75`) and a
-  **daily scheduled run** publishes once the version ages past the cooldown
-  (idempotent, no-ops when the tap is current). A new version lands in the tap
-  within ~a day, not instantly
+- **Homebrew CLI** — `brew install MattJColes/lgtmaybe/lgtmaybe` (after
+  `brew tap MattJColes/lgtmaybe` + `brew trust MattJColes/lgtmaybe` — current
+  Homebrew requires trusting third-party taps), from the
+  `MattJColes/homebrew-lgtmaybe` tap. The formula (`scripts/update-homebrew-formula.sh`)
+  creates a venv and `pip install`s lgtmaybe + deps from **PyPI wheels** — *not*
+  per-dependency source `resource` stanzas: litellm's tree includes Rust sdists
+  (tokenizers, hf-xet) that can't build in Homebrew's sandbox, and the wheel path
+  sidesteps that (and the 24h `brew update-python-resources` cooldown) entirely.
+  The one wrinkle: the wheels ship prebuilt extension dylibs with `@rpath` ids
+  that Homebrew can't rewrite, so the formula declares **`preserve_rpath`** to
+  keep them (without it `brew install` errors "Failed to fix install linkage" and
+  exits non-zero). It's a plain source formula — no bottle, works on any
+  arch/macOS. `.github/workflows/homebrew.yml` regenerates the formula on each
+  release (release-please **calls** it via `workflow_call`, since a `release:
+  published` event isn't delivered for a `GITHUB_TOKEN` release), **actually
+  `brew install`s it as a gate** (so a broken formula is never published), then
+  commits to the tap; a daily schedule + `force` dispatch are the safety nets
 - **GitHub Action** — composite action (`action.yml`) that does keyless OIDC/WIF
   auth, then runs a GHCR image via the `action` entrypoint
 

--- a/docs/how-to/install-with-homebrew.md
+++ b/docs/how-to/install-with-homebrew.md
@@ -37,10 +37,12 @@ brew upgrade lgtmaybe
 ```
 
 Homebrew installs lgtmaybe into its own isolated virtualenv, so it never touches
-your system or project Python. The first install builds a few native
-dependencies from source (pydantic-core, tiktoken, tokenizers), which can take a
-minute. It also pulls the `ast-grep` formula, which lgtmaybe uses for cross-file
-symbol resolution during review.
+your system or project Python. The formula creates the venv and installs
+lgtmaybe and its dependencies from prebuilt **PyPI wheels** (no compiling), so a
+first install takes about a minute, mostly download time. It works on any
+architecture and macOS version — there's no prebuilt bottle to match. It also
+pulls the `ast-grep` formula, which lgtmaybe uses for cross-file symbol
+resolution during review.
 
 ## Which providers does the Homebrew build cover?
 

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -16,29 +16,32 @@ tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
 formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
-`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version. It
-regenerates the whole formula — including every PyPI resource stanza via
-`scripts/update-homebrew-formula.sh` — so a dependency bump is picked up too.
+`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version.
+`scripts/update-homebrew-formula.sh` writes a small formula that creates a venv
+and `pip install`s lgtmaybe + its dependencies from **PyPI wheels** (no
+per-dependency `resource` stanzas): litellm's tree includes Rust sdists
+(tokenizers, hf-xet) that can't build in Homebrew's sandbox, so the source-build
+approach is a dead end — the wheels work. The formula declares **`preserve_rpath`**
+so Homebrew keeps the wheels' `@rpath` extension-dylib ids instead of failing to
+rewrite them ("Failed to fix install linkage"). It's a plain source formula —
+no bottle — so it installs on any architecture and macOS version.
 
-Two things make the Homebrew publish less direct than PyPI/GHCR, and the
-workflow is built around both:
+The workflow:
 
-- A `release: published` event is **not** delivered for a release that
-  release-please cuts, because it is created with the built-in `GITHUB_TOKEN`
-  (GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN` to prevent
-  recursion). So `release-please.yml` **calls** `homebrew.yml` directly
-  (`workflow_call`) instead of relying on the event.
-- Homebrew's `brew update-python-resources` hardcodes a 24-hour PyPI cooldown
-  (`RELEASE_COOLDOWN_SECONDS`) and refuses to resolve a version published in the
-  last day — a supply-chain guard with no opt-out. A brand-new release therefore
-  **cannot** be turned into a formula immediately. The release-time call detects
-  this and defers; a **daily scheduled run** in `homebrew.yml` is the workhorse
-  that publishes the formula once the version has aged past the cooldown
-  (idempotent — a no-op when the tap is already current). Net effect: a new
-  version lands in the tap within roughly a day of release, not instantly. To
-  publish sooner, re-run `homebrew.yml` via **workflow_dispatch** with the
-  version once it is >24h old, or run `scripts/update-homebrew-formula.sh`
-  locally on a Mac.
+- Is **called** by `release-please.yml` (`workflow_call`) right after a release,
+  because a `release: published` event is **not** delivered for a release
+  release-please cuts with the built-in `GITHUB_TOKEN` (GitHub suppresses
+  downstream triggers from `GITHUB_TOKEN` to prevent recursion). A daily
+  `schedule` and a manual `workflow_dispatch` (with an optional `force` to
+  re-publish the same version) are the safety nets.
+- **Installs the regenerated formula in CI before committing it** — a real
+  `brew install` of the formula gates the push, so a formula that doesn't install
+  is never published. (You can seed/verify it by hand on a Mac by running
+  `scripts/update-homebrew-formula.sh <version> path/to/Formula/lgtmaybe.rb`.)
+
+Net effect: a new version lands in the tap within minutes of release — no PyPI
+cooldown to wait out, since `brew update-python-resources` (which imposes one)
+isn't used.
 
 Commit messages must follow conventional-commit format — `.github/workflows/commitlint.yml`
 enforces it on PRs so release-please can compute the next version.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -232,10 +232,12 @@ brew upgrade lgtmaybe
 ```
 
 Homebrew installs lgtmaybe into its own isolated virtualenv, so it never touches
-your system or project Python. The first install builds a few native
-dependencies from source (pydantic-core, tiktoken, tokenizers), which can take a
-minute. It also pulls the `ast-grep` formula, which lgtmaybe uses for cross-file
-symbol resolution during review.
+your system or project Python. The formula creates the venv and installs
+lgtmaybe and its dependencies from prebuilt **PyPI wheels** (no compiling), so a
+first install takes about a minute, mostly download time. It works on any
+architecture and macOS version — there's no prebuilt bottle to match. It also
+pulls the `ast-grep` formula, which lgtmaybe uses for cross-file symbol
+resolution during review.
 
 ## Which providers does the Homebrew build cover?
 
@@ -2226,29 +2228,32 @@ tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
 formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
-`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version. It
-regenerates the whole formula — including every PyPI resource stanza via
-`scripts/update-homebrew-formula.sh` — so a dependency bump is picked up too.
+`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version.
+`scripts/update-homebrew-formula.sh` writes a small formula that creates a venv
+and `pip install`s lgtmaybe + its dependencies from **PyPI wheels** (no
+per-dependency `resource` stanzas): litellm's tree includes Rust sdists
+(tokenizers, hf-xet) that can't build in Homebrew's sandbox, so the source-build
+approach is a dead end — the wheels work. The formula declares **`preserve_rpath`**
+so Homebrew keeps the wheels' `@rpath` extension-dylib ids instead of failing to
+rewrite them ("Failed to fix install linkage"). It's a plain source formula —
+no bottle — so it installs on any architecture and macOS version.
 
-Two things make the Homebrew publish less direct than PyPI/GHCR, and the
-workflow is built around both:
+The workflow:
 
-- A `release: published` event is **not** delivered for a release that
-  release-please cuts, because it is created with the built-in `GITHUB_TOKEN`
-  (GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN` to prevent
-  recursion). So `release-please.yml` **calls** `homebrew.yml` directly
-  (`workflow_call`) instead of relying on the event.
-- Homebrew's `brew update-python-resources` hardcodes a 24-hour PyPI cooldown
-  (`RELEASE_COOLDOWN_SECONDS`) and refuses to resolve a version published in the
-  last day — a supply-chain guard with no opt-out. A brand-new release therefore
-  **cannot** be turned into a formula immediately. The release-time call detects
-  this and defers; a **daily scheduled run** in `homebrew.yml` is the workhorse
-  that publishes the formula once the version has aged past the cooldown
-  (idempotent — a no-op when the tap is already current). Net effect: a new
-  version lands in the tap within roughly a day of release, not instantly. To
-  publish sooner, re-run `homebrew.yml` via **workflow_dispatch** with the
-  version once it is >24h old, or run `scripts/update-homebrew-formula.sh`
-  locally on a Mac.
+- Is **called** by `release-please.yml` (`workflow_call`) right after a release,
+  because a `release: published` event is **not** delivered for a release
+  release-please cuts with the built-in `GITHUB_TOKEN` (GitHub suppresses
+  downstream triggers from `GITHUB_TOKEN` to prevent recursion). A daily
+  `schedule` and a manual `workflow_dispatch` (with an optional `force` to
+  re-publish the same version) are the safety nets.
+- **Installs the regenerated formula in CI before committing it** — a real
+  `brew install` of the formula gates the push, so a formula that doesn't install
+  is never published. (You can seed/verify it by hand on a Mac by running
+  `scripts/update-homebrew-formula.sh <version> path/to/Formula/lgtmaybe.rb`.)
+
+Net effect: a new version lands in the tap within minutes of release — no PyPI
+cooldown to wait out, since `brew update-python-resources` (which imposes one)
+isn't used.
 
 Commit messages must follow conventional-commit format — `.github/workflows/commitlint.yml`
 enforces it on PRs so release-please can compute the next version.

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# Regenerate the Homebrew formula for lgtmaybe with up-to-date PyPI resources.
+# Regenerate the Homebrew formula for lgtmaybe.
 #
-# litellm pulls a large transitive dependency tree, so a source-install formula
-# needs every transitive dependency as a `resource` stanza. Hand-maintaining that
-# is infeasible — this script regenerates the whole formula from the published
-# PyPI release instead, so a dependency bump is picked up automatically. The CI
-# job (.github/workflows/homebrew.yml) runs it on each release; a maintainer can
-# also run it locally on a Mac to seed or verify the tap before the first release.
+# lgtmaybe's dependency tree (via litellm) includes Rust extension packages
+# (tokenizers, hf-xet) whose sdists cannot be built inside Homebrew's sandboxed
+# build. So instead of vendoring every dependency as a source `resource` stanza
+# — the usual Homebrew-Python approach, which fails to build this tree — the
+# formula installs lgtmaybe and its dependencies from upstream PyPI **wheels**
+# into an isolated virtualenv. This is not Homebrew-core audit style, but it
+# builds reliably for a personal tap and tracks new releases with no
+# hand-maintained resource list. It also sidesteps the 24h PyPI cooldown that
+# `brew update-python-resources` imposes, so a release can publish immediately.
 #
-# Requires macOS with Homebrew installed (for `brew update-python-resources`) and
-# python3 on PATH.
+# Requires python3 on PATH (and, to seed/verify locally, macOS with Homebrew).
 #
 # Usage:
 #   scripts/update-homebrew-formula.sh <version> <output-formula-path>
@@ -24,9 +26,11 @@ OUT="${2:?usage: update-homebrew-formula.sh <version> <output-formula-path>}"
 VERSION="${VERSION#lgtmaybe-v}"
 VERSION="${VERSION#v}"
 
-# 1. Resolve the sdist URL + sha256 for this version from PyPI. The release
-#    workflow can fire before PyPI's trusted-publishing job has finished, so poll
-#    until the version is available (up to ~10 minutes) rather than racing it.
+# Resolve the sdist URL + sha256 for this version from PyPI. The formula still
+# carries the sdist as its `url`/`sha256` (Homebrew requires a checksummed
+# source); the install step pulls the dependency tree as wheels. The release
+# workflow can fire before PyPI's trusted-publishing job has finished, so poll
+# until the version is available rather than racing it.
 pypi_json=""
 for attempt in $(seq 1 60); do
   if pypi_json="$(curl -fsSL "https://pypi.org/pypi/lgtmaybe/${VERSION}/json" 2>/dev/null)"; then
@@ -40,34 +44,21 @@ if [ -z "$pypi_json" ]; then
   exit 1
 fi
 
-read -r SDIST_URL SDIST_SHA AGE_SECONDS <<EOF
+read -r SDIST_URL SDIST_SHA <<EOF
 $(printf '%s' "$pypi_json" | python3 -c '
 import json, sys
-from datetime import datetime, timezone
 data = json.load(sys.stdin)
 sdist = next(u for u in data["urls"] if u["packagetype"] == "sdist")
-uploaded = sdist.get("upload_time_iso_8601") or sdist.get("upload_time") or ""
-try:
-    dt = datetime.fromisoformat(uploaded.replace("Z", "+00:00"))
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    age = int((datetime.now(timezone.utc) - dt).total_seconds())
-except ValueError:
-    age = 10**9  # unknown upload time — assume old, let brew decide
-print(sdist["url"], sdist["digests"]["sha256"], age)
+print(sdist["url"], sdist["digests"]["sha256"])
 ')
 EOF
 
-echo "lgtmaybe ${VERSION}: ${SDIST_URL} (uploaded ${AGE_SECONDS}s ago)" >&2
+echo "lgtmaybe ${VERSION}: ${SDIST_URL}" >&2
 
-# 2. Write the formula skeleton. `brew update-python-resources` fills in the
-#    `resource` stanzas below the `depends_on` lines.
+# Write the formula. `${SDIST_URL}`/`${SDIST_SHA}` are expanded by bash here;
+# `#{version}` is left literal for Ruby. The install builds an isolated venv and
+# installs lgtmaybe (which pulls its dependency wheels from PyPI).
 mkdir -p "$(dirname "$OUT")"
-# Resolve OUT to an absolute path. `brew update-python-resources` parses a
-# relative arg shaped like `tap/Formula/lgtmaybe.rb` as a tap-qualified formula
-# NAME (tap `tap/formula`, formula `lgtmaybe.rb`) rather than a file path, and
-# fails with "No available formula". An absolute path is unambiguous.
-OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
 cat > "$OUT" <<RUBY
 class Lgtmaybe < Formula
   include Language::Python::Virtualenv
@@ -78,19 +69,23 @@ class Lgtmaybe < Formula
   sha256 "${SDIST_SHA}"
   license "MIT"
 
-  # The ast-grep-cli dependency ships a prebuilt binary via platform wheels, but
-  # Homebrew installs resources from sdists (--no-binary), so we get the binary
-  # from the core \`ast-grep\` formula instead and exclude ast-grep-cli from the
-  # venv (see --exclude-packages below). lgtmaybe finds it on PATH via
-  # shutil.which("ast-grep").
+  # The dependency wheels ship prebuilt extension dylibs (e.g. jiter) whose
+  # install names use @rpath and lack header padding, so Homebrew cannot rewrite
+  # them to an absolute path ("Failed to fix install linkage"). Preserve the
+  # @rpath ids — they resolve correctly from the venv's fixed location anyway.
+  preserve_rpath
+
   depends_on "ast-grep"
   depends_on "python@3.12"
-  # litellm pulls pydantic-core / tiktoken / tokenizers, whose sdists build with
-  # a Rust toolchain. Needed at build time only — not a runtime dependency.
-  depends_on "rust" => :build
 
   def install
-    virtualenv_install_with_resources
+    # lgtmaybe's dependency tree includes Rust extensions (tokenizers, hf-xet)
+    # whose sdists cannot build inside Homebrew's sandbox, so install lgtmaybe and
+    # its dependencies from upstream PyPI wheels into an isolated virtualenv. The
+    # venv is created plainly so ensurepip provides pip.
+    system "python3.12", "-m", "venv", libexec
+    system libexec/"bin/python", "-m", "pip", "install", "lgtmaybe==#{version}"
+    bin.install_symlink libexec/"bin/lgtmaybe"
   end
 
   test do
@@ -99,40 +94,4 @@ class Lgtmaybe < Formula
 end
 RUBY
 
-# 3. Register the formula's repo as a local Homebrew tap. `brew
-#    update-python-resources` refuses to operate on a loose .rb file ("Homebrew
-#    requires formulae to be in a tap") — the formula must live in a registered
-#    tap. The output path is a plain checkout of the tap repo, so symlink it into
-#    Homebrew's Library/Taps and address the formula by its tap NAME. brew then
-#    edits the same file we wrote (and that the caller commits + pushes).
-FORMULA_NAME="$(basename "$OUT" .rb)"
-REPO_DIR="$(cd "$(dirname "$(dirname "$OUT")")" && pwd -P)"
-TAP_LINK="$(brew --repository)/Library/Taps/local/homebrew-${FORMULA_NAME}"
-mkdir -p "$(dirname "$TAP_LINK")"
-ln -sfn "$REPO_DIR" "$TAP_LINK"
-export HOMEBREW_NO_REQUIRE_TAP_TRUST=1  # trust our own local tap
-TAP_FORMULA="local/${FORMULA_NAME}/${FORMULA_NAME}"
-
-# 4. Populate (or refresh) the resource stanzas for the full dependency tree.
-#    ast-grep-cli is excluded: its sdist would try to build/fetch a Rust binary
-#    inside Homebrew's network-sandboxed build and break `brew install`. The
-#    `depends_on "ast-grep"` above supplies that binary instead.
-#
-#    Homebrew hardcodes a `--uploaded-prior-to = now - RELEASE_COOLDOWN_SECONDS`
-#    (24h) pip cutoff to avoid resolving a freshly-compromised PyPI release. There
-#    is no flag to disable it, so a version published less than ~24h ago cannot be
-#    resolved yet. Distinguish that expected "too fresh" failure (exit 75, the
-#    caller defers to a later scheduled run) from a genuine resolution failure
-#    (propagate the real exit code so CI goes red).
-COOLDOWN_WITH_MARGIN=$((25 * 3600))  # 24h cooldown + 1h margin for clock skew
-if brew update-python-resources --exclude-packages=ast-grep-cli "$TAP_FORMULA"; then
-  echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2
-else
-  rc=$?
-  if [ "$AGE_SECONDS" -lt "$COOLDOWN_WITH_MARGIN" ]; then
-    echo "note: lgtmaybe ${VERSION} was published ${AGE_SECONDS}s ago, within Homebrew's 24h PyPI cooldown; brew cannot resolve its resources yet. Deferring — a later run will publish it once it ages past the cooldown." >&2
-    exit 75
-  fi
-  echo "error: brew update-python-resources failed for lgtmaybe ${VERSION} (exit ${rc}); the version is past the PyPI cooldown, so this is a real resolution failure." >&2
-  exit "$rc"
-fi
+echo "Wrote ${OUT} for lgtmaybe ${VERSION}" >&2


### PR DESCRIPTION
## Why

The Homebrew tap never produced a formula that actually installs. The original
design (`brew update-python-resources` → full source `resource` stanzas) is a
dead end for this dependency tree, and getting to a working install surfaced a
chain of issues. This switches to a wheel-based formula and fixes the final
blocker.

## What was wrong (in order discovered)

1. **Source build is impossible.** litellm pulls Rust sdists (`tokenizers`,
   `hf-xet`) that can't build in Homebrew's network-sandboxed build, so
   `brew update-python-resources` / source `resource` stanzas can't work.
2. **`pip install` from PyPI works** during a Homebrew build (network is fine;
   the earlier "network" failures were a venv bug — `virtualenv_create` makes the
   venv `--without-pip`). Creating the venv plainly (`python3.12 -m venv`, so
   `ensurepip` provides pip) fixed that.
3. **`brew install` still exited non-zero** with `Failed to fix install linkage`:
   Homebrew rewrites every installed dylib's id to an absolute path, but the
   prebuilt wheel extensions (e.g. `jiter`) have `@rpath` ids with no header
   padding, so the rewrite doesn't fit. Homebrew **preserves `@rpath` ids when
   the formula declares `preserve_rpath`** — adding it makes the install exit
   cleanly and link the CLI onto PATH.

## What this does

- `scripts/update-homebrew-formula.sh` now writes a small formula that creates a
  venv and `pip install`s lgtmaybe + deps from **PyPI wheels**, with
  `preserve_rpath`. No `resource` stanzas, no `brew update-python-resources` (so
  no 24h PyPI cooldown), **no bottle** — a plain source formula that installs on
  any architecture / macOS version.
- `.github/workflows/homebrew.yml` regenerates the formula on release
  (release-please calls it via `workflow_call`), then **actually `brew install`s
  it as a gate** before committing to the tap, so a non-installing formula is
  never published. Daily `schedule` + `force` `workflow_dispatch` are safety nets.
- Docs (`install-with-homebrew.md`, `releasing.md`, `CLAUDE.md`) updated to the
  wheel + `preserve_rpath` model; `llms-full.txt` regenerated.

## Verification

Dispatched the workflow for `0.7.0`: `brew install` exits 0, links `lgtmaybe`
onto the prefix, `lgtmaybe --help` runs, and the formula is committed to the tap.
End-user flow:

```bash
brew tap MattJColes/lgtmaybe
brew trust MattJColes/lgtmaybe
brew install lgtmaybe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvNCXRNJJ2ZGfRSpVPXrKa)_