### PR TITLE
feat: add openspec living specs anchored to code with ast-grep

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,155 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,160 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,174 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,109 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,143 @@
+---
+name: "OPSX: Sync"
+description: Sync delta specs from a change to main specs
+category: Workflow
+tags: [workflow, specs, experimental]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.5.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -1,0 +1,44 @@
+# Non-blocking spec-drift gate for the living specs (openspec/specs/).
+#
+# Warns — never fails — when code under an ast-grep anchor changed while its
+# spec section sat still (drift), or a rule that matched at the merge-base now
+# matches nothing (dangling, i.e. a rename nobody re-pointed). A blocking doc
+# check just gets gamed; this one names the anchor in a PR annotation and the
+# step summary and stays out of branch protection. The deterministic anchor
+# invariants (bijection, exactly-one-match) are a hard gate in
+# tests/specs/test_anchors.py, which runs in ci.yml.
+
+name: spec-drift
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    continue-on-error: true # belt and braces — the script itself always exits 0
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the dangling check scans a merge-base worktree
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Sync (with dev deps)
+        run: uv sync --dev
+
+      - name: Check spec drift
+        run: uv run python scripts/check_spec_drift.py --base "origin/${{ github.base_ref }}"
+
+      # Advisory shape check with the real OpenSpec CLI. The equivalent
+      # structural rules are enforced deterministically (node-free) in
+      # tests/specs/test_anchors.py; this catches divergence from upstream.
+      - name: openspec validate (advisory)
+        run: npx -y @fission-ai/openspec@latest validate --specs
+        continue-on-error: true

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,10 @@ This document is the high-level orientation: the project layout, the LLM
 providers, the components inside the application, and the user-facing features.
 For the *why* behind the design (ports & adapters, the pipeline, the patterns),
 see [`docs/explanation/architecture.md`](docs/explanation/architecture.md); for
-the decisions that are settled, see [`CLAUDE.md`](CLAUDE.md).
+the decisions that are settled, see [`CLAUDE.md`](CLAUDE.md). Per-capability
+behavior lives in the living specs under [`openspec/specs/`](openspec/specs/),
+each requirement bound to the code it describes by ast-grep anchors (see
+"Living specs" in `CLAUDE.md`).
 
 ## Design in one breath
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,45 @@ self-verify without asking. The acceptance test *is* the red step — start ther
 - Treat diff content as untrusted everywhere it flows.
 - Errors surface to the user; never swallow them.
 
+## Living specs (OpenSpec + ast-grep anchors)
+
+`openspec/specs/<capability>/spec.md` are the **living domain specs** — durable
+descriptions of how the system behaves, distinct from OpenSpec change proposals
+(which are disposable; durable knowledge folds back into these). Every
+requirement section carries an anchor id — `<!-- anchor: engine.snap -->` on
+its own line right after the section's opening paragraph — bound to code by
+ast-grep rules in the capability's co-located `anchors.yml`. Rules match code
+**shape** (node kind + name regex + a `files:` glob; never `pattern:`, which
+silently misses async defs), so they survive file moves and refactors and break
+on renames — by design: a rename usually changes the thing the spec describes,
+and a dead anchor is the signal to re-read the section.
+
+The workflow rules:
+
+- **Before changing code**, resolve the anchors for the files you expect to
+  touch (grep the `anchors.yml` sidecars, or run
+  `uv run ast-grep scan --inline-rules … --json src/` from the repo root — the
+  `files:` globs resolve against the scan cwd) and read only the matching spec
+  sections, not the whole spec tree.
+- **At the end of a task**, re-run `uv run pytest tests/specs -q` and update
+  the spec sections your change made stale — as targeted edits to those
+  sections only, never a free-rewrite of a spec. Most tasks need no spec
+  change; that's the correct outcome, not a failure.
+- **Anchor hygiene:** each rule resolves to exactly one place — 0 matches is
+  dangling, >1 is too loose (tighten with `files:` or `inside:`). Both are
+  drift and both fail `tests/specs/test_anchors.py` (bijection with the spec's
+  anchor ids, exactly-one-match, OpenSpec shape, 40-line section cap — split a
+  section rather than letting it grow into a changelog).
+- **The drift gate** (`scripts/check_spec_drift.py`,
+  `.github/workflows/spec-drift.yml`) is non-blocking by design: on each PR it
+  warns when anchored code changed while its spec section sat still, and when a
+  rule that matched at the merge-base matches nothing now (the rename case the
+  intersection check alone can't see). A warning names the anchor id — fix the
+  rule *and* re-read the section, don't just patch the regex.
+- `openspec validate --specs` must stay green (`npx -y
+  @fission-ai/openspec@latest validate --specs`); its parser reads only the
+  first line of a requirement's text for the SHALL/MUST check, so lead with it.
+
 ## Security-review coverage
 
 Two distinct concerns, kept separate:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -214,6 +214,10 @@ LLM or the GitHub API. Test layout mirrors `src/`:
 - `tests/core/`, `tests/local/` — diff parsing, local git context
 - `tests/docs/` + `tests/snapshots/` — committed schema snapshots and the
   generated-reference freshness check (see below)
+- `tests/specs/` — the living-spec anchor hygiene gate: every requirement in
+  `openspec/specs/*/spec.md` has an ast-grep anchor in its `anchors.yml` that
+  resolves to exactly one place in `src/` (see "Living specs" in `CLAUDE.md`;
+  the non-blocking PR drift warning is `scripts/check_spec_drift.py`)
 - `tests/e2e/` — live end-to-end against a local model server (deselected by
   default; see below)
 

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,25 @@
+schema: spec-driven
+
+# Project context — shown to AI when creating artifacts.
+context: |
+  lgtmaybe: a provider-agnostic PR reviewer (Python 3.11+, litellm spine,
+  hexagonal ports & adapters, uv-managed). Read CLAUDE.md first — it encodes
+  decisions that are made, not options. TDD is non-negotiable: acceptance test
+  first, red -> green -> refactor; CI rejects code without tests.
+  Conventional commits (commitlint gates PR titles/commits).
+
+  Living specs: openspec/specs/<capability>/spec.md. Every requirement section
+  carries an anchor id (`<!-- anchor: ... -->`) bound to code by ast-grep rules
+  in the co-located anchors.yml sidecar (kind + name regex, never `pattern:`).
+  tests/specs/test_anchors.py enforces hygiene (each rule resolves to exactly
+  one place); scripts/check_spec_drift.py warns on PRs when anchored code
+  changes without its spec section. See "Living specs" in CLAUDE.md.
+
+# Per-artifact rules.
+rules:
+  specs:
+    - Every requirement heading is immediately followed by its anchor comment
+    - Keep each requirement section under 40 lines; split instead of appending
+    - Describe current behavior; never invent aspirational requirements
+  proposal:
+    - Proposals are disposable; durable knowledge folds back into openspec/specs/

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -1,0 +1,39 @@
+# ast-grep anchors for cli-and-local — see "Living specs" in CLAUDE.md.
+
+cli.review-command:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^review$' }
+  files: [src/lgtmaybe/cli/**/*.py]
+
+cli.run-review:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^run_review$' }
+  files: [src/lgtmaybe/cli/**/*.py]
+
+cli.slash:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^parse_command$' }
+    files: [src/lgtmaybe/cli/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^dispatch$' }
+    files: [src/lgtmaybe/cli/**/*.py]
+
+cli.local-context:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^local_pr_context$' }
+  files: [src/lgtmaybe/local/**/*.py]
+
+cli.config:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^load_config$' }
+    files: [src/lgtmaybe/config/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^set_key$' }
+    files: [src/lgtmaybe/config/**/*.py]

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -1,0 +1,68 @@
+# cli-and-local Specification
+
+## Purpose
+
+The Click CLI (`cli/`), the slash-command router, local no-GitHub review of a
+git diff (`local/`), and layered config (`config/`) — one engine behind
+`review`, `comment`, and `action` entrypoints.
+
+## Requirements
+
+### Requirement: Review failures are loud
+
+The `review` command SHALL surface any failure: a short "review failed"
+comment is posted (when a PR is in play) and the CLI exits non-zero — never a
+silent success.
+<!-- anchor: cli.review-command -->
+
+#### Scenario: provider call dies mid-review
+- **WHEN** the review raises
+- **THEN** the run exits non-zero with the error surfaced, and a failure
+  comment is posted on the PR
+
+### Requirement: One orchestrator behind every entrypoint
+
+`run_review` SHALL orchestrate the shared flow — watermark read, incremental
+vs full decision, optional auto-describe, engine call, posting — so `review`,
+`comment`, and `action` never duplicate review logic.
+<!-- anchor: cli.run-review -->
+
+#### Scenario: Action synchronize event
+- **WHEN** the Action runs on `synchronize` with `incremental` unset
+- **THEN** the same orchestrator picks incremental review automatically
+
+### Requirement: Slash commands route to the same engine
+
+`issue_comment` events SHALL parse into commands — `/review` (with `full`
+forcing a full re-review), `/improve`, `/ask <q>` replying in-thread, and
+`/describe` upserting a structured description — all dispatched to the same
+engine and provider stack.
+<!-- anchor: cli.slash -->
+
+#### Scenario: reviewer comments /review full
+- **WHEN** the comment body is `/review full`
+- **THEN** a full review runs, bypassing triage and incremental scoping
+
+### Requirement: Local review needs no GitHub
+
+`lgtmaybe review` in a repo SHALL build the context from git alone: branch
+diff against the resolved base (`origin/HEAD` → `origin/main` →
+`origin/master` → `main` → `master`, `--base` overrides), `--working` for the
+whole worktree vs the merge-base, `--uncommitted` for edits vs HEAD, with
+commit subjects feeding the intent lens.
+<!-- anchor: cli.local-context -->
+
+#### Scenario: developer reviews before pushing
+- **WHEN** `lgtmaybe review --working` runs in a repo with no PR
+- **THEN** findings print locally (human/json/agent format); nothing posts
+
+### Requirement: Config layers merge, secrets never persist
+
+Config SHALL merge user-level file → repo `.lgtmaybe.yml` → CLI flags (most
+specific wins), and the user-level store persists only non-secret defaults —
+API keys stay in the environment, never written to disk.
+<!-- anchor: cli.config -->
+
+#### Scenario: user tries to persist a key
+- **WHEN** `lgtmaybe config set` targets an API key
+- **THEN** it is refused; keys are read from env/flags at run time only

--- a/openspec/specs/core-contracts/anchors.yml
+++ b/openspec/specs/core-contracts/anchors.yml
@@ -1,0 +1,46 @@
+# ast-grep anchors for core-contracts — see "Living specs" in CLAUDE.md.
+# Rules match code shape (kind + name), never paths/lines or `pattern:`.
+
+core.provider-port:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^ProviderClient$' }
+  files: [src/lgtmaybe/**/*.py]
+
+core.gateway-port:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^GitHubGateway$' }
+  files: [src/lgtmaybe/**/*.py]
+
+core.engine-port:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^ReviewEngine$' }
+  files: [src/lgtmaybe/core/**/*.py]
+
+core.finding:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^ReviewFinding$' }
+  files: [src/lgtmaybe/**/*.py]
+
+core.config:
+  - rule:
+      kind: class_definition
+      has: { field: name, regex: '^ReviewConfig$' }
+    files: [src/lgtmaybe/**/*.py]
+  - rule:
+      kind: class_definition
+      has: { field: name, regex: '^Severity$' }
+    files: [src/lgtmaybe/**/*.py]
+
+core.lenses:
+  - rule:
+      kind: class_definition
+      has: { field: name, regex: '^ReviewCategory$' }
+    files: [src/lgtmaybe/**/*.py]
+  - rule:
+      kind: class_definition
+      has: { field: name, regex: '^ReviewPreset$' }
+    files: [src/lgtmaybe/**/*.py]

--- a/openspec/specs/core-contracts/spec.md
+++ b/openspec/specs/core-contracts/spec.md
@@ -1,0 +1,83 @@
+# core-contracts Specification
+
+## Purpose
+
+The frozen contracts everything else codes against: the hexagonal ports in
+`core/ports.py` (the seams between the engine and the outside world) and the
+strict pydantic models in `core/models.py` (the wire format between all
+tracks). These froze in the foundation step; adapters and the engine are built
+against them, and fakes drop in through them.
+
+## Requirements
+
+### Requirement: Provider port
+
+`ProviderClient` SHALL be the only seam to an LLM backend: one `complete()`
+call taking chat messages and a model id and returning a `ProviderResult`.
+Adapters (litellm) and fakes implement it; nothing else in the engine talks to
+a model.
+<!-- anchor: core.provider-port -->
+
+#### Scenario: engine calls any backend the same way
+- **WHEN** the engine needs a completion, for any provider
+- **THEN** it calls `ProviderClient.complete(messages, model, **opts)` and gets
+  a `ProviderResult` back, with no provider-specific branching in the engine
+
+### Requirement: GitHub gateway port
+
+`GitHubGateway` SHALL expose PR context retrieval and review posting as the
+only GitHub seam. Implementations fetch the diff via API only — PR code is
+never checked out or executed (fork safety under `pull_request_target`).
+<!-- anchor: core.gateway-port -->
+
+#### Scenario: review round-trip through the port
+- **WHEN** a review runs against a PR
+- **THEN** context arrives via `get_pr_context()` and results leave via
+  `post_review(findings, summary)` — no other GitHub access from the engine
+
+### Requirement: Engine port
+
+`ReviewEngine` SHALL map `(PRContext, ReviewConfig)` to
+`(list[ReviewFinding], summary)`. Callers (CLI, Action, slash commands) depend
+on this signature, not on the pipeline inside.
+<!-- anchor: core.engine-port -->
+
+#### Scenario: any caller, one entrypoint
+- **WHEN** the CLI, the Action, or a slash command wants a review
+- **THEN** it injects its ports and calls `review(ctx, cfg)`
+
+### Requirement: Findings are structured output only
+
+`ReviewFinding` SHALL be the only shape a finding takes: severity, file, line,
+side, title, body, optional suggestion, verbatim `anchor` line, `anchored`
+flag, 0-10 `confidence`, and the originating lens `category`. Models are
+strict (`extra="forbid"`), so drifted or injected fields are rejected — prose
+is never parsed.
+<!-- anchor: core.finding -->
+
+#### Scenario: model returns an unexpected field
+- **WHEN** the LLM's JSON carries a field the contract doesn't declare
+- **THEN** validation rejects it rather than silently accepting it
+
+### Requirement: One config surface with ordered severities
+
+`ReviewConfig` SHALL be the single knob surface for a review (provider, model,
+filters, caps, toggles); `Severity` SHALL order `info < low < medium < high <
+critical` so floors like `min_severity` compare with `>=`.
+<!-- anchor: core.config -->
+
+#### Scenario: severity floor filters findings
+- **WHEN** `min_severity` is `medium`
+- **THEN** `low` and `info` findings are dropped before posting
+
+### Requirement: Nine built-in lenses, preset-shaped fan-out
+
+`ReviewCategory` SHALL enumerate the nine built-in lenses (security,
+correctness, deprecation, tests, documentation, performance, complexity,
+intent, ponytail). `ReviewPreset` SHALL shape the fan-out: `fast` (default)
+covers all nine in four calls; `full` runs one call per lens.
+<!-- anchor: core.lenses -->
+
+#### Scenario: default preset batches the lenses
+- **WHEN** a review runs with no preset override
+- **THEN** the nine lenses fan out as four concurrent calls

--- a/openspec/specs/finding-quality/anchors.yml
+++ b/openspec/specs/finding-quality/anchors.yml
@@ -1,0 +1,35 @@
+# ast-grep anchors for finding-quality — see "Living specs" in CLAUDE.md.
+
+quality.reflect:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^reflect_findings$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+quality.verdicts:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_parse_verdicts$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+quality.suppress:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^apply_suppressions$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+quality.rules:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^apply_finding_rules$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+quality.symbol-resolution:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^resolve_needs$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^build_symbol_resolver$' }
+    files: [src/lgtmaybe/engine/**/*.py]

--- a/openspec/specs/finding-quality/spec.md
+++ b/openspec/specs/finding-quality/spec.md
@@ -1,0 +1,68 @@
+# finding-quality Specification
+
+## Purpose
+
+The passes between raw lens output and what gets posted: suppression,
+self-reflection with cross-file humility (`engine/reflect.py`), confidence
+scoring, cross-file symbol resolution for deferred verdicts, and declarative
+finding rules — all biased to never silently drop a real finding.
+
+## Requirements
+
+### Requirement: Self-reflection with a keep-all safe default
+
+After merge/dedupe the provider SHALL audit its own findings and drop the ones
+it marks low-confidence, including cross-file false positives whose validity
+hinges on unshown code — while gap findings (a missing test/doc on the diff
+itself) stay valid. An unparseable audit keeps everything.
+<!-- anchor: quality.reflect -->
+
+#### Scenario: reflection output can't be parsed
+- **WHEN** the audit reply fails to parse
+- **THEN** every finding is kept — a broken audit never silently drops findings
+
+### Requirement: Verdicts are lenient to read, strict to act on
+
+Each kept verdict SHALL carry a 0-10 confidence score (the auditor tries to
+disprove the finding to reach it); `min_confidence` drops findings scored
+below it, and an unscored kept finding survives any threshold.
+<!-- anchor: quality.verdicts -->
+
+#### Scenario: kept finding has no score
+- **WHEN** a verdict keeps a finding but omits `confidence`
+- **THEN** the finding survives even a `min_confidence` of 10
+
+### Requirement: Suppressions apply before reflection
+
+Known-fine findings SHALL be dropped before the reflection pass — ignored
+fingerprints and inline suppression comments — so audit budget is never spent
+on them.
+<!-- anchor: quality.suppress -->
+
+#### Scenario: a finding was previously dismissed
+- **WHEN** its fingerprint is in `ignore_fingerprints`
+- **THEN** it never reaches reflection or posting
+
+### Requirement: Finding rules are declarative, never code
+
+`finding_rules` SHALL be an ordered declarative match (path glob / lens
+category / title / severity floor, ANDed) to action (`drop` / `set_severity`),
+applied just before posting. Deliberately not a hook: no user code ever runs.
+<!-- anchor: quality.rules -->
+
+#### Scenario: a team downgrades a lens on a path
+- **WHEN** a rule matches `category: complexity` under `legacy/**`
+- **THEN** the action applies with no user code executed
+
+### Requirement: Deferred verdicts resolve real definitions
+
+A deferred cross-file symbol SHALL be located structurally with ast-grep in a
+read-only corpus of the PR's base branch (never executed), so the auditor
+re-judges against the real definition instead of guessing. Unsupported
+languages or any ast-grep failure fall back to the plain verdict.
+<!-- anchor: quality.symbol-resolution -->
+
+#### Scenario: auditor names a symbol outside the diff
+- **WHEN** a verdict needs `validate_tenant` defined in an unshown file
+- **THEN** ast-grep finds its file in the corpus and the auditor re-judges
+  against the actual code

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -1,0 +1,65 @@
+# ast-grep anchors for github-posting — see "Living specs" in CLAUDE.md.
+
+github.context:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^get_pr_context$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^RestGitHubGateway$' }
+      stopBy: end
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.post-review:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^post_review$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^RestGitHubGateway$' }
+      stopBy: end
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.fingerprint:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^finding_fingerprint$' }
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.demote:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_render_demoted$' }
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.incremental:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^compare_diff$' }
+    files: [src/lgtmaybe/github/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^mark_reviewed$' }
+    files: [src/lgtmaybe/github/**/*.py]
+
+github.resolve-fixed:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_resolve_fixed_threads$' }
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.reviewable:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^is_reviewable$' }
+  files: [src/lgtmaybe/github/**/*.py]
+
+github.labels:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^compute_labels$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^apply_pr_labels$' }
+    files: [src/lgtmaybe/github/**/*.py]

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -1,0 +1,100 @@
+# github-posting Specification
+
+## Purpose
+
+The GitHub REST adapter (`github/rest_gateway.py`): PR context via API only,
+idempotent review posting keyed by a hidden marker, fingerprint-driven
+resolve-on-fix, commit-scoped incremental review, and labels — everything
+best-effort where it must never fail the review.
+
+## Requirements
+
+### Requirement: Context comes from the API, never a checkout
+
+`get_pr_context` SHALL fetch the diff, metadata, and head text of reviewable
+files via the REST API only — PR code is never checked out or executed, which
+is what makes `pull_request_target` (secrets available) safe on fork PRs.
+<!-- anchor: github.context -->
+
+#### Scenario: fork PR is reviewed
+- **WHEN** the review runs with repo secrets on a fork PR
+- **THEN** no PR code is fetched other than as API-returned text
+
+### Requirement: Posting is idempotent via a hidden marker
+
+Reviews SHALL post as one batched REST review (inline comments + summary),
+with a hidden marker comment enabling in-place updates on re-run — the marker
+also carries the last-reviewed-SHA watermark that drives incremental review.
+<!-- anchor: github.post-review -->
+
+#### Scenario: review re-runs on the same PR
+- **WHEN** a review already exists from a prior run
+- **THEN** the summary is updated in place, not duplicated
+
+### Requirement: Findings carry fingerprints
+
+Each inline comment SHALL embed a hidden per-finding fingerprint derived from
+path and title, keying re-run dedupe and resolve-on-fix.
+<!-- anchor: github.fingerprint -->
+
+#### Scenario: same finding, next run
+- **WHEN** a re-run produces a finding whose fingerprint is already posted
+- **THEN** it is not posted again
+
+### Requirement: Unanchored findings are demoted, never guessed
+
+A finding whose anchor matched nothing (`anchored=False`) SHALL be rendered
+into the review body instead of posted inline — a wrong-line comment breaks
+trust faster than a finding without a precise line. `unanchored_min_severity`
+floors what is worth demoting.
+<!-- anchor: github.demote -->
+
+#### Scenario: anchor text matches no changed line
+- **WHEN** a finding's line is a guess
+- **THEN** it appears in the review body, not as an inline comment
+
+### Requirement: Incremental review is commit-scoped and safe
+
+A re-run with a watermark SHALL review only the compare-API diff since the
+last-reviewed SHA; the watermark moves only on success; force-push / same
+head / API failure fall back to a full review; LEFT-side findings are dropped
+(their coordinates are relative to the wrong base) and resolve-on-fix is
+scoped to the increment's files.
+<!-- anchor: github.incremental -->
+
+#### Scenario: a review run fails
+- **WHEN** posting fails after review
+- **THEN** the watermark does not move, so nothing is skipped next run
+
+### Requirement: Resolving threads is best-effort GraphQL
+
+When a finding is gone and GitHub marks its thread outdated, the thread SHALL
+be replied to and resolved via GraphQL (the one op REST can't do) —
+best-effort, never failing the review.
+<!-- anchor: github.resolve-fixed -->
+
+#### Scenario: GraphQL call errors
+- **WHEN** `resolveReviewThread` fails
+- **THEN** the review still completes and posts normally
+
+### Requirement: Generated and binary files are skipped
+
+Lockfiles, minified bundles, vendored trees, and binary files SHALL be
+excluded from review before any path filter or cap applies.
+<!-- anchor: github.reviewable -->
+
+#### Scenario: lockfile in the diff
+- **WHEN** the PR changes `uv.lock`
+- **THEN** it is skipped and never counts against `max_files`
+
+### Requirement: Labels touch only our own families
+
+Labels SHALL derive from data the review already computed — with `pr_labels`
+on: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` —
+and reconciliation SHALL touch only lgtmaybe's own label families —
+best-effort, never failing the review.
+<!-- anchor: github.labels -->
+
+#### Scenario: repo has unrelated labels
+- **WHEN** labels are reconciled
+- **THEN** labels outside lgtmaybe's families are never added or removed

--- a/openspec/specs/hardening/anchors.yml
+++ b/openspec/specs/hardening/anchors.yml
@@ -1,0 +1,35 @@
+# ast-grep anchors for hardening — see "Living specs" in CLAUDE.md.
+
+hardening.wrap-diff:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^wrap_diff$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^neutralise$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
+hardening.wrap-intent:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^wrap_intent$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+hardening.wrap-hints:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^wrap_hints$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+hardening.redact:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^redact$' }
+  files: [src/lgtmaybe/engine/redact.py]
+
+hardening.parse:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^parse_findings$' }
+  files: [src/lgtmaybe/engine/**/*.py]

--- a/openspec/specs/hardening/spec.md
+++ b/openspec/specs/hardening/spec.md
@@ -1,0 +1,69 @@
+# hardening Specification
+
+## Purpose
+
+The reviewer's own defenses, so a malicious PR can't subvert *us*: prompt
+injection defense with delimiter break-out neutralisation
+(`engine/injection.py`), secret redaction before anything leaves for the LLM
+(`engine/redact.py`), and structured-output parsing that recovers leniently
+but validates strictly (`engine/parse.py`). Diff content is untrusted
+everywhere it flows.
+
+## Requirements
+
+### Requirement: The diff is wrapped as untrusted data
+
+The diff SHALL enter the prompt only inside a delimited untrusted-data block,
+and forged delimiters in the content — any marker family, any case — SHALL be
+neutralised so an attacker diff cannot break out of the data block or forge a
+different block's markers.
+<!-- anchor: hardening.wrap-diff -->
+
+#### Scenario: attacker forges the end delimiter
+- **WHEN** a diff contains a `DIFF_END` (or any block's) marker
+- **THEN** the marker is neutralised before the diff is embedded
+
+### Requirement: Stated intent gets the same posture
+
+PR title/body/commit text SHALL be wrapped in its own untrusted block
+(`INTENT_START`/`INTENT_END`, both marker families neutralised) and sent only
+on the intent call — author-controlled text never rides along unmarked.
+<!-- anchor: hardening.wrap-intent -->
+
+#### Scenario: intent text tries to steer the reviewer
+- **WHEN** a PR description contains instructions to the model
+- **THEN** they arrive inside the neutralised intent block, marked untrusted
+
+### Requirement: Static-analysis hints are their own untrusted block
+
+Tool findings SHALL enter lens calls only as a wrapped HINTS block with its
+own neutralised marker family, framed as "confirm, contextualise, or discard".
+<!-- anchor: hardening.wrap-hints -->
+
+#### Scenario: hints accompany a batch
+- **WHEN** static analysis produced findings for a batch
+- **THEN** they are prepended wrapped, never as trusted instructions
+
+### Requirement: Secrets are redacted before egress
+
+Diffs, intent text, and expanded context SHALL be redacted before leaving for
+the LLM: AWS/OpenAI/GitHub (classic + fine-grained)/Slack/Google/Stripe keys,
+PEM private-key blocks, and quoted password / `Authorization` /
+connection-string credentials.
+<!-- anchor: hardening.redact -->
+
+#### Scenario: a committed key would leave the machine
+- **WHEN** a diff hunk contains an AWS access key
+- **THEN** the provider receives the hunk with the key replaced, never the key
+
+### Requirement: Parsing recovers leniently, validates strictly
+
+Model output SHALL be parsed as JSON with repair for common wrappers (fences,
+prose preamble), then validated against the strict finding schema — recovery
+never widens what is accepted, and unparseable output yields an error, not
+invented findings.
+<!-- anchor: hardening.parse -->
+
+#### Scenario: model wraps JSON in a code fence
+- **WHEN** the reply is valid findings JSON inside markdown fences
+- **THEN** parsing succeeds; fields still validate against the strict schema

--- a/openspec/specs/prompt-and-lenses/anchors.yml
+++ b/openspec/specs/prompt-and-lenses/anchors.yml
@@ -1,0 +1,33 @@
+# ast-grep anchors for prompt-and-lenses — see "Living specs" in CLAUDE.md.
+
+prompt.shared-preamble:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^build_shared_preamble$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+prompt.system:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^build_system_prompt$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+prompt.custom-lens:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^build_lens_prompt$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_build_lenses$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
+prompt.groups:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^build_group_prompt$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^build_correctness_prompt$' }
+    files: [src/lgtmaybe/engine/**/*.py]

--- a/openspec/specs/prompt-and-lenses/spec.md
+++ b/openspec/specs/prompt-and-lenses/spec.md
@@ -1,0 +1,62 @@
+# prompt-and-lenses Specification
+
+## Purpose
+
+How the review prompt is composed (`engine/prompt.py`): a lens-independent
+cacheable preamble, per-lens checklists each with a worked example, the fast
+preset's four-call grouping, and user-supplied custom lenses that fan out
+identically to the built-ins.
+
+## Requirements
+
+### Requirement: Split-prefix prompt shape for caching
+
+With `prompt_cache` on (default), every review call SHALL share a
+lens-independent system preamble and diff prefix, with the lens checklist as
+the final uncached block — so on routes with cache breakpoints, lenses 2..N
+read the preamble-plus-diff from cache. Other providers get the blocks joined
+back into the single plain message they always received.
+<!-- anchor: prompt.shared-preamble -->
+
+#### Scenario: provider without cache support
+- **WHEN** the model's route has no explicit cache breakpoint
+- **THEN** the call is byte-for-byte the legacy single-message shape
+
+### Requirement: Every focused prompt teaches by worked example
+
+Each lens prompt SHALL carry exactly one category-matched worked example with
+a real hunk header, and the contract SHALL explain the `line`/`side`
+arithmetic — the model is taught the coordinate system, not assumed to know it.
+<!-- anchor: prompt.system -->
+
+#### Scenario: security lens prompt is built
+- **WHEN** the security lens call is composed
+- **THEN** its prompt contains one security worked example with a real `@@`
+  hunk header
+
+### Requirement: Custom lenses are trusted config, fanned out uniformly
+
+Users SHALL add lenses via `extra_lenses` (id + instructions, optional worked
+example); the engine builds a uniform lens per built-in category and per
+custom lens and fans them all through the same merge/dedupe/reflect pipeline.
+Lens text enters the system prompt, so it is trusted config only — never
+sourced from PR-author content.
+<!-- anchor: prompt.custom-lens -->
+
+#### Scenario: a custom lens joins a review
+- **WHEN** `.lgtmaybe.yml` defines an extra lens
+- **THEN** it runs as one more concurrent lens call, findings merged like any
+  built-in
+
+### Requirement: Fast preset groups nine lenses into four calls
+
+The default `fast` preset SHALL cover all nine categories in four calls —
+dedicated security and correctness (stated intent folds into correctness with
+per-finding category attribution) plus merged code-health and artefacts calls.
+An explicit `categories` list overrides the grouping.
+<!-- anchor: prompt.groups -->
+
+#### Scenario: intent with no dedicated call
+- **WHEN** the fast preset runs and the PR states an intent
+- **THEN** intent findings come out of the correctness call, attributed to the
+  intent category

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -1,0 +1,33 @@
+# ast-grep anchors for provider-gateway — see "Living specs" in CLAUDE.md.
+
+provider.factory:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^build_provider$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
+provider.credentials:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^resolve_credentials$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
+provider.complete:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^complete$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^LiteLLMProvider$' }
+      stopBy: end
+  files: [src/lgtmaybe/providers/**/*.py]
+
+provider.defaults:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^default_timeout_for$' }
+    files: [src/lgtmaybe/providers/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^litellm_model_string$' }
+    files: [src/lgtmaybe/providers/**/*.py]

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -1,0 +1,61 @@
+# provider-gateway Specification
+
+## Purpose
+
+The LLM adapter track: one litellm-backed client behind the `ProviderClient`
+port, a factory that builds it from the `--provider` flag, and credential
+resolution as a chain of responsibility — the wedge being keyless OIDC/WIF for
+Bedrock/Vertex/Azure with no static cloud keys, ever.
+
+## Requirements
+
+### Requirement: One flag builds the whole client
+
+`build_provider` SHALL map `(provider, model)` plus optional key/base/fallback
+to a configured client — provider strategy selection lives here, not in the
+engine. All model slots (triage, review, reflect) share one provider and one
+set of credentials.
+<!-- anchor: provider.factory -->
+
+#### Scenario: user picks a provider
+- **WHEN** `--provider bedrock` is given
+- **THEN** the factory returns a client whose calls route via litellm's
+  bedrock path with ambient AWS credentials
+
+### Requirement: Credentials resolve by chain, fail with instructions
+
+Resolution SHALL try the chosen provider's native mode first (ambient cloud
+creds for bedrock/vertex/azure), then an API key from flag/env; ollama needs
+neither; openai-compatible needs an `api_base` with the key optional
+(placeholder when absent). Static cloud keys (AWS keys, service-account JSON)
+are never accepted or required; exhaustion fails with a clear
+"how to auth this provider" message.
+<!-- anchor: provider.credentials -->
+
+#### Scenario: nothing resolves
+- **WHEN** a provider has neither ambient creds nor a key
+- **THEN** the run fails naming exactly how to authenticate that provider
+
+### Requirement: Completion calls retry, fall back, and cache
+
+`LiteLLMProvider.complete` SHALL retry transient failures, switch to
+`fallback_model` when the primary is exhausted, and — on routes with explicit
+cache breakpoints — place them on the shared prefix so lens calls 2..N read
+the preamble-plus-diff from cache. Cache read/creation token counts land on
+`ProviderResult`.
+<!-- anchor: provider.complete -->
+
+#### Scenario: primary model keeps failing
+- **WHEN** retries on the primary model are exhausted and a fallback is set
+- **THEN** the call completes on the fallback model instead of failing the review
+
+### Requirement: Defaults are provider-aware
+
+Timeouts SHALL default long for local providers (ollama/openai-compatible)
+and short for cloud; the litellm model string is derived per provider so users
+give bare model ids.
+<!-- anchor: provider.defaults -->
+
+#### Scenario: no timeout configured
+- **WHEN** `timeout` is unset and the provider is ollama
+- **THEN** the local (long) default applies, not the cloud one

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -1,0 +1,75 @@
+# ast-grep anchors for review-pipeline — see "Living specs" in CLAUDE.md.
+
+engine.review:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^review$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^LLMReviewEngine$' }
+      stopBy: end
+  files: [src/lgtmaybe/engine/**/*.py]
+
+engine.fan-out:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_fan_out$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+engine.dedupe:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_dedupe$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+engine.snap:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_snap_findings$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^changed_line_index$' }
+    files: [src/lgtmaybe/core/**/*.py]
+
+engine.path-filters:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^passes_path_filters$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
+engine.recursive-walk:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^split_patch_into_hunks$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^batch_files$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
+engine.context-expansion:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^expand_hunks$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^trailing_context_lines$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
+engine.triage:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^triage_files$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^always_escalate$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
+engine.static-analysis:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^run_static_analysis$' }
+  files: [src/lgtmaybe/engine/**/*.py]

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -1,0 +1,117 @@
+# review-pipeline Specification
+
+## Purpose
+
+The engine (`engine/engine.py`) that turns a PR context into findings: a
+composable pipeline — redact → split → cap → static-analysis → triage →
+expand → batch → fan-out per lens → parse → merge/dedupe → snap → reflect →
+filter — with budget behaviors that degrade loudly, never silently.
+
+## Requirements
+
+### Requirement: The pipeline degrades loudly, never silently
+
+`LLMReviewEngine.review` SHALL run the stages in order and, when the soft
+whole-review deadline (`max_review_seconds`) passes, skip still-queued calls
+and return partial results with a notice — never a silent LGTM. Any stage
+failure surfaces to the caller.
+<!-- anchor: engine.review -->
+
+#### Scenario: deadline passes mid-review
+- **WHEN** lens calls are still queued after `max_review_seconds`
+- **THEN** they are skipped and the summary carries a partial-results notice
+
+### Requirement: Per-lens fan-out through one bounded executor
+
+Every (batch, lens) call SHALL run through one global thread pool sized by
+`max_concurrency` (auto: 8 cloud, 1 for ollama/openai-compatible), so local
+servers are never flooded and cloud reviews parallelise.
+<!-- anchor: engine.fan-out -->
+
+#### Scenario: local provider stays serial
+- **WHEN** the provider is ollama and `max_concurrency` is unset
+- **THEN** lens calls run one at a time
+
+### Requirement: Findings merge and dedupe across lenses
+
+After the fan-out, findings SHALL be merged and de-duplicated keyed on
+path/line/side, so overlapping lenses never post the same comment twice.
+<!-- anchor: engine.dedupe -->
+
+#### Scenario: two lenses flag the same line
+- **WHEN** security and correctness both return a finding on one line
+- **THEN** a single finding survives the merge
+
+### Requirement: Line anchoring never trusts model arithmetic
+
+Each finding carries a verbatim `anchor` line; the engine SHALL re-anchor
+`line` to the real changed line whose content matches (exact → whitespace →
+unique substring, nearest-to-model-line tiebreak). An anchor matching nothing
+marks the finding `anchored=False` so the gateway demotes it rather than
+posting on a wrong line.
+<!-- anchor: engine.snap -->
+
+#### Scenario: model miscounts the line
+- **WHEN** a finding's `line` is off but its `anchor` text matches a changed line
+- **THEN** the finding snaps to the matching line before posting
+
+### Requirement: Path filters apply after the skip filter
+
+The user's `include_paths` allowlist and `exclude_paths` denylist SHALL apply
+right after generated/binary skipping; exclude wins, and `**/`-prefixed
+patterns also match at the repo root.
+<!-- anchor: engine.path-filters -->
+
+#### Scenario: a file is both included and excluded
+- **WHEN** a path matches `include_paths` and `exclude_paths`
+- **THEN** it is excluded
+
+### Requirement: Over-budget files walk hunk-by-hunk
+
+When one file's diff exceeds `max_input_tokens`, the engine SHALL decompose it
+into per-hunk mini-diffs (each keeping its file header so line/side still bind
+to the real diff) and batch those normally — nothing is dropped and each
+call's context stays small. Files within budget are reviewed whole.
+<!-- anchor: engine.recursive-walk -->
+
+#### Scenario: single file exceeds the budget
+- **WHEN** a file's patch alone is over `max_input_tokens` and `recursive` is on
+- **THEN** each of its hunks is reviewed as its own mini-diff
+
+### Requirement: Context expansion is asymmetric and bounded
+
+Hunks SHALL be padded with surrounding file content, budget-scaled and capped
+by `context_lines`: the full budget before the hunk, a quarter (floored at one
+line) after — the enclosing signature explains a change better than what
+follows. Inline positions stay bound to the real diff, so context-only lines
+never carry comments.
+<!-- anchor: engine.context-expansion -->
+
+#### Scenario: context lines never take comments
+- **WHEN** a finding lands on an expansion-only line
+- **THEN** it maps to nothing in the real diff and is dropped, never mis-posted
+
+### Requirement: Triage never skips past the security floor
+
+With `triage_model` set, a cheap model SHALL rank files and skip
+plainly-non-substantive ones — but a deterministic floor (security
+paths/tokens, static-analysis hits, large hunks) always escalates past triage,
+any triage failure reviews everything, and skips are named in the summary.
+<!-- anchor: engine.triage -->
+
+#### Scenario: triage tries to skip a security-sensitive file
+- **WHEN** a file the cheap model would skip matches the security floor
+- **THEN** the strong model reviews it anyway
+
+### Requirement: Static analysis grounds, never posts
+
+Installed tools SHALL run sandboxed when static analysis is enabled — ruff,
+bandit, and semgrep with local rules only; scrubbed env, no network, hard
+timeout, temp dir, never a checkout — and their findings enter the prompt only
+as an untrusted HINTS block ("confirm, contextualise, or discard"). Raw tool
+findings are never posted; a missing tool is skipped silently.
+<!-- anchor: engine.static-analysis -->
+
+#### Scenario: semgrep has no local rules
+- **WHEN** static analysis runs without `semgrep_rules` configured
+- **THEN** semgrep does not run at all (never `--config auto`)

--- a/scripts/check_spec_drift.py
+++ b/scripts/check_spec_drift.py
@@ -1,0 +1,334 @@
+"""Spec-drift gate: warn when anchored code changes and its spec section doesn't.
+
+Every requirement section in openspec/specs/<capability>/spec.md carries an
+anchor id (`<!-- anchor: ... -->`) bound to code by ast-grep rules in the
+capability's anchors.yml sidecar. On a PR this script:
+
+1. scans the sidecar rules at HEAD and at the merge-base with the target branch
+   (a temporary git worktree — the scan cwd matters: `files:` globs resolve
+   against it, so both scans run from a repo root targeting src/);
+2. flags DANGLING rules — matched at the base, match nothing now (a rename or
+   removal nobody re-pointed; intersection alone goes blind here);
+3. flags DRIFT — a rule's match intersects the PR's changed lines while the diff
+   touched neither that anchor's spec section nor its sidecar.
+
+Warnings only — the exit code is always 0. A stale spec is not a broken build,
+and a blocking doc check just gets gamed. The deterministic half of the
+convention (each rule resolves to exactly one place, ids are a bijection) is a
+hard gate in tests/specs/test_anchors.py instead.
+
+Usage: uv run python scripts/check_spec_drift.py --base origin/main
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from lgtmaybe.core.diffparse import changed_line_index
+
+ANCHOR_RE = re.compile(r"^<!-- anchor: (?P<id>[a-z0-9.-]+) -->$")
+SCAN_TARGET = "src/"
+
+
+@dataclass(frozen=True)
+class AnchorRule:
+    """One ast-grep rule from a sidecar, addressable as anchor_id + __N suffix."""
+
+    anchor_id: str
+    rule_id: str
+    rule: dict[str, object]
+    files: list[str]
+    sidecar: str  # repo-relative posix path of the anchors.yml it came from
+
+
+@dataclass(frozen=True)
+class Match:
+    """One ast-grep match, 1-based inclusive line range."""
+
+    file: str
+    start_line: int
+    end_line: int
+
+
+@dataclass(frozen=True)
+class SpecSection:
+    """A requirement section's location inside its spec.md (1-based lines)."""
+
+    anchor_id: str
+    spec_path: str
+    heading_line: int
+    anchor_line: int
+    end_line: int
+
+
+@dataclass(frozen=True)
+class DriftWarning:
+    kind: str  # "dangling" | "drift"
+    anchor_id: str
+    spec_path: str
+    anchor_line: int
+    detail: str
+
+
+def load_anchors(root: Path) -> list[AnchorRule]:
+    """Parse every openspec/specs/*/anchors.yml under *root*.
+
+    A sidecar maps anchor id → either one ``{rule, files}`` object or a list of
+    them; both normalise to one AnchorRule per rule with an ``__N`` suffix.
+    """
+    rules: list[AnchorRule] = []
+    for sidecar in sorted(root.glob("openspec/specs/*/anchors.yml")):
+        loaded = yaml.safe_load(sidecar.read_text(encoding="utf-8")) or {}
+        rel = sidecar.relative_to(root).as_posix()
+        for anchor_id, entry in loaded.items():
+            entries = entry if isinstance(entry, list) else [entry]
+            for n, item in enumerate(entries):
+                rules.append(
+                    AnchorRule(
+                        anchor_id=anchor_id,
+                        rule_id=f"{anchor_id}__{n}",
+                        rule=item["rule"],
+                        files=list(item["files"]),
+                        sidecar=rel,
+                    )
+                )
+    return rules
+
+
+def to_inline_rules(rules: list[AnchorRule]) -> str:
+    """Translate sidecar rules into one ast-grep scan --inline-rules string."""
+    docs = []
+    for r in rules:
+        docs.append(
+            yaml.safe_dump(
+                {"id": r.rule_id, "language": "python", "files": r.files, "rule": r.rule},
+                sort_keys=False,
+            )
+        )
+    return "\n---\n".join(docs)
+
+
+def parse_scan_output(json_text: str) -> dict[str, list[Match]]:
+    """Group ast-grep --json output by rule id, converting to 1-based lines."""
+    matches: dict[str, list[Match]] = {}
+    for item in json.loads(json_text or "[]"):
+        matches.setdefault(item["ruleId"], []).append(
+            Match(
+                file=item["file"],
+                start_line=item["range"]["start"]["line"] + 1,
+                end_line=item["range"]["end"]["line"] + 1,
+            )
+        )
+    return matches
+
+
+def run_scan(binary: str, inline_rules: str, cwd: Path) -> dict[str, list[Match]]:
+    """Run one ast-grep scan from *cwd* (so files: globs resolve) over src/."""
+    result = subprocess.run(
+        [binary, "scan", "--inline-rules", inline_rules, "--json", SCAN_TARGET],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return parse_scan_output(result.stdout)
+
+
+def extract_sections(spec_md: str, spec_path: str) -> dict[str, SpecSection]:
+    """Map anchor id → its requirement section's line range in *spec_md*.
+
+    The anchor comment sits inside its ``### Requirement:`` section — by
+    convention on its own line right after the opening paragraph (OpenSpec's
+    parser reads the first block after the heading as the requirement text, so
+    the comment can't sit above it). A section runs from its heading to the
+    line before the next ``##``/``###`` heading (or EOF). A comment outside any
+    requirement section is skipped — the hygiene test flags that shape error.
+    """
+    lines = spec_md.splitlines()
+    sections: dict[str, SpecSection] = {}
+    heading: int | None = None  # 1-based line of the enclosing requirement heading
+    for i, line in enumerate(lines):
+        if line.startswith("### Requirement:"):
+            heading = i + 1
+            continue
+        if line.startswith("### ") or line.startswith("## "):
+            heading = None
+            continue
+        m = ANCHOR_RE.match(line.strip())
+        if not m or heading is None:
+            continue
+        end = len(lines)
+        for j in range(i + 1, len(lines)):
+            if lines[j].startswith("### ") or lines[j].startswith("## "):
+                end = j
+                break
+        anchor_id = m.group("id")
+        sections[anchor_id] = SpecSection(
+            anchor_id=anchor_id,
+            spec_path=spec_path,
+            heading_line=heading,
+            anchor_line=i + 1,
+            end_line=end,
+        )
+    return sections
+
+
+def changed_right_lines(diff: str) -> dict[str, set[int]]:
+    """RIGHT-side (new-file) changed line numbers per path, from a unified diff."""
+    changed: dict[str, set[int]] = {}
+    for (path, side), entries in changed_line_index(diff).items():
+        if side == "RIGHT":
+            changed.setdefault(path, set()).update(line for line, _ in entries)
+    return changed
+
+
+def classify(
+    *,
+    rules: list[AnchorRule],
+    baseline: dict[str, list[Match]],
+    head: dict[str, list[Match]],
+    changed: dict[str, set[int]],
+    sections: dict[str, SpecSection],
+    touched_paths: set[str],
+) -> list[DriftWarning]:
+    """The two checks, per rule, deduped to one warning per (kind, anchor)."""
+    warnings: dict[tuple[str, str], DriftWarning] = {}
+    for rule in rules:
+        section = sections.get(rule.anchor_id)
+        spec_path = section.spec_path if section else rule.sidecar
+        anchor_line = section.anchor_line if section else 1
+        head_matches = head.get(rule.rule_id, [])
+        if not head_matches:
+            if baseline.get(rule.rule_id):
+                warnings.setdefault(
+                    ("dangling", rule.anchor_id),
+                    DriftWarning(
+                        kind="dangling",
+                        anchor_id=rule.anchor_id,
+                        spec_path=spec_path,
+                        anchor_line=anchor_line,
+                        detail=(
+                            f"anchor {rule.anchor_id} is dangling — {rule.rule_id} matched at "
+                            f"the merge-base but matches nothing now (renamed or removed?); "
+                            f"re-point the rule in {rule.sidecar} and re-read its spec section"
+                        ),
+                    ),
+                )
+            continue
+        hit = any(
+            changed.get(m.file, set()) & set(range(m.start_line, m.end_line + 1))
+            for m in head_matches
+        )
+        if not hit:
+            continue
+        section_touched = rule.sidecar in touched_paths or (
+            section is not None
+            and changed.get(section.spec_path, set())
+            & set(range(section.heading_line, section.end_line + 1))
+        )
+        if not section_touched:
+            warnings.setdefault(
+                ("drift", rule.anchor_id),
+                DriftWarning(
+                    kind="drift",
+                    anchor_id=rule.anchor_id,
+                    spec_path=spec_path,
+                    anchor_line=anchor_line,
+                    detail=(
+                        f"code under anchor {rule.anchor_id} changed but its spec section in "
+                        f"{spec_path} did not — update the section or confirm it still holds"
+                    ),
+                ),
+            )
+    return list(warnings.values())
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _load_sections(root: Path) -> dict[str, SpecSection]:
+    sections: dict[str, SpecSection] = {}
+    for spec in sorted(root.glob("openspec/specs/*/spec.md")):
+        rel = spec.relative_to(root).as_posix()
+        sections.update(extract_sections(spec.read_text(encoding="utf-8"), rel))
+    return sections
+
+
+def _report(warnings: list[DriftWarning]) -> None:
+    for w in warnings:
+        print(f"::warning file={w.spec_path},line={w.anchor_line}::{w.detail}")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    lines = ["## Spec drift", ""]
+    if warnings:
+        lines += ["| anchor | kind | detail |", "|---|---|---|"]
+        lines += [f"| `{w.anchor_id}` | {w.kind.upper()} | {w.detail} |" for w in warnings]
+    else:
+        lines.append("No drift: anchored code and spec sections moved together (or not at all).")
+    body = "\n".join(lines) + "\n"
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(body)
+    else:
+        print(body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="ref to diff against (merge-base)")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent.parent
+    binary = shutil.which("ast-grep")
+    if binary is None:
+        print("::warning::ast-grep binary not found — spec-drift check skipped")
+        return 0
+    rules = load_anchors(root)
+    if not rules:
+        print("no anchor rules found — nothing to check")
+        return 0
+
+    merge_base = _git(root, "merge-base", args.base, "HEAD")
+    diff = _git(root, "diff", f"{merge_base}...HEAD")
+    inline = to_inline_rules(rules)
+    head_matches = run_scan(binary, inline, root)
+
+    worktree = Path(tempfile.mkdtemp(prefix="spec-drift-base-"))
+    try:
+        _git(root, "worktree", "add", "--detach", str(worktree), merge_base)
+        baseline = run_scan(binary, inline, worktree)
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=root,
+            capture_output=True,
+        )
+
+    warnings = classify(
+        rules=rules,
+        baseline=baseline,
+        head=head_matches,
+        changed=changed_right_lines(diff),
+        sections=_load_sections(root),
+        touched_paths={path for path, _ in changed_line_index(diff)},
+    )
+    _report(warnings)
+    return 0  # warnings only, by design — see module docstring
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/specs/test_anchors.py
+++ b/tests/specs/test_anchors.py
@@ -1,0 +1,150 @@
+"""Hygiene gate for the living specs (openspec/specs/) and their ast-grep anchors.
+
+Every requirement section in a spec carries an anchor id (an invisible HTML
+comment) bound to code by ast-grep rules in the capability's co-located
+``anchors.yml`` sidecar. This suite enforces the convention deterministically:
+
+- spec.md anchor ids and anchors.yml rule ids are a bijection, per capability
+- every rule resolves to EXACTLY one place in src/ (0 = dangling, >1 = too loose)
+- every spec.md has the OpenSpec shape (Purpose / Requirements / Scenario, SHALL)
+- requirement sections stay under the 40-line soft cap (split, don't append)
+
+The non-deterministic half of the convention — "did anchored code change while
+its spec section sat still?" — lives in scripts/check_spec_drift.py and warns
+(never fails) on PRs via .github/workflows/spec-drift.yml.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from lgtmaybe.engine.astgrep import _find_binary
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SPECS_DIR = REPO_ROOT / "openspec" / "specs"
+
+# Allow importing the drift script without it being a package (the
+# tests/docs/test_reference_fresh.py pattern).
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_spec_drift import (  # noqa: E402
+    extract_sections,
+    load_anchors,
+    run_scan,
+    to_inline_rules,
+)
+
+SECTION_LINE_CAP = 40
+ANCHOR_RE = re.compile(r"^<!-- anchor: (?P<id>[a-z0-9.-]+) -->$")
+
+
+def _spec_files() -> list[Path]:
+    return sorted(SPECS_DIR.glob("*/spec.md"))
+
+
+def _spec_anchor_ids(spec: Path) -> list[str]:
+    ids = []
+    for line in spec.read_text(encoding="utf-8").splitlines():
+        m = ANCHOR_RE.match(line.strip())
+        if m:
+            ids.append(m.group("id"))
+    return ids
+
+
+def test_living_specs_exist() -> None:
+    assert _spec_files(), (
+        f"no living specs found under {SPECS_DIR} — "
+        "expected openspec/specs/<capability>/spec.md files"
+    )
+
+
+def test_anchor_ids_are_a_bijection_per_capability() -> None:
+    """Every spec anchor id has a sidecar rule in the same capability dir, and
+    vice versa; ids are globally unique."""
+    rules = load_anchors(REPO_ROOT)
+    seen_spec_ids: set[str] = set()
+    for spec in _spec_files():
+        spec_ids = _spec_anchor_ids(spec)
+        assert len(spec_ids) == len(set(spec_ids)), f"duplicate anchor ids in {spec}"
+        duplicates = seen_spec_ids & set(spec_ids)
+        assert not duplicates, f"anchor ids reused across specs: {sorted(duplicates)}"
+        seen_spec_ids |= set(spec_ids)
+
+        sidecar = spec.parent / "anchors.yml"
+        assert sidecar.exists(), f"{spec.parent.name} has a spec.md but no anchors.yml"
+        sidecar_rel = sidecar.relative_to(REPO_ROOT).as_posix()
+        sidecar_ids = {r.anchor_id for r in rules if r.sidecar == sidecar_rel}
+        assert set(spec_ids) == sidecar_ids, (
+            f"{spec.parent.name}: spec.md and anchors.yml disagree — "
+            f"only in spec.md: {sorted(set(spec_ids) - sidecar_ids)}, "
+            f"only in anchors.yml: {sorted(sidecar_ids - set(spec_ids))}"
+        )
+
+    all_sidecar_ids = {r.anchor_id for r in rules}
+    assert all_sidecar_ids == seen_spec_ids
+
+
+def test_every_rule_resolves_to_exactly_one_place() -> None:
+    """The anchor-hygiene invariant: 0 matches = dangling, >1 = too loose."""
+    binary = _find_binary()
+    assert binary is not None, "ast-grep binary missing — it ships with the ast-grep-cli core dep"
+    rules = load_anchors(REPO_ROOT)
+    assert rules, "no anchor rules found"
+    matches = run_scan(binary, to_inline_rules(rules), REPO_ROOT)
+    problems = []
+    for rule in rules:
+        hits = matches.get(rule.rule_id, [])
+        if len(hits) != 1:
+            where = ", ".join(f"{m.file}:{m.start_line}" for m in hits) or "nothing"
+            problems.append(f"{rule.rule_id} (from {rule.sidecar}) matched {where}")
+    assert not problems, (
+        "each anchor rule must resolve to exactly one place — "
+        "tighten with files:/inside: or fix the dangling rule:\n  " + "\n  ".join(problems)
+    )
+
+
+def test_specs_have_openspec_shape() -> None:
+    for spec in _spec_files():
+        text = spec.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        assert "## Purpose" in text, f"{spec}: missing '## Purpose'"
+        assert "## Requirements" in text, f"{spec}: missing '## Requirements'"
+        sections = extract_sections(text, spec.relative_to(REPO_ROOT).as_posix())
+        headings = [i for i, line in enumerate(lines) if line.startswith("### Requirement:")]
+        assert headings, f"{spec}: no '### Requirement:' sections"
+        assert len(sections) == len(headings), (
+            f"{spec}: every '### Requirement:' section must contain its "
+            f"'<!-- anchor: ... -->' comment — on its own line right after the opening "
+            f"paragraph ({len(headings)} headings, {len(sections)} anchored)"
+        )
+        for section in sections.values():
+            body = "\n".join(lines[section.heading_line - 1 : section.end_line])
+            assert "#### Scenario:" in body, (
+                f"{spec}: requirement '{section.anchor_id}' has no '#### Scenario:' block"
+            )
+            # `openspec validate` only reads the FIRST line of the requirement
+            # text for the keyword check, so SHALL/MUST has to land there.
+            first_prose = next(
+                (ln for ln in lines[section.heading_line : section.end_line] if ln.strip()),
+                "",
+            )
+            assert "SHALL" in first_prose or "MUST" in first_prose, (
+                f"{spec}: requirement '{section.anchor_id}' must state SHALL/MUST on the "
+                f"first line of its text (openspec validate reads only that line)"
+            )
+
+
+def test_requirement_sections_respect_the_size_cap() -> None:
+    """Soft cap from the convention: a section that outgrows ~40 lines should be
+    split or summarised at write time, not appended to forever."""
+    for spec in _spec_files():
+        text = spec.read_text(encoding="utf-8")
+        for section in extract_sections(text, spec.name).values():
+            size = section.end_line - section.heading_line + 1
+            if size > SECTION_LINE_CAP:
+                pytest.fail(
+                    f"{spec}: section '{section.anchor_id}' is {size} lines "
+                    f"(cap {SECTION_LINE_CAP}) — split it or tighten the prose"
+                )

--- a/tests/specs/test_spec_drift.py
+++ b/tests/specs/test_spec_drift.py
@@ -1,0 +1,265 @@
+"""Unit tests for the pure functions in scripts/check_spec_drift.py.
+
+The drift gate itself is warnings-only CI plumbing; these tests pin down the
+deterministic core: sidecar parsing, rule translation, spec-section extraction,
+changed-line intersection, and the DANGLING/DRIFT classification — all with
+inline fixtures, no subprocess and no git.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_spec_drift import (  # noqa: E402
+    AnchorRule,
+    Match,
+    SpecSection,
+    changed_right_lines,
+    classify,
+    extract_sections,
+    load_anchors,
+    parse_scan_output,
+    to_inline_rules,
+)
+
+SIDECAR = textwrap.dedent(
+    """
+    one.single:
+      rule:
+        kind: function_definition
+        has: { field: name, regex: '^lonely$' }
+      files: [src/pkg/**/*.py]
+
+    two.listed:
+      - rule: { kind: class_definition, has: { field: name, regex: '^First$' } }
+        files: [src/pkg/a/**]
+      - rule: { kind: class_definition, has: { field: name, regex: '^Second$' } }
+        files: [src/pkg/b/**]
+    """
+)
+
+SPEC = textwrap.dedent(
+    """\
+    # thing Specification
+
+    ## Purpose
+    Words.
+
+    ## Requirements
+
+    ### Requirement: Single anchored thing
+
+    The thing SHALL be single.
+    <!-- anchor: one.single -->
+
+    #### Scenario: it is single
+    - **WHEN** asked
+    - **THEN** single
+
+    ### Requirement: Listed thing
+
+    The thing SHALL be listed.
+    <!-- anchor: two.listed -->
+
+    #### Scenario: it is listed
+    - **WHEN** asked
+    - **THEN** listed
+    """
+)
+
+
+def _write_capability(root: Path, name: str, spec: str, sidecar: str) -> None:
+    cap = root / "openspec" / "specs" / name
+    cap.mkdir(parents=True)
+    (cap / "spec.md").write_text(spec, encoding="utf-8")
+    (cap / "anchors.yml").write_text(sidecar, encoding="utf-8")
+
+
+def test_load_anchors_normalises_single_and_list_forms(tmp_path: Path) -> None:
+    _write_capability(tmp_path, "thing", SPEC, SIDECAR)
+    rules = load_anchors(tmp_path)
+    assert [r.rule_id for r in rules] == ["one.single__0", "two.listed__0", "two.listed__1"]
+    assert all(r.sidecar == "openspec/specs/thing/anchors.yml" for r in rules)
+    single = rules[0]
+    assert single.anchor_id == "one.single"
+    assert single.files == ["src/pkg/**/*.py"]
+    assert single.rule["kind"] == "function_definition"
+
+
+def test_to_inline_rules_emits_one_scan_document_per_rule() -> None:
+    rules = [
+        AnchorRule(
+            anchor_id="a.b",
+            rule_id="a.b__0",
+            rule={"kind": "function_definition"},
+            files=["src/**"],
+            sidecar="openspec/specs/x/anchors.yml",
+        ),
+        AnchorRule(
+            anchor_id="c.d",
+            rule_id="c.d__0",
+            rule={"kind": "class_definition"},
+            files=["src/**"],
+            sidecar="openspec/specs/y/anchors.yml",
+        ),
+    ]
+    text = to_inline_rules(rules)
+    docs = [d for d in text.split("\n---\n") if d.strip()]
+    assert len(docs) == 2
+    assert "id: a.b__0" in docs[0]
+    assert "language: python" in docs[0]
+    assert "kind: class_definition" in docs[1]
+
+
+def test_extract_sections_finds_ranges_and_the_last_section() -> None:
+    sections = extract_sections(SPEC, "openspec/specs/thing/spec.md")
+    assert set(sections) == {"one.single", "two.listed"}
+    single = sections["one.single"]
+    assert single == SpecSection(
+        anchor_id="one.single",
+        spec_path="openspec/specs/thing/spec.md",
+        heading_line=8,
+        anchor_line=11,
+        end_line=16,
+    )
+    listed = sections["two.listed"]
+    assert listed.heading_line == 17
+    assert listed.end_line == len(SPEC.splitlines())  # last section runs to EOF
+
+
+def test_parse_scan_output_converts_to_one_based_lines() -> None:
+    payload = (
+        '[{"ruleId": "a.b__0", "file": "src/x.py",'
+        ' "range": {"start": {"line": 4}, "end": {"line": 9}}}]'
+    )
+    matches = parse_scan_output(payload)
+    assert matches == {"a.b__0": [Match(file="src/x.py", start_line=5, end_line=10)]}
+
+
+def test_changed_right_lines_reads_a_unified_diff() -> None:
+    diff = textwrap.dedent(
+        """\
+        diff --git a/src/x.py b/src/x.py
+        --- a/src/x.py
+        +++ b/src/x.py
+        @@ -1,3 +1,4 @@
+         def f():
+        -    return 1
+        +    x = 2
+        +    return x
+        """
+    )
+    assert changed_right_lines(diff) == {"src/x.py": {2, 3}}
+
+
+def _section(anchor_id: str = "a.b") -> SpecSection:
+    return SpecSection(
+        anchor_id=anchor_id,
+        spec_path="openspec/specs/x/spec.md",
+        heading_line=8,
+        anchor_line=9,
+        end_line=20,
+    )
+
+
+def _rule(anchor_id: str = "a.b", rule_id: str = "a.b__0") -> AnchorRule:
+    return AnchorRule(
+        anchor_id=anchor_id,
+        rule_id=rule_id,
+        rule={"kind": "function_definition"},
+        files=["src/**"],
+        sidecar="openspec/specs/x/anchors.yml",
+    )
+
+
+def test_classify_flags_a_dangling_rule() -> None:
+    warnings = classify(
+        rules=[_rule()],
+        baseline={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        head={},
+        changed={},
+        sections={"a.b": _section()},
+        touched_paths=set(),
+    )
+    assert [w.kind for w in warnings] == ["dangling"]
+    assert warnings[0].anchor_id == "a.b"
+    assert warnings[0].spec_path == "openspec/specs/x/spec.md"
+
+
+def test_classify_never_flags_a_brand_new_anchor_as_dangling() -> None:
+    # Rule matches nothing at the merge-base because the anchor (or the code)
+    # didn't exist there yet.
+    warnings = classify(
+        rules=[_rule()],
+        baseline={},
+        head={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        changed={"src/x.py": {10}, "openspec/specs/x/spec.md": {9}},
+        sections={"a.b": _section()},
+        touched_paths={"src/x.py", "openspec/specs/x/spec.md"},
+    )
+    assert warnings == []
+
+
+def test_classify_flags_drift_when_code_moved_and_spec_sat_still() -> None:
+    warnings = classify(
+        rules=[_rule()],
+        baseline={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        head={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        changed={"src/x.py": {12}},
+        sections={"a.b": _section()},
+        touched_paths={"src/x.py"},
+    )
+    assert [w.kind for w in warnings] == ["drift"]
+    assert "a.b" in warnings[0].detail
+
+
+def test_classify_stays_quiet_when_the_pr_did_not_touch_anchored_code() -> None:
+    warnings = classify(
+        rules=[_rule()],
+        baseline={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        head={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        changed={"src/other.py": {3}},
+        sections={"a.b": _section()},
+        touched_paths={"src/other.py"},
+    )
+    assert warnings == []
+
+
+def test_classify_stays_quiet_when_the_spec_section_moved_too() -> None:
+    warnings = classify(
+        rules=[_rule()],
+        baseline={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        head={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        changed={"src/x.py": {12}, "openspec/specs/x/spec.md": {10}},  # 10 is inside 8..20
+        sections={"a.b": _section()},
+        touched_paths={"src/x.py", "openspec/specs/x/spec.md"},
+    )
+    assert warnings == []
+
+
+def test_classify_stays_quiet_when_the_sidecar_was_retuned() -> None:
+    warnings = classify(
+        rules=[_rule()],
+        baseline={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        head={"a.b__0": [Match(file="src/x.py", start_line=5, end_line=30)]},
+        changed={"src/x.py": {12}},
+        sections={"a.b": _section()},
+        touched_paths={"src/x.py", "openspec/specs/x/anchors.yml"},
+    )
+    assert warnings == []
+
+
+def test_classify_reports_one_warning_per_anchor_not_per_rule() -> None:
+    match = Match(file="src/x.py", start_line=5, end_line=30)
+    warnings = classify(
+        rules=[_rule(), _rule(rule_id="a.b__1")],
+        baseline={"a.b__0": [match], "a.b__1": [match]},
+        head={"a.b__0": [match], "a.b__1": [match]},
+        changed={"src/x.py": {12}},
+        sections={"a.b": _section()},
+        touched_paths={"src/x.py"},
+    )
+    assert len(warnings) == 1


### PR DESCRIPTION
Implements the convention from [Anchoring specs to code with ast-grep](https://coles.codes/posts/anchoring-specs-to-code-with-ast-grep/): a small set of living domain specs bound to the code they describe by structural ast-grep anchors, with a deterministic hygiene gate and a non-blocking PR drift gate.

## What's in here

**Living specs** — 8 capabilities under `openspec/specs/<capability>/spec.md` (OpenSpec 1.5 shape, `openspec validate --specs` green): `core-contracts`, `review-pipeline`, `prompt-and-lenses`, `hardening`, `finding-quality`, `provider-gateway`, `github-posting`, `cli-and-local` — 46 requirements describing current behavior, sourced from CLAUDE.md and the code.

**Anchors** — every requirement carries an id (`<!-- anchor: engine.snap -->` right after its opening paragraph) bound to code by ast-grep rules in the capability's co-located `anchors.yml`. Rules match code *shape* (node kind + name regex + `files:` glob, never `pattern:` — it silently misses async Python defs), so they survive moves/refactors and break loudly on renames, by design. The binary is already a core dep (`ast-grep-cli`, used by `engine/astgrep.py`) — no new dependency.

**Hygiene gate (hard, in the CI matrix)** — `tests/specs/test_anchors.py`: spec ids ↔ sidecar rules are a bijection; every rule resolves to **exactly one** place in `src/` (0 = dangling, >1 = too loose); OpenSpec shape (incl. SHALL on the first line of requirement text — the validator only reads that line); 40-line section cap. `tests/specs/test_spec_drift.py` unit-tests the drift script's pure functions.

**Drift gate (non-blocking, on PRs)** — `scripts/check_spec_drift.py` + `.github/workflows/spec-drift.yml`: scans the rules at HEAD and at the merge-base (temp git worktree), then warns per anchor on
- **DANGLING** — matched at the base, matches nothing now (the rename case line-intersection alone can't see), and
- **DRIFT** — a match intersects the PR's changed lines while neither the anchor's spec section nor its sidecar moved.

Warnings land as `::warning` annotations + a step-summary table; the script always exits 0 and the workflow stays out of branch protection. Changed-line parsing reuses `lgtmaybe.core.diffparse.changed_line_index`.

**Workflow docs** — new "Living specs (OpenSpec + ast-grep anchors)" section in CLAUDE.md (resolve anchors before a change, targeted spec edits only, anchor hygiene, split-don't-append), cross-links in ARCHITECTURE.md / DEVELOPMENT.md, and the committed `openspec init --tools claude` scaffolding (`.claude/commands/opsx/*`, `.claude/skills/openspec-*`, `openspec/config.yaml`) so agents share one spec workflow.

## Verification

- Full gate green locally: `uv lock --check`, `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (1137 passed; 17 new).
- `npx -y @fission-ai/openspec@latest validate --specs` — 8/8 valid.
- Drift gate smoke-tested end-to-end on throwaway commits: body edit of `_dedupe` without the spec → DRIFT warning; rename `_dedupe` → DANGLING warning; code edit + spec section touched together → quiet; no code changes → quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLtBnbDSToXG4wkAtk2c1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLtBnbDSToXG4wkAtk2c1V)_