### PR TITLE
refactor: remove dead code and needless indirection found by ponytail audit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -214,7 +214,6 @@ runs:
         docker run --rm \
           -e GITHUB_TOKEN \
           -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH \
-          -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL \
           -e INPUT_PROVIDER -e INPUT_MODEL -e INPUT_PRESET \
           -e INPUT_FALLBACK_MODEL -e INPUT_REFLECT_MODEL \
           -e INPUT_TRIAGE_MODEL \

--- a/src/lgtmaybe/__init__.py
+++ b/src/lgtmaybe/__init__.py
@@ -1,8 +1,1 @@
 """lgtmaybe — provider-agnostic PR reviewer."""
-
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("lgtmaybe")
-except PackageNotFoundError:  # not installed (e.g. running from a raw checkout)
-    __version__ = "0.11.0"

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -355,7 +355,7 @@ def execute_describe(cfg: ReviewConfig, runtime: RuntimeOptions) -> None:
         _log.warning("auto-describe failed — continuing without it", exc_info=True)
 
 
-def execute_review(cfg: ReviewConfig, runtime: RuntimeOptions, *, dry_run: bool) -> None:
+def execute_review(cfg: ReviewConfig, runtime: RuntimeOptions) -> None:
     """Build adapters, run the review, surface failures back to the PR.
 
     Shared by the ``review`` command and the ``action`` entrypoint.
@@ -371,15 +371,11 @@ def execute_review(cfg: ReviewConfig, runtime: RuntimeOptions, *, dry_run: bool)
     # From here we have a gateway, so any failure is surfaced back to the PR as
     # a short comment rather than failing silently — then we exit non-zero.
     try:
-        findings, summary = run_review(github=github, engine=engine, cfg=cfg, dry_run=dry_run)
+        run_review(github=github, engine=engine, cfg=cfg, dry_run=False)
     except Exception as exc:
-        if not dry_run:
-            _post_failure(github, exc)
+        _post_failure(github, exc)
         raise click.ClickException(f"review failed: {exc}") from exc
 
-    if dry_run:
-        click.echo(f"[dry-run] {summary}")
-        click.echo(render_findings(findings, summary, fmt="json"))
     if runtime.profile:
         click.echo(profiler.render())
 
@@ -435,17 +431,15 @@ def _post_failure(github: GitHubGateway, exc: Exception) -> None:
 def pr_url_from_event(event: dict[str, Any]) -> str:
     """Build the PR URL from a pull_request(_target) event payload.
 
-    Honours ``GITHUB_SERVER_URL`` for the link, though only github.com is
-    supported end to end — the URL parser and the REST gateway both speak to
-    api.github.com.
+    Only github.com is supported end to end — the URL parser and the REST
+    gateway both speak to api.github.com.
     """
-    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
     try:
         repo = event["repository"]["full_name"]
         number = event["pull_request"]["number"]
     except (KeyError, TypeError) as exc:
         raise click.ClickException(f"event payload missing required field: {exc}") from exc
-    return f"{server}/{repo}/pull/{number}"
+    return f"https://github.com/{repo}/pull/{number}"
 
 
 def action_inputs() -> dict[str, str | None]:

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -432,7 +432,7 @@ def action() -> None:
     # description first — best-effort, never blocks the review.
     if should_auto_describe(cfg, event_action=event_action):
         execute_describe(cfg, runtime)
-    execute_review(cfg, runtime, dry_run=False)
+    execute_review(cfg, runtime)
 
 
 @config_cmd.command("path")

--- a/src/lgtmaybe/cli/render.py
+++ b/src/lgtmaybe/cli/render.py
@@ -52,7 +52,7 @@ def _render_agent(findings: list[ReviewFinding], summary: str) -> str:
         lines.append(f"    Issue: {f.body}")
         if f.suggestion is not None:
             lines.append("    Suggested fix:")
-            lines.extend(f"        {s}" for s in f.suggestion.splitlines() or [f.suggestion])
+            lines.extend(f"        {s}" for s in f.suggestion.splitlines())
         lines.append("")
     lines.append(
         f"{len(findings)} finding(s) to address. After applying the fixes, re-run "

--- a/src/lgtmaybe/cli/slash.py
+++ b/src/lgtmaybe/cli/slash.py
@@ -56,17 +56,14 @@ def parse_command(body: str) -> ParsedCommand | None:
 
 
 def dispatch(
-    parsed: ParsedCommand | None,
+    parsed: ParsedCommand,
     *,
     github: GitHubGateway,
     engine: ReviewEngine,
     provider: ProviderClient,
     cfg: ReviewConfig,
 ) -> None:
-    """Route a parsed slash command to the engine or provider. No-op for None."""
-    if parsed is None:
-        return
-
+    """Route a parsed slash command to the engine or provider."""
     if parsed.name in (SlashCommand.review, SlashCommand.improve):
         # `/review full` forces a genuinely full re-review: no incremental
         # scoping AND no triage skipping. A bare `/review` honours config.
@@ -86,37 +83,21 @@ def dispatch(
         return
 
     if parsed.name is SlashCommand.describe:
-        from lgtmaybe.engine.describe import build_description
+        # Same lazy import as run_review above, for the same circularity reason.
+        from lgtmaybe.cli import run_describe
 
-        body = build_description(github.get_pr_context(), cfg, provider)
-        # Prefer the idempotent upsert (edits our previous description in
-        # place); fall back to a plain comment on a gateway without it.
-        post_describe = getattr(github, "post_describe_comment", None)
-        if post_describe is not None:
-            post_describe(body)
-        else:
-            github.post_issue_comment(body)
+        run_describe(github, provider, cfg)
         return
-
-
-def _reply(
-    provider: ProviderClient,
-    github: GitHubGateway,
-    cfg: ReviewConfig,
-    system: str,
-    user_extra: str = "",
-) -> str:
-    """Gather PR context, redact+wrap the diff, and return the provider's reply."""
-    ctx = github.get_pr_context()
-    user = wrap_diff(redact(ctx.diff)) + user_extra
-    result = provider.complete(
-        [{"role": "system", "content": system}, {"role": "user", "content": user}],
-        model=cfg.model,
-    )
-    return result.text
 
 
 def _answer_question(
     provider: ProviderClient, github: GitHubGateway, cfg: ReviewConfig, question: str
 ) -> str:
-    return _reply(provider, github, cfg, _ASK_SYSTEM, f"\n\nQuestion: {question}")
+    """Redact+wrap the diff and ask the provider the user's question over it."""
+    ctx = github.get_pr_context()
+    user = wrap_diff(redact(ctx.diff)) + f"\n\nQuestion: {question}"
+    result = provider.complete(
+        [{"role": "system", "content": _ASK_SYSTEM}, {"role": "user", "content": user}],
+        model=cfg.model,
+    )
+    return result.text

--- a/src/lgtmaybe/cli/slash.py
+++ b/src/lgtmaybe/cli/slash.py
@@ -87,7 +87,6 @@ def dispatch(
         from lgtmaybe.cli import run_describe
 
         run_describe(github, provider, cfg)
-        return
 
 
 def _answer_question(

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -15,6 +15,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 # Side of the diff a comment attaches to, matching the GitHub review API.
 Side = Literal["LEFT", "RIGHT"]
 
+# The PR-label families lgtmaybe owns (F4). Shared vocabulary between the engine
+# (which computes the labels) and the GitHub adapter (which reconciles them,
+# removing stale labels with these shapes) — one definition so a renamed family
+# can't silently break the reconcile.
+EFFORT_PREFIX = "review-effort/"
+SECURITY_LABEL = "possible-security-issue"
+SPLITTING_LABEL = "consider-splitting"
+
 
 class Severity(StrEnum):
     """Finding severity, ordered low → high for `min_severity` filtering."""

--- a/src/lgtmaybe/engine/__init__.py
+++ b/src/lgtmaybe/engine/__init__.py
@@ -1,30 +1,13 @@
 """lgtmaybe.engine — the review pipeline (Track C)."""
 
 from .astgrep import SymbolResolver, build_symbol_resolver
-from .compress import batch_files, context_lines_for_budget, count_tokens
 from .engine import LLMReviewEngine, ReviewIncompleteError
-from .injection import wrap_diff
-from .parse import ParseError, parse_findings
-from .prompt import build_system_prompt
-from .redact import redact
-from .reflect import reflect_findings
-from .retrieve import FileFetcher, resolve_needs
+from .retrieve import FileFetcher
 
 __all__ = [
     "LLMReviewEngine",
     "ReviewIncompleteError",
-    # building blocks
-    "batch_files",
-    "context_lines_for_budget",
-    "count_tokens",
-    "wrap_diff",
-    "ParseError",
-    "parse_findings",
-    "build_system_prompt",
-    "redact",
-    "reflect_findings",
     "FileFetcher",
-    "resolve_needs",
     "SymbolResolver",
     "build_symbol_resolver",
 ]

--- a/src/lgtmaybe/engine/astgrep.py
+++ b/src/lgtmaybe/engine/astgrep.py
@@ -25,8 +25,9 @@ import json
 import re
 import shutil
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import Any
 
 from lgtmaybe.core.logging import get_logger
 
@@ -46,7 +47,7 @@ AstGrepRunner = Callable[[str, str, Path], str]
 # A structural scan of one repo is sub-second (validated at ~20ms over this repo);
 # the timeout only caps a pathological run, never a normal one.
 _SCAN_TIMEOUT = 20
-_DEFAULT_MAX_CANDIDATES = 3
+_MAX_CANDIDATES = 3
 # Only resolve identifier-shaped names. This both filters out path-shaped `needs`
 # (handled by the path fetcher) and keeps the symbol safe to drop into the rule's
 # ``regex: ^<name>$`` — an identifier carries no regex or YAML metacharacters.
@@ -136,11 +137,6 @@ def _find_binary() -> str | None:
     return shutil.which("ast-grep")
 
 
-def ast_grep_available(*, find_binary: Callable[[], str | None] = _find_binary) -> bool:
-    """True when the ast-grep binary is on PATH."""
-    return find_binary() is not None
-
-
 def _rule_yaml(language: str, kinds: tuple[str, ...], symbol: str) -> str:
     """An inline ast-grep rule: a definition node of *language* named *symbol*.
 
@@ -159,7 +155,7 @@ def _rule_yaml(language: str, kinds: tuple[str, ...], symbol: str) -> str:
     )
 
 
-def _default_runner(binary: str, rule_yaml: str, root: Path) -> str:
+def _default_runner(binary: str, rule_yaml: str, target: Path) -> str:
     """Run ``ast-grep scan`` with an inline rule, returning stdout (or "").
 
     Exit codes are ignored on purpose: a no-match scan exits 0 with ``[]`` and a
@@ -169,7 +165,7 @@ def _default_runner(binary: str, rule_yaml: str, root: Path) -> str:
     """
     try:
         proc = subprocess.run(
-            [binary, "scan", "--inline-rules", rule_yaml, "--json=compact", str(root)],
+            [binary, "scan", "--inline-rules", rule_yaml, "--json=compact", str(target)],
             capture_output=True,
             text=True,
             timeout=_SCAN_TIMEOUT,
@@ -180,23 +176,31 @@ def _default_runner(binary: str, rule_yaml: str, root: Path) -> str:
     return proc.stdout or ""
 
 
-def _parse_paths(stdout: str, root: Path) -> list[str]:
-    """Repo-relative file paths from ast-grep's compact JSON match array.
+def iter_matches(stdout: str) -> Iterator[dict[str, Any]]:
+    """The dict entries of ast-grep's compact JSON match array.
 
-    Tolerates empty or malformed output (returns []). A path that doesn't sit under
-    *root* (shouldn't happen — we scan *root*) is skipped rather than leaked as an
-    absolute path.
+    Tolerates empty or malformed output (yields nothing) — shared guard
+    scaffolding for every ast-grep output parser.
     """
     try:
         data = json.loads(stdout or "[]")
     except json.JSONDecodeError:
-        return []
+        return
     if not isinstance(data, list):
-        return []
-    out: list[str] = []
+        return
     for match in data:
-        if not isinstance(match, dict):
-            continue
+        if isinstance(match, dict):
+            yield match
+
+
+def _parse_paths(stdout: str, root: Path) -> list[str]:
+    """Repo-relative file paths from ast-grep's compact JSON match array.
+
+    A path that doesn't sit under *root* (shouldn't happen — we scan *root*) is
+    skipped rather than leaked as an absolute path.
+    """
+    out: list[str] = []
+    for match in iter_matches(stdout):
         file = match.get("file")
         if not isinstance(file, str) or not file:
             continue
@@ -213,7 +217,6 @@ def build_symbol_resolver(
     *,
     runner: AstGrepRunner | None = None,
     find_binary: Callable[[], str | None] = _find_binary,
-    max_candidates: int = _DEFAULT_MAX_CANDIDATES,
 ) -> SymbolResolver | None:
     """A resolver mapping a symbol name to the file(s) defining it — or None.
 
@@ -221,7 +224,8 @@ def build_symbol_resolver(
     reflection pass on its existing path-only fetch (no behaviour change).
     Otherwise returns a callable that, given a symbol the auditor deferred on,
     structurally searches the corpus (``get_root()``, resolved and cached on first
-    use) for its definition and returns up to *max_candidates* repo-relative paths.
+    use) for its definition and returns up to :data:`_MAX_CANDIDATES`
+    repo-relative paths.
 
     Best-effort throughout: a non-identifier symbol, an absent corpus, an
     unsupported language, or any ast-grep failure yields [] so the deferral falls
@@ -248,7 +252,7 @@ def build_symbol_resolver(
         found: list[str] = []
         seen: set[str] = set()
         for language, kinds in _LANG_KINDS.items():
-            if len(found) >= max_candidates:
+            if len(found) >= _MAX_CANDIDATES:
                 break
             stdout = run(binary, _rule_yaml(language, kinds, name), root)
             for rel in _parse_paths(stdout, root):
@@ -256,7 +260,7 @@ def build_symbol_resolver(
                     continue
                 seen.add(rel)
                 found.append(rel)
-                if len(found) >= max_candidates:
+                if len(found) >= _MAX_CANDIDATES:
                     break
         if found:
             _log.info(

--- a/src/lgtmaybe/engine/boundaries.py
+++ b/src/lgtmaybe/engine/boundaries.py
@@ -16,20 +16,15 @@ fixed-line pad.
 
 from __future__ import annotations
 
-import json
-import subprocess
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
 from lgtmaybe.core.logging import get_logger
 
-from .astgrep import _find_binary
+from .astgrep import _default_runner, _find_binary, iter_matches
 
 _log = get_logger(__name__)
-
-# One file parse is tens of milliseconds; the timeout only caps pathology.
-_SCAN_TIMEOUT = 10
 
 # Abstracts the ast-grep subprocess: (binary, rule_yaml, file) -> stdout ("" on
 # failure). Injected so tests don't have to shell out.
@@ -85,32 +80,10 @@ def definition_starts(
     return _parse_starts(stdout)
 
 
-def _default_runner(binary: str, rule_yaml: str, target: Path) -> str:
-    try:
-        proc = subprocess.run(
-            [binary, "scan", "--inline-rules", rule_yaml, "--json=compact", str(target)],
-            capture_output=True,
-            text=True,
-            timeout=_SCAN_TIMEOUT,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    return proc.stdout or ""
-
-
 def _parse_starts(stdout: str) -> list[int]:
     """1-based, de-duplicated, sorted start lines from ast-grep's match array."""
-    try:
-        data = json.loads(stdout or "[]")
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(data, list):
-        return []
     starts: set[int] = set()
-    for match in data:
-        if not isinstance(match, dict):
-            continue
+    for match in iter_matches(stdout):
         line = match.get("range", {}).get("start", {}).get("line")
         if isinstance(line, int) and line >= 0:
             starts.add(line + 1)  # ast-grep lines are 0-based

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -13,7 +13,7 @@ from typing import Any
 from lgtmaybe.core.diffparse import parse_hunk_header
 
 _MAX_CONTEXT_LINES = 20
-_MIN_CONTEXT_LINES = 0
+
 # Scale: remaining_tokens / _SCALE gives context lines, capped at _MAX_CONTEXT_LINES.
 # At 100k budget with 500 tokens used → 99,500 / 5000 = 19 lines.
 # At 100k budget with 90k tokens used → 10,000 / 5000 = 2 lines.
@@ -144,13 +144,9 @@ def context_lines_for_budget(remaining_tokens: int) -> int:
     A larger remaining budget yields more context; a smaller one yields less.
     The result is capped between 0 and _MAX_CONTEXT_LINES.
     """
-    if remaining_tokens <= 0:
-        return _MIN_CONTEXT_LINES
-
     # Scale: every _SCALE remaining tokens buys one context line,
     # up to _MAX_CONTEXT_LINES.
-    lines = remaining_tokens // _SCALE
-    return min(int(lines), _MAX_CONTEXT_LINES)
+    return max(0, min(remaining_tokens // _SCALE, _MAX_CONTEXT_LINES))
 
 
 def _enclosing_boundary(boundaries: list[int], new_start: int) -> int | None:
@@ -193,13 +189,12 @@ def expand_hunks(
     patch: str,
     file_content: str | None,
     n: int,
-    after: int | None = None,
+    after: int,
     boundaries: list[int] | None = None,
 ) -> str:
     """Pad each hunk in *patch* with surrounding lines from *file_content*.
 
-    Up to *n* lines are added before each hunk and up to *after* lines after it
-    (``after=None`` keeps the original symmetric contract: *n* on both sides).
+    Up to *n* lines are added before each hunk and up to *after* lines after it.
     The extra lines are drawn from the head-revision file text and rendered as
     normal unchanged context (space-prefixed), giving the model the function and
     definitions around a change. Hunk headers are rewritten so each hunk's
@@ -218,7 +213,7 @@ def expand_hunks(
     """
     if n <= 0 or not file_content:
         return patch
-    n_after = n if after is None else max(0, after)
+    n_after = max(0, after)
 
     content_lines = file_content.splitlines()
     out: list[str] = []

--- a/src/lgtmaybe/engine/injection.py
+++ b/src/lgtmaybe/engine/injection.py
@@ -73,24 +73,16 @@ INTENT_PREAMBLE = (
 
 
 def neutralise(text: str) -> str:
-    """Public marker neutralisation for auxiliary untrusted blocks.
-
-    For callers (e.g. the triage pass) that build their own labelled block but
-    must still keep untrusted content from forging any of the sentinel marker
-    families used elsewhere in the prompt.
-    """
-    return _neutralise_markers(text)
-
-
-def _neutralise_markers(diff: str) -> str:
-    """Defang any forged delimiter tokens in *diff* so it can't close the block early.
+    """Defang any forged delimiter tokens in *text* so it can't close a block early.
 
     We swap the underscore for a hyphen (``DIFF_END`` → ``DIFF-END``): the literal
     sentinel no longer appears in the content, while the text stays readable to the
     model as plain data. Matching is case-insensitive (the original case is
-    preserved bar the underscore) so cased variants are defanged too.
+    preserved bar the underscore) so cased variants are defanged too. Also for
+    callers (e.g. the triage pass) that build their own labelled block but must
+    still keep untrusted content from forging any sentinel marker family.
     """
-    return _MARKER_RE.sub(lambda m: m.group(0).replace("_", "-"), diff)
+    return _MARKER_RE.sub(lambda m: m.group(0).replace("_", "-"), text)
 
 
 def wrap_diff(diff: str) -> str:
@@ -99,7 +91,7 @@ def wrap_diff(diff: str) -> str:
     The diff is neutralised first so a forged delimiter can't close the data
     block early, then the review task is restated after the block.
     """
-    safe = _neutralise_markers(diff)
+    safe = neutralise(diff)
     return f"{INJECTION_PREAMBLE}{_START}\n{safe}\n{_END}{_TASK_SUFFIX}"
 
 
@@ -119,7 +111,7 @@ def wrap_hints(hints: str) -> str:
     message (which can quote hostile code) can't close the block early or fake
     a diff/intent block.
     """
-    safe = _neutralise_markers(hints)
+    safe = neutralise(hints)
     return f"{HINTS_PREAMBLE}{_HINTS_START}\n{safe}\n{_HINTS_END}"
 
 
@@ -129,5 +121,5 @@ def wrap_intent(intent: str) -> str:
     Neutralised like the diff: a forged delimiter in a PR description can't close
     the block early, and intent text can't forge a diff block either.
     """
-    safe = _neutralise_markers(intent)
+    safe = neutralise(intent)
     return f"{INTENT_PREAMBLE}{_INTENT_START}\n{safe}\n{_INTENT_END}"

--- a/src/lgtmaybe/engine/labels.py
+++ b/src/lgtmaybe/engine/labels.py
@@ -16,14 +16,14 @@ best-effort by the GitHub adapter — a labelling failure never fails a review.
 
 from __future__ import annotations
 
-from lgtmaybe.core.models import PRContext, ReviewFinding, Severity
-
-# The label families this module owns. The adapter removes stale labels with
-# these shapes before adding the fresh set, so an effort score that drops
-# between pushes doesn't leave both labels behind.
-EFFORT_PREFIX = "review-effort/"
-SECURITY_LABEL = "possible-security-issue"
-SPLITTING_LABEL = "consider-splitting"
+from lgtmaybe.core.models import (
+    EFFORT_PREFIX,
+    SECURITY_LABEL,
+    SPLITTING_LABEL,
+    PRContext,
+    ReviewFinding,
+    Severity,
+)
 
 # Changed-line thresholds for effort scores 2..5 (score 1 = below the first).
 _EFFORT_THRESHOLDS = (50, 200, 500, 1000)

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -812,23 +812,17 @@ def build_custom_lens_block(lens: CustomLens) -> str:
     return f"{_LENS_LEAD_IN}\n\n{body}\n\n{example}"
 
 
-@lru_cache(maxsize=len(ReviewCategory) + 1)
-def build_system_prompt(category: ReviewCategory | None = None) -> str:
-    """Return the system message for the review LLM.
+@lru_cache(maxsize=len(ReviewCategory))
+def build_system_prompt(category: ReviewCategory) -> str:
+    """Return the system message for the review LLM's *category* lens.
 
-    With a ``category``, the prompt carries only that lens's section and a
-    matching worked example; with no category, it carries the union of every
-    section (the monolithic prompt) and a generic example.
+    The prompt carries only that lens's section and a matching worked example.
 
     Cached: the prompts are deterministic, and the engine rebuilds one per
     category on every batch — caching makes those rebuilds free.
     """
-    if category is None:
-        example = _GENERIC_EXAMPLE
-        body = "\n\n".join(_CATEGORY_SECTIONS[c] for c in ReviewCategory)
-    else:
-        example = _CATEGORY_EXAMPLES[category]
-        body = _CATEGORY_SECTIONS[category]
+    example = _CATEGORY_EXAMPLES[category]
+    body = _CATEGORY_SECTIONS[category]
     return f"{_SHARED_HEADER}\n{example}\n\n{body}\n\n{_SHARED_RULES}\n"
 
 

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -7,8 +7,7 @@ complexity, intent) plus a category-appropriate worked example. The engine asks
 for each ``ReviewCategory`` in its own LLM call, so each call concentrates on a
 single lens — and sees a few-shot example of *its own* finding type, not a
 security one (a pickle example on the docs lens anchors the model to the wrong
-finding type). ``build_system_prompt()`` with no category returns the union of
-every section (the original monolithic prompt) with a generic example.
+finding type).
 """
 
 from __future__ import annotations

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -251,7 +251,7 @@ def _audit(
     ctx: PRContext,
     cfg: ReviewConfig,
     provider: ProviderClient,
-    fetched_paths: list[str] | None = None,
+    fetched_paths: list[str],
 ) -> dict[int, _ParsedVerdict]:
     """Run one auditor completion over *findings* and return the parsed verdicts.
 
@@ -314,7 +314,7 @@ def _grounding_block(
     findings: list[ReviewFinding],
     ctx: PRContext,
     budget_tokens: int,
-    extra_paths: list[str] | None = None,
+    extra_paths: list[str],
 ) -> str:
     """Redacted head text of the files carrying a finding, fit into *budget_tokens*.
 
@@ -336,7 +336,7 @@ def _grounding_block(
     # Most-flagged first; stable on ties by first appearance order of the path.
     order = sorted(counts, key=lambda p: counts[p], reverse=True)
     # Then the deferral-fetched files (not a finding's own path), de-duplicated.
-    for path in extra_paths or []:
+    for path in extra_paths:
         if path not in counts:
             order.append(path)
             counts[path] = 0
@@ -350,7 +350,7 @@ def _grounding_block(
         text = redact(raw)
         full = count_tokens(text)
         if full > remaining:
-            text, used = _head_tail(text, remaining, full)
+            text, used = _head_tail(text, remaining)
         else:
             used = full
         if used <= 0:
@@ -366,24 +366,15 @@ def _grounding_block(
     return f"Full head text of the changed files (for verification only):\n{body}\n\n"
 
 
-def _head_tail(text: str, max_tokens: int, full_tokens: int | None = None) -> tuple[str, int]:
+def _head_tail(text: str, max_tokens: int) -> tuple[str, int]:
     """Keep the head and tail of *text* so its token count fits within *max_tokens*.
 
     Whole-file claims hinge on imports (top of file) and the symbol/usage near the
     flagged code, so keeping both ends — with a marker where the middle was cut —
-    is more useful for verification than a head-only truncation.
-
-    Returns ``(text, token_count)`` so the caller reuses the count instead of
-    recounting. Pass ``full_tokens`` (a count of *text* the caller already has) to
-    skip recomputing it here.
+    is more useful for verification than a head-only truncation. The caller only
+    invokes this for over-budget text; returns ``(text, token_count)`` so the
+    caller reuses the count instead of recounting.
     """
-    if max_tokens <= 0:
-        return "", 0
-    if full_tokens is None:
-        full_tokens = count_tokens(text)
-    if full_tokens <= max_tokens:
-        return text, full_tokens
-
     lines = text.split("\n")
     marker = "… [truncated] …"
     half = (max_tokens - count_tokens(marker)) // 2

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -21,7 +21,13 @@ from urllib.parse import quote
 import httpx
 
 from lgtmaybe.core.logging import get_logger
-from lgtmaybe.core.models import PRContext, ReviewFinding
+from lgtmaybe.core.models import (
+    EFFORT_PREFIX,
+    SECURITY_LABEL,
+    SPLITTING_LABEL,
+    PRContext,
+    ReviewFinding,
+)
 from lgtmaybe.core.ports import GitHubGateway
 
 from .checkout import clone_base_tree
@@ -263,13 +269,16 @@ class RestGitHubGateway(GitHubGateway):
         the body), it is updated in-place rather than creating a duplicate.
 
         The ``diff`` parameter is optional; when omitted the method fetches the
-        PR diff to build the commentable-line index.
+        PR diff to build the commentable-line index. With no findings there is
+        nothing to anchor, so the fetch is skipped — a failure notice must not
+        re-fetch the whole PR context (and must still post when that fetch is
+        exactly what failed).
         """
-        if diff is None:
+        if diff is None and findings:
             ctx = self.get_pr_context()
             diff = ctx.diff
 
-        commentable: CommentableLines = build_commentable_lines(diff)
+        commentable: CommentableLines = build_commentable_lines(diff or "")
         comments, demoted, broad = self._partition_findings(findings, commentable)
 
         body = f"{summary}{_render_demoted(demoted)}{_render_broad(broad)}\n\n{self._marker}"
@@ -429,8 +438,7 @@ class RestGitHubGateway(GitHubGateway):
             managed = {
                 name
                 for name in current
-                if name.startswith("review-effort/")
-                or name in ("possible-security-issue", "consider-splitting")
+                if name.startswith(EFFORT_PREFIX) or name in (SECURITY_LABEL, SPLITTING_LABEL)
             }
             for stale in sorted(managed - set(labels)):
                 # The label name is a single path segment — quote it fully, or

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -40,14 +40,6 @@ class TestPrUrlFromEvent:
         }
         assert pr_url_from_event(event) == "https://github.com/org/my-repo/pull/42"
 
-    def test_honours_github_server_url(self, monkeypatch):
-        monkeypatch.setenv("GITHUB_SERVER_URL", "https://ghe.example.com")
-        event = {
-            "repository": {"full_name": "org/repo"},
-            "pull_request": {"number": 7},
-        }
-        assert pr_url_from_event(event) == "https://ghe.example.com/org/repo/pull/7"
-
     def test_missing_field_raises_clean_click_exception(self):
         """A malformed event payload surfaces a clear ClickException, not KeyError."""
         import click

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -212,7 +212,7 @@ class TestGitHubReviewErrorSurfacing:
         )
 
         with pytest.raises(click.ClickException):
-            cli_module.execute_review(_default_cfg(), RuntimeOptions(pr_url="x"), dry_run=False)
+            cli_module.execute_review(_default_cfg(), RuntimeOptions(pr_url="x"))
 
         assert len(github.posted) == 1
         posted_findings, posted_summary = github.posted[0]

--- a/tests/cli/test_slash.py
+++ b/tests/cli/test_slash.py
@@ -162,18 +162,6 @@ class TestDispatch:
         assert "**Change type:** feature" in body
         assert "| `a.py` |" in body
 
-    def test_dispatch_ignores_none(self):
-        github = FakeGitHub()
-        dispatch(
-            None,
-            github=github,
-            engine=FakeEngine(FakeProvider()),
-            provider=FakeProvider(),
-            cfg=_cfg(),
-        )
-        assert github.posted == []
-        assert github.comments == []
-
 
 def _write_event(tmp_path: Path, body: str) -> Path:
     event = {

--- a/tests/engine/test_astgrep.py
+++ b/tests/engine/test_astgrep.py
@@ -8,6 +8,7 @@ shapes and JSON parsing are verified end to end.
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -16,16 +17,10 @@ from lgtmaybe.engine.astgrep import (
     _rule_yaml as rule_yaml,
 )
 from lgtmaybe.engine.astgrep import (
-    ast_grep_available,
     build_symbol_resolver,
 )
 
 _HAVE_BINARY = "ast-grep"  # any non-None string stands in for "binary present"
-
-
-def test_available_reflects_binary_presence() -> None:
-    assert ast_grep_available(find_binary=lambda: "/usr/bin/ast-grep") is True
-    assert ast_grep_available(find_binary=lambda: None) is False
 
 
 def test_build_returns_none_without_binary() -> None:
@@ -102,10 +97,9 @@ def test_resolver_caps_candidates(tmp_path: Path) -> None:
         lambda: tmp_path,
         runner=lambda *_: payload,
         find_binary=lambda: _HAVE_BINARY,
-        max_candidates=2,
     )
     assert resolve is not None
-    assert len(resolve("x")) == 2
+    assert len(resolve("x")) == 3
 
 
 def test_resolver_returns_empty_when_no_corpus_root() -> None:
@@ -140,7 +134,7 @@ def test_malformed_runner_output_is_tolerated(tmp_path: Path) -> None:
     assert resolve("foo") == []
 
 
-@pytest.mark.skipif(not ast_grep_available(), reason="ast-grep binary not installed")
+@pytest.mark.skipif(shutil.which("ast-grep") is None, reason="ast-grep binary not installed")
 def test_real_ast_grep_finds_definitions_across_languages(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
     pkg.mkdir()

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -190,7 +190,7 @@ def test_expand_hunks_adds_surrounding_lines() -> None:
     # Hunk covers new-file lines 5..6 (e, E2); ask for 2 lines either side.
     patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
 
-    expanded = expand_hunks(patch, _CONTENT, 2)
+    expanded = expand_hunks(patch, _CONTENT, 2, after=2)
 
     # Two leading lines (c, d) and two trailing lines (g, h) are added as context.
     assert "\n c\n d\n" in expanded
@@ -201,19 +201,19 @@ def test_expand_hunks_adds_surrounding_lines() -> None:
 
 def test_expand_hunks_noop_when_n_zero() -> None:
     patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
-    assert expand_hunks(patch, _CONTENT, 0) == patch
+    assert expand_hunks(patch, _CONTENT, 0, after=0) == patch
 
 
 def test_expand_hunks_noop_when_no_content() -> None:
     patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
-    assert expand_hunks(patch, None, 5) == patch
+    assert expand_hunks(patch, None, 5, after=1) == patch
 
 
 def test_expand_hunks_clamps_at_file_edges() -> None:
     # Hunk at the very top of the file: no leading context possible, and a huge
     # n must not read past either end.
     patch = "diff --git a/f.py b/f.py\n@@ -1,1 +1,1 @@\n a\n"
-    expanded = expand_hunks(patch, _CONTENT, 100)
+    expanded = expand_hunks(patch, _CONTENT, 100, after=100)
 
     # No phantom lines before line 1.
     assert "@@ -1," in expanded
@@ -234,12 +234,6 @@ def test_expand_hunks_asymmetric_pads_fewer_after() -> None:
     assert " h\n" not in expanded
     # Header widened by 3 leading + 1 trailing = 4.
     assert "@@ -2,6 +2,6 @@" in expanded
-
-
-def test_expand_hunks_default_stays_symmetric() -> None:
-    # Without an explicit `after`, both sides pad by n — the original contract.
-    patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
-    assert expand_hunks(patch, _CONTENT, 2) == expand_hunks(patch, _CONTENT, 2, after=2)
 
 
 def test_trailing_context_lines_ratio() -> None:

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -277,8 +277,8 @@ def test_focused_prompt_excludes_other_categories(category: ReviewCategory) -> N
             assert marker not in prompt, f"{category.value} prompt leaked {other.value} section"
 
 
-def test_full_prompt_still_contains_every_category() -> None:
-    """The no-arg call is the union of all sections (backward compatible)."""
+def test_union_of_focused_prompts_contains_every_category() -> None:
+    """Every category's signature section appears in some focused prompt."""
     prompt = _union_prompt().lower()
     for marker in _SIGNATURE.values():
         assert marker in prompt

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -7,6 +7,16 @@ import pytest
 from lgtmaybe.core.models import CustomLens, ReviewCategory, ReviewFinding, Severity
 from lgtmaybe.engine.prompt import build_lens_prompt, build_system_prompt
 
+
+def _union_prompt() -> str:
+    """The union of every focused lens prompt — a convenient assertion surface.
+
+    Production only ever builds per-category prompts; asserting against the
+    union checks "some lens covers X" without caring which one.
+    """
+    return "\n\n".join(build_system_prompt(c) for c in ReviewCategory)
+
+
 # A term that appears only in each category's own section, used to prove a
 # focused prompt carries its section and excludes the others'.
 _SIGNATURE = {
@@ -28,17 +38,16 @@ def test_build_system_prompt_is_cached() -> None:
     assert build_system_prompt(ReviewCategory.security) is build_system_prompt(
         ReviewCategory.security
     )
-    assert build_system_prompt() is build_system_prompt()
 
 
 def test_prompt_contains_all_severity_levels() -> None:
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     for level in ("info", "low", "medium", "high", "critical"):
         assert level in prompt, f"severity level '{level}' missing from system prompt"
 
 
 def test_prompt_contains_json_contract() -> None:
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     # Must describe the JSON output fields
     for field in ("severity", "path", "line", "title", "body", "suggestion"):
         assert field in prompt, f"JSON field '{field}' missing from system prompt"
@@ -47,7 +56,7 @@ def test_prompt_contains_json_contract() -> None:
 def test_contract_requires_suggestion_to_be_replacement_code() -> None:
     """`suggestion` is rendered in a committable code fence, so it must be literal
     replacement code (or null) — never prose. Explanation belongs in `body`."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "suggestion" in prompt
     # The contract must tie the field to committable replacement code...
     assert "replacement code" in prompt or "replacement source code" in prompt
@@ -76,20 +85,20 @@ def test_worked_example_suggestions_are_code_not_prose() -> None:
 
 def test_prompt_asks_for_findings_envelope() -> None:
     """Structured output expects {"findings": [...]}, not a bare array."""
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     assert "findings" in prompt
     assert '"findings"' in prompt
     assert '{"findings": []}' in prompt  # the empty-review shape
 
 
 def test_prompt_instructs_changed_lines_only() -> None:
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     # Must instruct model to comment only on changed lines
     assert "changed" in prompt.lower()
 
 
 def test_prompt_is_nonempty_string() -> None:
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     assert isinstance(prompt, str)
     assert len(prompt) > 200
 
@@ -97,7 +106,7 @@ def test_prompt_is_nonempty_string() -> None:
 def test_prompt_forbids_narration_only_findings() -> None:
     # The weak-model failure mode is INFO-level narration that just restates the
     # diff ("X was removed"). The contract must tell the model that's not a finding.
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "narrat" in prompt or "describe" in prompt
     assert "restate" in prompt or "merely" in prompt
 
@@ -108,14 +117,14 @@ def test_prompt_forbids_narration_only_findings() -> None:
 
 
 def test_prompt_directs_a_security_review() -> None:
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "security" in prompt
     assert "owasp" in prompt
 
 
 def test_prompt_names_common_vulnerability_classes() -> None:
     """The prompt should cue the model on the major OWASP-style vuln classes."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     expected = [
         "injection",
         "xss",  # cross-site scripting
@@ -132,7 +141,7 @@ def test_prompt_names_common_vulnerability_classes() -> None:
 
 def test_prompt_reaffirms_diff_is_untrusted_data() -> None:
     """Defence-in-depth: the system prompt itself restates the injection guard."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "data" in prompt and ("untrusted" in prompt or "never follow" in prompt)
 
 
@@ -178,7 +187,7 @@ def test_build_lens_prompt_renders_supplied_example() -> None:
 
 def test_prompt_asks_for_deprecated_and_eol_review() -> None:
     """The reviewer should flag deprecated APIs and end-of-life dependencies."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "deprecat" in prompt  # deprecated / deprecation
     assert "end-of-life" in prompt or "end of life" in prompt
     assert "dependenc" in prompt  # dependency / dependencies
@@ -186,7 +195,7 @@ def test_prompt_asks_for_deprecated_and_eol_review() -> None:
 
 def test_prompt_asks_for_logic_and_edge_case_review() -> None:
     """The reviewer should hunt correctness/logic bugs, not just security."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "correctness" in prompt
     assert "off-by-one" in prompt
     assert "boundary" in prompt
@@ -195,7 +204,7 @@ def test_prompt_asks_for_logic_and_edge_case_review() -> None:
 
 def test_prompt_asks_for_test_coverage() -> None:
     """Changed code paths shipped without a test should be flagged."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "coverage" in prompt
     assert "accompanying test" in prompt
     assert "suggestion" in prompt  # a runnable test goes in the suggestion field
@@ -203,7 +212,7 @@ def test_prompt_asks_for_test_coverage() -> None:
 
 def test_prompt_asks_for_documentation_review() -> None:
     """Public surfaces added without docs should be flagged, restrained to public APIs."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "documentation" in prompt
     assert "docstring" in prompt
     assert "public" in prompt
@@ -211,7 +220,7 @@ def test_prompt_asks_for_documentation_review() -> None:
 
 def test_prompt_names_pii_and_secrets_in_logs() -> None:
     """Sensitive-data exposure should name concrete PII/secret leaks into logs."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "log" in prompt
     assert "pii" in prompt
     assert "ssn" in prompt  # SSNs
@@ -220,7 +229,7 @@ def test_prompt_names_pii_and_secrets_in_logs() -> None:
 
 def test_prompt_asks_for_performance_review() -> None:
     """The reviewer should flag performance regressions, graded by impact."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "performance" in prompt
     assert "n+1" in prompt  # N+1 queries / repeated calls in a loop
     assert "quadratic" in prompt
@@ -228,7 +237,7 @@ def test_prompt_asks_for_performance_review() -> None:
 
 def test_prompt_asks_for_complexity_review() -> None:
     """The reviewer should flag needless complexity, restrained and low severity."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "complexity" in prompt
     assert "cyclomatic" in prompt
     assert "nest" in prompt  # deep nesting
@@ -237,7 +246,7 @@ def test_prompt_asks_for_complexity_review() -> None:
 
 def test_prompt_asks_for_ponytail_review() -> None:
     """The 'lazy senior dev' lens: flag code that needn't exist (YAGNI, use stdlib)."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "yagni" in prompt
     assert "never wrote" in prompt  # the best code is the code you never wrote
     assert "standard library" in prompt
@@ -270,7 +279,7 @@ def test_focused_prompt_excludes_other_categories(category: ReviewCategory) -> N
 
 def test_full_prompt_still_contains_every_category() -> None:
     """The no-arg call is the union of all sections (backward compatible)."""
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     for marker in _SIGNATURE.values():
         assert marker in prompt
 
@@ -376,18 +385,18 @@ def test_each_focused_prompt_carries_a_worked_example(category: ReviewCategory) 
 def test_prompt_explains_line_number_mapping() -> None:
     """`line` is a file line number computed from the hunk header — a wrong line
     means the finding silently maps to nothing and is dropped."""
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     assert "hunk header" in prompt.lower()
     assert "LEFT" in prompt and "RIGHT" in prompt
 
 
 def test_prompt_asks_for_one_finding_per_distinct_issue() -> None:
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "each distinct issue" in prompt
 
 
 def test_prompt_asks_for_a_verbatim_anchor() -> None:
-    prompt = build_system_prompt()
+    prompt = _union_prompt()
     assert "anchor" in prompt
     assert "verbatim" in prompt.lower()
 
@@ -399,7 +408,7 @@ def test_every_category_example_includes_an_anchor() -> None:
 
 
 def test_prompt_warns_minus_lines_are_removed_not_duplicates() -> None:
-    prompt = build_system_prompt().lower()
+    prompt = _union_prompt().lower()
     assert "removed" in prompt
     # A modify pair must not be read as a redefinition / duplication.
     assert "defined twice" in prompt or "duplicat" in prompt

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -399,19 +399,6 @@ def test_head_tail_returns_text_and_accurate_token_count() -> None:
     assert used <= 200
 
 
-def test_head_tail_within_budget_returns_full_text_and_count() -> None:
-    """When the text already fits, _head_tail returns it unchanged with its count."""
-    from lgtmaybe.engine.compress import count_tokens
-    from lgtmaybe.engine.reflect import _head_tail
-
-    text = "short\nfile\n"
-
-    out, used = _head_tail(text, 10_000)
-
-    assert out == text
-    assert used == count_tokens(text)
-
-
 # ---------------------------------------------------------------------------
 # TRACK D — bounded retrieval escalation (verify, don't cull)
 #

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -9,6 +9,7 @@ ollama e2e run.
 from __future__ import annotations
 
 import json
+import shutil
 
 import pytest
 
@@ -16,7 +17,7 @@ from evals import run as run_mod
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.models import PRContext, Provider, ProviderResult, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ProviderClient
-from lgtmaybe.engine.astgrep import ast_grep_available, build_symbol_resolver
+from lgtmaybe.engine.astgrep import build_symbol_resolver
 from lgtmaybe.engine.compress import split_patch_into_hunks
 from lgtmaybe.engine.reflect import reflect_findings
 from lgtmaybe.github import is_reviewable
@@ -169,7 +170,7 @@ def test_loader_sets_corpus_root_only_for_fixtures_with_a_repo_dir() -> None:
     assert by_name["badcode"].corpus_root is None
 
 
-@pytest.mark.skipif(not ast_grep_available(), reason="ast-grep binary not installed")
+@pytest.mark.skipif(shutil.which("ast-grep") is None, reason="ast-grep binary not installed")
 def test_real_ast_grep_resolves_cross_file_symbols_in_the_corpus() -> None:
     """Real ast-grep, rooted at the fixture corpus, maps each deferred symbol to the
     file that defines it — the resolution the auditor relies on."""
@@ -194,7 +195,7 @@ class _ScriptedProvider(ProviderClient):
         return ProviderResult(text=self._texts[idx], input_tokens=5, output_tokens=5)
 
 
-@pytest.mark.skipif(not ast_grep_available(), reason="ast-grep binary not installed")
+@pytest.mark.skipif(shutil.which("ast-grep") is None, reason="ast-grep binary not installed")
 def test_end_to_end_symbol_deferral_drops_forbidden_finding_with_real_ast_grep() -> None:
     """The whole chain, no fakes in the resolution path: a finding is deferred on a
     SYMBOL; real ast-grep finds its file in the corpus; the real read-only reader


### PR DESCRIPTION
## What

A ponytail-lens audit ("the best code is the code you never wrote") of `src/`, applied to lgtmaybe itself: five parallel audit passes over the whole tree, every candidate finding verified against real call sites before acting, fixes applied, then an adversarial re-review of the resulting diff. Net **−122 lines** with behaviour preserved on every production path.

## Changes

**Dead code**
- `lgtmaybe/__init__.py`: drop the unread `__version__` — nothing imports it, and its `"0.11.0"` fallback literal silently drifted on every release (not release-please-managed).
- `engine/__init__.py`: prune the re-export facade to the five names consumers actually import at package level.
- `engine/prompt.py`: `build_system_prompt` now requires a category — the no-category "monolithic prompt" branch had no production caller (tests assert against a union helper instead).
- `engine/astgrep.py`: drop `ast_grep_available` (only used in test skipifs, which now use `shutil.which` directly).
- `cli/__init__.py`: drop `execute_review`'s `dry_run` parameter — every entry point passed `False`, making the `[dry-run]` echo branch unreachable (`run_review`'s own live `dry_run` is untouched). Remove the `GITHUB_SERVER_URL` read that could only no-op or manufacture a guaranteed downstream parse failure (the URL regex hardcodes github.com), plus the matching dead `-e GITHUB_REPOSITORY -e GITHUB_SERVER_URL` forwards in `action.yml`.
- `cli/slash.py`: remove the `dispatch(None)` guard (the caller already returns before dispatch on a non-command).

**Duplication**
- `cli/slash.py`: `/describe` reimplemented `run_describe` line for line (with drift in the fallback chain) — it now calls `run_describe` via the same lazy import `run_review` already uses; the one-caller `_reply`/`_answer_question` chain is inlined.
- `engine/boundaries.py`: shares `_default_runner` and the JSON-guard scaffolding (`iter_matches`) with `engine/astgrep.py` instead of carrying byte-identical copies.
- `core/models.py` now hosts the PR-label families (`EFFORT_PREFIX`, `SECURITY_LABEL`, `SPLITTING_LABEL`); previously `engine/labels.py` exported them while `rest_gateway`'s stale-label reconcile re-hardcoded the literals — a renamed family would have silently broken the reconcile.

**Unreachable defensive branches / YAGNI knobs**
- `engine/reflect.py`: `_head_tail` loses the guards its only caller makes unreachable and the `full_tokens` param that existed solely for the removed fits-budget early return (the `half <= 0` regression guard stays); `_audit`/`_grounding_block` path params are required, dropping `None` legs no caller used.
- `engine/compress.py`: `expand_hunks`'s trailing pad is required — the symmetric `after=None` back-compat contract was test-only; `context_lines_for_budget` collapses to one expression.
- `engine/astgrep.py`: drop the `max_candidates` knob (the only non-default value in the repo was its own unit test).
- `engine/injection.py`: merge the `neutralise`/`_neutralise_markers` duplicate names into one public function.
- `cli/render.py`: drop the `splitlines() or [f.suggestion]` fallback, which could only fire on an empty suggestion and then emitted a blank indented line.

**Efficiency**
- `github/rest_gateway.py`: a findings-free `post_review` (the failure-notice path) no longer fetches the entire PR context — diff plus every reviewable file's head text — to build a commentable-line index that an empty findings list never consults. This also means the failure notice still posts when `get_pr_context` is exactly what failed.

## Verification

- Full suite: **1132 passed** (was 1137 — five tests that existed only to pin removed dead branches were deleted/merged); ruff lint + format clean.
- `tests/specs`: 17 passed — every ast-grep anchor still resolves to exactly one match; no spec section describes the removed internals, so no spec edits were needed.
- A second adversarial review pass over the diff traced each hunk end to end (empty-diff commentable index, all `expand_hunks`/`build_system_prompt` call sites, import-cycle checks for the moved constants, `_head_tail`'s caller invariants) and found no behavioural change on any production path.

Deliberately **not** flagged/removed: documented design decisions (prompt-cache split shape, `_fan_out` warm-up primer, DI test seams, `count_tokens` tiktoken fallback, `checkout.py`'s fork-safe base clone) — all verified as live, intentional features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJPyJnWa9M5YJF9YSku5Np

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPyJnWa9M5YJF9YSku5Np)_