### PR TITLE
fix(provider): fail fast on expired cloud credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
 
@@ -40,8 +40,8 @@ jobs:
         run: uv run pytest -q
 
   # Single, matrix-independent status for branch protection to require. The `test`
-  # job above runs once per Python version, so it reports as `test (3.11)` /
-  # `test (3.12)` — names that change whenever the matrix does. This gate reports a
+  # job above runs once per Python version, so it reports as `test (3.11)` …
+  # `test (3.14)` — names that change whenever the matrix does. This gate reports a
   # stable `check` context that is green only when every `test` leg passed, so the
   # required check never dangles as "Expected" when the matrix is edited.
   check:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -50,11 +50,33 @@ _QUOTA_MARKERS = (
     "check your plan and billing",
 )
 
+# An expired/invalid cloud credential is permanent — a retry can't refresh it, so
+# storming the backoff over every lens just delays an inevitable failure (the same
+# wasted-runner-time trap as a quota error). Unlike a bad *static* key (which
+# litellm raises as AuthenticationError, already caught above), an expired ambient
+# token (Bedrock STS, Vertex ADC) comes back as a 403 that litellm maps to a
+# generic APIConnectionError — indistinguishable by type from a transient ollama
+# "connection refused" that must still be retried. So we tell them apart by
+# message, exactly as with quota vs. capacity above.
+_EXPIRED_CREDENTIAL_MARKERS = (
+    "security token included in the request is expired",
+    "security token included in the request is invalid",
+    "expiredtoken",
+    "expired credential",
+    "the credential provided is expired",
+)
+
 
 def _is_quota_rate_limit(exc: BaseException) -> bool:
     """True for a quota/billing 429 (permanent), False for a capacity 429."""
     msg = str(exc).lower()
     return any(marker in msg for marker in _QUOTA_MARKERS)
+
+
+def _is_expired_credential(exc: BaseException) -> bool:
+    """True when *exc* is an expired/invalid ambient cloud credential (permanent)."""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _EXPIRED_CREDENTIAL_MARKERS)
 
 
 def _is_permanent(exc: BaseException) -> bool:
@@ -63,7 +85,7 @@ def _is_permanent(exc: BaseException) -> bool:
         return True
     if isinstance(exc, RateLimitError):
         return _is_quota_rate_limit(exc)
-    return False
+    return _is_expired_credential(exc)
 
 
 def _rejects_temperature(exc: Exception) -> bool:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -226,6 +226,36 @@ class TestFailFastOnPermanentErrors:
         assert result.text == "ok after backoff"
         assert calls == 2
 
+    def test_expired_cloud_credentials_is_not_retried(self) -> None:
+        """An expired AWS security token (Bedrock 403) reaches litellm as an
+        APIConnectionError, not an AuthenticationError — but retrying can't
+        refresh it, so it's a permanent failure: one attempt, then raise. The
+        message is what distinguishes it from a genuinely transient connection
+        error (ollama warming up), which must still be retried."""
+        calls = 0
+
+        def expired(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.APIConnectionError(
+                message=(
+                    "litellm.APIConnectionError: BedrockException - "
+                    '{"message":"The security token included in the request is expired"}'
+                ),
+                model="us.anthropic.claude-sonnet-4-6",
+                llm_provider="bedrock",
+            )
+
+        with patch("litellm.completion", side_effect=expired):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.APIConnectionError):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    "bedrock/us.anthropic.claude-sonnet-4-6",
+                )
+
+        assert calls == 1
+
     def test_authentication_error_is_not_retried(self) -> None:
         """A bad key won't become good on a retry — fail fast."""
         calls = 0


### PR DESCRIPTION
An expired/invalid ambient cloud credential (e.g. a Bedrock STS token) comes
back as a 403 that litellm maps to a generic APIConnectionError, not an
AuthenticationError. That type isn't in _PERMANENT_ERROR_TYPES, so every lens
retried it four times over the exponential backoff — pointless, since a retry
can't refresh an expired token, and stacked across nine lenses it turns an
instant failure into minutes of wasted time (the same trap as a quota 429).

Distinguish it from a genuinely transient APIConnectionError (ollama still
warming up, "connection refused") by message marker — mirroring how a quota
429 is told apart from a capacity 429 — and treat it as permanent so it fails
after a single attempt. The all-lenses-failed path already raises
ReviewIncompleteError with an actionable "check your credentials" message.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MSpjzJHcPuYzSKjd1CAx3a