### PR TITLE
feat(diff): skip generated llms.txt/llms-full.txt files in review

### DIFF
--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -26,7 +26,8 @@ like the diff.
 Before the diff reaches the model it is cleaned:
 
 - **Non-reviewable files are skipped** — lockfiles, minified/bundled assets,
-  vendored directories, and binaries. Reviewing them is noise and wastes tokens.
+  vendored directories, generated LLM-index corpora (`llms.txt` / `llms-full.txt`),
+  and binaries. Reviewing them is noise and wastes tokens.
 - **Secrets are redacted** — anything that looks like a key or token is stripped
   from the diff before it leaves your environment for the provider.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4016,7 +4016,8 @@ like the diff.
 Before the diff reaches the model it is cleaned:
 
 - **Non-reviewable files are skipped** — lockfiles, minified/bundled assets,
-  vendored directories, and binaries. Reviewing them is noise and wastes tokens.
+  vendored directories, generated LLM-index corpora (`llms.txt` / `llms-full.txt`),
+  and binaries. Reviewing them is noise and wastes tokens.
 - **Secrets are redacted** — anything that looks like a key or token is stripped
   from the diff before it leaves your environment for the provider.
 

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -79,8 +79,8 @@ best-effort, never failing the review.
 
 ### Requirement: Generated and binary files are skipped
 
-Lockfiles, minified bundles, vendored trees, and binary files SHALL be
-excluded from review before any path filter or cap applies.
+Lockfiles, minified bundles, vendored trees, binary files, and generated LLM-index corpora (`llms.txt` / `llms-full.txt`) SHALL be excluded from review
+before any path filter or cap applies.
 <!-- anchor: github.reviewable -->
 
 #### Scenario: lockfile in the diff

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -8,8 +8,9 @@ deleted, or context line in the diff — so the gateway can post findings on rea
 diff lines and silently drop anything that isn't (e.g. a finding the model put
 on an expanded-context-only line).
 
-Skip filter: lockfiles, minified bundles, vendored/generated paths and binary
-files are dropped before review to save tokens and avoid noise.
+Skip filter: lockfiles, minified bundles, vendored/generated paths, generated
+LLM-index corpora (llms.txt / llms-full.txt), and binary files are dropped before
+review to save tokens and avoid noise.
 """
 
 from __future__ import annotations
@@ -121,6 +122,10 @@ _SKIP_FILENAMES = frozenset(
         "mix.lock",
         "Package.resolved",
         "gradle.lockfile",
+        # Generated LLM-index corpora (llmstxt.org): machine-written whole-docs
+        # dumps, never meaningfully line-reviewed.
+        "llms.txt",
+        "llms-full.txt",
     }
 )
 

--- a/tests/github/test_diff.py
+++ b/tests/github/test_diff.py
@@ -167,6 +167,16 @@ def test_is_reviewable_rejects_generated_globs() -> None:
     assert not is_reviewable("__generated__/foo.py")
 
 
+def test_is_reviewable_rejects_generated_llms_files() -> None:
+    """llms.txt / llms-full.txt (the llmstxt.org convention) are generated
+    whole-docs corpora — skip them by exact name, at the root or nested."""
+    assert not is_reviewable("llms.txt")
+    assert not is_reviewable("llms-full.txt")
+    assert not is_reviewable("docs/llms-full.txt")
+    # Control: a normal .txt is still reviewed — we skip by name, not extension.
+    assert is_reviewable("docs/notes.txt")
+
+
 def test_is_reviewable_accepts_dotfiles_and_configs() -> None:
     """Config/source-ish files that are not on a skip list should be reviewed."""
     assert is_reviewable(".github/workflows/ci.yml")


### PR DESCRIPTION
## What & why

Follow-up to #199, which fixed *this repo's* self-review timeout with a repo `.lgtmaybe.yml` excluding generated docs. This generalizes that into the product: add `llms.txt` / `llms-full.txt` (the [llmstxt.org](https://llmstxt.org/) convention) to the global skip filter so **every** lgtmaybe user's reviews skip generated LLM-index corpora.

These are machine-written whole-docs dumps that are never meaningfully line-reviewed and — with `recursive` on — explode into many slow model calls (exactly what timed out the self-review on #197). They're the same category as the lockfiles already in `_SKIP_FILENAMES`.

## Change

- **`src/lgtmaybe/github/diff.py`** — add `"llms.txt"` and `"llms-full.txt"` to `_SKIP_FILENAMES`. Skipped by **exact filename**, not a glob, so a hand-written `llms-notes.txt` isn't swept up; a plain `.txt` stays reviewable (we skip by name, not extension). Module docstring updated.
- **`tests/github/test_diff.py`** — `test_is_reviewable_rejects_generated_llms_files` (written red-first): asserts `llms.txt` / `llms-full.txt` skip at the root and nested, with a control that `docs/notes.txt` is still reviewable.
- **`openspec/specs/github-posting/spec.md`** — the `github.reviewable` requirement prose now names the generated LLM-index category.
- **Docs** — `docs/explanation/what-gets-reviewed.md` skip bullet updated; `docs/llms-full.txt` regenerated to stay fresh.

## Testing

- Red→green on the new test; `uv run pytest -q` → **1190 passed**.
- `tests/docs` (freshness) + `tests/specs` green; `openspec validate --specs` → 8 passed; `ruff check` / `ruff format --check` clean.

## Note

This is the product-wide behavior. The repo's own `.lgtmaybe.yml` from #199 stays as belt-and-suspenders (it also covers `docs/reference/config.md`, which is repo-specific and not a product-wide skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014m3ruzHVuAqe3Ni72grqR6)_