### PR TITLE
fix(deps): cap litellm below 1.92 on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ dependencies = [
     "ast-grep-cli>=0.44.0",
     "click>=8.4.1",
     "httpx>=0.28.1",
-    "litellm>=1.87.1",
+    # litellm 1.92.0 ships only cp311–cp313 compiled wheels; its sdist needs
+    # pyo3 0.23 (max Python 3.13), so 3.14 installs fail. Cap it there until
+    # upstream publishes cp314 wheels or a pyo3 with 3.14 support.
+    "litellm>=1.87.1; python_version < '3.14'",
+    "litellm>=1.87.1,<1.92; python_version >= '3.14'",
     "pydantic>=2.7",
     "pyyaml>=6.0.3",
     "tenacity>=9.1.4",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version < '3.14'",
 ]
 
 [[package]]
@@ -1133,7 +1134,8 @@ dependencies = [
     { name = "ast-grep-cli" },
     { name = "click" },
     { name = "httpx" },
-    { name = "litellm" },
+    { name = "litellm", version = "1.91.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "litellm", version = "1.92.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tenacity" },
@@ -1176,7 +1178,8 @@ requires-dist = [
     { name = "click", specifier = ">=8.4.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "litellm", specifier = ">=1.87.1" },
+    { name = "litellm", marker = "python_full_version < '3.14'", specifier = ">=1.87.1" },
+    { name = "litellm", marker = "python_full_version >= '3.14'", specifier = ">=1.87.1,<1.92" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'static-analysis'", specifier = ">=0.5" },
@@ -1272,21 +1275,51 @@ wheels = [
 
 [[package]]
 name = "litellm"
+version = "1.91.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
+]
+dependencies = [
+    { name = "aiohttp", marker = "python_full_version >= '3.14'" },
+    { name = "click", marker = "python_full_version >= '3.14'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.14'" },
+    { name = "jinja2", marker = "python_full_version >= '3.14'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
+    { name = "openai", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.14'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.14'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/33/879369fe202498a307e1130bae1f59c5f226362afc07829ba5a0279a563d/litellm-1.91.3.tar.gz", hash = "sha256:096cee401dfd353f050422adc6ed9b25da0fc5e110fc923ce3f0ffa5bc5c2957", size = 14875767, upload-time = "2026-07-11T22:43:32.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/3c/157c54c924f9e6025797545a0cd915a98e98ad8d3f9011502a575781d4b5/litellm-1.91.3-py3-none-any.whl", hash = "sha256:5be4df2bdf5459f46a6224a75046f365dc979995a37a81f5aa3ce29f92f534cf", size = 16674504, upload-time = "2026-07-11T22:43:30.517Z" },
+]
+
+[[package]]
+name = "litellm"
 version = "1.92.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.14'",
+]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/ea/5522be7e0dbcaa7c3fddfd2834f387c6e8eab47c0cc65f2a74657c815af7/litellm-1.92.0.tar.gz", hash = "sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d", size = 15098143, upload-time = "2026-07-12T01:15:59.828Z" }
 wheels = [


### PR DESCRIPTION
## What

Fixes the failing `ci` run [29497115066](https://github.com/MattJColes/lgtmaybe/actions/runs/29497115066): the `test (3.14)` leg (and the `check` gate behind it) broke after #180 bumped litellm to 1.92.0.

## Why it broke

litellm 1.92.0 replaced its pure-Python `py3-none-any` wheel with compiled `cp311`–`cp313` manylinux wheels (a new Rust extension) and publishes **no cp314 wheel**. On Python 3.14, `uv sync` falls back to the sdist, whose build pins pyo3 0.23.5 — which supports at most Python 3.13:

```
error: the configured Python interpreter version (3.14) is newer than
PyO3's maximum supported version (3.13)
```

This would also break any user's `pip install lgtmaybe` on 3.14, not just CI.

## Fix

Split the litellm constraint by environment marker in `pyproject.toml`:

- Python < 3.14 keeps `litellm>=1.87.1` (resolves 1.92.0, unchanged)
- Python >= 3.14 gets `litellm>=1.87.1,<1.92` (resolves 1.91.3, the last pure-Python release)

and regenerated `uv.lock`, which now forks litellm by marker. The cap can be dropped once upstream ships cp314 wheels (or a pyo3 release with 3.14 support).

## Verification

- Statically checked every package on the ≥3.14 resolution path in the new lock ships a cp314-usable Linux wheel (pure `py3-none`/`py314`, `cp314`, or `abi3`) — all do; 3.14 CI was green on litellm 1.91.x before the bump.
- `uv lock --check`, `ruff check`, `ruff format --check`, `mypy`, and `pytest` (1137 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2f3PQB2QCHrpx3q6Ks6uY

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2f3PQB2QCHrpx3q6Ks6uY)_