### PR TITLE
feat(cli): add help command with usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ lgtmaybe review \
 ```
 
 No GitHub token and no pull request needed — `lgtmaybe review` reads your local
-`git` diff and prints the findings. To post reviews on real pull requests, wire
-up the [GitHub Action](#use-as-a-github-action). See
+`git` diff and prints the findings. `lgtmaybe help` lists every command with
+usage examples; `lgtmaybe help review` shows the full option reference. To post
+reviews on real pull requests, wire up the
+[GitHub Action](#use-as-a-github-action). See
 [Getting Started](docs/tutorial/getting-started.md) for the full walkthrough.
 
 > **Picking a model:** use a **coding** model, and **bigger/newer is more

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -20,8 +20,11 @@ pip install lgtmaybe
 Verify it:
 
 ```bash
-lgtmaybe --help
+lgtmaybe help
 ```
+
+That prints the command list with usage examples; `lgtmaybe help <command>`
+(e.g. `lgtmaybe help review`) shows the full option reference for one command.
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -215,8 +215,11 @@ pip install lgtmaybe
 Verify it:
 
 ```bash
-lgtmaybe --help
+lgtmaybe help
 ```
+
+That prints the command list with usage examples; `lgtmaybe help <command>`
+(e.g. `lgtmaybe help review`) shows the full option reference for one command.
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -488,7 +488,21 @@ def action_inputs() -> dict[str, str | None]:
     }
 
 
-@click.group()
+_EPILOG = """\
+\b
+Examples:
+  lgtmaybe review                          Review your branch vs the default branch
+  lgtmaybe review --working                Include uncommitted edits too
+  lgtmaybe review --provider ollama --model qwen3:27b
+  lgtmaybe review --format json            Machine-readable findings
+  lgtmaybe config init                     One-time provider/model setup
+  lgtmaybe help COMMAND                    Detailed help for any command
+\b
+Docs: https://mattjcoles.github.io/lgtmaybe/
+"""
+
+
+@click.group(epilog=_EPILOG)
 def main() -> None:
     """lgtmaybe — provider-agnostic PR reviewer."""
 

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -351,7 +351,13 @@ def review(
 @click.option("--fallback-model", default=None, help="Model to retry with if the primary fails")
 @click.option("--api-key", default=None, envvar="LGTMAYBE_API_KEY", help="API key")
 @click.option("--api-base", default=None, help="API base URL (e.g. ollama)")
-@click.option("--config", "config_path", default=".lgtmaybe.yml", show_default=True)
+@click.option(
+    "--config",
+    "config_path",
+    default=".lgtmaybe.yml",
+    show_default=True,
+    help="Path to a per-repo config file",
+)
 def comment(
     event_path: str,
     provider: str | None,
@@ -477,3 +483,27 @@ def config_init() -> None:
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Wrote {store.user_config_path()}")
+
+
+@main.command(name="help")
+@click.argument("command_path", nargs=-1, metavar="[COMMAND]...")
+@click.pass_context
+def help_command(ctx: click.Context, command_path: tuple[str, ...]) -> None:
+    """Show help for lgtmaybe or a specific command.
+
+    `lgtmaybe help review` shows the full option reference for `review`;
+    nested paths work too: `lgtmaybe help config set`.
+    """
+    # Walk the command tree from the main group, rebuilding the context chain
+    # so the usage line matches `lgtmaybe <command...> --help` exactly.
+    target_ctx = ctx.parent if ctx.parent is not None else ctx
+    cmd = target_ctx.command
+    for name in command_path:
+        sub = cmd.get_command(target_ctx, name) if isinstance(cmd, click.Group) else None
+        if sub is None:
+            raise click.UsageError(
+                f"No such command {name!r}. Run `lgtmaybe help` to list commands."
+            )
+        target_ctx = click.Context(sub, info_name=name, parent=target_ctx)
+        cmd = sub
+    click.echo(cmd.get_help(target_ctx))

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -1,0 +1,76 @@
+"""The `help` command: overview with examples, per-command help, nested paths."""
+
+from __future__ import annotations
+
+import re
+
+from click.testing import CliRunner
+
+from lgtmaybe.cli import main
+
+
+def test_help_lists_commands_and_examples() -> None:
+    result = CliRunner().invoke(main, ["help"])
+    assert result.exit_code == 0
+    for command in ("review", "comment", "action", "config", "help"):
+        assert command in result.output
+    assert "Examples:" in result.output
+    assert "lgtmaybe review" in result.output
+    assert "https://mattjcoles.github.io/lgtmaybe/" in result.output
+
+
+def test_help_command_matches_dash_dash_help() -> None:
+    runner = CliRunner()
+    via_help = runner.invoke(main, ["help", "review"])
+    via_flag = runner.invoke(main, ["review", "--help"])
+    assert via_help.exit_code == 0
+    assert via_flag.exit_code == 0
+    assert via_help.output == via_flag.output
+
+
+def test_help_nested_subcommand() -> None:
+    runner = CliRunner()
+    via_help = runner.invoke(main, ["help", "config", "set"])
+    via_flag = runner.invoke(main, ["config", "set", "--help"])
+    assert via_help.exit_code == 0
+    assert via_help.output == via_flag.output
+    assert "KEY VALUE" in via_help.output
+
+
+def test_help_group_lists_subcommands() -> None:
+    result = CliRunner().invoke(main, ["help", "config"])
+    assert result.exit_code == 0
+    for sub in ("path", "show", "get", "set", "init"):
+        assert sub in result.output
+
+
+def test_help_unknown_command_errors() -> None:
+    result = CliRunner().invoke(main, ["help", "bogus"])
+    assert result.exit_code != 0
+    assert "No such command 'bogus'" in result.output
+    assert "lgtmaybe help" in result.output
+
+
+def test_help_path_through_non_group_errors() -> None:
+    result = CliRunner().invoke(main, ["help", "review", "extra"])
+    assert result.exit_code != 0
+    assert "No such command 'extra'" in result.output
+
+
+def test_bare_invocation_shows_enriched_help() -> None:
+    # Click >= 8.2 treats a group invoked with no args as a usage error
+    # (exit 2) while still printing the full help — assert the content only.
+    result = CliRunner().invoke(main, [])
+    assert "Examples:" in result.output
+    for command in ("review", "comment", "action", "config", "help"):
+        assert command in result.output
+
+
+def test_comment_options_all_have_help_text() -> None:
+    result = CliRunner().invoke(main, ["comment", "--help"])
+    assert result.exit_code == 0
+    for line in result.output.splitlines():
+        match = re.match(r"^\s+(--[a-z-]+)(?: \S+)?\s*(.*)$", line)
+        if match and match.group(1) != "--help":
+            assert match.group(2), f"option {match.group(1)} has no help text"
+    assert "config file" in result.output


### PR DESCRIPTION
## What

Adds a git-style `lgtmaybe help` command and enriches the CLI's help output with the instructions and examples users expect from a help menu.

- **`lgtmaybe help [COMMAND]...`** — prints the Click help for the named command, byte-identical to `<command> --help`. Nested paths work (`lgtmaybe help config set`); an unknown name errors with `No such command 'x'. Run \`lgtmaybe help\` to list commands.` and exit code 2.
- **Usage examples + docs link** on the main group via an `epilog`, so bare `lgtmaybe`, `lgtmaybe --help`, and `lgtmaybe help` all show the command list, six common examples (local review, `--working`, provider selection, JSON output, `config init`, `help COMMAND`), and the docs URL.
- **Polish:** `comment --config` gets its missing help text.
- **Docs:** README quick-start and `docs/how-to/install-the-cli.md` now point at `lgtmaybe help`; `llms-full.txt` regenerated.

## How

The `help` command walks the command tree from the `main` group's context, rebuilding the Click context chain (`info_name`/`parent`) per hop so the usage line matches the real `--help` output exactly. Plain Click, no new dependencies.

## Tests (TDD)

New `tests/cli/test_help.py` (written red-first): overview content, `help review` == `review --help`, nested `help config set`, group listing, unknown-command and path-through-non-group errors, bare-invocation content, and every `comment` option having help text. Full suite: 1120 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So7US1wrb86EdKM9iBDyDJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01So7US1wrb86EdKM9iBDyDJ)_