### PR TITLE
ci: review PRs automatically with OpenRouter deepseek-v4-pro

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -1,18 +1,22 @@
-# Dogfood: lgtmaybe reviews its own PRs with OpenAI gpt-5.5.
+# Dogfood: lgtmaybe reviews its own PRs via OpenRouter (deepseek/deepseek-v4-pro).
 # Runs the in-repo action (./) so changes to action.yml are exercised too.
-# Add an OPENAI_API_KEY repo secret.
+# Add an OPENROUTER_API_KEY repo secret.
 #
-# ON DEMAND ONLY: a real provider review costs money + runs a live model, so this
-# does NOT fire automatically on every PR. A maintainer triggers it by commenting
-# a slash command (/review, /improve, /ask, /describe) on the PR.
+# Reviews run automatically on PRs from trusted authors (owner / member /
+# collaborator), and on demand via slash commands (/review, /improve, /ask,
+# /describe, /diagram) — a maintainer can opt an external PR in by commenting
+# /review on it. deepseek-v4-pro is cheap enough to run per-PR; on a
+# `synchronize` push the review is incremental (only the new commits).
 name: lgtmaybe
 
 on:
+  pull_request_target:
   issue_comment:
     types: [created]
 
-# issue_comment runs against the BASE repo (secrets available); the action only
-# ever reads the diff via the API and never checks out PR code.
+# pull_request_target and issue_comment run against the BASE repo (secrets
+# available); the action only ever reads the diff via the API and never checks
+# out PR code.
 permissions:
   contents: read
   pull-requests: write
@@ -23,13 +27,15 @@ concurrency:
 
 jobs:
   review:
-    # Comment-triggered only, and only on a PR: a slash command from a trusted
-    # author (repo owner / org member / collaborator). This keeps a drive-by /ask
-    # or /review from a stranger from spending the provider budget, and skips
-    # comments that aren't on a pull request.
+    # Only trusted authors (repo owner / org member / collaborator) trigger a
+    # review — automatically on their PRs, or via a slash command. This keeps a
+    # drive-by /ask or /review from a stranger from spending the provider
+    # budget, and skips comments that aren't on a pull request.
     if: >-
-      github.event.issue.pull_request &&
-      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      (github.event_name == 'pull_request_target' &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+      (github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # A healthy full review runs in a handful of minutes; cap it so a wedged
     # model call can't sit on the runner for GitHub's 6-hour default. Fail-fast on
@@ -40,6 +46,6 @@ jobs:
       - uses: actions/checkout@v7 # base repo only — for action.yml + .lgtmaybe.yml config
       - uses: ./
         with:
-          provider: openai
-          model: gpt-5.4-mini
-          api_key: ${{ secrets.OPENAI_API_KEY }}
+          provider: openrouter
+          model: deepseek/deepseek-v4-pro
+          api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## What & why

Applies lgtmaybe to its own repo as a GitHub Action per the docs ([Use as a GitHub Action](https://mattjcoles.github.io/lgtmaybe/how-to/use-as-github-action/)), using **OpenRouter** with **[`deepseek/deepseek-v4-pro`](https://openrouter.ai/deepseek/deepseek-v4-pro)**.

The repo already had a dogfood workflow, but it was **on-demand only** (slash-command triggered, OpenAI `gpt-5.4-mini`). This switches it to the docs' standard shape — `examples/workflows/review-openrouter.yml` — so trusted-author PRs get reviewed **automatically**:

- **`pull_request_target`** trigger added alongside `issue_comment` — reviews run on PR open and incrementally on each push (`synchronize` reviews only the new commits). Slash commands (`/review`, `/improve`, `/ask`, `/describe`, `/diagram`) still work, and a maintainer can opt an external PR in by commenting `/review`.
- **Provider/model** switched to `openrouter` + `deepseek/deepseek-v4-pro` — cheap enough to run per-PR, which is what makes going automatic reasonable.
- **Kept** from the existing workflow: the in-repo action (`uses: ./`, so `action.yml` changes stay exercised), the trusted-author (`OWNER`/`MEMBER`/`COLLABORATOR`) gate, the per-PR concurrency group with cancel-in-progress, and the 20-minute timeout.

Fork safety is unchanged: `pull_request_target` runs against the base repo and lgtmaybe never checks out or executes PR code — the diff is fetched via the API only.

## Setup required after merge

Add an **`OPENROUTER_API_KEY`** repository secret (Settings → Secrets and variables → Actions). Without it, triggered runs will fail with a clear auth error from the credential resolver. The old `OPENAI_API_KEY` secret is no longer used by this workflow.

## Testing

- Workflow YAML parses (`yaml.safe_load`).
- Trigger/gate/inputs mirror the documented `examples/workflows/review-openrouter.yml` shape, adapted to keep the in-repo `./` action and existing concurrency/timeout hardening.
- Behaviour is exercised on the first trusted-author PR after merge (or comment `/review` on any PR to trigger it manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqoLYuJkpkLSUV2VHPcGb

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqoLYuJkpkLSUV2VHPcGb)_