### PR TITLE
feat(engine): review-effort/risk labels + declarative finding rules (F4 + F5b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,20 @@ pattern, event bus, plugin framework.
      `--prompt-cache/--no-prompt-cache`, Action input `prompt_cache`);
      cache read/creation token counts land on `ProviderResult` and are logged.
    - **Summary line:** names the **model** used (no cost — lgtmaybe does not
-     compute or report cost).
+     compute or report cost). `ReviewConfig.summary_template` (default None)
+     lets teams restyle it with `{count}`/`{provider}`/`{model}` placeholders;
+     a bad template falls back to the built-in line.
+   - **Finding rules (F5b):** `ReviewConfig.finding_rules` — ordered
+     declarative match (path glob / lens `category` / `title_contains` /
+     `min_severity`, ANDed) → action (`drop` / `set_severity`), applied in
+     `engine/rules.py` just before posting. Deliberately NOT an arbitrary
+     hook: no user code ever runs. Findings carry an engine-stamped
+     `category` (the originating lens id) that rules and labels key on.
+   - **PR labels (F4):** `ReviewConfig.pr_labels` (default off; Action input
+     `pr_labels`) — `engine/labels.py` derives `review-effort/1-5`,
+     `possible-security-issue` (high/critical security-lens finding), and
+     `consider-splitting` (sprawling diff) from data already computed; the
+     gateway reconciles only lgtmaybe's own label families, best-effort.
    - **Clean review:** zero findings on a fully-reviewed PR posts `👍 LGTM!`
      (comment only — no GitHub approval state) — still naming the model.
 4. **Packaging (sequential, last) — DONE:** the two distribution variants over

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
     description: "On a freshly opened (or reopened) PR, post a structured description comment — title, change type, summary, per-file walkthrough, and an intent check — before the review runs, updated in place by later /describe runs. Off by default."
     required: false
     default: ""
+  pr_labels:
+    description: "Attach labels derived from the review (no extra model calls): a review-effort/1-5 size estimate, possible-security-issue when a high/critical security finding posts, and consider-splitting when the diff spans many unrelated directories. Best-effort; off by default."
+    required: false
+    default: ""
   aws_role_arn:
     description: "IAM role ARN to assume via GitHub OIDC for bedrock. No static AWS key is ever stored."
     required: false
@@ -182,6 +186,7 @@ runs:
         INPUT_INCREMENTAL: ${{ inputs.incremental }}
         INPUT_STATIC_ANALYSIS: ${{ inputs.static_analysis }}
         INPUT_AUTO_DESCRIBE: ${{ inputs.auto_describe }}
+        INPUT_PR_LABELS: ${{ inputs.pr_labels }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
       run: |
@@ -197,7 +202,7 @@ runs:
           -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS -e INPUT_RESOLVE_FIXED \
           -e INPUT_RECURSIVE -e INPUT_STRUCTURED_OUTPUT -e INPUT_SYMBOL_RESOLUTION \
           -e INPUT_PROMPT_CACHE -e INPUT_INCREMENTAL -e INPUT_STATIC_ANALYSIS \
-          -e INPUT_AUTO_DESCRIBE \
+          -e INPUT_AUTO_DESCRIBE -e INPUT_PR_LABELS \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -29,6 +29,9 @@ provides defaults for all runs.
   - [static_analysis](#static_analysis)
   - [triage_model](#triage_model)
   - [auto_describe](#auto_describe)
+  - [pr_labels](#pr_labels)
+  - [finding_rules](#finding_rules)
+  - [summary_template](#summary_template)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -370,6 +373,62 @@ auto_describe: true
 ```
 
 Default: `false`.
+
+### pr_labels
+
+Attach labels derived from the finished review — **no extra model calls**:
+
+- `review-effort/1` … `review-effort/5` — a size estimate from the changed
+  lines, so reviewers can gauge the PR at a glance;
+- `possible-security-issue` — a high/critical finding from the security lens
+  was posted;
+- `consider-splitting` — the diff spans many unrelated top-level directories.
+
+Labels are reconciled on each run (a stale `review-effort/2` is removed when
+the score changes) and only lgtmaybe's own label families are ever touched.
+Best-effort: a labelling failure never fails the review.
+
+```yaml
+pr_labels: true
+```
+
+Default: `false`.
+
+### finding_rules
+
+Declarative post-processing applied to findings just before posting — the
+safe alternative to arbitrary post-processing hooks (rules can only filter or
+re-grade; **no user code ever runs**). Each rule has a `match` (all specified
+fields must match) and an `action`; rules apply in order.
+
+Match fields: `path` (glob, `**/`-prefix also matches at the repo root),
+`category` (the lens that produced the finding — `security`, `correctness`,
+…, or a custom lens id), `title_contains` (case-insensitive substring), and
+`min_severity` (at or above). Actions: `drop: true` or `set_severity`.
+
+```yaml
+finding_rules:
+  # complexity nits in tests aren't worth a comment
+  - match: {path: "tests/**", category: complexity}
+    action: {drop: true}
+  # documentation findings are informational for this repo
+  - match: {category: documentation}
+    action: {set_severity: info}
+```
+
+Default: no rules.
+
+### summary_template
+
+Custom template for the review summary line, for teams matching a house
+style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`. A
+template that fails to format falls back to the built-in line.
+
+```yaml
+summary_template: "🤖 {count} finding(s) · {model}"
+```
+
+Default: unset (the built-in `N findings · provider X · model Y` line).
 
 ### resolve_fixed
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1722,6 +1722,9 @@ provides defaults for all runs.
   - [static_analysis](#static_analysis)
   - [triage_model](#triage_model)
   - [auto_describe](#auto_describe)
+  - [pr_labels](#pr_labels)
+  - [finding_rules](#finding_rules)
+  - [summary_template](#summary_template)
   - [resolve_fixed](#resolve_fixed)
   - [extra_lenses](#extra_lenses)
   - [lens_paths](#lens_paths)
@@ -2063,6 +2066,62 @@ auto_describe: true
 ```
 
 Default: `false`.
+
+### pr_labels
+
+Attach labels derived from the finished review — **no extra model calls**:
+
+- `review-effort/1` … `review-effort/5` — a size estimate from the changed
+  lines, so reviewers can gauge the PR at a glance;
+- `possible-security-issue` — a high/critical finding from the security lens
+  was posted;
+- `consider-splitting` — the diff spans many unrelated top-level directories.
+
+Labels are reconciled on each run (a stale `review-effort/2` is removed when
+the score changes) and only lgtmaybe's own label families are ever touched.
+Best-effort: a labelling failure never fails the review.
+
+```yaml
+pr_labels: true
+```
+
+Default: `false`.
+
+### finding_rules
+
+Declarative post-processing applied to findings just before posting — the
+safe alternative to arbitrary post-processing hooks (rules can only filter or
+re-grade; **no user code ever runs**). Each rule has a `match` (all specified
+fields must match) and an `action`; rules apply in order.
+
+Match fields: `path` (glob, `**/`-prefix also matches at the repo root),
+`category` (the lens that produced the finding — `security`, `correctness`,
+…, or a custom lens id), `title_contains` (case-insensitive substring), and
+`min_severity` (at or above). Actions: `drop: true` or `set_severity`.
+
+```yaml
+finding_rules:
+  # complexity nits in tests aren't worth a comment
+  - match: {path: "tests/**", category: complexity}
+    action: {drop: true}
+  # documentation findings are informational for this repo
+  - match: {category: documentation}
+    action: {set_severity: info}
+```
+
+Default: no rules.
+
+### summary_template
+
+Custom template for the review summary line, for teams matching a house
+style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`. A
+template that fails to format falls back to the built-in line.
+
+```yaml
+summary_template: "🤖 {count} finding(s) · {model}"
+```
+
+Default: unset (the built-in `N findings · provider X · model Y` line).
 
 ### resolve_fixed
 
@@ -2510,6 +2569,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
+| `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `incremental` | boolean / null | No | `null` | Incremental |
@@ -2519,6 +2579,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
+| `pr_labels` | boolean | No | `False` | Pr Labels |
 | `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `recursive` | boolean | No | `True` | Recursive |
@@ -2527,6 +2588,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
 | `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
+| `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
 | `temperature` | number | No | `0.0` | Temperature |
 | `timeout` | integer / null | No | `null` | Timeout |
@@ -2569,6 +2631,7 @@ The structured output the model must return for each inline comment. All fields 
 | `anchored` | boolean | No | `True` | Anchored |
 | `body` | string | Yes | — | Body |
 | `broad` | boolean | No | `False` | Broad |
+| `category` | string / null | No | `null` | Category |
 | `confidence` | integer / null | No | `null` | Confidence |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
@@ -2663,6 +2726,108 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "CustomLens",
       "type": "object"
     },
+    "FindingRule": {
+      "additionalProperties": false,
+      "description": "One declarative post-processing rule, applied in list order.\n\nThe safe alternative to arbitrary user hooks: rules can only filter or\nre-grade findings \u2014 no user code ever executes.",
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/FindingRuleAction"
+        },
+        "match": {
+          "$ref": "#/$defs/FindingRuleMatch",
+          "default": {
+            "category": null,
+            "min_severity": null,
+            "path": null,
+            "title_contains": null
+          }
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "title": "FindingRule",
+      "type": "object"
+    },
+    "FindingRuleAction": {
+      "additionalProperties": false,
+      "description": "What a matched rule does: drop the finding, or remap its severity.",
+      "properties": {
+        "drop": {
+          "default": false,
+          "title": "Drop",
+          "type": "boolean"
+        },
+        "set_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "FindingRuleAction",
+      "type": "object"
+    },
+    "FindingRuleMatch": {
+      "additionalProperties": false,
+      "description": "The selector of a finding rule. Every specified field must match (AND).\n\nAn empty match selects every finding. ``path`` is an fnmatch glob against\nthe repo-relative path (a ``**/`` prefix also matches at the repo root,\nlike the path filters); ``category`` is the originating lens id;\n``title_contains`` is a case-insensitive substring; ``min_severity``\nselects findings at or above that severity.",
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
+        },
+        "min_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "title_contains": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title Contains"
+        }
+      },
+      "title": "FindingRuleMatch",
+      "type": "object"
+    },
     "Provider": {
       "description": "The backend selected by the `--provider` flag.",
       "enum": [
@@ -2724,6 +2889,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": false,
           "title": "Broad",
           "type": "boolean"
+        },
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
         },
         "confidence": {
           "anyOf": [
@@ -2908,6 +3085,13 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "Extra Lenses",
       "type": "array"
     },
+    "finding_rules": {
+      "items": {
+        "$ref": "#/$defs/FindingRule"
+      },
+      "title": "Finding Rules",
+      "type": "array"
+    },
     "ignore_fingerprints": {
       "items": {
         "type": "string"
@@ -2971,6 +3155,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": null,
       "title": "Num Ctx"
     },
+    "pr_labels": {
+      "default": false,
+      "title": "Pr Labels",
+      "type": "boolean"
+    },
     "prompt_cache": {
       "default": true,
       "title": "Prompt Cache",
@@ -3023,6 +3212,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": true,
       "title": "Structured Output",
       "type": "boolean"
+    },
+    "summary_template": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Summary Template"
     },
     "symbol_resolution": {
       "default": true,
@@ -3118,6 +3319,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": false,
       "title": "Broad",
       "type": "boolean"
+    },
+    "category": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Category"
     },
     "confidence": {
       "anyOf": [

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -22,6 +22,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
+| `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `incremental` | boolean / null | No | `null` | Incremental |
@@ -31,6 +32,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
+| `pr_labels` | boolean | No | `False` | Pr Labels |
 | `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `recursive` | boolean | No | `True` | Recursive |
@@ -39,6 +41,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
 | `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
+| `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
 | `temperature` | number | No | `0.0` | Temperature |
 | `timeout` | integer / null | No | `null` | Timeout |
@@ -81,6 +84,7 @@ The structured output the model must return for each inline comment. All fields 
 | `anchored` | boolean | No | `True` | Anchored |
 | `body` | string | Yes | — | Body |
 | `broad` | boolean | No | `False` | Broad |
+| `category` | string / null | No | `null` | Category |
 | `confidence` | integer / null | No | `null` | Confidence |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
@@ -175,6 +179,108 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "CustomLens",
       "type": "object"
     },
+    "FindingRule": {
+      "additionalProperties": false,
+      "description": "One declarative post-processing rule, applied in list order.\n\nThe safe alternative to arbitrary user hooks: rules can only filter or\nre-grade findings \u2014 no user code ever executes.",
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/FindingRuleAction"
+        },
+        "match": {
+          "$ref": "#/$defs/FindingRuleMatch",
+          "default": {
+            "category": null,
+            "min_severity": null,
+            "path": null,
+            "title_contains": null
+          }
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "title": "FindingRule",
+      "type": "object"
+    },
+    "FindingRuleAction": {
+      "additionalProperties": false,
+      "description": "What a matched rule does: drop the finding, or remap its severity.",
+      "properties": {
+        "drop": {
+          "default": false,
+          "title": "Drop",
+          "type": "boolean"
+        },
+        "set_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "FindingRuleAction",
+      "type": "object"
+    },
+    "FindingRuleMatch": {
+      "additionalProperties": false,
+      "description": "The selector of a finding rule. Every specified field must match (AND).\n\nAn empty match selects every finding. ``path`` is an fnmatch glob against\nthe repo-relative path (a ``**/`` prefix also matches at the repo root,\nlike the path filters); ``category`` is the originating lens id;\n``title_contains`` is a case-insensitive substring; ``min_severity``\nselects findings at or above that severity.",
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
+        },
+        "min_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "title_contains": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title Contains"
+        }
+      },
+      "title": "FindingRuleMatch",
+      "type": "object"
+    },
     "Provider": {
       "description": "The backend selected by the `--provider` flag.",
       "enum": [
@@ -236,6 +342,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": false,
           "title": "Broad",
           "type": "boolean"
+        },
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
         },
         "confidence": {
           "anyOf": [
@@ -420,6 +538,13 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "Extra Lenses",
       "type": "array"
     },
+    "finding_rules": {
+      "items": {
+        "$ref": "#/$defs/FindingRule"
+      },
+      "title": "Finding Rules",
+      "type": "array"
+    },
     "ignore_fingerprints": {
       "items": {
         "type": "string"
@@ -483,6 +608,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": null,
       "title": "Num Ctx"
     },
+    "pr_labels": {
+      "default": false,
+      "title": "Pr Labels",
+      "type": "boolean"
+    },
     "prompt_cache": {
       "default": true,
       "title": "Prompt Cache",
@@ -535,6 +665,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": true,
       "title": "Structured Output",
       "type": "boolean"
+    },
+    "summary_template": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Summary Template"
     },
     "symbol_resolution": {
       "default": true,
@@ -630,6 +772,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": false,
       "title": "Broad",
       "type": "boolean"
+    },
+    "category": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Category"
     },
     "confidence": {
       "anyOf": [

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -239,6 +239,14 @@ def run_review(
         # index is built from the diff the comments will anchor to — the
         # incremental diff's context lines aren't necessarily in the PR diff.
         github.post_review(findings, summary, diff=ctx.diff)
+        if cfg.pr_labels:
+            # Effort/risk labels from data already computed — best-effort,
+            # and only on gateways that support them (fakes don't).
+            apply_labels = getattr(github, "apply_pr_labels", None)
+            if apply_labels is not None:
+                from lgtmaybe.engine.labels import compute_labels
+
+                apply_labels(compute_labels(findings, ctx))
 
     return findings, summary
 
@@ -447,6 +455,7 @@ def action_inputs() -> dict[str, str | None]:
         "incremental": get("INCREMENTAL"),
         "static_analysis": get("STATIC_ANALYSIS"),
         "auto_describe": get("AUTO_DESCRIBE"),
+        "pr_labels": get("PR_LABELS"),
         "config_path": get("CONFIG_PATH"),
     }
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -341,6 +341,7 @@ def action() -> None:
         prompt_cache=inputs["prompt_cache"],
         incremental=inputs["incremental"],
         auto_describe=inputs["auto_describe"],
+        pr_labels=inputs["pr_labels"],
     )
     raw_sa = inputs["static_analysis"]
     cfg = _apply_static_analysis_flag(

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -161,6 +161,11 @@ class ReviewFinding(_Strict):
     # or the auditor omitted a score. Findings scoring below
     # `ReviewConfig.min_confidence` are dropped; the score is surfaced in output.
     confidence: int | None = Field(default=None, ge=0, le=10)
+    # Engine-derived: the id of the lens (built-in ReviewCategory value or
+    # custom lens id) whose call produced this finding — the model's own value
+    # is overwritten. Drives the security label and category-matched
+    # finding_rules; surfaced in JSON output. None only for legacy inputs.
+    category: str | None = None
 
     @field_validator("severity", mode="before")
     @classmethod
@@ -258,6 +263,46 @@ class ReflectionResult(_Strict):
     """
 
     verdicts: list[Verdict]
+
+
+class FindingRuleMatch(_Strict):
+    """The selector of a finding rule. Every specified field must match (AND).
+
+    An empty match selects every finding. ``path`` is an fnmatch glob against
+    the repo-relative path (a ``**/`` prefix also matches at the repo root,
+    like the path filters); ``category`` is the originating lens id;
+    ``title_contains`` is a case-insensitive substring; ``min_severity``
+    selects findings at or above that severity.
+    """
+
+    path: str | None = None
+    category: str | None = None
+    title_contains: str | None = None
+    min_severity: Severity | None = None
+
+
+class FindingRuleAction(_Strict):
+    """What a matched rule does: drop the finding, or remap its severity."""
+
+    drop: bool = False
+    set_severity: Severity | None = None
+
+    @model_validator(mode="after")
+    def _has_an_effect(self) -> FindingRuleAction:
+        if not self.drop and self.set_severity is None:
+            raise ValueError("a finding rule action must drop or set_severity")
+        return self
+
+
+class FindingRule(_Strict):
+    """One declarative post-processing rule, applied in list order.
+
+    The safe alternative to arbitrary user hooks: rules can only filter or
+    re-grade findings — no user code ever executes.
+    """
+
+    match: FindingRuleMatch = Field(default=FindingRuleMatch())
+    action: FindingRuleAction
 
 
 class FileWalkthrough(_Strict):
@@ -394,6 +439,23 @@ class ReviewConfig(_Strict):
     # get audited by a better judge. Same provider/credentials as `model` — only
     # the model id changes (the provider client is built once).
     reflect_model: str | None = None
+    # Declarative finding post-processing, applied in order just before
+    # posting: each rule's match (path glob / category / title substring /
+    # severity floor, ANDed) selects findings and its action drops them or
+    # remaps their severity. A safe alternative to arbitrary user hooks — no
+    # user code ever runs. Empty (default) = no post-processing.
+    finding_rules: list[FindingRule] = Field(default_factory=list)
+    # Custom template for the review summary line. Placeholders: {count}
+    # (findings posted), {provider}, {model}. None (default) keeps the built-in
+    # line; a template that fails to format falls back to it too.
+    summary_template: str | None = None
+    # PR labels (GitHub posting only): attach a review-effort/1-5 size
+    # estimate, a possible-security-issue flag when a high/critical
+    # security-lens finding posts, and a consider-splitting hint when the diff
+    # sprawls across many unrelated top-level directories. Derived entirely
+    # from data the review already computes — no extra model calls.
+    # Best-effort (a label failure never fails the review). Default off.
+    pr_labels: bool = False
     # Auto-describe: when the GitHub Action is triggered by a PR being opened
     # (or reopened), post a structured description comment — title, change
     # type, summary, per-file walkthrough, intent check — before the review

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -303,10 +303,16 @@ class LLMReviewEngine(ReviewEngine):
         #    low-confidence guess, so surface it only when it's high/critical.
         filtered = [f for f in all_findings if _passes_severity_floor(f, cfg)]
 
-        plural = "s" if len(filtered) != 1 else ""
-        summary_line = (
-            f"{len(filtered)} finding{plural} · provider {cfg.provider} · model {cfg.model}"
-        )
+        # 9b. Declarative post-processing (finding_rules, default none): the
+        #     team's drop / severity-remap rules, applied last so they see
+        #     exactly what would otherwise post. Imported lazily — rules.py
+        #     imports this module's glob matcher, so a top import would cycle.
+        if cfg.finding_rules:
+            from .rules import apply_finding_rules
+
+            filtered = apply_finding_rules(filtered, cfg)
+
+        summary_line = _summary_line(len(filtered), cfg)
 
         notices = []
         if capped_files:
@@ -388,8 +394,33 @@ class LLMReviewEngine(ReviewEngine):
         except ParseError:
             _log.warning("unparseable model output", extra={"lens": lens.id})
             return [], "unparseable model output"
+        # Stamp the originating lens (engine-derived — the model's own value is
+        # overwritten): it drives the security label and category-matched
+        # finding_rules, and surfaces in JSON output.
+        findings = [f.model_copy(update={"category": lens.id}) for f in findings]
         _log.info("lens reviewed", extra={"lens": lens.id, "findings": len(findings)})
         return findings, None
+
+
+def _summary_line(count: int, cfg: ReviewConfig) -> str:
+    """The review summary line: the user's template, or the built-in default.
+
+    A template that fails to format (unknown placeholder, stray brace) is
+    logged and falls back to the default — a cosmetic option must never fail
+    a review.
+    """
+    if cfg.summary_template:
+        try:
+            return cfg.summary_template.format(
+                count=count, provider=cfg.provider.value, model=cfg.model
+            )
+        except (KeyError, IndexError, ValueError) as exc:
+            _log.warning(
+                "summary_template failed to format — using the default",
+                extra={"error": str(exc)},
+            )
+    plural = "s" if count != 1 else ""
+    return f"{count} finding{plural} · provider {cfg.provider} · model {cfg.model}"
 
 
 def passes_path_filters(path: str, *, include: list[str], exclude: list[str]) -> bool:

--- a/src/lgtmaybe/engine/labels.py
+++ b/src/lgtmaybe/engine/labels.py
@@ -1,0 +1,68 @@
+"""Review-effort and risk labels (F4), derived from the finished review.
+
+No extra model calls: everything here is computed from the diff and the
+findings the review already produced. Three labels:
+
+- ``review-effort/1``–``5`` — a size estimate from the changed-line count, so
+  reviewers can gauge a PR at a glance;
+- ``possible-security-issue`` — a high/critical finding from the security
+  lens posted this run;
+- ``consider-splitting`` — the diff sprawls across many unrelated top-level
+  directories, a hint that it bundles several themes.
+
+The set is config-gated (``ReviewConfig.pr_labels``, default off) and applied
+best-effort by the GitHub adapter — a labelling failure never fails a review.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.models import PRContext, ReviewFinding, Severity
+
+# The label families this module owns. The adapter removes stale labels with
+# these shapes before adding the fresh set, so an effort score that drops
+# between pushes doesn't leave both labels behind.
+EFFORT_PREFIX = "review-effort/"
+SECURITY_LABEL = "possible-security-issue"
+SPLITTING_LABEL = "consider-splitting"
+
+# Changed-line thresholds for effort scores 2..5 (score 1 = below the first).
+_EFFORT_THRESHOLDS = (50, 200, 500, 1000)
+
+# "Sprawls across unrelated themes" heuristic: at least this many distinct
+# top-level directories AND this many changed files. Deliberately conservative
+# — a wrong split hint is pure noise.
+_MIN_SPRAWL_DIRS = 4
+_MIN_SPRAWL_FILES = 10
+
+
+def compute_labels(findings: list[ReviewFinding], ctx: PRContext) -> list[str]:
+    """The labels this review's outcome earns for the PR."""
+    labels = [f"{EFFORT_PREFIX}{_effort_score(ctx.diff)}"]
+    if any(f.category == "security" and f.severity >= Severity.high for f in findings):
+        labels.append(SECURITY_LABEL)
+    if _sprawls(ctx.changed_files):
+        labels.append(SPLITTING_LABEL)
+    return labels
+
+
+def _effort_score(diff: str) -> int:
+    """1–5 from the number of added/removed lines in *diff*."""
+    changed = sum(
+        1
+        for line in diff.splitlines()
+        if (line.startswith("+") and not line.startswith("+++"))
+        or (line.startswith("-") and not line.startswith("---"))
+    )
+    score = 1
+    for threshold in _EFFORT_THRESHOLDS:
+        if changed >= threshold:
+            score += 1
+    return score
+
+
+def _sprawls(changed_files: list[str]) -> bool:
+    """Whether the change set spans enough unrelated areas to suggest splitting."""
+    if len(changed_files) < _MIN_SPRAWL_FILES:
+        return False
+    top_level = {path.split("/", 1)[0] for path in changed_files}
+    return len(top_level) >= _MIN_SPRAWL_DIRS

--- a/src/lgtmaybe/engine/rules.py
+++ b/src/lgtmaybe/engine/rules.py
@@ -1,0 +1,64 @@
+"""Declarative finding post-processing (F5b).
+
+``ReviewConfig.finding_rules`` lets a team filter or re-grade findings before
+posting — drop the complexity lens in test files, downgrade documentation
+nits, and so on — through pure declarative match/action rules. Deliberately
+NOT an arbitrary post-processing hook: rules can only drop or remap severity,
+so config stays data and no user code ever executes (executing user Python
+would widen the attack surface the reviewer exists to guard).
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import FindingRule, ReviewConfig, ReviewFinding
+
+from .engine import _matches_glob  # same package; the one canonical glob matcher
+
+_log = get_logger(__name__)
+
+
+def apply_finding_rules(findings: list[ReviewFinding], cfg: ReviewConfig) -> list[ReviewFinding]:
+    """Run *findings* through the configured rules, in order.
+
+    A ``drop`` removes the finding immediately; a ``set_severity`` remaps it
+    and later rules see the new severity. With no rules (the default) the
+    input is returned unchanged.
+    """
+    if not cfg.finding_rules:
+        return findings
+
+    kept: list[ReviewFinding] = []
+    dropped = 0
+    for finding in findings:
+        out: ReviewFinding | None = finding
+        for rule in cfg.finding_rules:
+            if out is None:
+                break
+            if not _matches(rule, out):
+                continue
+            if rule.action.drop:
+                out = None
+            elif rule.action.set_severity is not None:
+                out = out.model_copy(update={"severity": rule.action.set_severity})
+        if out is None:
+            dropped += 1
+        else:
+            kept.append(out)
+    if dropped:
+        _log.info("finding rules dropped findings", extra={"count": dropped})
+    return kept
+
+
+def _matches(rule: FindingRule, finding: ReviewFinding) -> bool:
+    match = rule.match
+    if match.path is not None and not _matches_glob(finding.path, match.path):
+        return False
+    if match.category is not None and finding.category != match.category:
+        return False
+    if (
+        match.title_contains is not None
+        and match.title_contains.lower() not in finding.title.lower()
+    ):
+        return False
+    return match.min_severity is None or finding.severity >= match.min_severity

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -16,6 +16,7 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -408,6 +409,49 @@ class RestGitHubGateway(GitHubGateway):
             timeout=_TIMEOUT,
         )
         created.raise_for_status()
+
+    def apply_pr_labels(self, labels: list[str]) -> None:
+        """Reconcile our managed PR labels to exactly *labels*. Best-effort.
+
+        Only labels this tool owns (the ``review-effort/`` family,
+        ``possible-security-issue``, ``consider-splitting``) are ever removed —
+        anything a human applied is untouched. Any API failure is logged and
+        swallowed: a labelling hiccup must never fail an otherwise-successful
+        review. Adapter-only, beyond the frozen port.
+        """
+        try:
+            base = f"https://api.github.com/repos/{self._repo}/issues/{self._pr_number}"
+            current: set[str] = {
+                item["name"]
+                for resp in self._paginate(f"{base}/labels?per_page=100")
+                for item in resp.json()
+            }
+            managed = {
+                name
+                for name in current
+                if name.startswith("review-effort/")
+                or name in ("possible-security-issue", "consider-splitting")
+            }
+            for stale in sorted(managed - set(labels)):
+                # The label name is a single path segment — quote it fully, or
+                # the slash in "review-effort/2" would read as a path separator.
+                resp = self._client.delete(
+                    f"{base}/labels/{quote(stale, safe='')}",
+                    headers={**self._headers, "Accept": "application/vnd.github+json"},
+                    timeout=_TIMEOUT,
+                )
+                resp.raise_for_status()
+            to_add = sorted(set(labels) - current)
+            if to_add:
+                resp = self._client.post(
+                    f"{base}/labels",
+                    headers={**self._headers, "Accept": "application/vnd.github+json"},
+                    json={"labels": to_add},
+                    timeout=_TIMEOUT,
+                )
+                resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — labels are auxiliary, never fatal
+            _log.warning("applying PR labels failed: %s", exc)
 
     # ------------------------------------------------------------------
     # Incremental review (adapter-only methods, beyond the frozen port)

--- a/tests/cli/test_incremental_review.py
+++ b/tests/cli/test_incremental_review.py
@@ -247,3 +247,44 @@ def test_run_describe_posts_via_the_idempotent_upsert() -> None:
     assert len(github.described) == 1
     assert github.described[0].startswith("## Add a thing")
     assert github.comments == []
+
+
+# ---------------------------------------------------------------------------
+# PR labels (F4): applied only when opted in, on capable gateways
+# ---------------------------------------------------------------------------
+
+
+class LabelFakeGitHub(FakeGitHub):
+    def __init__(self, ctx: PRContext | None = None) -> None:
+        super().__init__(ctx)
+        self.labels: list[list[str]] = []
+
+    def apply_pr_labels(self, labels: list[str]) -> None:
+        self.labels.append(labels)
+
+
+def test_pr_labels_applied_when_enabled() -> None:
+    github = LabelFakeGitHub(CTX)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(pr_labels=True), dry_run=False)
+
+    assert len(github.labels) == 1
+    assert any(label.startswith("review-effort/") for label in github.labels[0])
+
+
+def test_pr_labels_off_by_default() -> None:
+    github = LabelFakeGitHub(CTX)
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(), dry_run=False)
+
+    assert github.labels == []
+
+
+def test_pr_labels_skipped_on_dry_run_and_plain_gateway() -> None:
+    github = FakeGitHub(CTX)  # no apply_pr_labels — must not crash
+    engine = RecordingEngine()
+
+    run_review(github=github, engine=engine, cfg=_cfg(pr_labels=True), dry_run=False)
+    run_review(github=github, engine=engine, cfg=_cfg(pr_labels=True), dry_run=True)

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1512,3 +1512,49 @@ def test_raw_hints_are_never_posted_as_findings(monkeypatch) -> None:  # type: i
     findings, _summary = engine.review(_HINT_CTX, _sa_cfg())
 
     assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# summary template (F5b)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_template_formats_the_summary_line() -> None:
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        summary_template="{count} issue(s) — reviewed by {model} on {provider}",
+    )
+
+    _findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert "issue(s) — reviewed by llama3 on ollama" in summary
+
+
+def test_bad_summary_template_falls_back_to_default() -> None:
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", summary_template="{nonsense}")
+
+    _findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert "provider ollama · model llama3" in summary
+
+
+def test_finding_rules_run_before_the_summary_count(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from lgtmaybe.core.models import FindingRule
+
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        finding_rules=[FindingRule.model_validate({"action": {"drop": True}})],
+    )
+
+    findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert findings == []
+    assert "0 findings" in summary

--- a/tests/engine/test_labels.py
+++ b/tests/engine/test_labels.py
@@ -1,0 +1,86 @@
+"""Review-effort and risk labels (F4) — derived from data already computed.
+
+``compute_labels`` turns the finished review into PR labels with **no extra
+model calls**: a ``review-effort/1``-``5`` size estimate from the diff, a
+``possible-security-issue`` flag when a high/critical security-lens finding
+posts, and a ``consider-splitting`` hint when the diff sprawls across many
+unrelated top-level directories. Config-gated (``pr_labels``, default off).
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.models import PRContext, ReviewFinding, Severity
+from lgtmaybe.engine.labels import compute_labels
+
+_SMALL_DIFF = "diff --git a/a.py b/a.py\n@@ -1 +1,2 @@\n old\n+new\n"
+
+
+def _ctx(diff: str = _SMALL_DIFF, files: list[str] | None = None) -> PRContext:
+    return PRContext(
+        diff=diff,
+        changed_files=files or ["a.py"],
+        base_sha="abc",
+        head_sha="def",
+        repo="org/repo",
+        pr_number=12,
+    )
+
+
+def _finding(category: str | None, severity: Severity) -> ReviewFinding:
+    return ReviewFinding(
+        path="a.py",
+        line=1,
+        severity=severity,
+        title="t",
+        body="b",
+        category=category,
+    )
+
+
+def _diff_of_lines(n: int) -> str:
+    body = "\n".join(f"+line {i}" for i in range(n))
+    return f"diff --git a/a.py b/a.py\n@@ -1 +1,{n} @@\n{body}\n"
+
+
+def test_effort_scales_with_changed_lines() -> None:
+    assert "review-effort/1" in compute_labels([], _ctx(_diff_of_lines(10)))
+    assert "review-effort/2" in compute_labels([], _ctx(_diff_of_lines(100)))
+    assert "review-effort/3" in compute_labels([], _ctx(_diff_of_lines(300)))
+    assert "review-effort/4" in compute_labels([], _ctx(_diff_of_lines(700)))
+    assert "review-effort/5" in compute_labels([], _ctx(_diff_of_lines(1500)))
+
+
+def test_high_security_finding_adds_the_security_label() -> None:
+    labels = compute_labels([_finding("security", Severity.high)], _ctx())
+    assert "possible-security-issue" in labels
+
+    labels = compute_labels([_finding("security", Severity.critical)], _ctx())
+    assert "possible-security-issue" in labels
+
+
+def test_non_security_or_low_findings_do_not_add_the_security_label() -> None:
+    # High severity but a correctness finding — not the security lens.
+    assert "possible-security-issue" not in compute_labels(
+        [_finding("correctness", Severity.high)], _ctx()
+    )
+    # Security lens but below high.
+    assert "possible-security-issue" not in compute_labels(
+        [_finding("security", Severity.medium)], _ctx()
+    )
+    # No category information at all (reflect-off legacy path) — stay quiet.
+    assert "possible-security-issue" not in compute_labels(
+        [_finding(None, Severity.critical)], _ctx()
+    )
+
+
+def test_sprawling_diff_gets_the_consider_splitting_hint() -> None:
+    files = [f"pkg{i}/mod{j}.py" for i in range(5) for j in range(3)]  # 5 dirs, 15 files
+    diff = "".join(f"diff --git a/{p} b/{p}\n@@ -1 +1,2 @@\n old\n+new\n" for p in files)
+    labels = compute_labels([], _ctx(diff, files))
+    assert "consider-splitting" in labels
+
+
+def test_focused_diff_gets_no_splitting_hint() -> None:
+    files = [f"pkg/mod{j}.py" for j in range(12)]  # many files, one theme
+    labels = compute_labels([], _ctx(_SMALL_DIFF, files))
+    assert "consider-splitting" not in labels

--- a/tests/engine/test_rules.py
+++ b/tests/engine/test_rules.py
@@ -1,0 +1,119 @@
+"""Declarative finding post-processing rules (F5b).
+
+``finding_rules`` is a safe, declarative alternative to arbitrary user hooks:
+ordered rules whose ``match`` (path glob / category / title substring /
+severity floor, ANDed) selects findings and whose ``action`` drops them or
+remaps their severity — applied just before posting. No user code ever runs.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.models import (
+    FindingRule,
+    Provider,
+    ReviewConfig,
+    ReviewFinding,
+    Severity,
+)
+from lgtmaybe.engine.rules import apply_finding_rules
+
+
+def _cfg(rules: list[dict[str, object]]) -> ReviewConfig:
+    return ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        finding_rules=[FindingRule.model_validate(r) for r in rules],
+    )
+
+
+def _finding(
+    path: str = "src/app.py",
+    category: str | None = "correctness",
+    title: str = "a bug",
+    severity: Severity = Severity.medium,
+) -> ReviewFinding:
+    return ReviewFinding(
+        path=path, line=1, severity=severity, title=title, body="b", category=category
+    )
+
+
+def test_no_rules_changes_nothing() -> None:
+    findings = [_finding()]
+    assert apply_finding_rules(findings, _cfg([])) == findings
+
+
+def test_drop_by_path_glob() -> None:
+    rules = [{"match": {"path": "tests/**"}, "action": {"drop": True}}]
+    kept = apply_finding_rules(
+        [_finding(path="tests/test_app.py"), _finding(path="src/app.py")], _cfg(rules)
+    )
+    assert [f.path for f in kept] == ["src/app.py"]
+
+
+def test_glob_with_leading_globstar_matches_repo_root() -> None:
+    rules = [{"match": {"path": "**/*.md"}, "action": {"drop": True}}]
+    kept = apply_finding_rules([_finding(path="README.md")], _cfg(rules))
+    assert kept == []
+
+
+def test_drop_by_category() -> None:
+    rules = [{"match": {"category": "complexity"}, "action": {"drop": True}}]
+    kept = apply_finding_rules(
+        [_finding(category="complexity"), _finding(category="security")], _cfg(rules)
+    )
+    assert [f.category for f in kept] == ["security"]
+
+
+def test_drop_by_title_substring_is_case_insensitive() -> None:
+    rules = [{"match": {"title_contains": "todo"}, "action": {"drop": True}}]
+    kept = apply_finding_rules([_finding(title="Leftover TODO marker")], _cfg(rules))
+    assert kept == []
+
+
+def test_min_severity_matches_at_or_above() -> None:
+    rules = [{"match": {"min_severity": "high"}, "action": {"drop": True}}]
+    kept = apply_finding_rules(
+        [_finding(severity=Severity.critical), _finding(severity=Severity.medium)],
+        _cfg(rules),
+    )
+    assert [f.severity for f in kept] == [Severity.medium]
+
+
+def test_match_fields_are_anded() -> None:
+    rules = [{"match": {"path": "tests/**", "category": "complexity"}, "action": {"drop": True}}]
+    kept = apply_finding_rules(
+        [
+            _finding(path="tests/test_app.py", category="complexity"),  # both → dropped
+            _finding(path="tests/test_app.py", category="security"),  # path only → kept
+            _finding(path="src/app.py", category="complexity"),  # category only → kept
+        ],
+        _cfg(rules),
+    )
+    assert len(kept) == 2
+
+
+def test_severity_remap() -> None:
+    rules = [{"match": {"category": "documentation"}, "action": {"set_severity": "info"}}]
+    kept = apply_finding_rules(
+        [_finding(category="documentation", severity=Severity.medium)], _cfg(rules)
+    )
+    assert kept[0].severity is Severity.info
+
+
+def test_rules_apply_in_order() -> None:
+    """A remap by an earlier rule changes what a later severity-matched rule sees."""
+    rules = [
+        {"match": {"category": "performance"}, "action": {"set_severity": "info"}},
+        {"match": {"min_severity": "high"}, "action": {"drop": True}},
+    ]
+    kept = apply_finding_rules(
+        [_finding(category="performance", severity=Severity.high)], _cfg(rules)
+    )
+    # Remapped to info before the drop rule ran — it no longer matches.
+    assert len(kept) == 1
+    assert kept[0].severity is Severity.info
+
+
+def test_empty_match_matches_everything() -> None:
+    rules = [{"action": {"drop": True}}]
+    assert apply_finding_rules([_finding(), _finding(path="x.py")], _cfg(rules)) == []

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -785,3 +785,49 @@ def test_post_describe_comment_scoped_by_marker_key() -> None:
     gateway.post_describe_comment("body")
 
     assert "<!-- lgtmaybe-describe:ollama/llama3 -->" in str(captured["body"])
+
+
+# ---------------------------------------------------------------------------
+# PR labels: reconcile the managed set, best-effort
+# ---------------------------------------------------------------------------
+
+LABELS_URL = f"{BASE_URL}/repos/{REPO}/issues/{PR_NUMBER}/labels"
+
+
+@respx.mock
+def test_apply_pr_labels_reconciles_managed_labels_only() -> None:
+    current = [{"name": "review-effort/2"}, {"name": "bug"}, {"name": "possible-security-issue"}]
+    respx.route(method="GET", url__startswith=LABELS_URL).mock(
+        return_value=httpx.Response(200, json=current)
+    )
+    deleted: list[str] = []
+
+    def capture_delete(request: httpx.Request) -> httpx.Response:
+        # The label name is one URL-encoded path segment after /labels/.
+        deleted.append(request.url.raw_path.decode().rsplit("/", 1)[-1])
+        return httpx.Response(200, json=[])
+
+    respx.route(method="DELETE", url__startswith=LABELS_URL).mock(side_effect=capture_delete)
+    added: dict[str, object] = {}
+
+    def capture_post(request: httpx.Request) -> httpx.Response:
+        added.update(json.loads(request.content))
+        return httpx.Response(200, json=[])
+
+    respx.route(method="POST", url=LABELS_URL).mock(side_effect=capture_post)
+
+    gateway = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN)
+    gateway.apply_pr_labels(["review-effort/4", "possible-security-issue"])
+
+    # Stale managed label removed; the human's "bug" label untouched.
+    assert deleted == ["review-effort%2F2"]  # slash quoted: one path segment
+    # Only the genuinely new label is added (the security one already exists).
+    assert added == {"labels": ["review-effort/4"]}
+
+
+@respx.mock
+def test_apply_pr_labels_swallows_api_failures() -> None:
+    respx.route(method="GET", url__startswith=LABELS_URL).mock(return_value=httpx.Response(500))
+
+    gateway = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN)
+    gateway.apply_pr_labels(["review-effort/1"])  # must not raise

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -48,6 +48,108 @@
       "title": "CustomLens",
       "type": "object"
     },
+    "FindingRule": {
+      "additionalProperties": false,
+      "description": "One declarative post-processing rule, applied in list order.\n\nThe safe alternative to arbitrary user hooks: rules can only filter or\nre-grade findings \u2014 no user code ever executes.",
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/FindingRuleAction"
+        },
+        "match": {
+          "$ref": "#/$defs/FindingRuleMatch",
+          "default": {
+            "category": null,
+            "min_severity": null,
+            "path": null,
+            "title_contains": null
+          }
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "title": "FindingRule",
+      "type": "object"
+    },
+    "FindingRuleAction": {
+      "additionalProperties": false,
+      "description": "What a matched rule does: drop the finding, or remap its severity.",
+      "properties": {
+        "drop": {
+          "default": false,
+          "title": "Drop",
+          "type": "boolean"
+        },
+        "set_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "FindingRuleAction",
+      "type": "object"
+    },
+    "FindingRuleMatch": {
+      "additionalProperties": false,
+      "description": "The selector of a finding rule. Every specified field must match (AND).\n\nAn empty match selects every finding. ``path`` is an fnmatch glob against\nthe repo-relative path (a ``**/`` prefix also matches at the repo root,\nlike the path filters); ``category`` is the originating lens id;\n``title_contains`` is a case-insensitive substring; ``min_severity``\nselects findings at or above that severity.",
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
+        },
+        "min_severity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "title_contains": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title Contains"
+        }
+      },
+      "title": "FindingRuleMatch",
+      "type": "object"
+    },
     "Provider": {
       "description": "The backend selected by the `--provider` flag.",
       "enum": [
@@ -109,6 +211,18 @@
           "default": false,
           "title": "Broad",
           "type": "boolean"
+        },
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Category"
         },
         "confidence": {
           "anyOf": [
@@ -293,6 +407,13 @@
       "title": "Extra Lenses",
       "type": "array"
     },
+    "finding_rules": {
+      "items": {
+        "$ref": "#/$defs/FindingRule"
+      },
+      "title": "Finding Rules",
+      "type": "array"
+    },
     "ignore_fingerprints": {
       "items": {
         "type": "string"
@@ -356,6 +477,11 @@
       "default": null,
       "title": "Num Ctx"
     },
+    "pr_labels": {
+      "default": false,
+      "title": "Pr Labels",
+      "type": "boolean"
+    },
     "prompt_cache": {
       "default": true,
       "title": "Prompt Cache",
@@ -408,6 +534,18 @@
       "default": true,
       "title": "Structured Output",
       "type": "boolean"
+    },
+    "summary_template": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Summary Template"
     },
     "symbol_resolution": {
       "default": true,

--- a/tests/snapshots/ReviewFinding.json
+++ b/tests/snapshots/ReviewFinding.json
@@ -42,6 +42,18 @@
       "title": "Broad",
       "type": "boolean"
     },
+    "category": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Category"
+    },
     "confidence": {
       "anyOf": [
         {


### PR DESCRIPTION
# F4 + F5b — labels, finding rules, and summary template

The last two feature workstreams from the Phase 0 audit (#166; after #168–#171), bundled as they're both small, opt-in, default-off customisation features.

## F4 — PR labels (no extra model calls)

With `pr_labels: true`, each review attaches labels derived entirely from data already computed:

- **`review-effort/1`–`5`** — a size estimate from the changed-line count (PR-Agent parity);
- **`possible-security-issue`** — a high/critical finding from the *security lens* was posted. To know a finding's lens, findings now carry an engine-stamped **`category`** (the originating lens id, overwriting anything the model claims) — also surfaced in JSON output and reused by F5b's rules;
- **`consider-splitting`** — the diff spans ≥4 unrelated top-level directories across ≥10 files (deliberately conservative — a wrong split hint is pure noise).

The gateway *reconciles* rather than appends: stale `review-effort/*` labels are removed when the score changes, only lgtmaybe's own label families are ever touched (human labels untouched), label names are URL-quoted as a single path segment (`review-effort/2` → `review-effort%2F2`), and everything is best-effort — a labelling failure never fails the review. Action input `pr_labels`.

## F5b — declarative post-processing + summary template

- **`finding_rules`** — ordered rules, each a `match` (path glob with the `**/` root nicety / lens `category` / case-insensitive `title_contains` / `min_severity`, all ANDed) and an `action` (`drop` or `set_severity`), applied just before posting so they see exactly what would otherwise post. Per the audit brief, this is deliberately **not** Gito-style arbitrary post-processing: rules can only filter or re-grade — no user code ever runs, keeping config as data and the attack surface closed. An action must have an effect (schema-validated).
- **`summary_template`** — restyle the summary line with `{count}`/`{provider}`/`{model}` placeholders for house style; a template that fails to format logs and falls back to the built-in line (a cosmetic option must never fail a review).

Both default off/empty → behaviour byte-for-byte unchanged.

## Tests

- Labels: effort bucketing across all five scores; security label only for high/critical **security-lens** findings (not correctness-high, not security-medium, not category-less); sprawl heuristic both ways; gateway reconcile (stale managed label removed, human label untouched, only-new added, URL-quoted delete path); API failure swallowed; run_review applies only when enabled + gateway-capable; dry-run and plain-gateway safe.
- Rules: drop by path/category/title/severity; AND semantics; in-order application (remap changes what later severity rules see); empty match = everything; no rules = identity; engine integration (summary counts post-rules).
- Template: renders custom line; bad placeholder falls back.
- 976 tests green; ruff + mypy clean; config reference, schema snapshots, `configure-lgtmaybe-yml.md`, `CLAUDE.md` updated.

With this, every feature workstream from the audit is done. The one remaining audit item is the **P4 remainder** (expand hunk context to the enclosing function/class boundary via ast-grep) — deferred: it needs on-disk files for ast-grep where the engine works on in-memory texts, and the asymmetric expansion already shipped in #166 captured the cheap high-value part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a)_