### PR TITLE
feat: prompt caching + audit-driven review improvements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -218,9 +218,15 @@ agent can apply) formats.
 run; generated/binary files are skipped automatically.
 
 **Reliability** — provider retries with fallback, provider-aware timeouts, a
-self-reflection pass to cut false positives (toggle with `--no-reflect`), and
+self-reflection pass to cut false positives (toggle with `--no-reflect`; its
+verdicts carry a 0–10 confidence score, filtered by `min_confidence`), and
 loud failure surfacing (a "review failed" comment + non-zero exit) rather than
 silent passes.
+
+**Cost** — on providers with an explicit prompt-cache breakpoint (anthropic,
+bedrock Claude/Nova) the static system prompt is marked `cache_control` so the
+per-lens fan-out re-reads it at the cached-input discount (`prompt_cache`,
+default on; feature-detected, byte-identical requests elsewhere).
 
 **Distribution** — `pip install lgtmaybe` (PyPI CLI) and the composite GitHub
 Action (keyless OIDC/WIF cloud auth, then runs the GHCR image). Release is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,14 +160,19 @@ pattern, event bus, plugin framework.
      `/ask <q>` + `/describe` reply in-thread (`post_issue_comment`, an
      adapter-only method beyond the frozen port).
    - **Guards (in the engine):** generated/binary files skipped via
-     `is_reviewable`; **file cap** reviews the top-N and posts a "reviewed top N
-     of M" notice.
+     `is_reviewable`; the user's `include_paths` allowlist / `exclude_paths`
+     denylist globs applied right after it (`engine.passes_path_filters`;
+     exclude wins, `**/`-prefixed patterns also match at the repo root);
+     **file cap** reviews the top-N and posts a "reviewed top N of M" notice.
    - **Context expansion:** `get_pr_context` also fetches the head text of
      reviewable files via the API (read-only, never a checkout) into
      `PRContext.file_contents`; the engine (`compress.expand_hunks`) pads each
      hunk with budget-scaled surrounding lines, capped by
      `ReviewConfig.context_lines` (default 20, `0` disables), redacted like the
-     diff. Inline positions stay bound to the **real** diff, so a finding on a
+     diff. The pad is **asymmetric** (`compress.trailing_context_lines`): the
+     full budget goes before each hunk, a quarter of it (floored at one line)
+     after — the enclosing signature/setup explains a change better than what
+     follows. Inline positions stay bound to the **real** diff, so a finding on a
      context-only line maps to nothing and is dropped — never mis-posted.
    - **Recursive walk (RLM):** when a single file's diff exceeds
      `max_input_tokens`, the engine **walks it hunk-by-hunk** instead of sending it
@@ -221,9 +226,14 @@ pattern, event bus, plugin framework.
    - **Self-reflection:** after merge/dedupe, `engine/reflect.py` asks the
      provider to audit its own findings for false positives and drops the ones it
      marks low-confidence. The verdict is structured (`ReflectionResult` —
-     `{"verdicts": [{"index", "keep"}]}`) with a lenient parser and a **keep-all
-     safe default** when it can't be parsed (never silently drop a real finding).
-     Skippable via `--no-reflect` for weaker models that over-prune. The auditor
+     `{"verdicts": [{"index", "keep", "confidence", "broad", "needs"}]}`) with a
+     lenient parser and a **keep-all safe default** when it can't be parsed
+     (never silently drop a real finding). Each kept verdict carries a **0–10
+     confidence score** (the auditor tries to disprove the finding to reach it);
+     `ReviewConfig.min_confidence` (default 0 = off, CLI `--min-confidence`)
+     drops findings scored below it, an unscored kept finding survives any
+     threshold, and the score lands on `ReviewFinding.confidence` in CLI/JSON
+     output. Skippable via `--no-reflect` for weaker models that over-prune. The auditor
      also drops **cross-file false positives** — findings whose validity hinges on
      an assumption about code outside the diff (a guard/field/handler that may live
      in an unshown file) — while **carving out gap findings** (a missing test/doc on
@@ -233,6 +243,17 @@ pattern, event bus, plugin framework.
    - **Determinism & timeouts:** `temperature` defaults to `0.0` for reproducible
      reviews; `timeout` is `None` → a provider-aware default (ollama gets a long
      one, cloud a short one). Both are `ReviewConfig` fields and CLI/Action inputs.
+   - **Prompt caching:** on routes with an explicit cache breakpoint (anthropic
+     `cache_control`; bedrock, where litellm emits a Converse `cachePoint` for
+     Claude/Nova) the adapter marks the static system prompt as an
+     ephemeral-cache block, so the per-lens fan-out and reflection re-read the
+     shared prefix at the cached-input discount. Feature-detected per model
+     (litellm capability map + the 1,024-token minimum block); volatile content
+     (diff/intent/findings) always stays in the user message, outside the cached
+     region; byte-identical requests on every other provider.
+     `ReviewConfig.prompt_cache` (default **on**; CLI
+     `--prompt-cache/--no-prompt-cache`, Action input `prompt_cache`);
+     cache read/creation token counts land on `ProviderResult` and are logged.
    - **Summary line:** names the **model** used (no cost — lgtmaybe does not
      compute or report cost).
    - **Clean review:** zero findings on a fully-reviewed PR posts `👍 LGTM!`

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "During reflection, use ast-grep to resolve a deferred finding's referenced symbol to the file that defines it — searched in a read-only shallow clone of the PR's base branch — so the auditor re-judges a cross-file finding against the real definition. On by default; set to false to disable."
     required: false
     default: ""
+  prompt_cache:
+    description: "Cache the static system prompt across the per-lens calls on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -157,6 +161,7 @@ runs:
         INPUT_RECURSIVE: ${{ inputs.recursive }}
         INPUT_STRUCTURED_OUTPUT: ${{ inputs.structured_output }}
         INPUT_SYMBOL_RESOLUTION: ${{ inputs.symbol_resolution }}
+        INPUT_PROMPT_CACHE: ${{ inputs.prompt_cache }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -170,6 +175,7 @@ runs:
           -e INPUT_TIMEOUT -e INPUT_TEMPERATURE \
           -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS -e INPUT_RESOLVE_FIXED \
           -e INPUT_RECURSIVE -e INPUT_STRUCTURED_OUTPUT -e INPUT_SYMBOL_RESOLUTION \
+          -e INPUT_PROMPT_CACHE \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -94,7 +94,12 @@ Default: `low` (suppresses only `info` findings).
 
 Glob patterns to restrict which files in the diff are reviewed.
 `include_paths` acts as an allowlist; `exclude_paths` acts as a denylist applied
-after the allowlist. Both default to empty (all files included).
+after the allowlist, so an exclude always wins. Both default to empty (all files
+included). Patterns match against the full repo-relative path, and a
+`**/`-prefixed pattern also matches at the repo root (so `**/*.lock` covers a
+root-level lockfile). The built-in skip filter for generated, vendored, and
+binary files runs first either way — an `include_paths` entry can't resurrect a
+lockfile.
 
 ```yaml
 include_paths:

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -160,15 +160,17 @@ Default: all nine categories.
 
 ### context_lines
 
-Ceiling on the number of unchanged lines added above and below each changed hunk,
-read from the head revision of the file so the model can review a change in the
-context of its surrounding code. The actual number used is the smaller of this
-ceiling and what the token budget allows, so it shrinks automatically on large
-PRs. Set it to `0` to disable context expansion and review the bare diff (no
-extra file content is fetched).
+Ceiling on the number of unchanged lines added around each changed hunk, read
+from the head revision of the file so the model can review a change in the
+context of its surrounding code. The pad is **asymmetric**: the full budget goes
+before the hunk (the enclosing signature and setup explain a change best) and a
+quarter of it — at least one line — goes after. The actual number used is the
+smaller of this ceiling and what the token budget allows, so it shrinks
+automatically on large PRs. Set it to `0` to disable context expansion and
+review the bare diff (no extra file content is fetched).
 
 ```yaml
-context_lines: 10   # at most 10 lines either side of each hunk; 0 disables
+context_lines: 10   # at most 10 lines before each hunk (2 after); 0 disables
 ```
 
 Default: `20`.

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -24,6 +24,7 @@ provides defaults for all runs.
   - [structured_output](#structured_output)
   - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
+  - [min_confidence](#min_confidence)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -247,6 +248,23 @@ reflect: false   # keep every finding; skip the false-positive audit
 Default: `true`. To audit a weak reviewer's findings with a stronger model
 instead of disabling the pass, set `reflect_model` to that model id (it uses the
 same provider and credentials as `model`).
+
+### min_confidence
+
+During reflection the auditor also scores each kept finding's confidence from
+0 (certainly a false positive) to 10 (certain it is real), reached by actively
+trying to disprove the finding against the diff and the file text. Findings
+scored **below** `min_confidence` are dropped before posting; the surviving
+score is shown in the CLI output and the JSON export. A finding the auditor
+keeps but doesn't score always survives the threshold — a missing score never
+drops a real finding. CLI: `--min-confidence`.
+
+```yaml
+min_confidence: 5   # drop findings the auditor scores 0-4
+```
+
+Default: `0` (no numeric filtering — reflection prunes only via its keep/drop
+verdicts, as before the score existed).
 
 ### resolve_fixed
 

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -22,6 +22,7 @@ provides defaults for all runs.
   - [context_lines](#context_lines)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
+  - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
@@ -200,6 +201,29 @@ structured_output: false   # only if your gateway rejects JSON-schema mode
 
 Default: `true`. See
 [Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
+
+### prompt_cache
+
+Cache the static system prompt across the per-lens review calls and the
+reflection call. lgtmaybe fans out one model call per lens, and every one of
+those calls shares the same large, static system prompt — on providers with an
+explicit cache breakpoint (**anthropic**, and **bedrock** Claude/Nova models)
+lgtmaybe marks that prompt with `cache_control` so every call after the first
+reads it from the provider's prompt cache at the cached-input discount instead
+of re-paying full input price. The diff and other per-PR content always stay
+outside the cached region.
+
+Support is feature-detected per model, and on every other provider (ollama,
+`openai-compatible`, and providers that cache automatically server-side like
+OpenAI) the request is sent unchanged — so leaving it on costs nothing. Turn it
+off only to rule caching out while debugging provider behaviour. CLI:
+`--no-prompt-cache`.
+
+```yaml
+prompt_cache: false   # send every call uncached, even on anthropic/bedrock
+```
+
+Default: `true`.
 
 ### reflect
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1783,7 +1783,12 @@ Default: `low` (suppresses only `info` findings).
 
 Glob patterns to restrict which files in the diff are reviewed.
 `include_paths` acts as an allowlist; `exclude_paths` acts as a denylist applied
-after the allowlist. Both default to empty (all files included).
+after the allowlist, so an exclude always wins. Both default to empty (all files
+included). Patterns match against the full repo-relative path, and a
+`**/`-prefixed pattern also matches at the repo root (so `**/*.lock` covers a
+root-level lockfile). The built-in skip filter for generated, vendored, and
+binary files runs first either way — an `include_paths` entry can't resurrect a
+lockfile.
 
 ```yaml
 include_paths:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1711,6 +1711,7 @@ provides defaults for all runs.
   - [context_lines](#context_lines)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
+  - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
@@ -1889,6 +1890,29 @@ structured_output: false   # only if your gateway rejects JSON-schema mode
 
 Default: `true`. See
 [Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
+
+### prompt_cache
+
+Cache the static system prompt across the per-lens review calls and the
+reflection call. lgtmaybe fans out one model call per lens, and every one of
+those calls shares the same large, static system prompt — on providers with an
+explicit cache breakpoint (**anthropic**, and **bedrock** Claude/Nova models)
+lgtmaybe marks that prompt with `cache_control` so every call after the first
+reads it from the provider's prompt cache at the cached-input discount instead
+of re-paying full input price. The diff and other per-PR content always stay
+outside the cached region.
+
+Support is feature-detected per model, and on every other provider (ollama,
+`openai-compatible`, and providers that cache automatically server-side like
+OpenAI) the request is sent unchanged — so leaving it on costs nothing. Turn it
+off only to rule caching out while debugging provider behaviour. CLI:
+`--no-prompt-cache`.
+
+```yaml
+prompt_cache: false   # send every call uncached, even on anthropic/bedrock
+```
+
+Default: `true`.
 
 ### reflect
 
@@ -2358,6 +2382,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
+| `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `recursive` | boolean | No | `True` | Recursive |
 | `reflect` | boolean | No | `True` | Reflect |
@@ -2418,6 +2443,8 @@ The normalised return value of one LLM completion, including token usage.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
+| `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
+| `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `output_tokens` | integer | Yes | — | Output Tokens |
 | `text` | string | Yes | — | Text |
@@ -2715,6 +2742,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": null,
       "title": "Num Ctx"
     },
+    "prompt_cache": {
+      "default": true,
+      "title": "Prompt Cache",
+      "type": "boolean"
+    },
     "provider": {
       "$ref": "#/$defs/Provider"
     },
@@ -2890,6 +2922,16 @@ The canonical machine-readable schemas. These are the source of truth for provid
   "additionalProperties": false,
   "description": "The normalised return of one LLM completion, with token usage.",
   "properties": {
+    "cache_creation_tokens": {
+      "default": 0,
+      "title": "Cache Creation Tokens",
+      "type": "integer"
+    },
+    "cache_read_tokens": {
+      "default": 0,
+      "title": "Cache Read Tokens",
+      "type": "integer"
+    },
     "input_tokens": {
       "title": "Input Tokens",
       "type": "integer"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1849,15 +1849,17 @@ Default: all nine categories.
 
 ### context_lines
 
-Ceiling on the number of unchanged lines added above and below each changed hunk,
-read from the head revision of the file so the model can review a change in the
-context of its surrounding code. The actual number used is the smaller of this
-ceiling and what the token budget allows, so it shrinks automatically on large
-PRs. Set it to `0` to disable context expansion and review the bare diff (no
-extra file content is fetched).
+Ceiling on the number of unchanged lines added around each changed hunk, read
+from the head revision of the file so the model can review a change in the
+context of its surrounding code. The pad is **asymmetric**: the full budget goes
+before the hunk (the enclosing signature and setup explain a change best) and a
+quarter of it — at least one line — goes after. The actual number used is the
+smaller of this ceiling and what the token budget allows, so it shrinks
+automatically on large PRs. Set it to `0` to disable context expansion and
+review the bare diff (no extra file content is fetched).
 
 ```yaml
-context_lines: 10   # at most 10 lines either side of each hunk; 0 disables
+context_lines: 10   # at most 10 lines before each hunk (2 after); 0 disables
 ```
 
 Default: `20`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1713,6 +1713,7 @@ provides defaults for all runs.
   - [structured_output](#structured_output)
   - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
+  - [min_confidence](#min_confidence)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -1936,6 +1937,23 @@ reflect: false   # keep every finding; skip the false-positive audit
 Default: `true`. To audit a weak reviewer's findings with a stronger model
 instead of disabling the pass, set `reflect_model` to that model id (it uses the
 same provider and credentials as `model`).
+
+### min_confidence
+
+During reflection the auditor also scores each kept finding's confidence from
+0 (certainly a false positive) to 10 (certain it is real), reached by actively
+trying to disprove the finding against the diff and the file text. Findings
+scored **below** `min_confidence` are dropped before posting; the surviving
+score is shown in the CLI output and the JSON export. A finding the auditor
+keeps but doesn't score always survives the threshold — a missing score never
+drops a real finding. CLI: `--min-confidence`.
+
+```yaml
+min_confidence: 5   # drop findings the auditor scores 0-4
+```
+
+Default: `0` (no numeric filtering — reflection prunes only via its keep/drop
+verdicts, as before the score existed).
 
 ### resolve_fixed
 
@@ -2386,6 +2404,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
+| `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
@@ -2437,6 +2456,7 @@ The structured output the model must return for each inline comment. All fields 
 | `anchored` | boolean | No | `True` | Anchored |
 | `body` | string | Yes | — | Body |
 | `broad` | boolean | No | `False` | Broad |
+| `confidence` | integer / null | No | `null` | Confidence |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
 | `severity` | `critical` / `high` / `info` / `low` / `medium` | Yes | — |  |
@@ -2592,6 +2612,20 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "title": "Broad",
           "type": "boolean"
         },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
         "line": {
           "minimum": 1,
           "title": "Line",
@@ -2727,6 +2761,13 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "max_input_tokens": {
       "default": 100000,
       "title": "Max Input Tokens",
+      "type": "integer"
+    },
+    "min_confidence": {
+      "default": 0,
+      "maximum": 10,
+      "minimum": 0,
+      "title": "Min Confidence",
       "type": "integer"
     },
     "min_severity": {
@@ -2871,6 +2912,20 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": false,
       "title": "Broad",
       "type": "boolean"
+    },
+    "confidence": {
+      "anyOf": [
+        {
+          "maximum": 10,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Confidence"
     },
     "line": {
       "minimum": 1,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -28,6 +28,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
+| `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `recursive` | boolean | No | `True` | Recursive |
 | `reflect` | boolean | No | `True` | Reflect |
@@ -88,6 +89,8 @@ The normalised return value of one LLM completion, including token usage.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
+| `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
+| `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `output_tokens` | integer | Yes | — | Output Tokens |
 | `text` | string | Yes | — | Text |
@@ -385,6 +388,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": null,
       "title": "Num Ctx"
     },
+    "prompt_cache": {
+      "default": true,
+      "title": "Prompt Cache",
+      "type": "boolean"
+    },
     "provider": {
       "$ref": "#/$defs/Provider"
     },
@@ -560,6 +568,16 @@ The canonical machine-readable schemas. These are the source of truth for provid
   "additionalProperties": false,
   "description": "The normalised return of one LLM completion, with token usage.",
   "properties": {
+    "cache_creation_tokens": {
+      "default": 0,
+      "title": "Cache Creation Tokens",
+      "type": "integer"
+    },
+    "cache_read_tokens": {
+      "default": 0,
+      "title": "Cache Read Tokens",
+      "type": "integer"
+    },
     "input_tokens": {
       "title": "Input Tokens",
       "type": "integer"

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -25,6 +25,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
+| `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
@@ -76,6 +77,7 @@ The structured output the model must return for each inline comment. All fields 
 | `anchored` | boolean | No | `True` | Anchored |
 | `body` | string | Yes | — | Body |
 | `broad` | boolean | No | `False` | Broad |
+| `confidence` | integer / null | No | `null` | Confidence |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
 | `severity` | `critical` / `high` / `info` / `low` / `medium` | Yes | — |  |
@@ -231,6 +233,20 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "title": "Broad",
           "type": "boolean"
         },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
         "line": {
           "minimum": 1,
           "title": "Line",
@@ -366,6 +382,13 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "max_input_tokens": {
       "default": 100000,
       "title": "Max Input Tokens",
+      "type": "integer"
+    },
+    "min_confidence": {
+      "default": 0,
+      "maximum": 10,
+      "minimum": 0,
+      "title": "Min Confidence",
       "type": "integer"
     },
     "min_severity": {
@@ -510,6 +533,20 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": false,
       "title": "Broad",
       "type": "boolean"
+    },
+    "confidence": {
+      "anyOf": [
+        {
+          "maximum": 10,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Confidence"
     },
     "line": {
       "minimum": 1,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -81,6 +81,7 @@ def build_provider_engine(
         fallback_model=runtime.fallback_model,
         timeout=cfg.timeout,
         temperature=cfg.temperature,
+        prompt_cache=cfg.prompt_cache,
         **extra,
     )
     engine = LLMReviewEngine(provider, fetch_file=fetch_file, resolve_symbol=resolve_symbol)
@@ -314,6 +315,7 @@ def action_inputs() -> dict[str, str | None]:
         "recursive": get("RECURSIVE"),
         "structured_output": get("STRUCTURED_OUTPUT"),
         "symbol_resolution": get("SYMBOL_RESOLUTION"),
+        "prompt_cache": get("PROMPT_CACHE"),
         "config_path": get("CONFIG_PATH"),
     }
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -172,6 +172,13 @@ from lgtmaybe.config.loader import load_config
     "the auditor re-judges with the real definition (--no-symbol-resolution disables)",
 )
 @click.option(
+    "--prompt-cache/--no-prompt-cache",
+    default=None,
+    help="Cache the static system prompt across the per-lens calls on providers "
+    "that support it (anthropic, bedrock Claude/Nova) — cached reads are billed "
+    "at a steep discount. Safe no-op elsewhere (--no-prompt-cache disables)",
+)
+@click.option(
     "--config",
     "config_path",
     default=".lgtmaybe.yml",
@@ -202,6 +209,7 @@ def review(
     recursive: bool | None,
     structured_output: bool | None,
     symbol_resolution: bool | None,
+    prompt_cache: bool | None,
     config_path: str,
 ) -> None:
     """Review local git changes and print findings — no GitHub needed."""
@@ -225,6 +233,7 @@ def review(
         recursive=recursive,
         structured_output=structured_output,
         symbol_resolution=symbol_resolution,
+        prompt_cache=prompt_cache,
     )
 
     runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
@@ -282,6 +291,7 @@ def action() -> None:
         recursive=inputs["recursive"],
         structured_output=inputs["structured_output"],
         symbol_resolution=inputs["symbol_resolution"],
+        prompt_cache=inputs["prompt_cache"],
     )
     runtime = RuntimeOptions(
         api_key=inputs["api_key"],

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -152,6 +152,13 @@ from lgtmaybe.config.loader import load_config
     "(--no-reflect keeps them all; useful for weaker models)",
 )
 @click.option(
+    "--min-confidence",
+    default=None,
+    type=click.IntRange(0, 10),
+    help="Drop findings the reflection auditor scores below this confidence "
+    "(0-10; default 0 = no numeric filtering, unscored findings always survive)",
+)
+@click.option(
     "--recursive/--no-recursive",
     default=None,
     help="Walk a file whose diff exceeds the token budget hunk-by-hunk (RLM-style) "
@@ -206,6 +213,7 @@ def review(
     timeout: int | None,
     temperature: float | None,
     reflect: bool | None,
+    min_confidence: int | None,
     recursive: bool | None,
     structured_output: bool | None,
     symbol_resolution: bool | None,
@@ -230,6 +238,7 @@ def review(
         timeout=timeout,
         temperature=temperature,
         reflect=reflect,
+        min_confidence=min_confidence,
         recursive=recursive,
         structured_output=structured_output,
         symbol_resolution=symbol_resolution,

--- a/src/lgtmaybe/cli/render.py
+++ b/src/lgtmaybe/cli/render.py
@@ -26,7 +26,8 @@ def render_findings(findings: list[ReviewFinding], summary: str, *, fmt: str = "
 
     lines: list[str] = []
     for f in findings:
-        lines.append(f"{f.path}:{f.line}  [{f.severity.upper()}] {f.title}")
+        score = f" (confidence {f.confidence}/10)" if f.confidence is not None else ""
+        lines.append(f"{f.path}:{f.line}  [{f.severity.upper()}] {f.title}{score}")
         lines.append(f"  {f.body}")
         if f.suggestion is not None:
             lines.append(f"  suggestion: {f.suggestion}")

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -218,6 +218,11 @@ class ProviderResult(_Strict):
     text: str
     input_tokens: int
     output_tokens: int
+    # Prompt-cache accounting, when the provider reports it: tokens read from a
+    # previously cached prefix, and tokens written to create one. Zero on
+    # providers/models without prompt caching (back-compat default).
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
 
 
 class PRContext(_Strict):
@@ -327,6 +332,14 @@ class ReviewConfig(_Strict):
     # prose/reasoning instead of findings. Disable for a model/provider that
     # doesn't support it (the lenient parser is the fallback).
     structured_output: bool = True
+    # Cache the static system prompt across the per-lens fan-out and reflection
+    # call. On providers with an explicit cache breakpoint (anthropic, bedrock
+    # Claude/Nova) the adapter marks the system prompt with cache_control —
+    # every call after the first reads the shared prefix at the provider's
+    # cached-input discount. Feature-detected per model and a safe no-op
+    # everywhere else (ollama, openai-compatible, and providers that cache
+    # automatically server-side), so leaving it on costs nothing.
+    prompt_cache: bool = True
 
     @model_validator(mode="after")
     def _lens_ids_are_unique(self) -> ReviewConfig:

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -118,6 +118,12 @@ class ReviewFinding(_Strict):
     # collapsed "Broader observations" section instead of inline, so the must-fix
     # list stays tight without dropping the observation.
     broad: bool = False
+    # Reflection-derived confidence that this finding is real (0 = certainly a
+    # false positive, 10 = certain), set by the self-reflection auditor's verdict
+    # — never self-reported by the reviewing model. None when reflection is off
+    # or the auditor omitted a score. Findings scoring below
+    # `ReviewConfig.min_confidence` are dropped; the score is surfaced in output.
+    confidence: int | None = Field(default=None, ge=0, le=10)
 
     @field_validator("severity", mode="before")
     @classmethod
@@ -200,6 +206,11 @@ class Verdict(_Strict):
     # merely because the referenced code wasn't in the diff. Optional with a
     # back-compat default so a model that omits it still validates.
     needs: list[str] = Field(default_factory=list)
+    # The auditor's 0-10 confidence that a KEPT finding is real (0 = certainly a
+    # false positive, 10 = certain). Optional with a back-compat default so a
+    # model that omits it still validates; an unscored kept finding survives any
+    # `min_confidence` threshold (safe default — never drop for a missing score).
+    confidence: int | None = Field(default=None, ge=0, le=10)
 
 
 class ReflectionResult(_Strict):
@@ -305,6 +316,11 @@ class ReviewConfig(_Strict):
     # get audited by a better judge. Same provider/credentials as `model` — only
     # the model id changes (the provider client is built once).
     reflect_model: str | None = None
+    # Drop findings the reflection auditor scores below this confidence (0-10).
+    # 0 (the default) disables numeric filtering — reflection then prunes only
+    # via its keep/drop verdicts, exactly as before the score existed. Findings
+    # the auditor keeps but doesn't score always survive the threshold.
+    min_confidence: int = Field(default=0, ge=0, le=10)
     # Finding fingerprints to permanently suppress — a team dismissing a known-fine
     # pattern. Each entry is a finding_fingerprint(path, title) hex id (surfaced in
     # the inline comment's hidden marker). Findings matching one are dropped before

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -152,9 +152,25 @@ def context_lines_for_budget(remaining_tokens: int) -> int:
     return min(int(lines), _MAX_CONTEXT_LINES)
 
 
-def expand_hunks(patch: str, file_content: str | None, n: int) -> str:
-    """Pad each hunk in *patch* with up to *n* surrounding lines from *file_content*.
+def trailing_context_lines(before: int) -> int:
+    """The trailing pad for a leading pad of *before* lines (asymmetric context).
 
+    The code BEFORE a change — the enclosing signature, setup, and definitions —
+    explains it far better than the code after, so the trailing side gets roughly
+    a quarter of the leading budget (PR-Agent weights its dynamic context the
+    same way), floored at one line so the model still sees what follows. Zero
+    stays zero: no leading pad means expansion is off entirely.
+    """
+    if before <= 0:
+        return 0
+    return max(1, before // 4)
+
+
+def expand_hunks(patch: str, file_content: str | None, n: int, after: int | None = None) -> str:
+    """Pad each hunk in *patch* with surrounding lines from *file_content*.
+
+    Up to *n* lines are added before each hunk and up to *after* lines after it
+    (``after=None`` keeps the original symmetric contract: *n* on both sides).
     The extra lines are drawn from the head-revision file text and rendered as
     normal unchanged context (space-prefixed), giving the model the function and
     definitions around a change. Hunk headers are rewritten so each hunk's
@@ -166,6 +182,7 @@ def expand_hunks(patch: str, file_content: str | None, n: int) -> str:
     """
     if n <= 0 or not file_content:
         return patch
+    n_after = n if after is None else max(0, after)
 
     content_lines = file_content.splitlines()
     out: list[str] = []
@@ -191,7 +208,7 @@ def expand_hunks(patch: str, file_content: str | None, n: int) -> str:
         last_new = new_start + new_len - 1
         trailing = [
             content_lines[i - 1]
-            for i in range(last_new + 1, min(len(content_lines), last_new + n) + 1)
+            for i in range(last_new + 1, min(len(content_lines), last_new + n_after) + 1)
         ]
         pending_trailing = trailing
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -25,7 +25,13 @@ from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
 from lgtmaybe.github import is_reviewable
 
 from .astgrep import SymbolResolver
-from .compress import batch_files, context_lines_for_budget, count_tokens, expand_hunks
+from .compress import (
+    batch_files,
+    context_lines_for_budget,
+    count_tokens,
+    expand_hunks,
+    trailing_context_lines,
+)
 from .injection import wrap_diff, wrap_intent
 from .parse import ParseError, parse_findings
 from .prompt import build_lens_prompt, build_system_prompt
@@ -133,15 +139,24 @@ class LLMReviewEngine(ReviewEngine):
 
         # 4. Pad each hunk with surrounding lines so the model sees the function
         #    and definitions around a change. The amount is budget-scaled and
-        #    capped by cfg.context_lines; content is the head file text the
-        #    gateway fetched (redacted), and is for understanding only —
-        #    inline-comment positions are always built from the real diff.
+        #    capped by cfg.context_lines; the pad is asymmetric — the code
+        #    before a change explains it better than the code after, so the
+        #    trailing side gets a quarter of the leading budget. Content is the
+        #    head file text the gateway fetched (redacted), and is for
+        #    understanding only — inline-comment positions are always built
+        #    from the real diff.
         used_tokens = count_tokens(clean_diff)
         remaining = max(0, cfg.max_input_tokens - used_tokens)
         ctx_lines = min(cfg.context_lines, context_lines_for_budget(remaining))
         if ctx_lines > 0 and ctx.file_contents:
+            after = trailing_context_lines(ctx_lines)
             file_patches = [
-                (path, expand_hunks(patch, redact(ctx.file_contents.get(path, "")), ctx_lines))
+                (
+                    path,
+                    expand_hunks(
+                        patch, redact(ctx.file_contents.get(path, "")), ctx_lines, after=after
+                    ),
+                )
                 for path, patch in file_patches
             ]
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from functools import partial
 
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
@@ -127,9 +128,16 @@ class LLMReviewEngine(ReviewEngine):
             lenses = [lens for lens in lenses if not lens.carries_intent]
             _log.info("intent lens skipped — no stated intent (title/description/commits)")
 
-        # 2. Split into per-file patches and drop generated/binary/vendored noise.
+        # 2. Split into per-file patches and drop generated/binary/vendored noise,
+        #    then apply the user's path filters (include_paths allowlist, then
+        #    exclude_paths denylist).
         file_patches = split_by_file(clean_diff, ctx.changed_files)
-        file_patches = [(path, patch) for path, patch in file_patches if is_reviewable(path)]
+        file_patches = [
+            (path, patch)
+            for path, patch in file_patches
+            if is_reviewable(path)
+            and passes_path_filters(path, include=cfg.include_paths, exclude=cfg.exclude_paths)
+        ]
 
         # 3. File cap: review only the first N reviewable files, note the rest.
         total_files = len(file_patches)
@@ -336,6 +344,26 @@ class LLMReviewEngine(ReviewEngine):
             return [], "unparseable model output"
         _log.info("lens reviewed", extra={"lens": lens.id, "findings": len(findings)})
         return findings, None
+
+
+def passes_path_filters(path: str, *, include: list[str], exclude: list[str]) -> bool:
+    """Whether *path* survives the config's glob filters.
+
+    ``include`` is an allowlist (empty = everything included) and ``exclude`` a
+    denylist applied after it — so an exclude always wins. Patterns are fnmatch
+    globs matched against the full path, with one gitignore-style nicety: a
+    ``**/``-prefixed pattern also matches at the repo root (plain fnmatch would
+    demand a literal slash, silently missing ``**/*.lock`` on a root lockfile).
+    """
+    if include and not any(_matches_glob(path, pattern) for pattern in include):
+        return False
+    return not any(_matches_glob(path, pattern) for pattern in exclude)
+
+
+def _matches_glob(path: str, pattern: str) -> bool:
+    if fnmatch(path, pattern):
+        return True
+    return pattern.startswith("**/") and fnmatch(path, pattern[3:])
 
 
 def _intent_text(ctx: PRContext) -> str:

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -8,6 +8,7 @@ review calls are, with a lenient parser + keep-all safe default as fallback.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any
 
 from lgtmaybe.core.logging import get_logger
@@ -33,8 +34,14 @@ You are a senior code reviewer auditing another reviewer's findings for false po
 
 Given a list of findings (as JSON) and the diff that generated them, return a JSON object \
 with a single key "verdicts": a list of \
-{"index": <finding index>, "keep": <true|false>, "broad": <true|false>, "needs": [<paths>]} \
-objects, one per finding.
+{"index": <finding index>, "keep": <true|false>, "confidence": <0-10>, "broad": <true|false>, \
+"needs": [<paths>]} objects, one per finding.
+
+"confidence" scores how confident you are that a KEPT finding is a real, correctly placed, \
+actionable issue: 0 means you are certain it is a false positive, 10 means you are certain \
+it is real. Score it by actively trying to DISPROVE the finding against the diff and the \
+file text provided below — a finding you cannot disprove but also cannot verify belongs in \
+the middle of the scale. For a dropped finding emit 0.
 
 If you would drop a finding ONLY because you cannot see a file or definition it depends on, \
 do NOT drop it — set "needs" to the file path(s) (and/or symbol names) you need to decide; \
@@ -84,8 +91,8 @@ patch target is wrong" — test-execution and mock/patch-target outcomes depend 
 test harness you cannot see, so such a claim is speculative.
 
 Return ONLY the JSON object, nothing else. Example:
-{"verdicts": [{"index": 0, "keep": true, "broad": false, "needs": []}, \
-{"index": 1, "keep": false, "broad": false, "needs": ["app/models.py"]}]}
+{"verdicts": [{"index": 0, "keep": true, "confidence": 9, "broad": false, "needs": []}, \
+{"index": 1, "keep": false, "confidence": 0, "broad": false, "needs": ["app/models.py"]}]}
 """
 
 
@@ -157,14 +164,35 @@ def _reflect_pass(
     deferred: list[ReviewFinding] = []
     deferred_needs: list[str] = []
     for i, finding in enumerate(findings):
-        keep, broad, needs = verdicts.get(i, (True, False, []))
-        if needs:
+        verdict = verdicts.get(i, _KEEP_VERDICT)
+        if verdict.needs:
             # The auditor can't decide without seeing more code — collect it for a
             # recheck rather than acting on this verdict's keep flag now.
             deferred.append(finding)
-            deferred_needs.extend(needs)
-        elif keep:
-            survivors.append(finding.model_copy(update={"broad": broad}))
+            deferred_needs.extend(verdict.needs)
+        elif verdict.keep:
+            if (
+                cfg.min_confidence > 0
+                and verdict.confidence is not None
+                and verdict.confidence < cfg.min_confidence
+            ):
+                # Kept but scored below the configured floor. An UNSCORED kept
+                # finding always survives — never drop for a missing score.
+                _log.info(
+                    "finding below min_confidence — dropping",
+                    extra={
+                        "path": finding.path,
+                        "title": finding.title,
+                        "confidence": verdict.confidence,
+                        "min_confidence": cfg.min_confidence,
+                    },
+                )
+                continue
+            survivors.append(
+                finding.model_copy(
+                    update={"broad": verdict.broad, "confidence": verdict.confidence}
+                )
+            )
 
     if not deferred:
         return survivors
@@ -217,7 +245,7 @@ def _audit(
     cfg: ReviewConfig,
     provider: ProviderClient,
     fetched_paths: list[str] | None = None,
-) -> dict[int, tuple[bool, bool, list[str]]]:
+) -> dict[int, _ParsedVerdict]:
     """Run one auditor completion over *findings* and return the parsed verdicts.
 
     Builds the grounded prompt (diff + redacted head text of flagged files, plus
@@ -361,37 +389,70 @@ def _head_tail(text: str, max_tokens: int, full_tokens: int | None = None) -> tu
     return result, count_tokens(result)
 
 
-def _parse_verdicts(raw: str) -> dict[int, tuple[bool, bool, list[str]]]:
-    """Parse the reflection verdict into an ``{index: (keep, broad, needs)}`` map.
+@dataclass(frozen=True)
+class _ParsedVerdict:
+    """One leniently parsed reflection verdict (see ``core.models.Verdict``).
+
+    A plain dataclass rather than the pydantic ``Verdict`` because parsing here
+    is forgiving — garbage values are coerced to safe defaults, never raised —
+    while the pydantic model stays strict for the ``response_format`` schema.
+    """
+
+    keep: bool
+    broad: bool = False
+    needs: tuple[str, ...] = ()
+    confidence: int | None = None
+
+
+# The safe default for a finding the auditor returned no verdict for: keep it,
+# non-broad, unscored — identical to the pre-verdict behaviour.
+_KEEP_VERDICT = _ParsedVerdict(keep=True)
+
+
+def _parse_verdicts(raw: str) -> dict[int, _ParsedVerdict]:
+    """Parse the reflection verdict into an ``{index: _ParsedVerdict}`` map.
 
     Accepts the structured ``{"verdicts": [{"index": i, "keep": bool, "broad":
-    bool, "needs": [...]}, ...]}`` envelope (``broad`` and ``needs`` optional,
-    defaulting to False / ``[]``), and (as a fallback for models that ignore the
-    schema) the legacy ``{"0": true, "1": false}`` index-to-bool map (no
-    actionability tier or deferral, so broad defaults False and needs empty).
-    Shares the findings parser's lenient extraction (:func:`iter_json_values`), so
-    reasoning blocks, code fences, and surrounding prose — including the
-    bracket-bearing prose that an ``openai-compatible`` gateway without JSON mode
-    emits — are tolerated.
+    bool, "needs": [...], "confidence": 0-10}, ...]}`` envelope (``broad``,
+    ``needs``, and ``confidence`` optional, defaulting to False / ``[]`` /
+    unscored), and (as a fallback for models that ignore the schema) the legacy
+    ``{"0": true, "1": false}`` index-to-bool map (no actionability tier,
+    deferral, or score). Shares the findings parser's lenient extraction
+    (:func:`iter_json_values`), so reasoning blocks, code fences, and
+    surrounding prose — including the bracket-bearing prose that an
+    ``openai-compatible`` gateway without JSON mode emits — are tolerated.
     """
     for data in iter_json_values(raw):
         if not isinstance(data, dict):
             continue
         if isinstance(data.get("verdicts"), list):
-            out: dict[int, tuple[bool, bool, list[str]]] = {}
+            out: dict[int, _ParsedVerdict] = {}
             for v in data["verdicts"]:
                 if isinstance(v, dict) and "index" in v and "keep" in v:
-                    out[int(v["index"])] = (
-                        bool(v["keep"]),
-                        bool(v.get("broad", False)),
-                        _coerce_needs(v.get("needs")),
+                    out[int(v["index"])] = _ParsedVerdict(
+                        keep=bool(v["keep"]),
+                        broad=bool(v.get("broad", False)),
+                        needs=tuple(_coerce_needs(v.get("needs"))),
+                        confidence=_coerce_confidence(v.get("confidence")),
                     )
             return out
         # legacy {"0": true, ...} — a dict of digit keys to bools (no broad/needs).
         if data and all(str(k).lstrip("-").isdigit() for k in data):
-            return {int(k): (bool(val), False, []) for k, val in data.items()}
+            return {int(k): _ParsedVerdict(keep=bool(val)) for k, val in data.items()}
 
     raise ValueError("unrecognised or unparseable verdict shape")
+
+
+def _coerce_confidence(value: object) -> int | None:
+    """Normalise a verdict's ``confidence`` into an int clamped to 0-10, or None.
+
+    Tolerates a model that omits it, emits a float, or emits garbage ("very
+    sure") — anything non-numeric means "unscored" (None), which survives every
+    threshold, so a sloppy score can never drop a finding.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return max(0, min(10, int(value)))
 
 
 def _coerce_needs(value: object) -> list[str]:

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -113,6 +113,14 @@ _SKIP_FILENAMES = frozenset(
         "Pipfile.lock",
         "composer.lock",
         "go.sum",
+        "uv.lock",
+        "bun.lock",
+        "bun.lockb",
+        "deno.lock",
+        "flake.lock",
+        "mix.lock",
+        "Package.resolved",
+        "gradle.lockfile",
     }
 )
 
@@ -136,6 +144,9 @@ _SKIP_GLOB_PATTERNS = (
     "*.generated.*",
     "__generated__/*",
     "*.d.ts",
+    # Sourcemaps are compiler output, never hand-written.
+    "*.js.map",
+    "*.css.map",
 )
 
 _SKIP_EXTENSIONS = frozenset(

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -73,6 +73,7 @@ def build_provider(
     azure_ad_token: str | None = None,
     fallback_model: str | None = None,
     timeout: int | None = None,
+    prompt_cache: bool = False,
     **extra_opts: Any,
 ) -> LiteLLMProvider:
     """Build a configured LiteLLMProvider for the given provider and model.
@@ -115,5 +116,6 @@ def build_provider(
     return LiteLLMProvider(
         model=resolved_model,
         fallback_model=resolved_fallback,
+        prompt_cache=prompt_cache,
         **opts,
     )

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -20,13 +20,30 @@ from litellm.exceptions import (
     PermissionDeniedError,
     RateLimitError,
 )
+from litellm.utils import supports_prompt_caching
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
+from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import ProviderResult
 from lgtmaybe.core.ports import Message, ProviderClient
 
+_log = get_logger(__name__)
+
 _DEFAULT_TIMEOUT = 60  # seconds
 _MAX_ATTEMPTS = 4
+
+# Prompt caching (of the static system prompt) is applied only on routes where
+# an EXPLICIT cache breakpoint is the mechanism: Anthropic direct (cache_control)
+# and Bedrock (litellm translates cache_control to a Converse cachePoint for
+# Claude and Nova). Other providers either cache automatically server-side with
+# no marker (OpenAI, Azure) or don't cache at all (ollama, most
+# openai-compatible servers) — for all of them the request is sent unchanged.
+_CACHE_CONTROL_PREFIXES = ("anthropic/", "bedrock/")
+
+# Anthropic's documented minimum cacheable block. A smaller prefix is silently
+# not cached (some models require even more), so below this the marker is pure
+# request-shape churn — skip it and send the message unchanged.
+_MIN_CACHEABLE_TOKENS = 1024
 
 # Errors that retrying cannot fix: bad credentials, a malformed/unsupported
 # request, an unknown model, a denied permission, and a content-policy block
@@ -118,10 +135,16 @@ class LiteLLMProvider(ProviderClient):
         *,
         model: str = "",
         fallback_model: str | None = None,
+        prompt_cache: bool = False,
         **default_opts: Any,
     ) -> None:
         self.model = model
         self.fallback_model = fallback_model
+        # Mark the static system prompt cacheable (cache_control) on routes that
+        # support an explicit cache breakpoint; a safe no-op everywhere else.
+        # A named constructor arg — NOT part of default_opts — so it can never
+        # leak into the litellm.completion call as an unknown parameter.
+        self.prompt_cache = prompt_cache
         self.default_opts: dict[str, Any] = default_opts
         # Set once a structured-output call comes back empty (see _call): the
         # backend's JSON-schema decoder is broken for this model, so every
@@ -149,6 +172,11 @@ class LiteLLMProvider(ProviderClient):
     def _complete_with_retry(
         self, messages: list[Message], model: str, **kwargs: Any
     ) -> ProviderResult:
+        # Applied per effective model (the primary and the fallback can differ
+        # in cache support), and to a copy — the caller's messages are not ours
+        # to mutate.
+        messages = self._with_cache_control(messages, model)
+
         @retry(
             retry=retry_if_exception(lambda exc: not _is_permanent(exc)),
             stop=stop_after_attempt(_MAX_ATTEMPTS),
@@ -190,15 +218,106 @@ class LiteLLMProvider(ProviderClient):
             response = litellm.completion(model=model, messages=messages, **kwargs)
         return self._map_response(response, model)
 
+    def _with_cache_control(self, messages: list[Message], model: str) -> list[Message]:
+        """Return *messages* with the system prompt marked cacheable, when it pays.
+
+        The system prompt is the static prefix (shared header + lens section +
+        worked example — identical across the per-lens fan-out and re-runs); the
+        volatile content (diff, intent, findings) is always in the user message,
+        so marking only the system message keeps the cached region stable. The
+        rewrite happens only when ALL of these hold — otherwise the request goes
+        out byte-for-byte unchanged:
+
+        - ``prompt_cache`` is enabled;
+        - the model rides a route where an explicit breakpoint is the caching
+          mechanism (:data:`_CACHE_CONTROL_PREFIXES`) AND litellm's capability
+          map says the model supports prompt caching;
+        - the system prompt clears Anthropic's 1,024-token minimum cacheable
+          block (a smaller block is silently not cached).
+        """
+        if not self.prompt_cache or not _supports_cache_control(model):
+            return messages
+        index = next(
+            (i for i, m in enumerate(messages) if m.get("role") == "system"),
+            None,
+        )
+        if index is None:
+            return messages
+        content = messages[index].get("content")
+        if not isinstance(content, str) or _count_tokens(content) < _MIN_CACHEABLE_TOKENS:
+            return messages
+        marked: Any = [{"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}]
+        out = list(messages)
+        out[index] = {**messages[index], "content": marked}
+        return out
+
     def _map_response(self, response: Any, model: str) -> ProviderResult:
         # Some providers return null content (e.g. a model that answered only via
         # a reasoning channel under JSON mode); treat that as empty, not a crash.
         text: str = response.choices[0].message.content or ""
-        input_tokens: int = response.usage.prompt_tokens
-        output_tokens: int = response.usage.completion_tokens
+        usage = response.usage
+        input_tokens: int = usage.prompt_tokens
+        output_tokens: int = usage.completion_tokens
+        cache_read, cache_creation = _cache_usage(usage)
+        if cache_read or cache_creation:
+            # Instrumentation: whether the static prefix hit or (re)wrote the
+            # cache — a run whose reads never climb has a busted prefix.
+            _log.info(
+                "prompt cache usage",
+                extra={
+                    "model": model,
+                    "cache_read_tokens": cache_read,
+                    "cache_creation_tokens": cache_creation,
+                },
+            )
 
         return ProviderResult(
             text=text,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
         )
+
+
+def _supports_cache_control(model: str) -> bool:
+    """Whether *model*'s route takes an explicit cache_control breakpoint.
+
+    Feature detection, not configuration: the route must be one where litellm
+    forwards ``cache_control`` (Anthropic direct; Bedrock, where it becomes a
+    Converse ``cachePoint``), and litellm's model-capability map must say the
+    model itself caches. Any lookup failure (an unknown or freshly released
+    model) means "don't mark" — caching is an optimisation, never worth an error.
+    """
+    if not model.startswith(_CACHE_CONTROL_PREFIXES):
+        return False
+    try:
+        return bool(supports_prompt_caching(model=model))
+    except Exception:
+        return False
+
+
+def _cache_usage(usage: Any) -> tuple[int, int]:
+    """Extract (cache_read, cache_creation) token counts from a usage object.
+
+    Anthropic/Bedrock report ``cache_read_input_tokens`` /
+    ``cache_creation_input_tokens``; OpenAI-style responses report reads under
+    ``prompt_tokens_details.cached_tokens``. All optional — absent means 0.
+    """
+    cache_read = getattr(usage, "cache_read_input_tokens", None)
+    if not cache_read:
+        details = getattr(usage, "prompt_tokens_details", None)
+        cache_read = getattr(details, "cached_tokens", None) if details is not None else None
+    cache_creation = getattr(usage, "cache_creation_input_tokens", None)
+    return int(cache_read or 0), int(cache_creation or 0)
+
+
+def _count_tokens(text: str) -> int:
+    """Token count for the minimum-cacheable-block check.
+
+    Reuses the engine's cached tiktoken encoder (len/4 fallback) — imported
+    lazily so building a provider never drags the engine in at import time.
+    """
+    from lgtmaybe.engine.compress import count_tokens
+
+    return count_tokens(text)

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -103,3 +103,28 @@ def test_human_output_renders_every_finding_with_one_trailing_summary() -> None:
     assert "unused import" in out
     assert out.count("2 findings · llama3") == 1
     assert out.rstrip().endswith("2 findings · llama3")
+
+
+def test_human_format_shows_confidence_when_scored() -> None:
+    finding = ReviewFinding(
+        path="a.py",
+        line=3,
+        severity=Severity.high,
+        title="real bug",
+        body="broken",
+        confidence=8,
+    )
+
+    out = render_findings([finding], "1 finding", fmt="human")
+
+    assert "(confidence 8/10)" in out
+
+
+def test_human_format_omits_confidence_when_unscored() -> None:
+    finding = ReviewFinding(
+        path="a.py", line=3, severity=Severity.high, title="real bug", body="broken"
+    )
+
+    out = render_findings([finding], "1 finding", fmt="human")
+
+    assert "confidence" not in out

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -8,6 +8,7 @@ from lgtmaybe.engine.compress import (
     count_tokens,
     expand_hunks,
     split_patch_into_hunks,
+    trailing_context_lines,
 )
 
 # ---------------------------------------------------------------------------
@@ -218,3 +219,33 @@ def test_expand_hunks_clamps_at_file_edges() -> None:
     assert "@@ -1," in expanded
     # Trailing context is clamped to the last real line (j) — no over-read.
     assert expanded.rstrip().endswith(" j")
+
+
+def test_expand_hunks_asymmetric_pads_fewer_after() -> None:
+    # The code BEFORE a change (signature, setup) explains it better than the
+    # code after, so an explicit `after` pads the two sides differently.
+    patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
+
+    expanded = expand_hunks(patch, _CONTENT, 3, after=1)
+
+    # Three leading lines (b, c, d) and exactly one trailing line (g).
+    assert "\n b\n c\n d\n" in expanded
+    assert "\n g\n" in expanded
+    assert " h\n" not in expanded
+    # Header widened by 3 leading + 1 trailing = 4.
+    assert "@@ -2,6 +2,6 @@" in expanded
+
+
+def test_expand_hunks_default_stays_symmetric() -> None:
+    # Without an explicit `after`, both sides pad by n — the original contract.
+    patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
+    assert expand_hunks(patch, _CONTENT, 2) == expand_hunks(patch, _CONTENT, 2, after=2)
+
+
+def test_trailing_context_lines_ratio() -> None:
+    # PR-Agent-style asymmetry: roughly a quarter of the leading budget,
+    # floored at one line so the model still sees what follows the change.
+    assert trailing_context_lines(20) == 5
+    assert trailing_context_lines(4) == 1
+    assert trailing_context_lines(1) == 1
+    assert trailing_context_lines(0) == 0

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1304,3 +1304,21 @@ def test_engine_without_fetcher_drops_deferred_finding() -> None:
     out, _ = engine.review(_CTX, cfg)
 
     assert out == []
+
+
+def test_context_expansion_is_asymmetric() -> None:
+    """The engine pads more lines before each hunk than after it — the code
+    leading up to a change (signature, setup) explains it better than what
+    follows, so the trailing budget is a quarter of the leading one."""
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", context_lines=4)
+
+    engine.review(_CTX_WITH_CONTENT, cfg)
+
+    sent = _first_user_diff(provider)
+    # 4 lines before the hunk (lines 1..4 = a..d) …
+    assert "\n a\n" in sent
+    # … but only max(1, 4 // 4) = 1 line after (line 7 = g).
+    assert "\n g\n" in sent
+    assert "\n h\n" not in sent

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -19,6 +19,7 @@ from lgtmaybe.core.models import (
 )
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
 from lgtmaybe.engine.compress import count_tokens
+from lgtmaybe.engine.engine import passes_path_filters
 from lgtmaybe.engine.redact import REDACTED_PLACEHOLDER
 from tests.fakes import FakeProvider
 
@@ -1322,3 +1323,82 @@ def test_context_expansion_is_asymmetric() -> None:
     # … but only max(1, 4 // 4) = 1 line after (line 7 = g).
     assert "\n g\n" in sent
     assert "\n h\n" not in sent
+
+
+# ---------------------------------------------------------------------------
+# include_paths / exclude_paths filtering
+# ---------------------------------------------------------------------------
+
+_TWO_FILE_CTX = PRContext(
+    diff=(
+        "diff --git a/src/app.py b/src/app.py\n@@ -1,1 +1,1 @@\n+x = 1\n"
+        "diff --git a/scripts/tool.py b/scripts/tool.py\n@@ -1,1 +1,1 @@\n+y = 2\n"
+    ),
+    changed_files=["src/app.py", "scripts/tool.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="org/repo",
+    pr_number=11,
+)
+
+
+def test_include_paths_reviews_only_matching_files() -> None:
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", include_paths=["src/**"])
+
+    engine.review(_TWO_FILE_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "src/app.py" in sent
+    assert "scripts/tool.py" not in sent
+
+
+def test_exclude_paths_drops_matching_files() -> None:
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", exclude_paths=["scripts/**"])
+
+    engine.review(_TWO_FILE_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "src/app.py" in sent
+    assert "scripts/tool.py" not in sent
+
+
+def test_exclude_paths_wins_over_include_paths() -> None:
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        include_paths=["src/**", "scripts/**"],
+        exclude_paths=["scripts/**"],
+    )
+
+    engine.review(_TWO_FILE_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "src/app.py" in sent
+    assert "scripts/tool.py" not in sent
+
+
+def test_empty_path_filters_review_everything() -> None:
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+
+    engine.review(_TWO_FILE_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "src/app.py" in sent
+    assert "scripts/tool.py" in sent
+
+
+def test_passes_path_filters_matches_root_level_with_leading_globstar() -> None:
+    # `**/*.lock` should match a repo-root lockfile too, the way gitignore
+    # patterns behave — a plain fnmatch would demand a literal slash.
+    assert not passes_path_filters("app.lock", include=[], exclude=["**/*.lock"])
+    assert not passes_path_filters("sub/app.lock", include=[], exclude=["**/*.lock"])
+    assert passes_path_filters("app.py", include=[], exclude=["**/*.lock"])
+    assert passes_path_filters("deep/nested/file.py", include=["**/*.py"], exclude=[])

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -624,3 +624,92 @@ def test_head_tail_truncates_within_budget() -> None:
     assert used == count_tokens(result)
     assert "[truncated]" in result
     assert result.startswith("line0")
+
+
+# ---------------------------------------------------------------------------
+# numeric confidence score (0-10) + min_confidence threshold
+# ---------------------------------------------------------------------------
+
+
+def _scored_envelope(verdicts: list[tuple[int, bool, int | None]]) -> str:
+    return json.dumps(
+        {
+            "verdicts": [
+                {"index": i, "keep": k, **({} if c is None else {"confidence": c})}
+                for i, k, c in verdicts
+            ]
+        }
+    )
+
+
+def _fake_with_text(text: str) -> FakeProvider:
+    return FakeProvider(result=ProviderResult(text=text, input_tokens=5, output_tokens=5))
+
+
+def test_confidence_is_copied_onto_the_surviving_finding() -> None:
+    provider = _fake_with_text(_scored_envelope([(0, True, 8)]))
+
+    kept = reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert len(kept) == 1
+    assert kept[0].confidence == 8
+
+
+def test_min_confidence_drops_kept_findings_scored_below_it() -> None:
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_confidence=7)
+    provider = _fake_with_text(_scored_envelope([(0, True, 9), (1, True, 3)]))
+
+    kept = reflect_findings([_HIGH, _LOW_CONF], _CTX, cfg, provider)
+
+    assert [f.title for f in kept] == ["real bug"]
+
+
+def test_unscored_verdict_survives_any_threshold() -> None:
+    """A model that omits the score must not have its findings dropped — the
+    keep-all instinct applies to a missing confidence too."""
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_confidence=7)
+    provider = _fake_with_text(_scored_envelope([(0, True, None)]))
+
+    kept = reflect_findings([_HIGH], _CTX, cfg, provider)
+
+    assert len(kept) == 1
+    assert kept[0].confidence is None
+
+
+def test_default_min_confidence_keeps_even_a_zero_score() -> None:
+    """min_confidence defaults to 0 = no numeric filtering — current behaviour
+    is preserved byte-for-byte unless a threshold is configured."""
+    provider = _fake_with_text(_scored_envelope([(0, True, 0)]))
+
+    kept = reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert len(kept) == 1
+
+
+def test_garbage_confidence_is_treated_as_unscored() -> None:
+    text = json.dumps({"verdicts": [{"index": 0, "keep": True, "confidence": "very sure"}]})
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", min_confidence=7)
+    provider = _fake_with_text(text)
+
+    kept = reflect_findings([_HIGH], _CTX, cfg, provider)
+
+    assert len(kept) == 1
+    assert kept[0].confidence is None
+
+
+def test_out_of_range_confidence_is_clamped() -> None:
+    provider = _fake_with_text(_scored_envelope([(0, True, 15)]))
+
+    kept = reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    assert kept[0].confidence == 10
+
+
+def test_reflect_prompt_asks_for_a_confidence_score() -> None:
+    provider = _fake_with_text(_scored_envelope([(0, True, 8)]))
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    system = provider.calls[0]["messages"][0]["content"]
+    assert "confidence" in system
+    assert "0" in system and "10" in system

--- a/tests/github/test_diff.py
+++ b/tests/github/test_diff.py
@@ -245,3 +245,24 @@ def test_no_newline_marker_does_not_shift_commentable_lines() -> None:
     assert ("f.txt", 2, "RIGHT") in index
     assert ("f.txt", 3, "RIGHT") not in index
     assert ("f.txt", 2, "LEFT") in index
+
+
+def test_is_reviewable_rejects_newer_lockfiles() -> None:
+    # Lockfiles from ecosystems that postdate the original list — all generated.
+    for path in (
+        "uv.lock",
+        "bun.lock",
+        "bun.lockb",
+        "deno.lock",
+        "flake.lock",
+        "mix.lock",
+        "Package.resolved",
+        "gradle.lockfile",
+        "backend/uv.lock",
+    ):
+        assert not is_reviewable(path), path
+
+
+def test_is_reviewable_rejects_sourcemaps() -> None:
+    assert not is_reviewable("assets/app.js.map")
+    assert not is_reviewable("assets/styles.css.map")

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -1,0 +1,205 @@
+"""Prompt caching of the static system prompt (P1).
+
+The static system prompt (shared header + lens section + worked example) is
+re-sent on every concurrent lens call and again on reflection. On providers
+that support explicit cache breakpoints (Anthropic direct, Bedrock Claude/Nova)
+the adapter marks the system message with ``cache_control: {"type": "ephemeral"}``
+so those calls read the prefix from cache instead of re-paying for it.
+
+Everything here monkeypatches ``litellm.completion`` at the boundary — no
+network. The contract under test:
+
+- the marker is attached ONLY on cache-capable provider routes (``anthropic/``,
+  ``bedrock/``) whose model litellm's capability map says supports caching;
+- only the (static) system message is marked — the user message (diff, intent)
+  stays outside the cached prefix;
+- below the documented 1,024-token minimum cacheable block the request is sent
+  unchanged (a smaller block would silently not cache);
+- with ``prompt_cache`` off, or on any other provider (ollama, openai-compatible,
+  …), the request is byte-for-byte what it was before this feature existed;
+- cache_read / cache_creation token counts are mapped into ``ProviderResult``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from lgtmaybe.core.models import Provider
+from lgtmaybe.providers.factory import build_provider
+from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+# A system prompt comfortably above the 1,024-token minimum cacheable block
+# (~6000 tokens at 4 chars/token).
+_BIG_SYSTEM = "You are an expert code reviewer. " + ("Review the diff carefully. " * 900)
+_SMALL_SYSTEM = "You are an expert code reviewer."
+
+_CACHEABLE_MODELS = [
+    "anthropic/claude-sonnet-4-20250514",
+    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "bedrock/us.amazon.nova-pro-v1:0",
+]
+
+_UNCACHEABLE_MODELS = [
+    "ollama/llama3",
+    "openai/gpt-4o",  # OpenAI caches automatically server-side — no marker
+    "openai/local-model",  # openai-compatible route
+    "azure/gpt-4o",
+    "openrouter/anthropic/claude-3.5-sonnet",
+    "vertex_ai/gemini-1.5-pro",
+    "zai/glm-4.6",
+]
+
+
+def _fake_response(content: str = "ok", **usage_extra: Any) -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, **usage_extra),
+    )
+
+
+def _messages(system: str = _BIG_SYSTEM) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "diff --git a/x b/x\n+dynamic content"},
+    ]
+
+
+def _sent_messages(model: str, *, prompt_cache: bool, system: str = _BIG_SYSTEM) -> list[Any]:
+    """Run one completion and return the messages litellm actually received."""
+    with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
+        provider = LiteLLMProvider(model=model, prompt_cache=prompt_cache)
+        provider.complete(_messages(system), model)
+    return mock_completion.call_args.kwargs["messages"]
+
+
+class TestCacheControlMarking:
+    @pytest.mark.parametrize("model", _CACHEABLE_MODELS)
+    def test_system_prompt_marked_cacheable_on_supported_models(self, model: str) -> None:
+        sent = _sent_messages(model, prompt_cache=True)
+        system = sent[0]
+        assert system["role"] == "system"
+        # Content becomes a single text block carrying the cache breakpoint.
+        assert isinstance(system["content"], list)
+        [block] = system["content"]
+        assert block["type"] == "text"
+        assert block["text"] == _BIG_SYSTEM
+        assert block["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.parametrize("model", _CACHEABLE_MODELS)
+    def test_dynamic_user_content_stays_outside_the_cached_region(self, model: str) -> None:
+        sent = _sent_messages(model, prompt_cache=True)
+        user = sent[1]
+        assert user["role"] == "user"
+        # The user message (diff + intent — volatile) is untouched: a plain
+        # string with no cache marker, so it never busts or joins the prefix.
+        assert isinstance(user["content"], str)
+
+    @pytest.mark.parametrize("model", _UNCACHEABLE_MODELS)
+    def test_request_unchanged_on_providers_without_cache_control(self, model: str) -> None:
+        sent = _sent_messages(model, prompt_cache=True)
+        assert sent == _messages()
+
+    def test_request_unchanged_when_prompt_cache_disabled(self) -> None:
+        sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=False)
+        assert sent == _messages()
+
+    def test_request_unchanged_below_minimum_cacheable_tokens(self) -> None:
+        """Anthropic silently ignores cache blocks under 1,024 tokens — sending
+        the marker would be a no-op, so the adapter doesn't rewrite the message."""
+        sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=True, system=_SMALL_SYSTEM)
+        assert sent == _messages(_SMALL_SYSTEM)
+
+    def test_request_unchanged_without_a_system_message(self) -> None:
+        messages = [{"role": "user", "content": "hi"}]
+        with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            provider.complete(list(messages), _CACHEABLE_MODELS[0])
+        assert mock_completion.call_args.kwargs["messages"] == messages
+
+    def test_capability_lookup_failure_is_a_safe_no_op(self) -> None:
+        """An unknown model (or a litellm map lookup error) must never break the
+        call — caching is an optimisation, so the request goes out unmarked."""
+        with patch(
+            "lgtmaybe.providers.litellm_provider.supports_prompt_caching",
+            side_effect=RuntimeError("boom"),
+        ):
+            sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=True)
+        assert sent == _messages()
+
+    def test_original_messages_list_is_not_mutated(self) -> None:
+        messages = _messages()
+        with patch("litellm.completion", return_value=_fake_response()):
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            provider.complete(messages, _CACHEABLE_MODELS[0])
+        assert messages == _messages()
+
+
+class TestCacheUsageMapping:
+    def test_cache_token_counts_mapped_from_usage(self) -> None:
+        response = _fake_response(
+            cache_read_input_tokens=1200,
+            cache_creation_input_tokens=345,
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            result = provider.complete(_messages(), _CACHEABLE_MODELS[0])
+        assert result.cache_read_tokens == 1200
+        assert result.cache_creation_tokens == 345
+
+    def test_cached_tokens_fall_back_to_prompt_tokens_details(self) -> None:
+        """OpenAI-style responses report cache reads under
+        usage.prompt_tokens_details.cached_tokens — map those too."""
+        response = _fake_response(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=800),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            result = provider.complete(_messages(), "openai/gpt-4o")
+        assert result.cache_read_tokens == 800
+        assert result.cache_creation_tokens == 0
+
+    def test_cache_token_counts_default_to_zero(self) -> None:
+        with patch("litellm.completion", return_value=_fake_response()):
+            provider = LiteLLMProvider()
+            result = provider.complete(_messages(), "ollama/llama3")
+        assert result.cache_read_tokens == 0
+        assert result.cache_creation_tokens == 0
+
+
+class TestFactoryThreading:
+    def test_factory_passes_prompt_cache_to_the_provider(self) -> None:
+        provider = build_provider(Provider.anthropic, "claude-sonnet-4", prompt_cache=True)
+        assert provider.prompt_cache is True
+
+    def test_factory_default_is_off_for_direct_construction(self) -> None:
+        provider = build_provider(Provider.anthropic, "claude-sonnet-4")
+        assert provider.prompt_cache is False
+
+    def test_prompt_cache_never_reaches_litellm_kwargs(self) -> None:
+        """`prompt_cache` steers the adapter; it must not leak into the
+        completion call as an (unknown) litellm parameter."""
+        provider = build_provider(Provider.anthropic, "claude-sonnet-4", prompt_cache=True)
+        assert "prompt_cache" not in provider.default_opts
+        with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
+            provider.complete(_messages(), "anthropic/claude-sonnet-4")
+        assert "prompt_cache" not in mock_completion.call_args.kwargs
+
+
+class TestProviderMatrix:
+    """Every provider either applies the marker or safely no-ops — never errors."""
+
+    @pytest.mark.parametrize("provider", list(Provider))
+    def test_prompt_cache_on_is_safe_for_every_provider(self, provider: Provider) -> None:
+        client = build_provider(
+            provider, "some-model", api_base="http://localhost:1234", prompt_cache=True
+        )
+        with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
+            result = client.complete(_messages(), "some-model")
+        assert result.text == "ok"
+        sent = mock_completion.call_args.kwargs["messages"]
+        # Whatever a provider does, the volatile user content is never marked.
+        assert isinstance(sent[-1]["content"], str)

--- a/tests/snapshots/ProviderResult.json
+++ b/tests/snapshots/ProviderResult.json
@@ -2,6 +2,16 @@
   "additionalProperties": false,
   "description": "The normalised return of one LLM completion, with token usage.",
   "properties": {
+    "cache_creation_tokens": {
+      "default": 0,
+      "title": "Cache Creation Tokens",
+      "type": "integer"
+    },
+    "cache_read_tokens": {
+      "default": 0,
+      "title": "Cache Read Tokens",
+      "type": "integer"
+    },
     "input_tokens": {
       "title": "Input Tokens",
       "type": "integer"

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -110,6 +110,20 @@
           "title": "Broad",
           "type": "boolean"
         },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
         "line": {
           "minimum": 1,
           "title": "Line",
@@ -245,6 +259,13 @@
     "max_input_tokens": {
       "default": 100000,
       "title": "Max Input Tokens",
+      "type": "integer"
+    },
+    "min_confidence": {
+      "default": 0,
+      "maximum": 10,
+      "minimum": 0,
+      "title": "Min Confidence",
       "type": "integer"
     },
     "min_severity": {

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -267,6 +267,11 @@
       "default": null,
       "title": "Num Ctx"
     },
+    "prompt_cache": {
+      "default": true,
+      "title": "Prompt Cache",
+      "type": "boolean"
+    },
     "provider": {
       "$ref": "#/$defs/Provider"
     },

--- a/tests/snapshots/ReviewFinding.json
+++ b/tests/snapshots/ReviewFinding.json
@@ -42,6 +42,20 @@
       "title": "Broad",
       "type": "boolean"
     },
+    "confidence": {
+      "anyOf": [
+        {
+          "maximum": 10,
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Confidence"
+    },
     "line": {
       "minimum": 1,
       "title": "Line",


### PR DESCRIPTION
# Phase 0 audit + performance/quality workstreams

This PR starts with the Phase 0 capability audit (below), then implements the surviving gaps in priority order as small, scoped commits. Note: this session can only push to one branch, so the "one PR per workstream" guidance is applied as one *commit series* per workstream here; each commit is independently revertable.

## Phase 0 audit

| Item | Capability | Verdict | Evidence |
|------|-----------|---------|----------|
| P1 | Prompt caching (`cache_control` / Bedrock `cachePoint`, `prompt_cache` toggle, cache metrics) | **ABSENT** → implemented here | No cache markers existed anywhere; `ProviderResult` had no cache fields. Prerequisites were already right: static per-lens system prompts (`engine/prompt.py`), volatile content in the user message (`engine/engine.py`) |
| P2 | Commit-scoped incremental review | **ABSENT** | Idempotency marker + per-finding fingerprints exist (`github/rest_gateway.py:31-37`) but no last-reviewed-SHA persistence, no `incremental` config, no `/review full` |
| P3 | Two-stage triage routing | **ABSENT** | Only `model` + `reflect_model` slots (`core/models.py`); no triage pass or risk ranking |
| P4a | Generated/binary deny-list | **PRESENT** (minor gaps) → gaps filled here | `is_reviewable` (`github/diff.py:193`) covered lockfiles, minified, vendored, snapshots, generated protobuf, binaries. Was missing a few newer lockfiles (`uv.lock`, `bun.lock(b)`, `deno.lock`, `flake.lock`) and sourcemaps |
| P4b | Token-budgeted batching + oversize handling | **PRESENT** | `batch_files` + RLM per-hunk walk (`engine/compress.py`) |
| P4c | Context expansion capped by budget | **PRESENT** | Budget-scaled before batching (`engine/engine.py`); padded patches re-counted by `batch_files` |
| P4d | Asymmetric / function-boundary context | **ABSENT** → asymmetric implemented here | `expand_hunks` padded symmetrically. Function/class-boundary expansion via ast-grep deliberately deferred (needs on-disk files; the asymmetric split is the cheap high-value piece) |
| F1 | Static-analysis fusion (ruff/bandit/semgrep) | **ABSENT** | No runner, no config block |
| F2 | Self-verification with confidence scoring | **PARTIAL** → numeric slice implemented here | Reflection already did grounded disproof: full-head-text grounding, adversarial drop-rules, cross-file `needs` deferral with bounded read-only retrieval + ast-grep symbol resolution, keep-all safe default. Only the numeric score + `min_confidence` threshold were missing |
| F3 | First-class `describe` | **PARTIAL** | `/describe` slash reply exists (`cli/slash.py`); no auto-run on PR open, no structured walkthrough, no idempotent description update |
| F4 | Review-effort / risk labels | **ABSENT** | No label logic |
| F5a | Lenses / path filters / severity floors / fingerprint ignores | **PARTIAL** → fixed here | All present **except `include_paths`/`exclude_paths`, which were declared on `ReviewConfig` and documented but enforced nowhere** — dead config, now wired into the engine |
| F5b | Post-processing rules + summary output template | **ABSENT** | Summary format hardcoded |

Where the audit overrides the task assumptions: P4 batching/budget-capping already existed, and F2's "attempt to disprove against the actual code" already existed via grounded retrieval — only the numeric-score slice was missing.

## Delivered in this PR

- [x] **Phase 0 audit** (table above)
- [x] **P1 — prompt caching** (`159c770`): `cache_control` on the static system prompt for anthropic + bedrock (Claude/Nova), feature-detected per model via litellm's capability map, 1,024-token minimum honoured, volatile content kept outside the cached region, byte-identical requests on all other providers. Cache read/creation token counts mapped into `ProviderResult` and logged. `prompt_cache` config (default on where supported), `--prompt-cache/--no-prompt-cache`, action input. Provider-matrix test proves safe no-op across all nine providers.
- [x] **P4 slices** (`94192d9`): asymmetric hunk context (full `context_lines` budget before each hunk, a quarter — floored at 1 — after, PR-Agent style) + deny-list additions (`uv.lock`, `bun.lock(b)`, `deno.lock`, `flake.lock`, `mix.lock`, `Package.resolved`, `gradle.lockfile`, JS/CSS sourcemaps).
- [x] **F5a — enforce `include_paths`/`exclude_paths`** (`2767711`): the documented allowlist/denylist globs now actually filter the reviewed files (exclude wins; `**/`-prefixed patterns also match at the repo root).
- [x] **F2 slice — confidence scoring** (`e122e13`): reflection verdicts now carry a 0–10 confidence score reached by trying to disprove the finding; `min_confidence` config + `--min-confidence` CLI flag (default 0 = no filtering, byte-for-byte current behaviour); score surfaced on findings in human/JSON output. Unscored or garbage scores can never drop a finding; the keep-all fallback is unchanged.
- [x] Docs: generated config reference + schema snapshots regenerated; `configure-lgtmaybe-yml.md`, `CLAUDE.md`, `ARCHITECTURE.md` updated.

Every existing behaviour is preserved: concurrency, reflection + symbol resolution, recursive hunk review, secret redaction, injection defence, idempotent comment updates, resolve-on-fix. All 872 tests green; ruff + mypy clean.

## Follow-ups (separate PRs, per the one-workstream-per-PR guidance)

- **P2** — commit-scoped incremental review (last-reviewed-SHA marker in the summary comment, force-push fallback, `/review full`)
- **P3** — two-stage triage routing (`triage_model`, risk ranking with a security-path floor)
- **F1** — static-analysis fusion (ruff/bandit/semgrep as sandboxed optional extras feeding the lens prompts)
- **F3** — promote `/describe` to a config-gated auto-describe with structured walkthrough
- **F4** — review-effort/risk labels · **F5b** — declarative finding post-processing + summary template
- **P4 remainder** — expand context to the enclosing function/class boundary where ast-grep can cheaply find it

## Explicitly deferred (F6 — considered, not built)

- **Repo-graph / RAG context engine** — too heavy for a CI-run tool; the bounded ast-grep symbol-resolution path already covers the highest-value cross-file lookups.
- **Changelog generation** — release-please already owns the changelog in this ecosystem; out of the reviewer's lane.
- **Add-docs generation** — the documentation lens flags gaps; generating docs is an authoring feature, not a review feature.
- **Similar-issue lookup** — needs an index/search infrastructure that contradicts the zero-infrastructure design.
- **Jira/Linear ticket compliance** — vendor-specific integration against the provider-agnostic, no-new-heavy-deps constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a