### PR TITLE
perf: cut redundant work in the pipeline and trim prompt token waste

### DIFF
--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -36,8 +36,15 @@ def _token_encoder() -> Any | None:
         return None
 
 
+@lru_cache(maxsize=256)
 def count_tokens(text: str) -> int:
-    """Return the token count for *text* using tiktoken, with a len/4 fallback."""
+    """Return the token count for *text* using tiktoken, with a len/4 fallback.
+
+    Memoized: the same text is counted repeatedly across a review — each
+    over-budget patch twice during recursive batching, the whole diff once per
+    reflection deferral hop — and encoding is O(len) each time. Bounded so the
+    cache can't retain an unbounded number of large diff strings.
+    """
     enc = _token_encoder()
     if enc is not None:
         return len(enc.encode(text))

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -563,7 +563,9 @@ class LLMReviewEngine(ReviewEngine):
                     for task_index, task in indexed:
                         pending[pool.submit(task)] = task_index
             while pending:
-                done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
+                # wait() copies its argument internally, so passing the dict's
+                # keys directly avoids building a second throwaway set per loop.
+                done, _ = wait(pending, return_when=FIRST_COMPLETED)
                 for future in done:
                     results[pending.pop(future)] = future.result()
                     batch_index = primer_batch.pop(future, -1)

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -81,8 +81,7 @@ def _example_block(
         f"{lead_in}\n\n"
         "```\n" + diff + "```\n\n"
         "a correct response is:\n\n"
-        "```json\n" + findings_json + "\n```\n\n"
-        'When there are no issues, return `{"findings": []}`.'
+        "```json\n" + findings_json + "\n```"
     )
 
 
@@ -301,10 +300,7 @@ graded `high` or `critical` when they cause wrong results, crashes, or data loss
 - **Aliasing & mutation** — mutable default arguments, storing a mutable value
   the caller still owns, mutating a collection while iterating over it.
 - **Wrong validation anchoring** — a regex anchored with `match` where full-match
-  semantics are needed, letting bad input through.
-
-Reason about the surrounding context lines, but only raise findings on changed
-lines."""
+  semantics are needed, letting bad input through."""
 
 _SECURITY_SECTION = """\
 ## Security review (be thorough — these are high-value findings)
@@ -429,7 +425,6 @@ Flag performance regressions the change introduces, graded by impact (`low` to
 - **Unbounded growth & leaks** — caches without eviction, listeners or
   subscriptions registered but never removed, queues or buffers that only grow.
 
-Reason about the surrounding context, but only raise findings on changed lines.
 Do not speculate about micro-optimisations with no measurable impact."""
 
 _COMPLEXITY_SECTION = """\
@@ -564,8 +559,7 @@ higher when a security advisory is involved):
 - abandoned, yanked, or known-vulnerable dependency versions;
 - typosquat-looking or incompatibly-licensed additions.
 
-Do NOT nag about self-evident, already-simple, or already-minimal code. Reason from
-the surrounding context, but only raise findings on changed lines."""
+Do NOT nag about self-evident, already-simple, or already-minimal code."""
 
 _ARTEFACTS_SECTION = """\
 ## Supporting artefacts (tests · documentation)
@@ -755,8 +749,7 @@ verify (hedge, lower the severity), never as confident `high`/`critical` fixes �
   ("X was removed", "Y now takes a new parameter", "this method is now async") — narration
   that restates the diff is not a finding. If the content is only a restatement of the
   change with no problem attached, omit it entirely.
-- Return `{"findings": []}` only when there are genuinely no issues.
-- Never output anything other than the JSON object."""
+- Return `{"findings": []}` only when there are genuinely no issues."""
 
 
 @lru_cache(maxsize=1)

--- a/src/lgtmaybe/engine/redact.py
+++ b/src/lgtmaybe/engine/redact.py
@@ -9,6 +9,7 @@ guarantee; it complements, never replaces, keeping real secrets out of git.
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 
 REDACTED_PLACEHOLDER = "[REDACTED]"
 
@@ -87,8 +88,15 @@ def _replace_value(m: re.Match[str]) -> str:
     return full.replace(value, REDACTED_PLACEHOLDER, 1)
 
 
+@lru_cache(maxsize=128)
 def redact(text: str) -> str:
-    """Return *text* with known secret patterns replaced by REDACTED_PLACEHOLDER."""
+    """Return *text* with known secret patterns replaced by REDACTED_PLACEHOLDER.
+
+    Memoized: the same file head text is redacted at several pipeline stages
+    (hunk expansion, reflection grounding, every deferral re-judge), and each
+    pass runs the full pattern battery over the whole input. Bounded so the
+    cache can't retain an unbounded number of large file texts.
+    """
     for pattern in _SIMPLE_PATTERNS:
         text = pattern.sub(REDACTED_PLACEHOLDER, text)
     for pattern in _VALUE_PATTERNS:

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -99,7 +99,7 @@ test harness you cannot see, so such a claim is speculative.
 
 Return ONLY the JSON object, nothing else. Example:
 {"verdicts": [{"index": 0, "keep": true, "confidence": 9, "broad": false, "needs": []}, \
-{"index": 1, "keep": false, "confidence": 0, "broad": false, "needs": ["app/models.py"]}]}
+{"index": 1, "keep": true, "confidence": 5, "broad": false, "needs": ["app/models.py"]}]}
 """
 
 
@@ -260,7 +260,15 @@ def _audit(
     verdict map. Raises on an unparseable verdict so the caller can apply its
     keep-all safe default.
     """
-    findings_json = json.dumps([f.model_dump(mode="json") for f in findings], indent=2)
+    # Engine-stamped fields are excluded: at audit time `anchored`/`broad`/
+    # `confidence` are always their placeholder defaults (they are populated
+    # AFTER the audit, from this very verdict), so serializing them is token
+    # noise — and a `"confidence": null` is actively confusing when the auditor
+    # is the party asked to produce the confidence score.
+    findings_json = json.dumps(
+        [f.model_dump(mode="json", exclude={"anchored", "broad", "confidence"}) for f in findings],
+        indent=2,
+    )
 
     # Asymmetric grounding: the reviews ran per-batch on slices; here the auditor
     # gets the full (redacted) head text of every file carrying a surviving

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -15,7 +15,7 @@ import re
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote
 
 import httpx
@@ -199,6 +199,12 @@ class RestGitHubGateway(GitHubGateway):
         # never record "reviewed up to head" — the next run would then skip
         # commits nobody reviewed.
         self._reviewed_sha: str | None = None
+        # Memoized marker-review lookup: last_reviewed_sha (incremental) and
+        # post_review both walk the full paginated reviews list for the same
+        # marker, and nothing posts a review between the two reads within one
+        # run — so the second walk is always identical. False = not looked up
+        # yet (None is a valid "no marker review" result).
+        self._existing_review_entry: tuple[int, str] | None | Literal[False] = False
 
     # ------------------------------------------------------------------
     # GitHubGateway implementation
@@ -665,15 +671,20 @@ class RestGitHubGateway(GitHubGateway):
 
         Follows Link rel=next pagination — a busy PR can hold more than one page
         of reviews, and missing the marker there would duplicate the review
-        instead of updating it.
+        instead of updating it. Memoized for the run: the incremental watermark
+        read and the post both need it, and no review is posted in between.
         """
+        if self._existing_review_entry is not False:
+            return self._existing_review_entry
         url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
         for resp in self._paginate(url):
             for review in resp.json():
                 body: str = review.get("body", "") or ""
                 if self._marker in body:
                     review_id: int = review["id"]
-                    return review_id, body
+                    self._existing_review_entry = (review_id, body)
+                    return self._existing_review_entry
+        self._existing_review_entry = None
         return None
 
     # ------------------------------------------------------------------

--- a/src/lgtmaybe/providers/__init__.py
+++ b/src/lgtmaybe/providers/__init__.py
@@ -1,8 +1,9 @@
 """providers — public surface for the provider track."""
 
+from typing import Any
+
 from lgtmaybe.providers.credentials import AuthConfig, resolve_credentials
 from lgtmaybe.providers.factory import build_provider
-from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
 __all__ = [
     "AuthConfig",
@@ -10,3 +11,14 @@ __all__ = [
     "build_provider",
     "resolve_credentials",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    # LiteLLMProvider is resolved lazily (PEP 562): importing it pulls in
+    # litellm, whose multi-second import would otherwise be paid by every CLI
+    # command — including ones that never talk to a model.
+    if name == "LiteLLMProvider":
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        return LiteLLMProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -14,11 +14,13 @@ litellm model-string conventions:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.constants import DEFAULT_OLLAMA_BASE
-from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+if TYPE_CHECKING:
+    from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
 _PREFIXES: dict[Provider, str] = {
     Provider.openai: "openai",
@@ -109,6 +111,10 @@ def build_provider(
     (:func:`default_timeout_for`) — so ollama always gets a long timeout without
     the caller having to ask. An explicit value is honoured as-is.
     """
+    # litellm's import is multi-second; deferring it here keeps `import
+    # lgtmaybe.cli` fast for commands that never build a provider (config, help).
+    from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
     resolved_model = litellm_model_string(provider, model)
     resolved_fallback = litellm_model_string(provider, fallback_model) if fallback_model else None
     opts: dict[str, Any] = dict(extra_opts)

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -165,6 +165,11 @@ class LiteLLMProvider(ProviderClient):
         # subsequent call skips response_format up front instead of paying a
         # wasted empty round-trip first. Sticky for the life of this provider.
         self._skip_response_format = False
+        # Memoized supports-cache-control answers: the review fans out many
+        # completions on the same model string, and the capability lookup is a
+        # pure function of it. Instance-scoped (not lru_cache) so tests that
+        # patch the litellm lookup stay isolated.
+        self._cache_capable: dict[str, bool] = {}
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
@@ -269,7 +274,11 @@ class LiteLLMProvider(ProviderClient):
           plain string and no marker is attached — byte-identical to the single
           user message these providers have always received.
         """
-        if not self.prompt_cache or not _supports_cache_control(model):
+        if not self.prompt_cache:
+            return _merge_user_messages(messages)
+        if model not in self._cache_capable:
+            self._cache_capable[model] = _supports_cache_control(model)
+        if not self._cache_capable[model]:
             return _merge_user_messages(messages)
 
         out = list(messages)

--- a/tests/cli/test_lazy_imports.py
+++ b/tests/cli/test_lazy_imports.py
@@ -1,0 +1,45 @@
+"""CLI startup cost: importing the CLI must not import litellm.
+
+litellm's import is multi-second; commands that never touch a model
+(``config show``, ``--help``) must not pay for it. The provider adapter is
+imported lazily, only when a provider is actually built.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_CHECK = "import sys; import lgtmaybe.cli; sys.exit(1 if 'litellm' in sys.modules else 0)"
+
+
+def test_importing_cli_does_not_import_litellm() -> None:
+    """`import lgtmaybe.cli` must leave litellm unimported (fresh interpreter)."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHECK],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        "importing lgtmaybe.cli pulled in litellm at module scope — "
+        "lightweight commands now pay its multi-second import\n"
+        f"stderr: {proc.stderr}"
+    )
+
+
+def test_build_provider_still_returns_litellm_provider() -> None:
+    """The lazy import must not change what the factory builds."""
+    from lgtmaybe.core.models import Provider
+    from lgtmaybe.providers.factory import build_provider
+    from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+    provider = build_provider(Provider.openai, "gpt-4o", api_key="k")
+    assert isinstance(provider, LiteLLMProvider)
+
+
+def test_providers_package_still_exports_litellm_provider() -> None:
+    """`from lgtmaybe.providers import LiteLLMProvider` keeps working lazily."""
+    import lgtmaybe.providers as providers
+
+    assert providers.LiteLLMProvider.__name__ == "LiteLLMProvider"

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -295,3 +295,16 @@ def test_no_boundaries_keeps_the_fixed_pad() -> None:
     assert expand_hunks(patch, _FN_CONTENT, 2, after=1, boundaries=[]) == expand_hunks(
         patch, _FN_CONTENT, 2, after=1
     )
+
+
+def test_count_tokens_memoizes_repeated_text() -> None:
+    """The same text is token-counted many times per review (batching, the
+    reflection reserve on every deferral hop) — repeats must hit a cache, not
+    re-encode the whole string."""
+    count_tokens.cache_clear()
+    text = "some diff text " * 200
+    first = count_tokens(text)
+    assert count_tokens(text) == first
+    info = count_tokens.cache_info()
+    assert info.hits >= 1
+    assert info.misses == 1

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from lgtmaybe.core.models import CustomLens, ReviewCategory, ReviewFinding, Severity
-from lgtmaybe.engine.prompt import build_lens_prompt, build_system_prompt
+from lgtmaybe.engine.prompt import build_lens_prompt, build_shared_preamble, build_system_prompt
 
 
 def _union_prompt() -> str:
@@ -475,3 +475,34 @@ def test_prompt_intent_fulfilment_is_not_a_defect() -> None:
     prompt = build_system_prompt(ReviewCategory.intent).lower()
     assert "fulfils the stated intent" in prompt or "fulfils the intent" in prompt
     assert "deliberate removal" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Token hygiene — shared instructions are stated once, not per lens/example
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", list(ReviewCategory))
+def test_empty_review_shape_stated_once(category: ReviewCategory) -> None:
+    """`{"findings": []}` is stated once (in the shared rules), not repeated in
+    every worked example — the examples ride the uncached per-lens block, so a
+    per-example restatement is paid on every fan-out call."""
+    assert build_system_prompt(category).count('{"findings": []}') == 1
+
+
+@pytest.mark.parametrize("category", list(ReviewCategory))
+def test_lens_sections_do_not_restate_the_changed_lines_rule(category: ReviewCategory) -> None:
+    """The changed-lines-only rule lives in the shared rules (cached preamble);
+    per-lens restatements ride the uncached suffix on every call."""
+    prompt = build_system_prompt(category)
+    assert "only raise findings on changed lines" not in prompt
+    # The authoritative shared-rules statement remains.
+    assert "Comment ONLY on changed lines" in prompt
+
+
+def test_json_only_rule_not_duplicated_in_shared_rules() -> None:
+    """The output contract's 'Return ONLY a JSON object' is not restated as a
+    second shared-rules bullet."""
+    preamble = build_shared_preamble()
+    assert "Return ONLY a JSON object" in preamble
+    assert "Never output anything other than" not in preamble

--- a/tests/engine/test_redact.py
+++ b/tests/engine/test_redact.py
@@ -248,3 +248,16 @@ def test_connection_string_pattern_is_not_quadratic() -> None:
     start = time.perf_counter()
     redact(pathological)
     assert time.perf_counter() - start < 2.0
+
+
+def test_redact_memoizes_repeated_text() -> None:
+    """The same file head text is redacted at several pipeline stages (hunk
+    expansion, reflection grounding, every deferral hop) — repeats must hit a
+    cache instead of re-running the whole pattern battery."""
+    redact.cache_clear()
+    text = 'api_key = "abcdefghijklmnop1234"\n' + ("plain line\n" * 50)
+    first = redact(text)
+    assert redact(text) == first
+    info = redact.cache_info()
+    assert info.hits >= 1
+    assert info.misses == 1

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -711,3 +711,44 @@ def test_reflect_prompt_asks_for_a_confidence_score() -> None:
     system = provider.calls[0]["messages"][0]["content"]
     assert "confidence" in system
     assert "0" in system and "10" in system
+
+
+def test_auditor_findings_json_excludes_engine_stamped_fields() -> None:
+    """The findings JSON sent to the auditor carries only audit-relevant fields.
+
+    ``anchored``, ``broad``, and ``confidence`` are engine-stamped AFTER the
+    audit — at audit time they are always their placeholder defaults, and a
+    ``"confidence": null`` is actively confusing when the auditor is the party
+    asked to produce the confidence score.
+    """
+    provider = _fake_with_verdict({0: True})
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    user = _user_text(provider.calls[0])
+    assert '"anchored"' not in user
+    assert '"broad"' not in user
+    assert '"confidence"' not in user
+    # The audit-relevant fields still travel.
+    assert '"path"' in user
+    assert '"title"' in user
+    assert '"severity"' in user
+
+
+def test_reflect_example_never_pairs_drop_with_needs() -> None:
+    """The worked example must not contradict the deferral instruction.
+
+    The prompt says: when more code is needed, do NOT drop — set ``needs``.
+    An example verdict pairing keep:false with a non-empty needs trains the
+    model to emit exactly the contradiction the lenient parser has to absorb.
+    """
+    from lgtmaybe.engine.reflect import _REFLECT_SYSTEM
+
+    start = _REFLECT_SYSTEM.rindex('{"verdicts"')
+    example = json.loads(_REFLECT_SYSTEM[start:].strip())
+    for verdict in example["verdicts"]:
+        if verdict.get("needs"):
+            assert verdict.get("keep") is True, (
+                "example defers (non-empty needs) with keep:false — "
+                "the instructions say a deferral must not be a drop"
+            )

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -831,3 +831,63 @@ def test_apply_pr_labels_swallows_api_failures() -> None:
 
     gateway = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN)
     gateway.apply_pr_labels(["review-effort/1"])  # must not raise
+
+
+@respx.mock
+def test_post_review_empty_findings_skips_diff_fetch() -> None:
+    """A findings-free post (e.g. the failure notice) must not fetch the PR.
+
+    With nothing to place inline there is no commentable-line index to build,
+    so the full get_pr_context fan-out (metadata, diff, per-file contents,
+    commits) would be pure waste on every failure path.
+    """
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+    pr_fetches: list[httpx.Request] = []
+
+    def capture_pr(request: httpx.Request) -> httpx.Response:
+        pr_fetches.append(request)
+        return httpx.Response(200, json=_pr_detail())
+
+    respx.route(method="GET", url__startswith=PR_URL).mock(side_effect=capture_pr)
+    respx.route(method="POST", url=REVIEWS_URL).mock(
+        return_value=httpx.Response(201, json={"id": 1})
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([], "review failed: provider quota exceeded")  # diff omitted
+
+    assert pr_fetches == [], "empty-findings post_review must not fetch the PR diff/context"
+
+
+@respx.mock
+def test_reviews_list_fetched_once_per_run() -> None:
+    """last_reviewed_sha + post_review share one paginated reviews lookup.
+
+    Both walk the reviews list for the same marker review; on an incremental
+    run they used to paginate the identical, unchanged list twice.
+    """
+    existing_review_id = 99
+    reviews_calls: list[httpx.Request] = []
+
+    def capture_reviews(request: httpx.Request) -> httpx.Response:
+        reviews_calls.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": existing_review_id,
+                    "body": f"Old summary {MARKER}\n<!-- lgtmaybe-reviewed:def5678 -->",
+                }
+            ],
+        )
+
+    respx.route(method="GET", url=REVIEWS_URL).mock(side_effect=capture_reviews)
+    respx.route(method="PUT", url=f"{REVIEWS_URL}/{existing_review_id}").mock(
+        return_value=httpx.Response(200, json={"id": existing_review_id})
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    assert gw.last_reviewed_sha() == "def5678"
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert len(reviews_calls) == 1, "the unchanged reviews list must not be re-paginated"

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -267,3 +267,24 @@ class TestProviderMatrix:
         sent = mock_completion.call_args.kwargs["messages"]
         # Whatever a provider does, the volatile user content is never marked.
         assert isinstance(sent[-1]["content"], str)
+
+
+def test_capability_lookup_memoized_per_model() -> None:
+    """The litellm capability map is consulted once per model, not per call.
+
+    A review fans out many completions on the same model string; the
+    supports-caching answer is a pure function of that string, so the
+    adapter memoizes it on the instance.
+    """
+    model = _CACHEABLE_MODELS[0]
+    with (
+        patch("litellm.completion", return_value=_fake_response()),
+        patch(
+            "lgtmaybe.providers.litellm_provider.supports_prompt_caching",
+            return_value=True,
+        ) as lookup,
+    ):
+        provider = LiteLLMProvider(model=model, prompt_cache=True)
+        for _ in range(3):
+            provider.complete(_messages(), model)
+    assert lookup.call_count == 1


### PR DESCRIPTION
## Summary

A multi-agent scan of the codebase (20 lenses: 10 performance, 10 prompt-optimization) surfaced 19 candidate findings; each was verified against the actual code and the pinned prompt tests before implementation. This PR lands the confirmed, low-risk ones. All changes are behavior-preserving and each carries a test (TDD: red → green). Rebased onto main after #184 (which independently landed one of the scan's findings — the empty-findings `post_review` fetch skip; this PR now adds a regression test for it).

## Performance

- **Lazy litellm import** — `providers/factory.py` now imports `LiteLLMProvider` inside `build_provider`, and `providers/__init__.py` resolves it via PEP 562 `__getattr__`. litellm's multi-second import is no longer paid by CLI commands that never build a provider (`config show`, `--help`). Guarded by a fresh-interpreter subprocess test.
- **Reviews list paginated once per run** — `last_reviewed_sha()` (incremental watermark) and `post_review` both walked the full paginated reviews list for the same marker review; the lookup is now memoized on the gateway (nothing posts a review between the two reads).
- **Capability lookup memoized** — `supports_prompt_caching` was consulted on every completion; a review fans out many calls on the same model string. Now memoized per provider instance (instance-scoped so tests that patch the lookup stay isolated).
- **`count_tokens` and `redact` memoized (bounded `lru_cache`)** — the same diff/file text was re-encoded and re-scrubbed across recursive batching, hunk expansion, reflection grounding, and every deferral re-judge hop. Both are pure `str → result` functions; caches are bounded (256/128) so large strings can't accumulate.
- **Fan-out loop** — dropped a per-iteration throwaway `set(pending)` copy (`wait()` copies its argument internally).
- **Test-only**: a regression test pinning the empty-findings `post_review` fetch skip that #184 introduced (`post_review([], notice)` must not run the full `get_pr_context` fan-out).

## Prompt token waste

The per-lens block is the *uncached* suffix billed at full rate on every fan-out call (4 calls on the fast preset, 9 on full), so duplication there is paid repeatedly:

- The empty-review shape (`{"findings": []}`) was stated in every worked example **and** in the shared rules **and** in the injection wrapper's task suffix — now stated once in the shared (cacheable) rules.
- Three lens sections (correctness, performance, code-health) restated the changed-lines-only rule that the shared rules already state more forcefully.
- A shared-rules bullet duplicated the output contract's "return ONLY the JSON object" instruction.
- The reflection auditor received every finding serialized with `anchored`/`broad`/`confidence` — engine-stamped fields that are always placeholder defaults at audit time (`"confidence": null` was actively confusing when the auditor is the party asked to *produce* the score). The projection now sends only audit-relevant fields.
- The reflection worked example paired `keep: false` with a non-empty `needs`, contradicting the deferral instruction ("do NOT drop — defer"); the example is now consistent (`keep: true`, mid-scale confidence).

All pinned prompt assertions (`test_prompt.py`, `test_injection.py`) still pass; new tests pin the deduplications so they can't regress.

## Verification

- Full suite on the rebased branch: **1161 passed** (includes `tests/specs` anchor/spec gates)
- `ruff check` + `ruff format --check` clean, `mypy src` clean
- No `ReviewConfig` changes, so the generated config reference is untouched; no spec sections went stale (behavior described by the living specs is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmAJxFcaGkwgHdivqruFf6