### PR TITLE
fix(evals): disable the review deadline in eval runs + one-command preset A/B

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -324,6 +324,30 @@ typically cross-file false positives where the relevant guard lives in a file th
 reviewer can't see. The `cross-file-fp` fixture is the worked example: one genuine
 in-diff catch alongside three forbidden cross-file claims.
 
+### Measuring what the fast preset trades away
+
+The default `fast` preset covers the nine lenses in four grouped calls;
+`--preset full` runs one call per lens. What that grouping costs in recall is a
+per-model question, so measure it on the model you actually run rather than
+trusting a generic claim. `evals/ab.py` sweeps the preset on the current tree
+in one command — first value is the baseline:
+
+```bash
+# Needs a live model — full-vs-fast recall/precision on the fixture set:
+uv run python -m evals.ab --provider ollama --model qwen3.6:35b \
+  --api-base http://localhost:11434 --preset full,fast --timeout 900
+```
+
+Each leg reviews every fixture through the real engine; only the preset varies
+(temperature pinned to 0, fixtures fixed). The report is the pooled
+recall/precision delta of `fast` against `full`. On a slow local model expect a
+`full` leg to take `~9 × per-call time` per big fixture — the eval harness
+disables the production `max_review_seconds` ceiling so a slow run measures
+recall, not the deadline. A single `--preset full` (no comma) instead pins the
+preset on both legs of a `--baseline-ref` comparison, for "did this change
+regress the full preset?" A/Bs between refs (both refs must be ≥ 0.10.0, where
+the flag exists).
+
 ### Benchmarking the recursive (RLM) walk
 
 `ReviewConfig.recursive` (default on) decides what happens when a single file's

--- a/evals/ab.py
+++ b/evals/ab.py
@@ -241,13 +241,43 @@ def main(argv: list[str] | None = None) -> int:
         "this comma-separated list on the CURRENT tree (e.g. 20,40,0) — a config A/B "
         "axis for the hunk-context window width",
     )
+    ap.add_argument(
+        "--preset",
+        default=None,
+        help="review preset. A comma-separated list (e.g. 'full,fast') sweeps the "
+        "preset on the CURRENT tree — the one-command full-vs-fast recall A/B, first "
+        "value as baseline. A single value applies to both legs of a --baseline-ref "
+        "comparison (the baseline ref must already know the flag, i.e. >= 0.10.0; "
+        "for older refs omit it and compare via --categories instead).",
+    )
     args = ap.parse_args(argv)
 
     fixtures_dir = Path(__file__).parent / "fixtures"
     passthrough = _provider_passthrough(args)
+    preset_values = [v.strip() for v in (args.preset or "").split(",") if v.strip()]
+    if len(preset_values) > 1 and args.context_lines is not None:
+        ap.error("sweep one config axis at a time: --preset list OR --context-lines")
+    if len(preset_values) == 1:
+        # A pinned preset is provider passthrough, not an axis: both legs get it.
+        passthrough += ["--preset", preset_values[0]]
 
     # Config axis: sweep one ReviewConfig setting on the current tree. Each value is
     # its own leg; we report each against the first as baseline.
+    if len(preset_values) > 1:
+        legs = [
+            _current_leg(
+                fixtures_dir,
+                provider=args.provider,
+                model=args.model,
+                extra_args=passthrough + ["--preset", v],
+                label=f"preset={v}",
+            )
+            for v in preset_values
+        ]
+        for leg in legs[1:]:
+            _print_report(ABReport(baseline=legs[0], current=leg))
+        return 0
+
     if args.context_lines is not None:
         values = [v.strip() for v in args.context_lines.split(",") if v.strip()]
         legs = [
@@ -266,7 +296,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if not args.baseline_ref:
-        ap.error("either --baseline-ref or --context-lines is required")
+        ap.error("either --baseline-ref, --context-lines, or a --preset list is required")
 
     baseline = _baseline_leg(
         args.baseline_ref,

--- a/evals/rlm.py
+++ b/evals/rlm.py
@@ -137,7 +137,14 @@ def _run_strategy_once(
     engine = LLMReviewEngine(tracker)
     matched = expected = 0
     parsed_all = True
-    overrides: dict[str, Any] = {"recursive": recursive, "reflect": reflect}
+    # No review deadline in a benchmark: the production ceiling would skip
+    # calls on a slow local model and corrupt the recall being measured
+    # (same reasoning as evals.run).
+    overrides: dict[str, Any] = {
+        "recursive": recursive,
+        "reflect": reflect,
+        "max_review_seconds": 0,
+    }
     if budget is not None:
         overrides["max_input_tokens"] = budget
     if categories is not None:

--- a/evals/run.py
+++ b/evals/run.py
@@ -163,6 +163,12 @@ def _review(
         timeout=timeout,
         reflect=reflect,
         recursive=recursive,
+        # Evals measure model quality, never wall-clock discipline: the
+        # production review deadline (max_review_seconds, default 600s) would
+        # skip calls mid-eval on a slow local model — a full-preset run on a
+        # big fixture easily exceeds 600s serially — and silently melt the
+        # recall it exists to measure. Always off here.
+        max_review_seconds=0,
         **cfg_overrides,
     )
     # Sampling params + ollama's num_ctx reach the model via build_provider → litellm.

--- a/tests/evals/test_ab.py
+++ b/tests/evals/test_ab.py
@@ -100,3 +100,72 @@ def test_verdict_no_change_reads_as_flat() -> None:
     )
     out = ab_verdict(report).lower()
     assert "no change" in out or "flat" in out
+
+
+class TestPresetAxis:
+    """The --preset flag: a list sweeps the preset on the current tree; a single
+    value pins it (passthrough to both legs of a ref comparison)."""
+
+    def _run(self, monkeypatch, argv: list[str]) -> list[tuple[str, list[str]]]:
+        """Run ab.main with legs faked out; returns (label, extra_args) per leg."""
+        import evals.ab as ab_mod
+
+        calls: list[tuple[str, list[str]]] = []
+
+        def fake_current_leg(fixtures_dir, *, provider, model, extra_args, label="working-tree"):
+            calls.append((label, list(extra_args)))
+            return _leg(label, 0.5, 0.9)
+
+        def fake_baseline_leg(ref, fixtures_dir, *, provider, model, extra_args):
+            calls.append((ref, list(extra_args)))
+            return _leg(ref, 0.5, 0.9)
+
+        monkeypatch.setattr(ab_mod, "_current_leg", fake_current_leg)
+        monkeypatch.setattr(ab_mod, "_baseline_leg", fake_baseline_leg)
+        assert ab_mod.main(argv) == 0
+        return calls
+
+    def test_preset_list_sweeps_on_the_current_tree(self, monkeypatch) -> None:
+        calls = self._run(
+            monkeypatch,
+            ["--provider", "ollama", "--model", "x", "--preset", "full,fast"],
+        )
+        assert [label for label, _ in calls] == ["preset=full", "preset=fast"]
+        assert ["--preset", "full"] == calls[0][1][-2:]
+        assert ["--preset", "fast"] == calls[1][1][-2:]
+
+    def test_single_preset_pins_both_legs_of_a_ref_comparison(self, monkeypatch) -> None:
+        calls = self._run(
+            monkeypatch,
+            [
+                "--provider",
+                "ollama",
+                "--model",
+                "x",
+                "--baseline-ref",
+                "v0.10.0",
+                "--preset",
+                "full",
+            ],
+        )
+        assert len(calls) == 2  # baseline + current
+        for _label, extra in calls:
+            assert "--preset" in extra and extra[extra.index("--preset") + 1] == "full"
+
+    def test_two_axes_at_once_is_an_error(self, monkeypatch) -> None:
+        import pytest as _pytest
+
+        with _pytest.raises(SystemExit):
+            self._run(
+                monkeypatch,
+                [
+                    "--provider",
+                    "ollama",
+                    "--model",
+                    "x",
+                    "--preset",
+                    "full,fast",
+                    "--context-lines",
+                    "20,0",
+                ],
+            )

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -534,3 +534,40 @@ def test_reflect_defaults_on_and_no_reflect_disables_it(monkeypatch: pytest.Monk
     seen.clear()
     run_mod.main(["--provider", "ollama", "--model", "x", "--min-recall", "0.0", "--no-reflect"])
     assert seen and all(v is False for v in seen)
+
+
+def _capture_cfg(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> list:
+    """Run main with *argv* and return the ReviewConfig objects the engine saw."""
+    seen: list = []
+    real_review = run_mod.LLMReviewEngine.review
+
+    def spy_review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+        seen.append(cfg)
+        return real_review(self, ctx, cfg)
+
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    monkeypatch.setattr(run_mod.LLMReviewEngine, "review", spy_review)
+    run_mod.main(argv)
+    return seen
+
+
+_BASE_ARGV = ["--provider", "ollama", "--model", "x", "--min-recall", "0.0"]
+
+
+def test_review_deadline_is_disabled_for_evals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production max_review_seconds ceiling must never apply in an eval:
+    on a slow local model it would skip calls mid-fixture and silently melt the
+    recall the run exists to measure."""
+    seen = _capture_cfg(monkeypatch, [*_BASE_ARGV, "--fixture", "badcode"])
+    assert seen and all(cfg.max_review_seconds == 0 for cfg in seen)
+
+
+def test_preset_flag_threads_to_review_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _capture_cfg(monkeypatch, [*_BASE_ARGV, "--fixture", "badcode", "--preset", "full"])
+    assert seen and all(cfg.preset.value == "full" for cfg in seen)
+
+
+def test_preset_defaults_to_the_production_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --preset the eval measures what production ships: fast."""
+    seen = _capture_cfg(monkeypatch, [*_BASE_ARGV, "--fixture", "badcode"])
+    assert seen and all(cfg.preset.value == "fast" for cfg in seen)


### PR DESCRIPTION
Follow-up to #174, unblocking the live full-vs-fast eval that PR left as an open item.

## The bug

#174 added `max_review_seconds` (default 600s) as a production wall-clock ceiling. The eval harness builds its `ReviewConfig` without touching it, so the ceiling applies to eval runs too — and on a slow local model a `--preset full` leg on a big fixture easily exceeds 600s of serial calls. The deadline then **skips calls mid-eval**, and the recall drop looks like a model/preset regression rather than the ops ceiling firing. Evals measure model quality, never wall-clock discipline, so `evals.run` and `evals.rlm` now always build their config with `max_review_seconds=0` (commented at both sites; covered by `test_review_deadline_is_disabled_for_evals`).

## The preset A/B, one command

`evals.ab` grows a `--preset` axis mirroring the existing `--context-lines` sweep:

```bash
uv run python -m evals.ab --provider ollama --model qwen3.6:35b \
  --api-base http://localhost:11434 --preset full,fast --timeout 900
```

A comma list sweeps the preset on the current tree (first value = baseline) and reports the pooled recall/precision delta of `fast` against `full` — the number the README's preset trade-off claim should carry. A single value pins the preset on both legs of a `--baseline-ref` comparison (both refs must be ≥ 0.10.0, where the flag exists; documented). Two axes at once is an error. `evals.run` also gains `--preset` threading tests, and DEVELOPMENT.md documents the recipe next to the RLM benchmark.

## Why the measurement isn't attached

I attempted to run the A/B in this session: the workspace network policy blocks every model-weights source (ollama.com, registry.ollama.ai, Hugging Face, GitHub release assets — all 403), the environment's AWS/GCP credentials are placeholders bedrock/vertex reject, and `api.anthropic.com` is reachable but has no injected auth. So this PR ships the corrected, one-command harness instead; the command above produces the measured number on any machine with a live model.

1,112 tests passing; ruff + format + strict mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJtx6spcYFp8i1LNCvSLGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJtx6spcYFp8i1LNCvSLGQ)_