### PR TITLE
docs: add Google Search Console verification file

### DIFF
--- a/docs/google0e7f011c11be4fd6.html
+++ b/docs/google0e7f011c11be4fd6.html
@@ -1,0 +1,1 @@
+google-site-verification: google0e7f011c11be4fd6.html


### PR DESCRIPTION
## What & why

Follow-up to #200. Adds the Google Search Console **HTML-file** verification token so the docs site can be verified as a URL-prefix property — which then lets us submit the sitemap (`https://mattjcoles.github.io/lgtmaybe/sitemap.xml`) and monitor indexing/coverage. This is the effective way to get a project *subpath* Pages site into Search Console (a root `robots.txt` can't live in this repo).

## Change

- `docs/google0e7f011c11be4fd6.html` — the verification file, copied verbatim into the built site by mkdocs (same mechanism as `llms.txt`), so after the Pages redeploy it's served at:
  `https://mattjcoles.github.io/lgtmaybe/google0e7f011c11be4fd6.html`

That's the exact URL Google fetches to confirm ownership of the `https://mattjcoles.github.io/lgtmaybe/` property. Per Google's guidance the file must **stay in place** to remain verified — so it's committed, not a one-off upload.

## Verification
- `uv run --group docs mkdocs build --strict` — clean; confirmed `site/google0e7f011c11be4fd6.html` is present with the exact token contents.

## After merge
1. GitHub Pages redeploys automatically (the workflow triggers on `docs/**` changes).
2. In Search Console, click **Verify** on the HTML-file method for the `https://mattjcoles.github.io/lgtmaybe/` property.
3. Submit `sitemap.xml` under **Sitemaps**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJanaabZAV4vqFD3ytVfF1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJanaabZAV4vqFD3ytVfF1)_