### PR TITLE
docs(marketing): add social strategy, loop playbook, and Show HN draft

### DIFF
--- a/marketing/LOOP_PLAYBOOK.md
+++ b/marketing/LOOP_PLAYBOOK.md
@@ -1,0 +1,74 @@
+# Marketing loop playbook
+
+The repeatable protocol an agent (Claude) executes each iteration. Written to be
+runnable from a fresh session: read [`STRATEGY.md`](STRATEGY.md), then
+[`backlog.md`](backlog.md) and [`log.md`](log.md), then run the four steps below.
+Suggested cadence: **weekly**. Run it via `/loop`, a scheduled Routine, or by
+asking Claude to "run the marketing loop".
+
+Hard constraints, every iteration:
+
+- The agent has no social accounts and must not create any. It drafts; Matt
+  posts. Deliverables are files in `marketing/drafts/` plus a short report.
+- Follow the rules of engagement in STRATEGY.md, especially disclosure and
+  one-venue-one-post.
+- All drafts in Matt's voice per the `writing-draft-blog-posts` skill (blog
+  posts get the full treatment including the AI-tell audit; comments and
+  short-form get the teaser rules).
+
+## Step 1 — Monitor (~10 min)
+
+Run these searches and record anything new in `log.md`:
+
+- Web search: `"CodeRabbit alternatives" 2026`, `"AI code review" open source site:reddit.com` (past week), `AI code review site:news.ycombinator.com` (past week), `lgtmaybe -site:github.com`
+- Check for new roundup/comparison articles that list competitors but not
+  lgtmaybe → add an outreach item to the backlog with the article URL and
+  author contact if findable.
+- Metrics snapshot: GitHub stars/forks (`MattJColes/lgtmaybe`), PyPI downloads
+  (`pypistats.org/packages/lgtmaybe`). Append to the metrics table in `log.md`.
+
+## Step 2 — Engage (~15 min)
+
+From the monitoring results, pick **at most 3** live threads (Reddit, HN,
+lobste.rs) where a comment from the author of lgtmaybe is the honest answer to
+the question being asked — someone asking for a self-hosted reviewer, an
+OIDC/no-keys setup, a CodeRabbit alternative, or hitting a problem lgtmaybe
+solves. For each, draft a comment into
+`marketing/drafts/comments-<date>.md` with the thread URL, the draft, and one
+line on why this thread. Value first, disclosure always, no drive-by links.
+
+If nothing qualifies, write nothing. Zero forced comments.
+
+## Step 3 — Create (~30 min)
+
+Take the top `ready` item from `backlog.md` and draft it:
+
+- **Blog posts** → `marketing/drafts/<slug>.md`, full voice-skill treatment.
+  Note in the draft where it should be syndicated (dev.to canonical, which
+  subreddit, HN-worthy or not) and a suggested title per venue.
+- **Reddit/HN posts** → same location, with title + body per venue rules
+  (HN: plain paragraphs, no markdown lists; Reddit: whatever the subreddit's
+  culture is — check its top posts first).
+- **Outreach notes** (roundup submissions, awesome-list PRs) → draft the
+  message/PR description; flag any that need Matt's account to send.
+- **Docs pages** (e.g. the comparison page) → these are code-repo changes;
+  draft the page and note it needs a normal PR through CI.
+
+One item per iteration. Move it from `ready` to `drafted` in the backlog.
+
+## Step 4 — Record and report
+
+1. Append an entry to `log.md`: date, what was monitored/found, threads
+   flagged, item drafted, metrics snapshot.
+2. Update `backlog.md` statuses (`idea` → `ready` → `drafted` → `posted` →
+   `done`; Matt moves things to `posted`).
+3. If running in a session with Matt: end with a short report — what's ready
+   for him to post, what needs his account, what changed in metrics. If running
+   headless: commit the changes to a branch and open a PR titled
+   `chore(marketing): loop iteration <date>` so the report is the PR body.
+
+## What Matt does between iterations
+
+- Review drafts, edit, post them, and mark backlog items `posted` with the URL.
+- Reply to comments on live posts (the loop flags unanswered ones in Step 1).
+- Veto anything — a `vetoed` status on a backlog item stops the loop touching it.

--- a/marketing/STRATEGY.md
+++ b/marketing/STRATEGY.md
@@ -1,0 +1,109 @@
+# lgtmaybe social strategy
+
+How we get lgtmaybe in front of developers, modelled on what worked for CodeRabbit
+and adapted for a solo, open-source, zero-budget project. This document is the
+durable strategy; the repeatable work lives in [`LOOP_PLAYBOOK.md`](LOOP_PLAYBOOK.md)
+and is executed on a cadence by an agent, with Matt doing the actual posting.
+
+## What CodeRabbit did (and what transfers)
+
+CodeRabbit grew bottom-up: a two-click GitHub App install, free for open source
+(100k+ OSS projects), positioned as a layer on top of the workflow you already
+have rather than a new tool to adopt. On top of that they built goodwill with a
+$1M open-source sponsorship commitment, kept a steady blog cadence, and let a
+large third-party ecosystem of "best AI code review tools" and "CodeRabbit
+alternatives" comparison posts do their SEO for them.
+
+What transfers to lgtmaybe:
+
+- **Free is the wedge, so lead with it.** CodeRabbit is free *for OSS*; lgtmaybe
+  is free for everyone because there's nothing to sell — MIT, bring your own
+  model. The ollama path is a review pipeline at literally $0.
+- **Low-friction install.** Their two-click install is our copy-paste workflow
+  file. Every post should end with the smallest possible "try it" block.
+- **Ride the comparison ecosystem.** Dozens of sites maintain "CodeRabbit
+  alternatives" roundups. Getting lgtmaybe listed in them is free distribution
+  with buyer-intent traffic. We can't buy placement, but most accept
+  submissions or respond to a polite note.
+- **Goodwill substitute.** No sponsorship budget, so the substitute is public
+  dogfooding (lgtmaybe reviews its own PRs — the repo is the demo) and genuinely
+  useful engagement in threads where people ask about AI code review.
+
+What does *not* transfer: paid ads, sponsorships, a sales motion, launch PR.
+Skip all of it.
+
+## Positioning (the angles, ranked)
+
+Every post leads with one of these. Never lead with "another AI code reviewer".
+
+1. **No keys in your secrets.** Keyless OIDC/WIF auth on Bedrock, Vertex, and
+   Azure. Nobody else leads with this and it's the strongest differentiator for
+   anyone in a cloud shop.
+2. **Your model, your infra, your data.** Provider-agnostic: seven hosted
+   providers, ollama, or any OpenAI-compatible endpoint. Code never transits a
+   vendor's SaaS. Strong for privacy-conscious teams, r/selfhosted, and
+   r/LocalLLaMA.
+3. **$0 reviews on local models.** ollama on your own hardware, no per-seat fee,
+   no usage meter.
+4. **Engineering depth.** The line-anchoring problem (LLMs miscount diff line
+   numbers), prompt-injection defense against malicious PRs, secret redaction
+   before egress, self-reflection to cut false positives. These make the best
+   HN/lobste.rs material because they're interesting even to people who'll never
+   install it.
+5. **Honest about being "maybe".** The name is the pitch: it's a reviewer, not a
+   gate. Self-aware beats overclaiming in developer channels.
+
+## Channels, ranked by comment quality
+
+Ranked by feedback quality, not raw reach (r/coding delivered 7.7K views and two
+useless comments on a previous post — reach without feedback is a last resort).
+
+| Channel | Use for | Cadence |
+|---|---|---|
+| Hacker News (Show HN, then engineering posts) | angles 4 and 1 | launch once, then only when a post is genuinely strong |
+| lobste.rs | engineering posts | same posts as HN, tagged properly |
+| r/LocalLLaMA, r/selfhosted | angle 3 | one post each, then comment-only |
+| r/aws, r/devops | angle 1 (OIDC/Bedrock) | one post, then comment-only |
+| r/ExperiencedDevs | judgement-led posts (what AI review is actually good for) | rare, only essay-grade material |
+| dev.to | republished blog posts for SEO | mirror each blog post with canonical URL |
+| coles.codes blog | the source of everything above | steady — the loop drafts these |
+| X / LinkedIn | short-form pointers to the above | ride-along, never the primary |
+| Comparison sites / awesome lists | passive SEO | one outreach pass, then check quarterly |
+
+## Content pillars
+
+1. **Engineering posts** (blog → HN/lobste.rs): line anchoring, prompt-injection
+   defense, recursive hunk walking, prompt-cache shaping. One idea per post.
+2. **Setup guides** (blog → dev.to → topical subreddit): keyless Bedrock review
+   in one workflow file; $0 reviews with ollama; the openai-compatible escape
+   hatch with llama.cpp.
+3. **Comparison content** (docs site): an honest "lgtmaybe vs CodeRabbit" page —
+   including where CodeRabbit is better (hosted, zero setup, IDE integration).
+   Honest comparisons get linked; puff pieces don't.
+4. **Dated survey posts**: "AI code review, late 2026" style — compounds in
+   search and is re-writable every six months.
+
+## Rules of engagement (non-negotiable)
+
+- **Always disclose.** Every post and comment says "I built this" or "I'm the
+  author". Astroturfing gets caught and the ban outlasts the project.
+- **Value first.** In someone else's thread, answer their actual question;
+  mention lgtmaybe only when it's the honest answer.
+- **One venue, one post.** Never cross-post the same link to multiple subreddits
+  in the same week. Each venue gets copy written for it.
+- **Reply to everything on our own posts** except low-effort slop accusations
+  (jokes and technical pushback get replies; one-word accounts don't).
+- **Never overclaim.** No "catches all bugs", no benchmark claims without a
+  published run. The evals harness exists; cite it or stay quiet.
+- **The agent drafts, Matt posts.** Nothing is published from an automated
+  account. All drafts land in `marketing/drafts/` for review.
+
+## Metrics (checked each loop iteration)
+
+- GitHub stars and forks (trend, not absolutes)
+- PyPI downloads via pypistats.org
+- New third-party mentions (roundups, alternatives pages, blog posts)
+- Per-post: comment quality in the thread, and GA4 engagement time on the blog
+
+A post that drives engaged readers beats one that drives views. Kill any venue
+that produces bounces two posts in a row.

--- a/marketing/backlog.md
+++ b/marketing/backlog.md
@@ -1,0 +1,18 @@
+# Content backlog
+
+Statuses: `idea` → `ready` → `drafted` → `posted` → `done` (or `vetoed`).
+The loop drafts the top `ready` item each iteration. Matt reorders freely.
+
+| # | Item | Angle | Venue(s) | Status |
+|---|---|---|---|---|
+| 1 | Show HN launch post | engineering depth + no keys | HN (Show HN), mirror to lobste.rs | drafted — `drafts/show-hn.md` |
+| 2 | "PR reviews from a local model for $0" — ollama setup guide | $0 local | blog → r/LocalLLaMA, r/selfhosted | ready |
+| 3 | "Keyless AI code review on Bedrock with GitHub OIDC" | no keys | blog → dev.to → r/aws | ready |
+| 4 | "LLMs can't count diff line numbers" — the line-anchoring problem | engineering depth | blog → HN/lobste.rs | ready |
+| 5 | Honest "lgtmaybe vs CodeRabbit" comparison page | comparison SEO | docs site (`docs/explanation/`) | ready |
+| 6 | Outreach pass: get listed in alternatives roundups (cubic.dev, surmado, qodo, alternativeto, saashub) + awesome-code-review / awesome-actions lists | comparison SEO | email/PR submissions | ready |
+| 7 | "Reviewing PRs that are trying to hack the reviewer" — prompt-injection defense | engineering depth | blog → HN/lobste.rs | idea |
+| 8 | Repo metadata polish: GitHub topics, social preview image, README badges (PyPI downloads, stars) | passive discovery | GitHub | idea |
+| 9 | Lightning-talk pitch: "what an AI reviewer gets wrong about your diff" | engineering depth | PyCon AU / Melbourne user groups | idea |
+| 10 | Dated survey: "AI code review, late 2026" | survey cadence | blog → HN | idea |
+| 11 | "The openai-compatible escape hatch" — llama.cpp / LM Studio / vLLM guide | your model | blog → dev.to | idea |

--- a/marketing/drafts/show-hn.md
+++ b/marketing/drafts/show-hn.md
@@ -1,0 +1,42 @@
+# Show HN draft
+
+Status: drafted, awaiting Matt's edit + post. HN strips markdown, so the body is
+plain paragraphs. Post from Matt's account; stay in the thread for the first few
+hours to answer questions (that's most of what decides whether it ranks).
+
+## Title
+
+Show HN: Lgtmaybe – open-source AI PR reviewer that runs on your own model
+
+## Body (first comment)
+
+I built lgtmaybe because I wanted AI review on my PRs without sending code
+through a third-party SaaS or putting another vendor's API key in my repo
+secrets. It's a Python CLI and GitHub Action, MIT licensed: it fetches the diff
+via the API (never checks out PR code), reviews it through a set of lenses
+(security, correctness, tests, performance, and so on), and posts inline
+comments plus a summary.
+
+The part I care most about is auth. On AWS Bedrock, GCP Vertex, or Azure it
+authenticates with GitHub OIDC, so there are no static keys anywhere. It also
+runs against ollama on your own hardware for $0, or any OpenAI-compatible
+endpoint if your provider isn't on the list.
+
+Two problems turned out to be more interesting than the reviewing itself. First,
+models miscount diff line numbers constantly, so every finding has to carry the
+verbatim line it's flagging and the engine re-anchors it against the real diff.
+A finding that can't be anchored gets demoted into the summary rather than
+posted inline on the wrong line, because one comment on the wrong line costs
+more trust than ten good ones earn. Second, the diff is untrusted input: a
+malicious PR can try to prompt-inject the reviewer, so the diff is wrapped as
+data with forged delimiters neutralised, and secrets are redacted before
+anything leaves your environment.
+
+The name is the joke I wanted before I'd written a line of it. It's a reviewer,
+not a gate: it says maybe, you decide.
+
+Repo: https://github.com/MattJColes/lgtmaybe
+Docs: https://mattjcoles.github.io/lgtmaybe/
+
+Happy to get into the line-anchoring or the injection handling if anyone's
+curious.

--- a/marketing/log.md
+++ b/marketing/log.md
@@ -1,0 +1,21 @@
+# Marketing loop log
+
+Newest entry first. Each loop iteration appends: date, monitoring findings,
+threads flagged, item drafted, metrics.
+
+## Metrics
+
+| Date | GitHub stars | Forks | PyPI downloads (30d) | Notes |
+|---|---|---|---|---|
+
+## Iterations
+
+### 2026-07-24 — iteration 0 (setup)
+
+- Created STRATEGY.md, LOOP_PLAYBOOK.md, backlog, and this log.
+- Researched CodeRabbit's playbook: bottom-up free-for-OSS wedge (100k+ OSS
+  projects), two-click install, $1M OSS sponsorship goodwill, and a large
+  third-party "alternatives/comparison" ecosystem doing their SEO.
+- Seeded the backlog (11 items) and drafted item 1 (Show HN) in
+  `drafts/show-hn.md`.
+- Next iteration: Step 1 monitoring pass + draft item 2 (ollama $0 guide).


### PR DESCRIPTION
Adds a `marketing/` directory with a loop-executable social strategy for lgtmaybe, modelled on CodeRabbit's growth playbook and adapted for a zero-budget open-source project.

## What's in it

- **`marketing/STRATEGY.md`** — the durable strategy: what CodeRabbit did (bottom-up free-for-OSS wedge, low-friction install, riding the third-party "alternatives/comparison" SEO ecosystem, goodwill) and what transfers; five positioning angles led by keyless OIDC and bring-your-own-model; channels ranked by comment quality rather than reach; content pillars; hard rules of engagement (always disclose authorship, value-first comments, one venue per post, agent drafts / Matt posts).
- **`marketing/LOOP_PLAYBOOK.md`** — the weekly agent-executable protocol: monitor (searches + metrics snapshot) → engage (up to 3 drafted comments for threads where lgtmaybe is the honest answer) → create (draft the top backlog item) → record (log + report). Written to be runnable from a fresh session via `/loop` or a scheduled Routine.
- **`marketing/backlog.md`** — 11 seeded content items (ollama $0 guide, keyless Bedrock OIDC guide, line-anchoring engineering post, honest vs-CodeRabbit comparison page, roundup outreach, and more).
- **`marketing/log.md`** — iteration log with a metrics table, seeded with iteration 0.
- **`marketing/drafts/show-hn.md`** — first deliverable: a ready-to-edit Show HN launch post.

Markdown only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqGhGw3TvZxCyNjBMoNR3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqGhGw3TvZxCyNjBMoNR3r)_