### PR TITLE
fix(homebrew): prefer wheels so litellm >=1.92 sdist never builds in the sandbox

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -79,12 +79,17 @@ class Lgtmaybe < Formula
   depends_on "python@3.12"
 
   def install
-    # lgtmaybe's dependency tree includes Rust extensions (tokenizers, hf-xet)
-    # whose sdists cannot build inside Homebrew's sandbox, so install lgtmaybe and
-    # its dependencies from upstream PyPI wheels into an isolated virtualenv. The
-    # venv is created plainly so ensurepip provides pip.
+    # lgtmaybe's dependency tree includes Rust extensions (tokenizers, hf-xet,
+    # and litellm >= 1.92, which ships only manylinux wheels) whose sdists
+    # cannot build inside Homebrew's sandbox (no Cargo), so install lgtmaybe
+    # and its dependencies from upstream PyPI wheels into an isolated
+    # virtualenv. --prefer-binary makes pip back off to the newest version
+    # that has a macOS-compatible wheel instead of grabbing a newer sdist it
+    # would then fail to compile. The venv is created plainly so ensurepip
+    # provides pip.
     system "python3.12", "-m", "venv", libexec
-    system libexec/"bin/python", "-m", "pip", "install", "lgtmaybe==#{version}"
+    system libexec/"bin/python", "-m", "pip", "install", "--prefer-binary",
+           "lgtmaybe==#{version}"
     bin.install_symlink libexec/"bin/lgtmaybe"
   end
 


### PR DESCRIPTION
Fixes the failing scheduled homebrew run: https://github.com/MattJColes/lgtmaybe/actions/runs/29908801885

## What broke

The formula's smoke-test (`brew install local/lgtmaybe/lgtmaybe`) failed with:

```
Cargo, the Rust package manager, is not installed or is not on PATH.
error: metadata-generation-failed
╰─> litellm
```

Root cause: **litellm 1.92.0 stopped publishing a pure-Python wheel** — from 1.92.0 onward PyPI only carries `cp3xx-manylinux` wheels (plus the sdist). On the macOS runner, `pip install lgtmaybe==0.12.1` (which allows `litellm>=1.87.1` on Python 3.12) resolved litellm 1.93.0, found no macOS-compatible wheel, and fell back to the sdist — which now requires Rust/Cargo to compile, and that can't happen inside Homebrew's sandboxed build.

## The fix

Add `--prefer-binary` to the formula's `pip install` in `scripts/update-homebrew-formula.sh`. pip then backs off to the newest litellm that has a macOS-compatible wheel (currently 1.91.4, `py3-none-any`) instead of grabbing a newer sdist it can't compile — and self-heals if litellm resumes publishing macOS wheels. This also makes the "install from PyPI wheels" approach the formula was already built on actually enforced for the whole tree.

## Verification

- `bash -n` + a live run of the generator script produce a well-formed formula for 0.12.1.
- The full `lgtmaybe==0.12.1` dependency tree resolves **wheel-only** under macOS arm64 / CPython 3.12 tags (`pip download --only-binary=:all: --platform macosx_14_0_arm64 --python-version 3.12`), with litellm resolving to 1.91.4.
- The workflow's own install smoke-test remains the real gate; the daily scheduled run will regenerate and publish the 0.12.1 formula once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WojEfRjP7YYsVNEbeD3pkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WojEfRjP7YYsVNEbeD3pkC)_