### PR TITLE
feat(github): commit-scoped incremental review (P2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,7 +226,11 @@ silent passes.
 **Cost** — on providers with an explicit prompt-cache breakpoint (anthropic,
 bedrock Claude/Nova) the static system prompt is marked `cache_control` so the
 per-lens fan-out re-reads it at the cached-input discount (`prompt_cache`,
-default on; feature-detected, byte-identical requests elsewhere).
+default on; feature-detected, byte-identical requests elsewhere). On a
+`synchronize` push the review is commit-scoped **incremental** by default:
+only the diff since the last completed review (a hidden watermark in the
+summary comment) is re-reviewed, falling back to a full review on a
+force-push or first run (`incremental`; `/review full` on demand).
 
 **Distribution** — `pip install lgtmaybe` (PyPI CLI) and the composite GitHub
 Action (keyless OIDC/WIF cloud auth, then runs the GHCR image). Release is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ so the provider list is never a cage.
   top adds retries / fallback.
 - **License:** MIT (already in `LICENSE`).
 - **Posting:** REST review API — batched inline comments + one summary.
-  Idempotent updates via a hidden marker comment. Each inline comment also carries
+  Idempotent updates via a hidden marker comment (which also carries the
+  last-reviewed-SHA watermark driving incremental review). Each inline comment also carries
   a hidden per-finding fingerprint (`finding_fingerprint(path, title)`); on a
   re-run, conversations whose finding is gone **and** whose thread GitHub marks
   outdated are replied to and resolved (`ReviewConfig.resolve_fixed`, default on).
@@ -185,6 +186,20 @@ pattern, event bus, plugin framework.
      `ReviewConfig.recursive` (default **on**; CLI `--recursive/--no-recursive`,
      Action input `recursive`); the on-demand A/B benchmark `python -m evals.rlm`
      measures recall + token cost of the walk vs sending whole against a live model.
+   - **Incremental review (commit-scoped):** on a re-run, `run_review` reads a
+     hidden watermark (`<!-- lgtmaybe-reviewed:<head_sha> -->`, stamped into the
+     summary comment by `mark_reviewed` on the success path only — a failure
+     never moves it) and reviews only the compare-API diff of the commits since
+     (`rest_gateway.compare_diff`, read-only). Falls back to a full review on
+     no-watermark / force-push (compare not "ahead") / same head / API failure.
+     New findings post as individual review comments (fingerprint-deduped —
+     the review-update endpoint can't add inline comments); resolve-on-fix is
+     scoped to the increment's files (`set_incremental_scope`) so an
+     un-re-reviewed finding is never spuriously resolved; LEFT-side findings
+     are dropped (their line numbers are relative to the last-reviewed head,
+     not the PR base). `ReviewConfig.incremental` (default None = auto: on for
+     the Action's `synchronize` event, full elsewhere; Action input
+     `incremental`); `/review full` forces a full re-review.
    - **Error surfacing:** any failure posts a short "review failed" comment and
      the CLI exits non-zero (`ClickException`) — never fails silently.
    - **Per-category fan-out:** the system prompt is composed per `ReviewCategory`

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: "Cache the static system prompt across the per-lens calls on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
     required: false
     default: ""
+  incremental:
+    description: "Commit-scoped incremental review: on a synchronize push, review only the diff of the commits added since the last completed review instead of the whole PR. Auto by default (on for synchronize, full review everywhere else); set to true/false to force. Falls back to a full review after a force-push/rebase or when no previous review exists. `/review full` forces a full re-review on demand."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -162,6 +166,7 @@ runs:
         INPUT_STRUCTURED_OUTPUT: ${{ inputs.structured_output }}
         INPUT_SYMBOL_RESOLUTION: ${{ inputs.symbol_resolution }}
         INPUT_PROMPT_CACHE: ${{ inputs.prompt_cache }}
+        INPUT_INCREMENTAL: ${{ inputs.incremental }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -175,7 +180,7 @@ runs:
           -e INPUT_TIMEOUT -e INPUT_TEMPERATURE \
           -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS -e INPUT_RESOLVE_FIXED \
           -e INPUT_RECURSIVE -e INPUT_STRUCTURED_OUTPUT -e INPUT_SYMBOL_RESOLUTION \
-          -e INPUT_PROMPT_CACHE \
+          -e INPUT_PROMPT_CACHE -e INPUT_INCREMENTAL \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -25,6 +25,7 @@ provides defaults for all runs.
   - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [min_confidence](#min_confidence)
+  - [incremental](#incremental)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -265,6 +266,30 @@ min_confidence: 5   # drop findings the auditor scores 0-4
 
 Default: `0` (no numeric filtering — reflection prunes only via its keep/drop
 verdicts, as before the score existed).
+
+### incremental
+
+Commit-scoped incremental review, for the GitHub posting path. On a re-run
+lgtmaybe reads a hidden watermark (the head SHA its last completed review
+covered) from its own summary comment and reviews **only the diff of the
+commits pushed since**, instead of the whole PR — faster, cheaper, and no
+re-noise on code that was already reviewed. New findings post as inline
+comments; findings on files outside the increment stay open, and are only
+auto-resolved by a run that actually re-reviewed their file.
+
+It always degrades to a **full review** when there is no watermark yet (first
+review), after a force-push/rebase (the increment would be meaningless), or if
+the compare fails. A failed review never moves the watermark, so no commit is
+ever silently skipped. Comment `/review full` on the PR to force a full
+re-review on demand.
+
+```yaml
+incremental: false   # every run reviews the whole PR
+```
+
+Default: auto — incremental on a `synchronize` push (new commits on an
+already-reviewed PR), full review everywhere else (open/reopen, slash
+commands, and the local CLI, which never uses it).
 
 ### resolve_fixed
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -36,7 +36,11 @@ All lgtmaybe workflows use the `pull_request_target` trigger, not
 
 The action derives the PR from the triggering event, so there is no `pr-url`
 input to set. On an `issue_comment` event it routes the slash command
-(`/review`, `/ask`, `/describe`, `/improve`) to the same engine.
+(`/review`, `/ask`, `/describe`, `/improve`) to the same engine. On a
+`synchronize` push the review is **incremental** by default — only the commits
+added since the last completed review are re-reviewed, and earlier findings
+stay open until fixed; comment `/review full` for a full re-review on demand,
+or pin the behaviour with the `incremental` input / config key.
 
 > **Note on cost.** With ollama the model runs on your own hardware, so reviews
 > are free. On a hosted provider each run uses tokens you pay for, so it's worth

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -316,7 +316,11 @@ All lgtmaybe workflows use the `pull_request_target` trigger, not
 
 The action derives the PR from the triggering event, so there is no `pr-url`
 input to set. On an `issue_comment` event it routes the slash command
-(`/review`, `/ask`, `/describe`, `/improve`) to the same engine.
+(`/review`, `/ask`, `/describe`, `/improve`) to the same engine. On a
+`synchronize` push the review is **incremental** by default — only the commits
+added since the last completed review are re-reviewed, and earlier findings
+stay open until fixed; comment `/review full` for a full re-review on demand,
+or pin the behaviour with the `incremental` input / config key.
 
 > **Note on cost.** With ollama the model runs on your own hardware, so reviews
 > are free. On a hosted provider each run uses tokens you pay for, so it's worth
@@ -1714,6 +1718,7 @@ provides defaults for all runs.
   - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [min_confidence](#min_confidence)
+  - [incremental](#incremental)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -1954,6 +1959,30 @@ min_confidence: 5   # drop findings the auditor scores 0-4
 
 Default: `0` (no numeric filtering — reflection prunes only via its keep/drop
 verdicts, as before the score existed).
+
+### incremental
+
+Commit-scoped incremental review, for the GitHub posting path. On a re-run
+lgtmaybe reads a hidden watermark (the head SHA its last completed review
+covered) from its own summary comment and reviews **only the diff of the
+commits pushed since**, instead of the whole PR — faster, cheaper, and no
+re-noise on code that was already reviewed. New findings post as inline
+comments; findings on files outside the increment stay open, and are only
+auto-resolved by a run that actually re-reviewed their file.
+
+It always degrades to a **full review** when there is no watermark yet (first
+review), after a force-push/rebase (the increment would be meaningless), or if
+the compare fails. A failed review never moves the watermark, so no commit is
+ever silently skipped. Comment `/review full` on the PR to force a full
+re-review on demand.
+
+```yaml
+incremental: false   # every run reviews the whole PR
+```
+
+Default: auto — incremental on a `synchronize` push (new commits on an
+already-reviewed PR), full review everywhere else (open/reopen, slash
+commands, and the local CLI, which never uses it).
 
 ### resolve_fixed
 
@@ -2402,6 +2431,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
+| `incremental` | boolean / null | No | `null` | Incremental |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
@@ -2752,6 +2782,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Include Paths",
       "type": "array"
+    },
+    "incremental": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Incremental"
     },
     "max_files": {
       "default": 50,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,6 +23,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
+| `incremental` | boolean / null | No | `null` | Incremental |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
@@ -373,6 +374,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Include Paths",
       "type": "array"
+    },
+    "incremental": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Incremental"
     },
     "max_files": {
       "default": 50,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -23,7 +23,9 @@ import click
 
 from lgtmaybe.cli.render import render_findings
 from lgtmaybe.cli.runtime import RuntimeOptions
-from lgtmaybe.core.models import Provider, ReviewConfig, ReviewFinding
+from lgtmaybe.core.diffparse import FILE_HEADER_RE
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import PRContext, Provider, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
 from lgtmaybe.engine import FileFetcher, LLMReviewEngine, SymbolResolver, build_symbol_resolver
 from lgtmaybe.github import RestGitHubGateway
@@ -31,7 +33,22 @@ from lgtmaybe.local import local_file_reader, local_pr_context
 from lgtmaybe.providers.credentials import resolve_credentials
 from lgtmaybe.providers.factory import build_provider
 
+_log = get_logger(__name__)
+
 _PR_URL_RE = re.compile(r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)")
+
+
+def resolve_auto_incremental(cfg: ReviewConfig, *, event_action: str) -> ReviewConfig:
+    """Resolve ``incremental=None`` (auto) against the triggering event's action.
+
+    Auto means: incremental on a ``synchronize`` push (the PR already had a
+    review to be incremental against, and only new commits landed), full
+    everywhere else (opened/reopened/manual). An explicit True/False from
+    config or the Action input always wins.
+    """
+    if cfg.incremental is not None:
+        return cfg
+    return cfg.model_copy(update={"incremental": event_action == "synchronize"})
 
 
 def parse_pr_url(pr_url: str) -> tuple[str, int]:
@@ -151,17 +168,87 @@ def run_review(
 
     Fetches PR context, runs the engine, and optionally posts the review.
     Returns (findings, summary) in all cases so callers can inspect output.
+
+    With ``cfg.incremental`` on and a gateway that supports it, only the diff
+    of the commits pushed since the last completed review is reviewed; every
+    degraded case (first review, force-push, compare failure, a gateway
+    without the adapter methods) falls back to the full review.
     """
     ctx = github.get_pr_context()
-    findings, summary = engine.review(ctx, cfg)
+    review_ctx, incremental_since = _incremental_context(github, ctx, cfg)
+    findings, summary = engine.review(review_ctx, cfg)
+
+    if incremental_since is not None:
+        # LEFT-side line numbers in an incremental diff are relative to the
+        # last-reviewed head, not the PR base — posting them would mis-anchor,
+        # so a (rare) deleted-line finding is dropped rather than mis-posted.
+        dropped = [f for f in findings if f.side != "RIGHT"]
+        if dropped:
+            _log.info(
+                "dropped LEFT-side findings in incremental mode",
+                extra={"count": len(dropped)},
+            )
+        findings = [f for f in findings if f.side == "RIGHT"]
+        summary += (
+            f"\n\n_Incremental review of the changes since {incremental_since[:7]} — "
+            "earlier findings stay open until fixed._"
+        )
 
     if not dry_run:
-        # Pass the diff we already fetched so post_review doesn't re-fetch the
-        # whole PR context (diff + file list + every file's contents) just to
-        # rebuild the commentable-line index.
+        # Record the watermark: this run completed a review of the current
+        # head, so the NEXT run may review only what lands after it. Never set
+        # on the failure path (a failure notice posts via post_review without
+        # this) — an unreviewed commit must not be skipped.
+        mark_reviewed = getattr(github, "mark_reviewed", None)
+        if mark_reviewed is not None:
+            mark_reviewed(ctx.head_sha)
+        if incremental_since is not None:
+            set_scope = getattr(github, "set_incremental_scope", None)
+            if set_scope is not None:
+                # Resolve-on-fix may only touch threads on files this run
+                # actually re-reviewed — absence elsewhere proves nothing.
+                set_scope(_diff_paths(review_ctx.diff))
+        # Pass the FULL PR diff (already fetched) so the commentable-line
+        # index is built from the diff the comments will anchor to — the
+        # incremental diff's context lines aren't necessarily in the PR diff.
         github.post_review(findings, summary, diff=ctx.diff)
 
     return findings, summary
+
+
+def _incremental_context(
+    github: GitHubGateway, ctx: PRContext, cfg: ReviewConfig
+) -> tuple[PRContext, str | None]:
+    """The context to review: ``(incremental ctx, last-reviewed sha)`` or ``(ctx, None)``.
+
+    Incremental only when ``cfg.incremental`` is truthy (None = auto resolves
+    upstream, and unresolved auto means full), the gateway has the adapter
+    methods (``last_reviewed_sha`` / ``compare_diff`` — fakes and the frozen
+    port don't), a watermark exists, head moved since, and the compare yields
+    a usable increment. Everything else returns the full context untouched.
+    """
+    if not cfg.incremental:
+        return ctx, None
+    last_reviewed_sha = getattr(github, "last_reviewed_sha", None)
+    compare_diff = getattr(github, "compare_diff", None)
+    if last_reviewed_sha is None or compare_diff is None:
+        return ctx, None
+    last_sha = last_reviewed_sha()
+    if not last_sha or last_sha == ctx.head_sha:
+        return ctx, None
+    increment = compare_diff(last_sha, ctx.head_sha)
+    if not increment or not increment.strip():
+        return ctx, None
+    _log.info(
+        "incremental review",
+        extra={"since": last_sha, "head": ctx.head_sha},
+    )
+    return ctx.model_copy(update={"diff": increment}), last_sha
+
+
+def _diff_paths(diff: str) -> set[str]:
+    """The file paths named by a unified diff's ``diff --git`` headers."""
+    return set(FILE_HEADER_RE.findall(diff))
 
 
 def execute_local_review(
@@ -316,6 +403,7 @@ def action_inputs() -> dict[str, str | None]:
         "structured_output": get("STRUCTURED_OUTPUT"),
         "symbol_resolution": get("SYMBOL_RESOLUTION"),
         "prompt_cache": get("PROMPT_CACHE"),
+        "incremental": get("INCREMENTAL"),
         "config_path": get("CONFIG_PATH"),
     }
 
@@ -348,5 +436,6 @@ __all__ = [
     "parse_pr_url",
     "pr_url_from_event",
     "render_findings",
+    "resolve_auto_incremental",
     "run_review",
 ]

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -24,6 +24,7 @@ from lgtmaybe.cli import (
     execute_review,
     main,
     pr_url_from_event,
+    resolve_auto_incremental,
 )
 from lgtmaybe.config import store
 from lgtmaybe.config.loader import load_config
@@ -301,6 +302,7 @@ def action() -> None:
         structured_output=inputs["structured_output"],
         symbol_resolution=inputs["symbol_resolution"],
         prompt_cache=inputs["prompt_cache"],
+        incremental=inputs["incremental"],
     )
     runtime = RuntimeOptions(
         api_key=inputs["api_key"],
@@ -315,6 +317,9 @@ def action() -> None:
         execute_comment(event, cfg, runtime)
         return
 
+    # incremental=None (auto): review only the new commits on a synchronize
+    # push, do a full review on open/reopen. Explicit config/input wins.
+    cfg = resolve_auto_incremental(cfg, event_action=str(event.get("action") or ""))
     runtime = replace(runtime, pr_url=pr_url_from_event(event))
     execute_review(cfg, runtime, dry_run=False)
 

--- a/src/lgtmaybe/cli/slash.py
+++ b/src/lgtmaybe/cli/slash.py
@@ -73,9 +73,17 @@ def dispatch(
         return
 
     if parsed.name in (SlashCommand.review, SlashCommand.improve):
-        ctx = github.get_pr_context()
-        findings, summary = engine.review(ctx, cfg)
-        github.post_review(findings, summary, diff=ctx.diff)
+        # `/review full` forces a full re-review even when config enables
+        # incremental mode; a bare `/review` honours the configured mode.
+        if parsed.arg.strip().lower() == "full":
+            cfg = cfg.model_copy(update={"incremental": False})
+        # Route through the shared pipeline so a slash-triggered review gets
+        # the same incremental handling and reviewed-watermark stamping as an
+        # event-triggered one. Imported lazily — lgtmaybe.cli imports this
+        # module's callers, so a module-level import would be circular.
+        from lgtmaybe.cli import run_review
+
+        run_review(github=github, engine=engine, cfg=cfg, dry_run=False)
         return
 
     if parsed.name is SlashCommand.ask:

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -327,6 +327,17 @@ class ReviewConfig(_Strict):
     # reflection and posting. Set it in .lgtmaybe.yml; an inline `# lgtmaybe: ignore`
     # comment on (or just above) a flagged line suppresses that finding too.
     ignore_fingerprints: list[str] = Field(default_factory=list)
+    # Commit-scoped incremental review: on a re-run, review only the diff of
+    # the commits pushed since the last completed review (read back from a
+    # hidden watermark in the summary comment) instead of the whole PR.
+    # None means auto: on when the GitHub Action is triggered by a synchronize
+    # push, off everywhere else (a from-scratch review is always full). Falls
+    # back to a full review when there is no watermark, the branch was
+    # force-pushed/rebased, or the compare fails. Findings on files outside
+    # the increment stay open — they are only resolved when a run that
+    # re-reviewed their file no longer produces them. `/review full` forces a
+    # full re-review on demand.
+    incremental: bool | None = None
     # Auto-resolve a previously-posted review conversation once its finding is
     # fixed: on a re-run, when a finding lgtmaybe flagged is no longer produced
     # and GitHub marks the thread outdated (the code under it changed), lgtmaybe

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -37,6 +37,11 @@ _GRAPHQL_URL = "https://api.github.com/graphql"
 # group is the finding fingerprint.
 _FINDING_MARKER = re.compile(r"<!-- lgtmaybe-finding:([0-9a-f]+) -->")
 
+# Hidden marker stamped into the summary review body recording the head SHA
+# this review covered, so the next run can review only the commits pushed
+# since (commit-scoped incremental review). The capture group is the SHA.
+_REVIEWED_MARKER = re.compile(r"<!-- lgtmaybe-reviewed:([0-9a-f]{7,40}) -->")
+
 
 def finding_fingerprint(path: str, title: str) -> str:
     """Stable short id for a finding's identity (its file and what it flags).
@@ -168,6 +173,18 @@ class RestGitHubGateway(GitHubGateway):
         # and only if a symbol deferral actually needs it). _done guards the one-shot.
         self._base_root: Path | None = None
         self._base_root_done = False
+        # Incremental-review scope: when set (via set_incremental_scope), only
+        # this run's reviewed paths. Resolve-on-fix then skips threads on other
+        # paths — a finding absent merely because its file wasn't re-reviewed
+        # this run must never be spuriously resolved. None = full review.
+        self._incremental_paths: set[str] | None = None
+        # Head SHA this run actually reviewed (set via mark_reviewed by the
+        # orchestrator on the success path only). Drives the reviewed-SHA stamp
+        # and re-run inline-comment posting. Deliberately NOT inferred inside
+        # post_review: a failure notice posts through the same method and must
+        # never record "reviewed up to head" — the next run would then skip
+        # commits nobody reviewed.
+        self._reviewed_sha: str | None = None
 
     # ------------------------------------------------------------------
     # GitHubGateway implementation
@@ -248,6 +265,14 @@ class RestGitHubGateway(GitHubGateway):
         comments, demoted, broad = self._partition_findings(findings, commentable)
 
         body = f"{summary}{_render_demoted(demoted)}{_render_broad(broad)}\n\n{self._marker}"
+        if self._reviewed_sha:
+            # Record how far this review got, so the next run can review only
+            # the commits pushed since (incremental review). Only stamped when
+            # the orchestrator marked this run as a completed review — a
+            # failure notice must not move the incremental watermark (and by
+            # replacing the body it clears any stale stamp, so the next run
+            # safely falls back to a full review).
+            body += f"\n<!-- lgtmaybe-reviewed:{self._reviewed_sha} -->"
         existing_id = self._find_existing_review()
 
         reviews_url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
@@ -263,6 +288,11 @@ class RestGitHubGateway(GitHubGateway):
                 timeout=_TIMEOUT,
             )
             resp.raise_for_status()
+            # The review-update endpoint can't add inline comments, so post the
+            # NEW findings (fingerprints not already on the PR) as individual
+            # review comments — otherwise a re-run's fresh findings would only
+            # ever appear in the summary body, silently losing their line.
+            self._post_new_inline_comments(comments, self._reviewed_sha)
             # A re-run: any of our prior conversations whose finding is now gone
             # (and whose code changed) is fixed — collapse it. Best-effort, so a
             # GraphQL hiccup never fails an otherwise-successful review.
@@ -340,6 +370,120 @@ class RestGitHubGateway(GitHubGateway):
             timeout=_TIMEOUT,
         )
         resp.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Incremental review (adapter-only methods, beyond the frozen port)
+    # ------------------------------------------------------------------
+
+    def last_reviewed_sha(self) -> str | None:
+        """The head SHA covered by our previous review, or None.
+
+        Read back from the hidden ``<!-- lgtmaybe-reviewed:… -->`` marker that
+        ``post_review`` stamps into the summary body. None when there is no
+        prior review, the review predates the marker, or the lookup fails —
+        the caller then runs a full review.
+        """
+        try:
+            entry = self._find_existing_review_entry()
+        except httpx.HTTPError:
+            return None
+        if entry is None:
+            return None
+        _review_id, body = entry
+        match = _REVIEWED_MARKER.search(body)
+        return match.group(1) if match else None
+
+    def compare_diff(self, base_sha: str, head_sha: str) -> str | None:
+        """Unified diff of the commits between *base_sha* and *head_sha*, or None.
+
+        Uses the compare API (read-only — never a checkout). Returns the diff
+        only when head is strictly **ahead** of the last-reviewed SHA (a normal
+        push). A force-push/rebase (``diverged``/``behind``), an ``identical``
+        compare, and any API failure (e.g. a GC'd SHA 404ing after a
+        force-push) all return None — the caller falls back to a full review
+        rather than trusting a meaningless increment.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/compare/{base_sha}...{head_sha}"
+        try:
+            status = self._get_json(url).get("status")
+            if status != "ahead":
+                _log.info(
+                    "incremental compare not usable — falling back to full review",
+                    extra={"status": status},
+                )
+                return None
+            resp = self._client.get(
+                url,
+                headers={**self._headers, "Accept": "application/vnd.github.v3.diff"},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            _log.info("incremental compare failed — falling back to full review: %s", exc)
+            return None
+        return resp.text
+
+    def set_incremental_scope(self, paths: set[str] | None) -> None:
+        """Restrict resolve-on-fix to threads on *paths* (None = no restriction).
+
+        Set by the incremental-review path with the files actually re-reviewed
+        this run: a finding on any other file is absent from this run's
+        findings only because its hunks weren't in the increment, so its
+        conversation must stay open rather than be spuriously resolved.
+        """
+        self._incremental_paths = paths
+
+    def mark_reviewed(self, head_sha: str) -> None:
+        """Declare that this run is a completed review of *head_sha*.
+
+        Called by the orchestrator on the success path, just before
+        ``post_review``. Enables the reviewed-SHA stamp (the incremental
+        watermark) and re-run inline-comment posting. Never called for a
+        failure notice — a failed run must not move the watermark.
+        """
+        self._reviewed_sha = head_sha
+
+    def _post_new_inline_comments(
+        self, comments: list[dict[str, Any]], head_sha: str | None
+    ) -> None:
+        """Post the inline comments whose finding isn't already on the PR.
+
+        The review-update endpoint only replaces the body, so on a re-run new
+        findings are posted as individual review comments (anchored to
+        *head_sha*). Each comment body already carries its hidden fingerprint;
+        comments whose fingerprint is already present on the PR are skipped, so
+        a re-run never duplicates an open conversation. Best-effort as a whole
+        — without a head SHA there is nothing to anchor to, so nothing posts.
+        """
+        if not comments or head_sha is None:
+            return
+        existing = self._existing_finding_fingerprints()
+        url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/comments"
+        for comment in comments:
+            match = _FINDING_MARKER.search(comment.get("body", ""))
+            if match is not None and match.group(1) in existing:
+                continue
+            resp = self._client.post(
+                url,
+                headers={**self._headers, "Accept": "application/vnd.github+json"},
+                json={**comment, "commit_id": head_sha},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+
+    def _existing_finding_fingerprints(self) -> set[str]:
+        """Fingerprints of every lgtmaybe finding already posted inline on the PR."""
+        url = (
+            f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}"
+            "/comments?per_page=100"
+        )
+        fingerprints: set[str] = set()
+        for resp in self._paginate(url):
+            for item in resp.json():
+                match = _FINDING_MARKER.search(item.get("body", "") or "")
+                if match is not None:
+                    fingerprints.add(match.group(1))
+        return fingerprints
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -422,7 +566,12 @@ class RestGitHubGateway(GitHubGateway):
             next_url = self._next_link(resp)
 
     def _find_existing_review(self) -> int | None:
-        """Return the ID of the first review whose body contains the marker, or None.
+        """Return the ID of the first review whose body contains the marker, or None."""
+        entry = self._find_existing_review_entry()
+        return entry[0] if entry is not None else None
+
+    def _find_existing_review_entry(self) -> tuple[int, str] | None:
+        """Return ``(id, body)`` of the first review carrying our marker, or None.
 
         Follows Link rel=next pagination — a busy PR can hold more than one page
         of reviews, and missing the marker there would duplicate the review
@@ -434,7 +583,7 @@ class RestGitHubGateway(GitHubGateway):
                 body: str = review.get("body", "") or ""
                 if self._marker in body:
                     review_id: int = review["id"]
-                    return review_id
+                    return review_id, body
         return None
 
     # ------------------------------------------------------------------
@@ -471,6 +620,7 @@ class RestGitHubGateway(GitHubGateway):
                   id
                   isResolved
                   isOutdated
+                  path
                   comments(first:1){ nodes{ body } }
                 }
               }
@@ -491,6 +641,13 @@ class RestGitHubGateway(GitHubGateway):
                 if node.get("isResolved"):
                     continue
                 if not node.get("isOutdated"):
+                    continue
+                if (
+                    self._incremental_paths is not None
+                    and node.get("path") not in self._incremental_paths
+                ):
+                    # Incremental run: this file wasn't re-reviewed, so its
+                    # finding's absence is no evidence it was fixed.
                     continue
                 comments = node.get("comments", {}).get("nodes", [])
                 first_body = comments[0].get("body", "") if comments else ""

--- a/tests/cli/test_incremental_review.py
+++ b/tests/cli/test_incremental_review.py
@@ -1,0 +1,216 @@
+"""Orchestration of commit-scoped incremental review (P2) in run_review.
+
+With ``cfg.incremental`` on and a gateway that can supply the last-reviewed
+SHA and the compare diff, ``run_review`` reviews only the increment and posts
+against the full PR diff. Every degraded case — no marker (first review),
+force-push/rebase (compare returns None), same head, a gateway without the
+adapter methods — falls back to the full review, byte-for-byte the old
+behaviour.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.cli import resolve_auto_incremental, run_review
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ReviewConfig,
+    ReviewFinding,
+    Severity,
+)
+from lgtmaybe.core.ports import ReviewEngine
+from tests.fakes import FakeGitHub
+
+FULL_DIFF = (
+    "diff --git a/src/app.py b/src/app.py\n@@ -1 +1,2 @@\n old\n+new\n"
+    "diff --git a/src/other.py b/src/other.py\n@@ -1 +1,2 @@\n old\n+other\n"
+)
+INC_DIFF = "diff --git a/src/app.py b/src/app.py\n@@ -1,2 +1,3 @@\n old\n new\n+newer\n"
+
+CTX = PRContext(
+    diff=FULL_DIFF,
+    changed_files=["src/app.py", "src/other.py"],
+    base_sha="base0000",
+    head_sha="head2222",
+    repo="org/repo",
+    pr_number=5,
+)
+
+
+def _cfg(**overrides: object) -> ReviewConfig:
+    return ReviewConfig(provider=Provider.ollama, model="llama3", **overrides)  # type: ignore[arg-type]
+
+
+class RecordingEngine(ReviewEngine):
+    """Returns canned findings; records the ctx it was asked to review."""
+
+    def __init__(self, findings: list[ReviewFinding] | None = None) -> None:
+        self.findings = findings or []
+        self.reviewed_ctxs: list[PRContext] = []
+
+    def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
+        self.reviewed_ctxs.append(ctx)
+        return list(self.findings), "1 finding · summary"
+
+
+class IncrementalFakeGitHub(FakeGitHub):
+    """FakeGitHub with the incremental adapter methods, recording calls."""
+
+    def __init__(
+        self,
+        ctx: PRContext | None = None,
+        *,
+        last_sha: str | None = None,
+        compare_result: str | None = None,
+    ) -> None:
+        super().__init__(ctx)
+        self._last_sha = last_sha
+        self._compare_result = compare_result
+        self.compare_calls: list[tuple[str, str]] = []
+        self.marked_reviewed: list[str] = []
+        self.scopes: list[set[str] | None] = []
+        self.last_reviewed_calls = 0
+
+    def last_reviewed_sha(self) -> str | None:
+        self.last_reviewed_calls += 1
+        return self._last_sha
+
+    def compare_diff(self, base_sha: str, head_sha: str) -> str | None:
+        self.compare_calls.append((base_sha, head_sha))
+        return self._compare_result
+
+    def mark_reviewed(self, head_sha: str) -> None:
+        self.marked_reviewed.append(head_sha)
+
+    def set_incremental_scope(self, paths: set[str] | None) -> None:
+        self.scopes.append(paths)
+
+
+def test_incremental_reviews_only_the_increment() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha="head1111", compare_result=INC_DIFF)
+    engine = RecordingEngine()
+
+    _findings, summary = run_review(
+        github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False
+    )
+
+    # The engine saw only the increment; the post anchored against the full diff.
+    assert engine.reviewed_ctxs[0].diff == INC_DIFF
+    assert github.posted_diffs == [FULL_DIFF]
+    assert "head111" in summary  # names the last-reviewed SHA (short form)
+    # Resolve-on-fix restricted to the files actually re-reviewed this run.
+    assert github.scopes == [{"src/app.py"}]
+    assert github.marked_reviewed == ["head2222"]
+
+
+def test_no_marker_falls_back_to_full_review() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha=None)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False)
+
+    assert engine.reviewed_ctxs[0].diff == FULL_DIFF
+    assert github.compare_calls == []
+    assert github.scopes == []  # full review: resolve-on-fix unrestricted
+
+
+def test_force_push_falls_back_to_full_review() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha="head1111", compare_result=None)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False)
+
+    assert engine.reviewed_ctxs[0].diff == FULL_DIFF
+    assert github.compare_calls == [("head1111", "head2222")]
+
+
+def test_same_head_falls_back_to_full_review_without_compare() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha="head2222", compare_result=INC_DIFF)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False)
+
+    assert engine.reviewed_ctxs[0].diff == FULL_DIFF
+    assert github.compare_calls == []
+
+
+def test_incremental_off_never_queries_the_marker() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha="head1111", compare_result=INC_DIFF)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(), dry_run=False)  # default: auto/off
+
+    assert engine.reviewed_ctxs[0].diff == FULL_DIFF
+    assert github.last_reviewed_calls == 0
+
+
+def test_gateway_without_incremental_methods_reviews_full() -> None:
+    github = FakeGitHub(CTX)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False)
+
+    assert engine.reviewed_ctxs[0].diff == FULL_DIFF
+
+
+def test_left_side_findings_dropped_in_incremental_mode() -> None:
+    """LEFT-side line numbers from an incremental diff are relative to the
+    last-reviewed head, not the PR base — posting them would mis-anchor."""
+    left = ReviewFinding(
+        path="src/app.py", line=1, side="LEFT", severity=Severity.high, title="l", body="b"
+    )
+    right = ReviewFinding(
+        path="src/app.py", line=3, side="RIGHT", severity=Severity.high, title="r", body="b"
+    )
+    github = IncrementalFakeGitHub(CTX, last_sha="head1111", compare_result=INC_DIFF)
+    engine = RecordingEngine(findings=[left, right])
+
+    findings, _summary = run_review(
+        github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False
+    )
+
+    assert [f.side for f in findings] == ["RIGHT"]
+
+
+def test_full_review_still_marks_the_watermark() -> None:
+    """Even a full review records the reviewed head SHA, so the NEXT run can be
+    incremental."""
+    github = IncrementalFakeGitHub(CTX, last_sha=None)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=False)
+
+    assert github.marked_reviewed == ["head2222"]
+
+
+def test_dry_run_never_marks_or_scopes() -> None:
+    github = IncrementalFakeGitHub(CTX, last_sha="head1111", compare_result=INC_DIFF)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(incremental=True), dry_run=True)
+
+    assert github.marked_reviewed == []
+    assert github.posted == []
+
+
+# ---------------------------------------------------------------------------
+# auto-resolution: incremental=None means "on for a synchronize push"
+# ---------------------------------------------------------------------------
+
+
+def test_auto_resolves_on_for_synchronize_event() -> None:
+    cfg = _cfg()  # incremental defaults to None (auto)
+    resolved = resolve_auto_incremental(cfg, event_action="synchronize")
+    assert resolved.incremental is True
+
+
+def test_auto_resolves_off_for_opened_event() -> None:
+    resolved = resolve_auto_incremental(_cfg(), event_action="opened")
+    assert resolved.incremental is False
+
+
+def test_explicit_config_wins_over_auto() -> None:
+    on = resolve_auto_incremental(_cfg(incremental=True), event_action="opened")
+    assert on.incremental is True
+    off = resolve_auto_incremental(_cfg(incremental=False), event_action="synchronize")
+    assert off.incremental is False

--- a/tests/cli/test_slash.py
+++ b/tests/cli/test_slash.py
@@ -210,3 +210,66 @@ class TestCommentCommand:
         assert result.exit_code == 0, result.output
         assert github.posted == []
         assert github.comments == []
+
+
+class TestReviewFull:
+    def test_review_full_forces_a_full_review(self):
+        """`/review full` overrides `incremental: true` config — the engine
+        must see the whole PR diff, not an increment."""
+        from lgtmaybe.core.models import PRContext
+        from tests.cli.test_incremental_review import (
+            INC_DIFF,
+            IncrementalFakeGitHub,
+            RecordingEngine,
+        )
+
+        ctx = PRContext(
+            diff="diff --git a/f.py b/f.py\n@@ -1 +1,2 @@\n old\n+new\n",
+            changed_files=["f.py"],
+            base_sha="b",
+            head_sha="head2222",
+            repo="o/r",
+            pr_number=1,
+        )
+        github = IncrementalFakeGitHub(ctx, last_sha="head1111", compare_result=INC_DIFF)
+        engine = RecordingEngine()
+
+        dispatch(
+            parse_command("/review full"),
+            github=github,
+            engine=engine,
+            provider=FakeProvider(),
+            cfg=_cfg().model_copy(update={"incremental": True}),
+        )
+
+        assert engine.reviewed_ctxs[0].diff == ctx.diff  # full, not INC_DIFF
+        assert github.last_reviewed_calls == 0
+
+    def test_bare_review_honours_incremental_config(self):
+        from lgtmaybe.core.models import PRContext
+        from tests.cli.test_incremental_review import (
+            INC_DIFF,
+            IncrementalFakeGitHub,
+            RecordingEngine,
+        )
+
+        ctx = PRContext(
+            diff="diff --git a/f.py b/f.py\n@@ -1 +1,2 @@\n old\n+new\n",
+            changed_files=["f.py"],
+            base_sha="b",
+            head_sha="head2222",
+            repo="o/r",
+            pr_number=1,
+        )
+        github = IncrementalFakeGitHub(ctx, last_sha="head1111", compare_result=INC_DIFF)
+        engine = RecordingEngine()
+
+        dispatch(
+            parse_command("/review"),
+            github=github,
+            engine=engine,
+            provider=FakeProvider(),
+            cfg=_cfg().model_copy(update={"incremental": True}),
+        )
+
+        assert engine.reviewed_ctxs[0].diff == INC_DIFF

--- a/tests/github/test_incremental.py
+++ b/tests/github/test_incremental.py
@@ -1,0 +1,325 @@
+"""Gateway primitives for commit-scoped incremental review (P2).
+
+Four contracts, all respx-mocked:
+
+- ``post_review`` stamps a hidden ``<!-- lgtmaybe-reviewed:<head_sha> -->``
+  marker into the summary body so the next run knows where the last review
+  stopped;
+- ``last_reviewed_sha`` reads that marker back from the existing review;
+- ``compare_diff`` returns the unified diff of ``last...head`` when head is
+  strictly ahead (a normal push), and None on a force-push/rebase (diverged),
+  an identical compare, or any API failure — the caller then falls back to a
+  full review;
+- ``set_incremental_scope`` restricts resolve-on-fix to threads on paths
+  inside the increment, so a finding that simply wasn't re-reviewed this run
+  is never spuriously resolved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+
+from lgtmaybe.core.models import ReviewFinding, Severity
+from lgtmaybe.github import RestGitHubGateway
+from lgtmaybe.github.rest_gateway import finding_fingerprint
+
+REPO = "owner/repo"
+PR_NUMBER = 42
+TOKEN = "ghp_test"
+
+BASE_URL = "https://api.github.com"
+PR_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}"
+REVIEWS_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}/reviews"
+REVIEW_COMMENTS_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}/comments"
+GRAPHQL_URL = f"{BASE_URL}/graphql"
+
+MARKER = "<!-- lgtmaybe -->"
+
+SAMPLE_DIFF = """\
+diff --git a/src/app.py b/src/app.py
+index 0000001..0000002 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1,2 +1,3 @@
+ import os
++import sys
+ x = 1
+"""
+
+FINDING = ReviewFinding(
+    path="src/app.py",
+    line=2,
+    side="RIGHT",
+    severity=Severity.medium,
+    title="Import order",
+    body="sys should be before os",
+)
+
+
+def _gateway() -> RestGitHubGateway:
+    return RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# reviewed-SHA marker: stamped on post, read back on the next run
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_post_review_stamps_last_reviewed_sha_marker_when_marked() -> None:
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+    captured: dict[str, object] = {}
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"id": 1})
+
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture)
+
+    gateway = _gateway()
+    gateway.mark_reviewed("headsha123")
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert "<!-- lgtmaybe-reviewed:headsha123 -->" in str(captured["body"])
+
+
+@respx.mock
+def test_unmarked_post_does_not_stamp_a_watermark() -> None:
+    """A failure notice posts through post_review WITHOUT mark_reviewed — it
+    must not record 'reviewed up to head' (the next run would skip commits
+    nobody reviewed), and replacing the body clears any stale stamp."""
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+    captured: dict[str, object] = {}
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"id": 1})
+
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture)
+
+    _gateway().post_review([], "⚠️ lgtmaybe review failed: boom", diff=SAMPLE_DIFF)
+
+    assert "lgtmaybe-reviewed" not in str(captured["body"])
+
+
+@respx.mock
+def test_last_reviewed_sha_reads_marker_from_existing_review() -> None:
+    existing = [{"id": 7, "body": f"Old summary\n\n{MARKER}\n<!-- lgtmaybe-reviewed:cafe1234 -->"}]
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=existing))
+
+    assert _gateway().last_reviewed_sha() == "cafe1234"
+
+
+@respx.mock
+def test_last_reviewed_sha_none_without_marker() -> None:
+    existing = [{"id": 7, "body": f"Old summary {MARKER}"}]  # pre-P2 review: no SHA stamp
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=existing))
+
+    assert _gateway().last_reviewed_sha() is None
+
+
+@respx.mock
+def test_last_reviewed_sha_none_without_existing_review() -> None:
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    assert _gateway().last_reviewed_sha() is None
+
+
+@respx.mock
+def test_last_reviewed_sha_none_on_api_error() -> None:
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(500))
+
+    assert _gateway().last_reviewed_sha() is None
+
+
+# ---------------------------------------------------------------------------
+# compare_diff: the increment, or None → full-review fallback
+# ---------------------------------------------------------------------------
+
+COMPARE_URL = f"{BASE_URL}/repos/{REPO}/compare/cafe1234...headsha123"
+
+
+def _mock_compare(status: str, diff: str = SAMPLE_DIFF) -> None:
+    def respond(request: httpx.Request) -> httpx.Response:
+        if "diff" in request.headers.get("Accept", ""):
+            return httpx.Response(200, text=diff)
+        return httpx.Response(200, json={"status": status})
+
+    respx.route(method="GET", url=COMPARE_URL).mock(side_effect=respond)
+
+
+@respx.mock
+def test_compare_diff_returns_increment_when_ahead() -> None:
+    _mock_compare("ahead")
+
+    assert _gateway().compare_diff("cafe1234", "headsha123") == SAMPLE_DIFF
+
+
+@respx.mock
+def test_compare_diff_none_when_diverged() -> None:
+    """A force-push/rebase makes the last-reviewed SHA diverge from head — the
+    increment is meaningless, so the caller must fall back to a full review."""
+    _mock_compare("diverged")
+
+    assert _gateway().compare_diff("cafe1234", "headsha123") is None
+
+
+@respx.mock
+def test_compare_diff_none_when_identical() -> None:
+    _mock_compare("identical")
+
+    assert _gateway().compare_diff("cafe1234", "headsha123") is None
+
+
+@respx.mock
+def test_compare_diff_none_on_api_error() -> None:
+    """A GC'd SHA after a force-push 404s — degrade to full review, never raise."""
+    respx.route(method="GET", url=COMPARE_URL).mock(return_value=httpx.Response(404))
+
+    assert _gateway().compare_diff("cafe1234", "headsha123") is None
+
+
+# ---------------------------------------------------------------------------
+# update path posts NEW inline comments (deduped by fingerprint)
+# ---------------------------------------------------------------------------
+
+
+def _mock_update_flow(
+    existing_comment_fps: list[str],
+) -> tuple[list[dict[str, object]], respx.Route]:
+    """Mock a re-run: existing review found, PUT body, list review comments,
+    capture POSTed new comments. Returns (captured_new_comments, put_route)."""
+    existing = [{"id": 99, "body": f"Old summary {MARKER}"}]
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=existing))
+    put_route = respx.route(method="PUT", url=f"{REVIEWS_URL}/99").mock(
+        return_value=httpx.Response(200, json={"id": 99})
+    )
+    existing_comments = [
+        {"id": i, "body": f"stuff\n\n<!-- lgtmaybe-finding:{fp} -->"}
+        for i, fp in enumerate(existing_comment_fps)
+    ]
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=existing_comments)
+    )
+    posted: list[dict[str, object]] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        posted.append(json.loads(request.content))
+        return httpx.Response(201, json={"id": 1000 + len(posted)})
+
+    respx.route(method="POST", url=REVIEW_COMMENTS_URL).mock(side_effect=capture)
+    return posted, put_route
+
+
+@respx.mock
+def test_rerun_posts_new_inline_comment_with_commit_id() -> None:
+    posted, put_route = _mock_update_flow(existing_comment_fps=[])
+
+    gateway = _gateway()
+    gateway.mark_reviewed("headsha123")
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert put_route.called  # body still updated in place
+    assert len(posted) == 1
+    assert posted[0]["path"] == "src/app.py"
+    assert posted[0]["line"] == 2
+    assert posted[0]["side"] == "RIGHT"
+    assert posted[0]["commit_id"] == "headsha123"
+
+
+@respx.mock
+def test_rerun_skips_inline_comment_already_posted() -> None:
+    fp = finding_fingerprint(FINDING.path, FINDING.title)
+    posted, _put = _mock_update_flow(existing_comment_fps=[fp])
+
+    gateway = _gateway()
+    gateway.mark_reviewed("headsha123")
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert posted == []
+
+
+# ---------------------------------------------------------------------------
+# incremental scope on resolve-on-fix
+# ---------------------------------------------------------------------------
+
+
+def _thread(fingerprint: str, path: str, tid: str) -> dict[str, object]:
+    return {
+        "id": tid,
+        "isResolved": False,
+        "isOutdated": True,
+        "path": path,
+        "comments": {"nodes": [{"body": f"x <!-- lgtmaybe-finding:{fingerprint} -->"}]},
+    }
+
+
+class _GraphQL:
+    """Route the GraphQL endpoint: serve threads, record resolutions."""
+
+    def __init__(self, threads: list[dict[str, object]]) -> None:
+        self._threads = threads
+        self.resolved: list[str] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        query: str = payload["query"]
+        if "reviewThreads" in query:
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": self._threads,
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        if "addPullRequestReviewThreadReply" in query:
+            return httpx.Response(200, json={"data": {"addPullRequestReviewThreadReply": {}}})
+        if "resolveReviewThread" in query:
+            self.resolved.append(payload["variables"]["threadId"])
+            return httpx.Response(200, json={"data": {"resolveReviewThread": {}}})
+        raise AssertionError(f"unexpected GraphQL query: {query}")
+
+
+@respx.mock
+def test_incremental_scope_never_resolves_thread_outside_reviewed_paths() -> None:
+    """A finding on an un-re-reviewed file is absent from this run's findings
+    only because its hunk wasn't in the increment — its thread must stay open."""
+    posted, _put = _mock_update_flow(existing_comment_fps=[])
+    graphql = _GraphQL(
+        threads=[
+            _thread(finding_fingerprint("other.py", "old bug"), path="other.py", tid="OUT"),
+            _thread(finding_fingerprint("src/app.py", "gone bug"), path="src/app.py", tid="IN"),
+        ]
+    )
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=graphql)
+
+    gateway = _gateway()
+    gateway.set_incremental_scope({"src/app.py"})
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    # The in-scope gone finding resolves; the out-of-scope one is untouched.
+    assert graphql.resolved == ["IN"]
+
+
+@respx.mock
+def test_no_scope_keeps_full_resolve_behaviour() -> None:
+    posted, _put = _mock_update_flow(existing_comment_fps=[])
+    graphql = _GraphQL(
+        threads=[_thread(finding_fingerprint("other.py", "old bug"), path="other.py", tid="T1")]
+    )
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=graphql)
+
+    _gateway().post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert graphql.resolved == ["T1"]

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -251,6 +251,18 @@
       "title": "Include Paths",
       "type": "array"
     },
+    "incremental": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Incremental"
+    },
     "max_files": {
       "default": 50,
       "title": "Max Files",


### PR DESCRIPTION
# P2 — commit-scoped incremental review

Follow-up workstream from the Phase 0 audit (#166). On a `synchronize` push, lgtmaybe now reviews **only the diff of the commits added since its last completed review** instead of the whole PR — faster, cheaper, and no re-noise on code that was already reviewed.

## How it works

- **Watermark.** `post_review` stamps a hidden `<!-- lgtmaybe-reviewed:<head_sha> -->` marker into the existing summary comment (alongside the idempotency marker). The next run reads it back via `last_reviewed_sha()`.
- **Watermark integrity.** The stamp is driven by an explicit `mark_reviewed(head_sha)` call that only the success path makes. A failure notice posts through the same `post_review` without it — so a failed run never moves the watermark (and, by replacing the body, clears a stale one). No commit is ever silently skipped.
- **The increment.** `compare_diff(last, head)` uses the GitHub compare API (read-only, never a checkout). The increment is used only when the compare status is strictly `ahead`; a force-push/rebase (`diverged`), an `identical` compare, a GC'd SHA 404, no watermark (first review / pre-P2 review), same head, or a gateway without the adapter methods all **fall back to a full review**.
- **New findings actually post on re-runs.** The review-update endpoint can only replace the body, so previously a re-run's fresh findings silently lost their inline placement. The update path now posts new findings as individual review comments, fingerprint-deduped against the PR so open conversations are never duplicated.
- **No spurious resolutions.** Resolve-on-fix is scoped to the increment's files (`set_incremental_scope`, thread `path` added to the GraphQL query): a finding absent from this run only because its file wasn't re-reviewed stays open. Resolution still requires the finding gone **and** the thread outdated, as before.
- **Anchoring safety.** Inline comments anchor against the full PR diff's commentable-line index; LEFT-side findings are dropped in incremental mode (their line numbers are relative to the last-reviewed head, not the PR base — posting them would mis-anchor).
- **Config.** `ReviewConfig.incremental` — `None` (default) means **auto**: incremental on the Action's `synchronize` event, full everywhere else, so current behaviour is unchanged for opens/reopens, slash commands, and the local CLI. Explicit `true`/`false` (config key or Action input) wins. `/review full` forces a full re-review on demand; slash reviews now route through the shared `run_review` pipeline so they get the same handling.

## Tests

- Gateway (respx): watermark stamped when marked / never on an unmarked (failure) post; watermark read-back incl. pre-P2 and error cases; `compare_diff` ahead/diverged/identical/404; re-run inline-comment posting with `commit_id` + fingerprint dedupe; scope-restricted vs unrestricted resolve-on-fix.
- Orchestration: incremental happy path (engine sees only the increment, post anchors on the full diff, scope + watermark set); fallbacks for no-marker, force-push, same-head, plain gateway, incremental-off; LEFT-side drop; dry-run never marks; auto-resolution (`synchronize` → on, `opened` → off, explicit wins).
- Slash: `/review full` overrides `incremental: true`; bare `/review` honours it.
- All 898 tests green; ruff + mypy clean. Generated config reference, schema snapshots, and docs (`configure-lgtmaybe-yml.md`, `use-as-github-action.md`, `CLAUDE.md`, `ARCHITECTURE.md`) updated.

Remaining audit follow-ups (separate PRs): P3 triage routing, F1 static-analysis fusion, F3 auto-describe, F4 labels, F5b output templates, P4 function-boundary context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a)_