### PR TITLE
feat(engine): function-boundary context, per-tool lint floors, eval A/B coverage

### DIFF
--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -20,6 +20,7 @@ provides defaults for all runs.
   - [max_input_tokens](#max_input_tokens)
   - [categories](#categories)
   - [context_lines](#context_lines)
+  - [function_context](#function_context)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
   - [prompt_cache](#prompt_cache)
@@ -188,6 +189,22 @@ context_lines: 10   # at most 10 lines before each hunk (2 after); 0 disables
 
 Default: `20`.
 
+### function_context
+
+Extend each hunk's leading pad up to the **enclosing function or class
+signature** when it sits above the fixed `context_lines` window — the
+signature and setup explain a change better than an arbitrary cut. Boundaries
+are found structurally with ast-grep (already bundled for symbol resolution;
+parsing only, never executing) for Python, JS/TS/TSX, Go, Rust, Java, and
+Ruby, with a bounded reach so a distant definition can't drown the diff.
+Unsupported languages and any ast-grep failure keep the plain fixed-line pad.
+
+```yaml
+function_context: false   # fixed-line padding only
+```
+
+Default: `true`.
+
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
@@ -321,6 +338,8 @@ static_analysis:
   enabled: true
   tools: [ruff, bandit]        # default: ruff, bandit, semgrep
   min_severity: low            # floor on mapped tool severity (default info)
+  tool_min_severity:           # per-tool overrides of the global floor
+    ruff: medium               # only medium+ from ruff; bandit keeps `low`
   # semgrep_rules: .semgrep.yml  # local rules; semgrep is skipped without them
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1713,6 +1713,7 @@ provides defaults for all runs.
   - [max_input_tokens](#max_input_tokens)
   - [categories](#categories)
   - [context_lines](#context_lines)
+  - [function_context](#function_context)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
   - [prompt_cache](#prompt_cache)
@@ -1881,6 +1882,22 @@ context_lines: 10   # at most 10 lines before each hunk (2 after); 0 disables
 
 Default: `20`.
 
+### function_context
+
+Extend each hunk's leading pad up to the **enclosing function or class
+signature** when it sits above the fixed `context_lines` window — the
+signature and setup explain a change better than an arbitrary cut. Boundaries
+are found structurally with ast-grep (already bundled for symbol resolution;
+parsing only, never executing) for Python, JS/TS/TSX, Go, Rust, Java, and
+Ruby, with a bounded reach so a distant definition can't drown the diff.
+Unsupported languages and any ast-grep failure keep the plain fixed-line pad.
+
+```yaml
+function_context: false   # fixed-line padding only
+```
+
+Default: `true`.
+
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
@@ -2014,6 +2031,8 @@ static_analysis:
   enabled: true
   tools: [ruff, bandit]        # default: ruff, bandit, semgrep
   min_severity: low            # floor on mapped tool severity (default info)
+  tool_min_severity:           # per-tool overrides of the global floor
+    ruff: medium               # only medium+ from ruff; bandit keeps `low`
   # semgrep_rules: .semgrep.yml  # local rules; semgrep is skipped without them
 ```
 
@@ -2570,6 +2589,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
 | `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
+| `function_context` | boolean | No | `True` | Function Context |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `incremental` | boolean / null | No | `null` | Incremental |
@@ -2586,7 +2606,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `reflect` | boolean | No | `True` | Reflect |
 | `reflect_model` | string / null | No | `null` | Reflect Model |
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
-| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'semgrep_rules': None}` |  |
+| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
@@ -3001,6 +3021,16 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": null,
           "title": "Semgrep Rules"
         },
+        "tool_min_severity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Severity"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/StaticAnalysisTool"
+          },
+          "title": "Tool Min Severity",
+          "type": "object"
+        },
         "tools": {
           "default": [
             "ruff",
@@ -3091,6 +3121,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Finding Rules",
       "type": "array"
+    },
+    "function_context": {
+      "default": true,
+      "title": "Function Context",
+      "type": "boolean"
     },
     "ignore_fingerprints": {
       "items": {
@@ -3201,6 +3236,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "enabled": false,
         "min_severity": "info",
         "semgrep_rules": null,
+        "tool_min_severity": {},
         "tools": [
           "ruff",
           "bandit",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,6 +23,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
 | `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
+| `function_context` | boolean | No | `True` | Function Context |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
 | `include_paths` | list[string] | No | `[]` | Include Paths |
 | `incremental` | boolean / null | No | `null` | Incremental |
@@ -39,7 +40,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `reflect` | boolean | No | `True` | Reflect |
 | `reflect_model` | string / null | No | `null` | Reflect Model |
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
-| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'semgrep_rules': None}` |  |
+| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
@@ -454,6 +455,16 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": null,
           "title": "Semgrep Rules"
         },
+        "tool_min_severity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Severity"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/StaticAnalysisTool"
+          },
+          "title": "Tool Min Severity",
+          "type": "object"
+        },
         "tools": {
           "default": [
             "ruff",
@@ -544,6 +555,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Finding Rules",
       "type": "array"
+    },
+    "function_context": {
+      "default": true,
+      "title": "Function Context",
+      "type": "boolean"
     },
     "ignore_fingerprints": {
       "items": {
@@ -654,6 +670,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "enabled": false,
         "min_severity": "info",
         "semgrep_rules": null,
+        "tool_min_severity": {},
         "tools": [
           "ruff",
           "bandit",

--- a/evals/fixtures/static-hints/diff.txt
+++ b/evals/fixtures/static-hints/diff.txt
@@ -1,0 +1,27 @@
+diff --git a/report.py b/report.py
+new file mode 100644
+--- /dev/null
++++ b/report.py
+@@ -0,0 +1,22 @@
++import hashlib
++import subprocess
++
++import requests
++import yaml
++
++
++def load_config(path):
++    with open(path) as fh:
++        return yaml.load(fh.read())
++
++
++def fetch_metrics(url):
++    return requests.get(url, verify=False)
++
++
++def run_export(name):
++    subprocess.call("export.sh " + name, shell=True)
++
++
++def digest(payload):
++    return hashlib.md5(payload).hexdigest()

--- a/evals/fixtures/static-hints/expected.json
+++ b/evals/fixtures/static-hints/expected.json
@@ -1,0 +1,29 @@
+{
+  "name": "static-hints",
+  "changed_file": "report.py",
+  "expected": [
+    {
+      "label": "unsafe yaml.load without SafeLoader (deserialization)",
+      "line": 10,
+      "keywords": ["yaml", "safe_load", "loader", "deserial", "unsafe"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "TLS certificate verification disabled (verify=False)",
+      "line": 14,
+      "keywords": ["verify", "tls", "ssl", "certificate", "insecure", "mitm"],
+      "severity_at_least": "medium"
+    },
+    {
+      "label": "command injection via shell=True string concat",
+      "line": 18,
+      "keywords": ["shell", "injection", "command", "subprocess", "untrusted"],
+      "severity_at_least": "high"
+    },
+    {
+      "label": "weak hash md5",
+      "line": 22,
+      "keywords": ["md5", "weak", "hash", "sha-256", "sha256", "insecure", "collision"]
+    }
+  ]
+}

--- a/evals/fixtures/static-hints/head/report.py
+++ b/evals/fixtures/static-hints/head/report.py
@@ -1,0 +1,22 @@
+import hashlib
+import subprocess
+
+import requests
+import yaml
+
+
+def load_config(path):
+    with open(path) as fh:
+        return yaml.load(fh.read())
+
+
+def fetch_metrics(url):
+    return requests.get(url, verify=False)
+
+
+def run_export(name):
+    subprocess.call("export.sh " + name, shell=True)
+
+
+def digest(payload):
+    return hashlib.md5(payload).hexdigest()

--- a/evals/run.py
+++ b/evals/run.py
@@ -19,7 +19,7 @@ import sys
 from datetime import date
 from pathlib import Path
 
-from lgtmaybe.core.models import Provider, ReviewCategory, ReviewConfig
+from lgtmaybe.core.models import Provider, ReviewCategory, ReviewConfig, StaticAnalysisConfig
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError, build_symbol_resolver
 from lgtmaybe.local import local_file_reader
 from lgtmaybe.providers.credentials import resolve_credentials
@@ -67,6 +67,12 @@ def _load_fixtures() -> list[tuple[str, Fixture]]:
         corpus = d / "repo"
         if corpus.is_dir():
             manifest.corpus_root = corpus
+        # A `head/` subdir carries the changed files' HEAD text (what the
+        # GitHub gateway would fetch), feeding static analysis and context
+        # expansion during the eval run.
+        head = d / "head"
+        if head.is_dir():
+            manifest.head_root = head
         out.append((diff, manifest))
     return out
 
@@ -130,6 +136,8 @@ def _review(
     top_k: int | None = None,
     categories: list[ReviewCategory] | None = None,
     context_lines: int | None = None,
+    static_analysis: bool = False,
+    triage_model: str | None = None,
 ):
     ctx = _eval_ctx(diff, manifest)
     cfg_overrides: dict[str, object] = {}
@@ -139,6 +147,12 @@ def _review(
         cfg_overrides["categories"] = categories
     if context_lines is not None:
         cfg_overrides["context_lines"] = context_lines
+    if static_analysis:
+        # A/B the F1 fusion: installed tools run over the fixture's head/ text
+        # and their findings ground the lens prompts, exactly as in production.
+        cfg_overrides["static_analysis"] = StaticAnalysisConfig(enabled=True)
+    if triage_model is not None:
+        cfg_overrides["triage_model"] = triage_model
     cfg = ReviewConfig(
         provider=provider,
         model=model,
@@ -316,6 +330,21 @@ def main(argv: list[str] | None = None) -> int:
         "path-only fetch so a run can A/B the cross-file false-positive rate",
     )
     ap.add_argument(
+        "--static-analysis",
+        dest="static_analysis",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="enable static-analysis fusion (F1) so installed tools (ruff/bandit) "
+        "ground the review with hints over the fixtures' head/ text — run the same "
+        "model with and without to measure the fusion's recall delta",
+    )
+    ap.add_argument(
+        "--triage-model",
+        default=None,
+        help="cheap triage model (P3) run before the strong --model, so a run can "
+        "measure what two-stage routing costs in recall on the fixture set",
+    )
+    ap.add_argument(
         "--json",
         dest="json_out",
         action="store_true",
@@ -351,6 +380,8 @@ def main(argv: list[str] | None = None) -> int:
             top_k=args.top_k,
             categories=categories,
             context_lines=args.context_lines,
+            static_analysis=args.static_analysis,
+            triage_model=args.triage_model,
         )
         for diff, m in fixtures
     ]

--- a/evals/scorer.py
+++ b/evals/scorer.py
@@ -51,6 +51,12 @@ class Fixture(BaseModel):
     # reader + ast-grep symbol resolver rooted here, so a deferred cross-file verdict
     # can fetch the real definition — exactly the path symbol resolution adds.
     corpus_root: Path | None = Field(default=None, exclude=True)
+    # HEAD text of the fixture's changed files (a ``head/`` subdir next to
+    # ``diff.txt``), loader-populated like ``corpus_root``. When present it
+    # becomes ``PRContext.file_contents`` — the input static-analysis fusion,
+    # context expansion, and function-boundary padding all key on — so those
+    # features can be A/B-measured against fixtures instead of running dark.
+    head_root: Path | None = Field(default=None, exclude=True)
 
 
 class FixtureScore(BaseModel):
@@ -212,6 +218,16 @@ def score_fixture(
 
 def _eval_ctx(diff: str, manifest: Fixture) -> PRContext:
     """The synthetic PRContext every eval review runs against (no real PR)."""
+    file_contents: dict[str, str] = {}
+    if manifest.head_root is not None:
+        # The head/ dir mirrors the changed files' HEAD text — the same shape
+        # the GitHub gateway fetches — feeding static analysis, context
+        # expansion, and boundary padding during an eval run.
+        file_contents = {
+            str(p.relative_to(manifest.head_root)): p.read_text()
+            for p in sorted(manifest.head_root.rglob("*"))
+            if p.is_file()
+        }
     return PRContext(
         diff=diff,
         changed_files=[manifest.changed_file],
@@ -219,6 +235,7 @@ def _eval_ctx(diff: str, manifest: Fixture) -> PRContext:
         head_sha="1",
         repo="eval/eval",
         pr_number=0,
+        file_contents=file_contents,
     )
 
 

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -118,6 +118,10 @@ class StaticAnalysisConfig(_Strict):
     # LOW/MEDIUM/HIGH → low/medium/high; semgrep INFO/WARNING/ERROR →
     # info/medium/high). Hints below it are dropped before prompting.
     min_severity: Severity = Severity.info
+    # Per-tool overrides of `min_severity` — e.g. keep every bandit hit but
+    # take only medium+ from ruff. A tool without an entry uses the global
+    # floor; a tool's own entry always wins, in either direction.
+    tool_min_severity: dict[StaticAnalysisTool, Severity] = Field(default_factory=dict)
     # Local semgrep rules file/dir passed as --config. semgrep is SKIPPED when
     # unset: its registry configs (`--config auto`) fetch over the network,
     # which the sandbox forbids.
@@ -423,6 +427,12 @@ class ReviewConfig(_Strict):
     # Ceiling on surrounding context lines added around each hunk. The engine
     # uses min(context_lines, what the token budget allows); 0 disables it.
     context_lines: int = 20
+    # Extend each hunk's LEADING pad up to the enclosing function/class
+    # signature when ast-grep can cheaply find it (bounded reach; PR-Agent's
+    # enclosing-scope expansion) — the signature explains a change better than
+    # an arbitrary cut. Falls back to the fixed-line pad for unsupported
+    # languages or any ast-grep failure. Off = fixed-line padding only.
+    function_context: bool = True
     # Per-request timeout (seconds) for each provider completion call. None means
     # "auto": the factory picks a provider-aware default (ollama gets a long one,
     # since local models are slow; cloud providers a short one). An explicit value

--- a/src/lgtmaybe/engine/boundaries.py
+++ b/src/lgtmaybe/engine/boundaries.py
@@ -1,0 +1,117 @@
+"""Function/class boundary detection for context expansion (P4 remainder).
+
+PR-Agent expands hunk context to the enclosing function rather than a fixed
+line count; this module supplies the boundaries. ast-grep (already a core
+dependency — the same binary symbol resolution uses, never a second AST
+stack) parses the head file text and reports where function/class definitions
+START, so ``compress.expand_hunks`` can pad the leading context up to the
+enclosing signature when it sits above the fixed window.
+
+Parsing, not executing: the text is written to a throwaway temp file and
+structurally scanned, the same fork-safety posture as symbol resolution and
+static analysis. Best-effort throughout — an unsupported language, a missing
+binary, or any ast-grep failure returns ``[]`` and the caller keeps the plain
+fixed-line pad.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from lgtmaybe.core.logging import get_logger
+
+from .astgrep import _find_binary
+
+_log = get_logger(__name__)
+
+# One file parse is tens of milliseconds; the timeout only caps pathology.
+_SCAN_TIMEOUT = 10
+
+# Abstracts the ast-grep subprocess: (binary, rule_yaml, file) -> stdout ("" on
+# failure). Injected so tests don't have to shell out.
+BoundaryRunner = Callable[[str, str, Path], str]
+
+# Extension -> (ast-grep language, block-level definition kinds). Deliberately a
+# narrower table than symbol resolution's: only kinds that OPEN a body worth
+# padding to (functions/methods/classes) — a variable_declarator boundary would
+# be noise. An extension not listed simply keeps the fixed-line pad.
+_LANG_DEFS: dict[str, tuple[str, tuple[str, ...]]] = {
+    ".py": ("python", ("function_definition", "class_definition")),
+    ".js": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
+    ".jsx": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
+    ".ts": (
+        "typescript",
+        ("function_declaration", "method_definition", "class_declaration"),
+    ),
+    ".tsx": ("tsx", ("function_declaration", "method_definition", "class_declaration")),
+    ".go": ("go", ("function_declaration", "method_declaration")),
+    ".rs": ("rust", ("function_item", "impl_item", "trait_item")),
+    ".java": ("java", ("method_declaration", "class_declaration")),
+    ".rb": ("ruby", ("method", "singleton_method", "class", "module")),
+}
+
+
+def definition_starts(
+    text: str,
+    path: str,
+    *,
+    runner: BoundaryRunner | None = None,
+    find_binary: Callable[[], str | None] = _find_binary,
+) -> list[int]:
+    """Sorted 1-based start lines of function/class definitions in *text*.
+
+    ``[]`` whenever boundaries can't be found cheaply and safely: unsupported
+    extension, no ast-grep binary, or any scan/parse failure — the caller then
+    pads by fixed line count exactly as before.
+    """
+    lang_defs = _LANG_DEFS.get(Path(path).suffix.lower())
+    if lang_defs is None:
+        return []
+    binary = find_binary()
+    if binary is None:
+        return []
+    language, kinds = lang_defs
+    kinds_flow = ", ".join(f"{{kind: {k}}}" for k in kinds)
+    rule = f"id: lgtmaybe-boundaries\nlanguage: {language}\nrule: {{any: [{kinds_flow}]}}\n"
+    run = runner if runner is not None else _default_runner
+    with tempfile.TemporaryDirectory(prefix="lgtmaybe-bounds-") as tmp:
+        target = Path(tmp) / f"file{Path(path).suffix.lower()}"
+        target.write_text(text)
+        stdout = run(binary, rule, target)
+    return _parse_starts(stdout)
+
+
+def _default_runner(binary: str, rule_yaml: str, target: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [binary, "scan", "--inline-rules", rule_yaml, "--json=compact", str(target)],
+            capture_output=True,
+            text=True,
+            timeout=_SCAN_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout or ""
+
+
+def _parse_starts(stdout: str) -> list[int]:
+    """1-based, de-duplicated, sorted start lines from ast-grep's match array."""
+    try:
+        data = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    starts: set[int] = set()
+    for match in data:
+        if not isinstance(match, dict):
+            continue
+        line = match.get("range", {}).get("start", {}).get("line")
+        if isinstance(line, int) and line >= 0:
+            starts.add(line + 1)  # ast-grep lines are 0-based
+    return sorted(starts)

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -6,6 +6,7 @@ Provides a dynamic context-line calculator for the remaining budget.
 
 from __future__ import annotations
 
+from bisect import bisect_right
 from functools import lru_cache
 from typing import Any
 
@@ -152,6 +153,22 @@ def context_lines_for_budget(remaining_tokens: int) -> int:
     return min(int(lines), _MAX_CONTEXT_LINES)
 
 
+def _enclosing_boundary(boundaries: list[int], new_start: int) -> int | None:
+    """The nearest definition start at or above *new_start*, if within reach.
+
+    *boundaries* is sorted ascending; the enclosing candidate is the last one
+    ``<= new_start``. None when there is none, or when it sits more than
+    :data:`_MAX_BOUNDARY_REACH` lines above (padding to it would drown the diff).
+    """
+    idx = bisect_right(boundaries, new_start) - 1
+    if idx < 0:
+        return None
+    candidate = boundaries[idx]
+    if new_start - candidate > _MAX_BOUNDARY_REACH:
+        return None
+    return candidate
+
+
 def trailing_context_lines(before: int) -> int:
     """The trailing pad for a leading pad of *before* lines (asymmetric context).
 
@@ -166,7 +183,19 @@ def trailing_context_lines(before: int) -> int:
     return max(1, before // 4)
 
 
-def expand_hunks(patch: str, file_content: str | None, n: int, after: int | None = None) -> str:
+# How far above a hunk the enclosing-definition pad may reach (lines). Beyond
+# this the "enclosing function" is so far away that padding to it would drown
+# the diff; the fixed-line pad applies instead.
+_MAX_BOUNDARY_REACH = 120
+
+
+def expand_hunks(
+    patch: str,
+    file_content: str | None,
+    n: int,
+    after: int | None = None,
+    boundaries: list[int] | None = None,
+) -> str:
     """Pad each hunk in *patch* with surrounding lines from *file_content*.
 
     Up to *n* lines are added before each hunk and up to *after* lines after it
@@ -175,6 +204,13 @@ def expand_hunks(patch: str, file_content: str | None, n: int, after: int | None
     normal unchanged context (space-prefixed), giving the model the function and
     definitions around a change. Hunk headers are rewritten so each hunk's
     start/length still describes the lines it now contains.
+
+    ``boundaries`` (sorted 1-based definition start lines, from
+    :func:`~lgtmaybe.engine.boundaries.definition_starts`) extends the LEADING
+    pad up to the enclosing function/class signature when it sits above the
+    fixed window and within :data:`_MAX_BOUNDARY_REACH` lines — the enclosing
+    signature explains a change better than an arbitrary cut. A boundary can
+    only ever widen the window, never shrink it.
 
     This is best-effort: with ``n <= 0`` or no file content the patch is returned
     unchanged, and reads are clamped to the file's bounds. The result is for the
@@ -204,7 +240,14 @@ def expand_hunks(patch: str, file_content: str | None, n: int, after: int | None
         section = header.section
 
         # Lines immediately before the hunk and after its last new-file line.
-        leading = [content_lines[i - 1] for i in range(max(1, new_start - n), new_start)]
+        lead_start = max(1, new_start - n)
+        if boundaries:
+            enclosing = _enclosing_boundary(boundaries, new_start)
+            if enclosing is not None and enclosing < lead_start:
+                # The enclosing definition starts above the fixed window and
+                # within reach — widen the pad up to its signature line.
+                lead_start = enclosing
+        leading = [content_lines[i - 1] for i in range(lead_start, new_start)]
         last_new = new_start + new_len - 1
         trailing = [
             content_lines[i - 1]

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -26,6 +26,7 @@ from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
 from lgtmaybe.github import is_reviewable
 
 from .astgrep import SymbolResolver
+from .boundaries import definition_starts
 from .compress import (
     batch_files,
     context_lines_for_budget,
@@ -188,7 +189,17 @@ class LLMReviewEngine(ReviewEngine):
                 (
                     path,
                     expand_hunks(
-                        patch, redact(ctx.file_contents.get(path, "")), ctx_lines, after=after
+                        patch,
+                        redact(ctx.file_contents.get(path, "")),
+                        ctx_lines,
+                        after=after,
+                        # Enclosing function/class boundaries (ast-grep; [] on
+                        # any failure) so the leading pad reaches the signature.
+                        boundaries=(
+                            definition_starts(ctx.file_contents.get(path, ""), path)
+                            if cfg.function_context and ctx.file_contents.get(path)
+                            else None
+                        ),
                     ),
                 )
                 for path, patch in file_patches

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -91,7 +91,9 @@ def run_static_analysis(file_contents: dict[str, str], cfg: ReviewConfig) -> lis
         for tool in sa.tools:
             findings.extend(_run_tool(tool, root, cfg))
 
-    kept = [f for f in findings if f.severity >= sa.min_severity]
+    # Per-tool floors win over the global floor, in either direction.
+    floors = {tool.value: floor for tool, floor in sa.tool_min_severity.items()}
+    kept = [f for f in findings if f.severity >= floors.get(f.tool, sa.min_severity)]
     dropped = len(findings) - len(kept)
     if findings:
         _log.info(

--- a/tests/engine/test_boundaries.py
+++ b/tests/engine/test_boundaries.py
@@ -1,0 +1,54 @@
+"""Function/class boundary detection for context expansion (P4 remainder).
+
+``definition_starts`` uses ast-grep (already a core dependency — the same tool
+symbol resolution uses, never a second AST stack) to find the 1-based start
+lines of function/class definitions in a file's head text, so hunk expansion
+can pad up to the enclosing signature instead of a fixed line count. Best
+effort throughout: an unknown language, a missing binary, or any ast-grep
+failure returns [] and the caller keeps the fixed-line pad.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.engine.boundaries import definition_starts
+
+_PY = """\
+import os
+
+CONST = 1
+
+
+def outer(a, b):
+    x = a + b
+    if x > 0:
+        for i in range(10):
+            x += i
+    return x
+
+
+class Thing:
+    def method(self):
+        y = 1
+        return y
+"""
+
+
+def test_python_definition_starts_found_with_real_ast_grep() -> None:
+    starts = definition_starts(_PY, "src/sample.py")
+
+    # def outer (line 6), class Thing (line 14), def method (line 15).
+    assert starts == [6, 14, 15]
+
+
+def test_unknown_extension_returns_nothing() -> None:
+    assert definition_starts("whatever", "notes.txt") == []
+
+
+def test_missing_binary_returns_nothing() -> None:
+    assert definition_starts(_PY, "src/sample.py", find_binary=lambda: None) == []
+
+
+def test_runner_failure_returns_nothing() -> None:
+    assert (
+        definition_starts(_PY, "src/sample.py", runner=lambda binary, rule, path: "not json") == []
+    )

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -249,3 +249,55 @@ def test_trailing_context_lines_ratio() -> None:
     assert trailing_context_lines(4) == 1
     assert trailing_context_lines(1) == 1
     assert trailing_context_lines(0) == 0
+
+
+# ---------------------------------------------------------------------------
+# expand_hunks: boundary-aware leading pad (P4 remainder)
+# ---------------------------------------------------------------------------
+
+# 30 lines: a def on line 3, hunk will sit far below it.
+_FN_CONTENT = "\n".join(
+    ["import os", "", "def handler(req):"]
+    + [f"    step_{i}()" for i in range(1, 26)]
+    + ["    return done"]
+)
+
+
+def test_boundary_extends_the_leading_pad_to_the_enclosing_def() -> None:
+    # Hunk at new-file line 20 with a 2-line fixed pad; the enclosing def is on
+    # line 3 — well above the fixed window, within reach.
+    patch = "diff --git a/f.py b/f.py\n@@ -20,1 +20,1 @@\n step_17()\n"
+
+    expanded = expand_hunks(patch, _FN_CONTENT, 2, after=1, boundaries=[3])
+
+    assert "\ndef handler(req):\n" in expanded or "\n def handler(req):\n" in expanded
+    # Header start moved up to the boundary line.
+    assert "@@ -3," in expanded
+
+
+def test_boundary_inside_the_fixed_window_changes_nothing() -> None:
+    patch = "diff --git a/f.py b/f.py\n@@ -4,1 +4,1 @@\n step_1()\n"
+
+    with_boundary = expand_hunks(patch, _FN_CONTENT, 5, after=1, boundaries=[3])
+    without = expand_hunks(patch, _FN_CONTENT, 5, after=1)
+
+    # The def on line 3 is already inside the 5-line fixed pad — the boundary
+    # must never SHRINK the window.
+    assert with_boundary == without
+
+
+def test_boundary_beyond_reach_is_ignored() -> None:
+    lines = ["def far_away():"] + [f"    l{i}" for i in range(1, 400)]
+    content = "\n".join(lines)
+    patch = "diff --git a/f.py b/f.py\n@@ -300,1 +300,1 @@\n l299\n"
+
+    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[1])
+
+    assert "def far_away" not in expanded  # 299 lines up: past the reach cap
+
+
+def test_no_boundaries_keeps_the_fixed_pad() -> None:
+    patch = "diff --git a/f.py b/f.py\n@@ -20,1 +20,1 @@\n step_17()\n"
+    assert expand_hunks(patch, _FN_CONTENT, 2, after=1, boundaries=[]) == expand_hunks(
+        patch, _FN_CONTENT, 2, after=1
+    )

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1558,3 +1558,46 @@ def test_finding_rules_run_before_the_summary_count(monkeypatch) -> None:  # typ
 
     assert findings == []
     assert "0 findings" in summary
+
+
+# ---------------------------------------------------------------------------
+# function-boundary context expansion (P4 remainder)
+# ---------------------------------------------------------------------------
+
+_FN_FILE = "\n".join(["def enclosing():"] + [f"    step_{i}()" for i in range(1, 30)])
+
+_FN_CTX = PRContext(
+    diff="diff --git a/f.py b/f.py\n@@ -20,1 +20,1 @@\n step_19()\n",
+    changed_files=["f.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="org/repo",
+    pr_number=6,
+    file_contents={"f.py": _FN_FILE},
+)
+
+
+def test_function_context_pads_to_the_enclosing_def(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("lgtmaybe.engine.engine.definition_starts", lambda text, path: [1])
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", context_lines=3)
+
+    engine.review(_FN_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "def enclosing():" in sent  # 19 lines above the hunk — beyond the fixed pad
+
+
+def test_function_context_off_keeps_the_fixed_pad(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("lgtmaybe.engine.engine.definition_starts", lambda text, path: [1])
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama, model="llama3", context_lines=3, function_context=False
+    )
+
+    engine.review(_FN_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "def enclosing():" not in sent

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -261,3 +261,41 @@ def test_format_hints_renders_tool_rule_path_line() -> None:
     assert "B307" in text
     assert "src/app.py:2" in text
     assert "eval" in text
+
+
+def test_per_tool_severity_floor_overrides_the_global_floor(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """tool_min_severity floors one tool without touching the others: ruff's
+    low-grade hits are dropped while bandit's medium hit survives."""
+    run = _FakeRun(outputs={"ruff": _ruff_output("/r"), "bandit": _bandit_output()})
+
+    class _Run(_FakeRun):
+        def __call__(self, argv, **kwargs):  # type: ignore[no-untyped-def]
+            tool = Path(str(argv[0])).name
+            self.calls.append({"argv": argv, **kwargs})
+            out = _ruff_output(str(kwargs["cwd"])) if tool == "ruff" else _bandit_output()
+            return SimpleNamespace(stdout=out, stderr="", returncode=0)
+
+    run = _Run()
+    _patch_tools(monkeypatch, run, present={"ruff", "bandit"})
+
+    findings = run_static_analysis(
+        FILES,
+        _cfg(tool_min_severity={StaticAnalysisTool.ruff: Severity.medium}),
+    )
+
+    assert [f.tool for f in findings] == ["bandit"]
+
+
+def test_per_tool_floor_defaults_to_the_global_floor(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    run = _FakeRun(outputs={"bandit": _bandit_output()})
+    _patch_tools(monkeypatch, run, present={"bandit"})
+
+    findings = run_static_analysis(
+        FILES,
+        _cfg(
+            min_severity=Severity.high,  # global floor drops bandit's medium…
+            tool_min_severity={StaticAnalysisTool.bandit: Severity.low},  # …but its own floor wins
+        ),
+    )
+
+    assert [f.tool for f in findings] == ["bandit"]

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -262,3 +262,59 @@ def test_fixtures_cover_performance_and_complexity_lenses() -> None:
         assert "complexity" in keywords and "cyclomatic" in keywords, (
             f"{name}: no complexity finding"
         )
+
+
+# ---------------------------------------------------------------------------
+# static-hints fixture (F1 A/B) + head/ loading
+# ---------------------------------------------------------------------------
+
+
+def test_static_hints_head_matches_the_diff() -> None:
+    """The head/ text must be exactly what the diff adds — a drifted copy would
+    lint different code than the model reviews."""
+    diff, manifest = _fixture("static-hints")
+
+    assert manifest.head_root is not None
+    head = (manifest.head_root / "report.py").read_text()
+    added = [
+        line[1:] for line in diff.splitlines() if line.startswith("+") and line != "+++ b/report.py"
+    ]
+    assert added == head.splitlines()
+
+
+def test_static_hints_plants_tool_detectable_bugs() -> None:
+    """Each planted bug is a pattern bandit fires on deterministically, so an
+    A/B run (--static-analysis on/off) measures the fusion's recall delta."""
+    _diff, manifest = _fixture("static-hints")
+    head = (manifest.head_root / "report.py").read_text()  # type: ignore[union-attr]
+
+    for marker in ("yaml.load", "verify=False", "shell=True", "hashlib.md5"):
+        assert marker in head, marker
+    # Every expected finding sits on a real added line of the diff.
+    lines = head.splitlines()
+    for exp in manifest.expected:
+        assert 1 <= exp.line <= len(lines)
+
+
+def test_head_root_set_only_for_fixtures_with_a_head_dir() -> None:
+    fixtures = run_mod._load_fixtures()
+    by_name = {m.name: m for _d, m in fixtures}
+    assert by_name["static-hints"].head_root is not None
+    assert by_name["badcode"].head_root is None
+
+
+def test_eval_ctx_loads_head_files_as_file_contents() -> None:
+    from evals.scorer import _eval_ctx
+
+    diff, manifest = _fixture("static-hints")
+    ctx = _eval_ctx(diff, manifest)
+
+    assert "report.py" in ctx.file_contents
+    assert "yaml.load" in ctx.file_contents["report.py"]
+
+
+def test_eval_ctx_without_head_dir_has_no_file_contents() -> None:
+    from evals.scorer import _eval_ctx
+
+    diff, manifest = _fixture("badcode")
+    assert _eval_ctx(diff, manifest).file_contents == {}

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -323,6 +323,16 @@
           "default": null,
           "title": "Semgrep Rules"
         },
+        "tool_min_severity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Severity"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/StaticAnalysisTool"
+          },
+          "title": "Tool Min Severity",
+          "type": "object"
+        },
         "tools": {
           "default": [
             "ruff",
@@ -413,6 +423,11 @@
       },
       "title": "Finding Rules",
       "type": "array"
+    },
+    "function_context": {
+      "default": true,
+      "title": "Function Context",
+      "type": "boolean"
     },
     "ignore_fingerprints": {
       "items": {
@@ -523,6 +538,7 @@
         "enabled": false,
         "min_severity": "info",
         "semgrep_rules": null,
+        "tool_min_severity": {},
         "tools": [
           "ruff",
           "bandit",


### PR DESCRIPTION
# The three deferred remnants, closed out

Follow-up to the audit series (#166–#172): the P4 remainder, the per-tool severity floors deferred from F1 (#169), and eval coverage so the new features' recall impact is measurable rather than assumed.

## 1. Function-boundary context expansion (P4 remainder)

Each hunk's **leading pad now extends up to the enclosing function/class signature** when it sits above the fixed `context_lines` window — PR-Agent's enclosing-scope expansion. Boundaries come from ast-grep (already a core dependency, the same binary symbol resolution uses — no second AST stack): the head file text is written to a throwaway temp file and structurally scanned for block-level definition kinds (Python, JS/TS/TSX, Go, Rust, Java, Ruby — a deliberately narrower kind table than symbol resolution's, since a `variable_declarator` boundary would be noise).

Guard rails: a bounded reach (120 lines) so a distant definition can't drown the diff; a boundary can only ever **widen** the window, never shrink it; and every failure mode — unsupported extension, missing binary, scan/parse failure — keeps the plain fixed-line pad. `function_context` config (default on; `false` restores fixed-line-only padding). Parsing, never executing — same fork-safety posture as symbol resolution and static analysis.

## 2. Per-tool severity floors (F1 deferral)

`static_analysis.tool_min_severity` overrides the global `min_severity` per tool — e.g. take only medium+ from ruff while keeping every bandit hit. A tool's own entry wins in either direction; tools without an entry keep the global floor.

## 3. Eval A/B coverage for the new features

- Fixtures can now ship a **`head/` dir** whose files load into `PRContext.file_contents` — the input static-analysis fusion, context expansion, and boundary padding all key on — so those features run against fixtures instead of running dark (`Fixture.head_root`, loader + `_eval_ctx` wiring).
- New **`static-hints`** fixture: a diff planting four security bugs bandit fires on deterministically (unsafe `yaml.load`, `verify=False`, `shell=True` injection, MD5) — verified end-to-end against real bandit (B506/B501/B602/B324 all fire on the exact catalogued lines).
- `python -m evals.run` grows **`--static-analysis`** and **`--triage-model`** flags, so the same yardstick can measure the fusion's recall delta (on/off) and what two-stage triage costs in recall.

## Tests

- Boundaries: real-ast-grep integration (definition starts on actual parse), unknown-extension / missing-binary / garbage-output fallbacks.
- Compress: boundary extends the leading pad + rewrites the hunk header; a boundary inside the fixed window changes nothing (never shrinks); beyond-reach ignored; empty list = identity.
- Engine: `function_context` on pads to the enclosing def; off keeps the fixed pad.
- Static analysis: per-tool floor drops one tool's weak hits while another's survive; a tool's own floor beats a stricter global floor.
- Evals: head/ text must exactly match the diff's added lines (drift guard); planted patterns present; expected lines in range; `head_root` set only when the dir exists; `_eval_ctx` loads/omits `file_contents` accordingly.
- 994 tests green; ruff + mypy clean; config reference, schema snapshots, `configure-lgtmaybe-yml.md` updated.

This closes out every item from the original audit brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYhjQhuLMPJ1treA5N6Y5a)_