### PR TITLE
docs: improve homepage feature showcase

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,35 +10,32 @@ description: Provider-agnostic AI code review for pull requests — OpenAI, Clau
 
 </div>
 
-Provider-agnostic AI PR reviewer. Seven hosted providers, local ollama, and any
-OpenAI-compatible endpoint — one flag, and no static keys for cloud providers. It
-posts inline comments and a summary straight onto the pull request.
+lgtmaybe reviews the code a pull request changes. Pick OpenAI, Claude, Bedrock,
+Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it as a
+GitHub Action or from your terminal. GitHub gets inline comments and one
+summary; locally, you get the same findings before you push.
 
-lgtmaybe reviews the lines a change touches. It runs in two places: as a
-GitHub Action on a pull request, or locally from the command line against your
-`git` diff before you push. As an Action it fetches the diff from the GitHub API
-and never checks out or runs your code. Locally it reads your working branch.
-Either way it pads each change with a few surrounding lines, so a finding lands
-with the function around it in view — but it only ever comments on the lines
-that actually changed.
+It reads the diff and a little surrounding code, but only comments on changed
+lines. On GitHub it never checks out or runs the pull request. Generated files
+and binaries are skipped, secrets are redacted, and all PR text is treated as
+untrusted.
 
-Reviews surface the things you'd want a careful reviewer to catch:
+It checks for:
 
-- **Logic and correctness bugs** — edge cases, null/None dereferences, off-by-one and boundary errors, mismatched or inverted ranges, unhandled error paths, races and TOCTOU, missed `await`s, and numeric or timezone bugs.
-- **Security vulnerabilities** — an OWASP-aligned sweep: injection, XSS, CSRF and open redirects, hardcoded secrets, broken authn/authz (including JWT pitfalls), path traversal, unrestricted uploads, SSRF, insecure deserialization and XXE, mass assignment, weak crypto, resource/DoS safety (including ReDoS), secrets or PII (passwords, tokens, SSNs, card data) leaking into logs, and CI/IaC misconfiguration.
-- **Missing or weak tests** — changed code paths shipped without a test (flagged with a suggested test to drop in), and tests that don't really test: assertion-free, over-mocked, or sleep-based.
-- **Documentation gaps and stale docs** — public APIs added without a docstring, names that contradict what the code does, and docstrings or comments the change just made wrong.
-- **Deprecated and end-of-life code** — deprecated APIs, end-of-life or vulnerable dependencies, and typosquat-looking additions, flagged when the diff shows them (with the modern replacement suggested where known).
-- **Intent** — does the PR do what it says? lgtmaybe compares the PR title, description, and commit names (or your local `git log` commit names on the CLI) against the diff, and flags out-of-scope hunks, contradictions, and promised behaviour that never lands.
-- **Ponytail** — the "lazy senior dev" lens: the best code is the code you never wrote. Flags code that needn't exist at all — YAGNI, reaching for the standard library, doing it in fewer lines.
+- **Correctness and security** — logic errors, missed `await`s, injection, auth mistakes, and leaked secrets.
+- **Code health** — performance problems, needless complexity, deprecations, and risky dependencies.
+- **Tests and documentation** — missing or weak tests, stale comments, and undocumented APIs.
+- **Intent** — whether the change does what its title, description, and commits say it does.
+- **Ponytail** — code you don't need, standard-library opportunities, and simpler ways to get the job done.
 
-Beyond the review itself, slash commands on the PR keep the reviewer's mental
-model of the code intact: **`/describe`** posts a structured description of the
-change (title, change type, per-file walkthrough, intent check), **`/diagram`**
-posts a [C4-style Mermaid diagram of the components the PR touches](how-to/generate-a-change-diagram.md)
-— a visual map of where the change sits in the system, rendered natively by
-GitHub — and **`/ask <question>`** answers questions about the change in-thread.
-`lgtmaybe diagram` prints the same change diagram locally, before you push.
+Findings are graded from `info` to `critical` and land on the exact changed
+line. A clean change just gets a 👍 **LGTM!**.
+
+Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
+**`/describe`** writes a structured overview, **`/diagram`** draws a
+[C4-style map of the change](how-to/generate-a-change-diagram.md), and
+**`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
+map locally before you push.
 
 ```mermaid
 C4Container
@@ -57,14 +54,6 @@ C4Container
     Rel(queue, worker, "delivers event (new)")
     Rel(worker, email, "sends confirmation (new)")
 ```
-
-Every finding is graded from `info` up to `critical`, so you can set the
-severity floor that matters to you. Each one lands as an inline comment on
-the exact line where the problem is, with a single summary at the top. On the CLI
-the same findings print to your terminal — ready to read, or to hand to an AI
-agent to apply. Before anything leaves for the model, generated files and
-binaries are skipped, secrets are redacted, and the diff is treated as untrusted
-input, hardened against prompt injection. A clean PR just gets a 👍 **LGTM!**.
 
 ## Start here
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,14 +42,20 @@ GitHub — and **`/ask <question>`** answers questions about the change in-threa
 
 ```mermaid
 C4Container
-    title User lookup after this change
-    Person(client, "Client")
-    Container(api, "User API", "Python", "Serves user reads")
-    ContainerDb(cache, "Redis cache", "Redis", "caches user rows (new)")
-    ContainerDb(db, "User DB", "Postgres")
-    Rel(client, api, "GET /users/{id}")
-    Rel(api, cache, "check cache (new)")
-    Rel(api, db, "on miss, query")
+    title Async order confirmations after this change
+    Person(customer, "Customer")
+    Container(web, "Storefront", "React", "Places orders")
+    Container(api, "Order API", "Python", "Creates orders (changed)")
+    ContainerDb(db, "Order database", "PostgreSQL", "Stores orders")
+    Container(queue, "Order events", "SQS", "Buffers OrderCreated events (new)")
+    Container(worker, "Notification worker", "Python", "Consumes order events (new)")
+    System_Ext(email, "Email provider", "Delivers confirmations")
+    Rel(customer, web, "places order")
+    Rel(web, api, "POST /orders")
+    Rel(api, db, "stores order")
+    Rel(api, queue, "publishes OrderCreated (new)")
+    Rel(queue, worker, "delivers event (new)")
+    Rel(worker, email, "sends confirmation (new)")
 ```
 
 Every finding is graded from `info` up to `critical`, so you can set the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -48,14 +48,20 @@ GitHub — and **`/ask <question>`** answers questions about the change in-threa
 
 ```mermaid
 C4Container
-    title User lookup after this change
-    Person(client, "Client")
-    Container(api, "User API", "Python", "Serves user reads")
-    ContainerDb(cache, "Redis cache", "Redis", "caches user rows (new)")
-    ContainerDb(db, "User DB", "Postgres")
-    Rel(client, api, "GET /users/{id}")
-    Rel(api, cache, "check cache (new)")
-    Rel(api, db, "on miss, query")
+    title Async order confirmations after this change
+    Person(customer, "Customer")
+    Container(web, "Storefront", "React", "Places orders")
+    Container(api, "Order API", "Python", "Creates orders (changed)")
+    ContainerDb(db, "Order database", "PostgreSQL", "Stores orders")
+    Container(queue, "Order events", "SQS", "Buffers OrderCreated events (new)")
+    Container(worker, "Notification worker", "Python", "Consumes order events (new)")
+    System_Ext(email, "Email provider", "Delivers confirmations")
+    Rel(customer, web, "places order")
+    Rel(web, api, "POST /orders")
+    Rel(api, db, "stores order")
+    Rel(api, queue, "publishes OrderCreated (new)")
+    Rel(queue, worker, "delivers event (new)")
+    Rel(worker, email, "sends confirmation (new)")
 ```
 
 Every finding is graded from `info` up to `critical`, so you can set the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -16,35 +16,32 @@ Source: https://mattjcoles.github.io/lgtmaybe/ — generated from the docs/ tree
 
 </div>
 
-Provider-agnostic AI PR reviewer. Seven hosted providers, local ollama, and any
-OpenAI-compatible endpoint — one flag, and no static keys for cloud providers. It
-posts inline comments and a summary straight onto the pull request.
+lgtmaybe reviews the code a pull request changes. Pick OpenAI, Claude, Bedrock,
+Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it as a
+GitHub Action or from your terminal. GitHub gets inline comments and one
+summary; locally, you get the same findings before you push.
 
-lgtmaybe reviews the lines a change touches. It runs in two places: as a
-GitHub Action on a pull request, or locally from the command line against your
-`git` diff before you push. As an Action it fetches the diff from the GitHub API
-and never checks out or runs your code. Locally it reads your working branch.
-Either way it pads each change with a few surrounding lines, so a finding lands
-with the function around it in view — but it only ever comments on the lines
-that actually changed.
+It reads the diff and a little surrounding code, but only comments on changed
+lines. On GitHub it never checks out or runs the pull request. Generated files
+and binaries are skipped, secrets are redacted, and all PR text is treated as
+untrusted.
 
-Reviews surface the things you'd want a careful reviewer to catch:
+It checks for:
 
-- **Logic and correctness bugs** — edge cases, null/None dereferences, off-by-one and boundary errors, mismatched or inverted ranges, unhandled error paths, races and TOCTOU, missed `await`s, and numeric or timezone bugs.
-- **Security vulnerabilities** — an OWASP-aligned sweep: injection, XSS, CSRF and open redirects, hardcoded secrets, broken authn/authz (including JWT pitfalls), path traversal, unrestricted uploads, SSRF, insecure deserialization and XXE, mass assignment, weak crypto, resource/DoS safety (including ReDoS), secrets or PII (passwords, tokens, SSNs, card data) leaking into logs, and CI/IaC misconfiguration.
-- **Missing or weak tests** — changed code paths shipped without a test (flagged with a suggested test to drop in), and tests that don't really test: assertion-free, over-mocked, or sleep-based.
-- **Documentation gaps and stale docs** — public APIs added without a docstring, names that contradict what the code does, and docstrings or comments the change just made wrong.
-- **Deprecated and end-of-life code** — deprecated APIs, end-of-life or vulnerable dependencies, and typosquat-looking additions, flagged when the diff shows them (with the modern replacement suggested where known).
-- **Intent** — does the PR do what it says? lgtmaybe compares the PR title, description, and commit names (or your local `git log` commit names on the CLI) against the diff, and flags out-of-scope hunks, contradictions, and promised behaviour that never lands.
-- **Ponytail** — the "lazy senior dev" lens: the best code is the code you never wrote. Flags code that needn't exist at all — YAGNI, reaching for the standard library, doing it in fewer lines.
+- **Correctness and security** — logic errors, missed `await`s, injection, auth mistakes, and leaked secrets.
+- **Code health** — performance problems, needless complexity, deprecations, and risky dependencies.
+- **Tests and documentation** — missing or weak tests, stale comments, and undocumented APIs.
+- **Intent** — whether the change does what its title, description, and commits say it does.
+- **Ponytail** — code you don't need, standard-library opportunities, and simpler ways to get the job done.
 
-Beyond the review itself, slash commands on the PR keep the reviewer's mental
-model of the code intact: **`/describe`** posts a structured description of the
-change (title, change type, per-file walkthrough, intent check), **`/diagram`**
-posts a [C4-style Mermaid diagram of the components the PR touches](how-to/generate-a-change-diagram.md)
-— a visual map of where the change sits in the system, rendered natively by
-GitHub — and **`/ask <question>`** answers questions about the change in-thread.
-`lgtmaybe diagram` prints the same change diagram locally, before you push.
+Findings are graded from `info` to `critical` and land on the exact changed
+line. A clean change just gets a 👍 **LGTM!**.
+
+Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
+**`/describe`** writes a structured overview, **`/diagram`** draws a
+[C4-style map of the change](how-to/generate-a-change-diagram.md), and
+**`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
+map locally before you push.
 
 ```mermaid
 C4Container
@@ -63,14 +60,6 @@ C4Container
     Rel(queue, worker, "delivers event (new)")
     Rel(worker, email, "sends confirmation (new)")
 ```
-
-Every finding is graded from `info` up to `critical`, so you can set the
-severity floor that matters to you. Each one lands as an inline comment on
-the exact line where the problem is, with a single summary at the top. On the CLI
-the same findings print to your terminal — ready to read, or to hand to an AI
-agent to apply. Before anything leaves for the model, generated files and
-binaries are skipped, secrets are redacted, and the diff is treated as untrusted
-input, hardened against prompt injection. A clean PR just gets a 👍 **LGTM!**.
 
 ## Start here
 

--- a/openspec/changes/improve-homepage-change-diagram-example/.openspec.yaml
+++ b/openspec/changes/improve-homepage-change-diagram-example/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/improve-homepage-change-diagram-example/README.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/README.md
@@ -1,0 +1,3 @@
+# improve-homepage-change-diagram-example
+
+Replace the homepage's minimal cache diagram with a richer, representative C4 change example.

--- a/openspec/changes/improve-homepage-change-diagram-example/design.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/design.md
@@ -1,16 +1,19 @@
 ## Context
 
 The homepage currently uses the generator prompt's minimal Redis cache example.
-It contains four nodes and marks only one dependency as new. The example is
-technically correct, but it does not show how a change diagram can connect
-changed application code, new asynchronous infrastructure, an external service,
-and unchanged immediate collaborators in one reviewable map.
+It contains four nodes and marks only one dependency as new. The overview before
+"Start here" is also 694 source words, much of it spent on long lists of examples
+for each review category. The page is technically complete, but readers have to
+work through too much detail before reaching the commands, diagram, and setup
+links.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Demonstrate the breadth of a realistic change diagram at homepage scale.
+- Keep the overview under 400 source words while retaining every review category
+  and trust-boundary feature.
 - Use only Mermaid C4 syntax and change labels supported by the current output
   contract.
 - Keep the example readable on the documentation site's mobile and desktop
@@ -32,6 +35,11 @@ and unchanged immediate collaborators in one reviewable map.
 - Mark the API as `(changed)` and the queue and worker as `(new)`. This mirrors
   the generator contract and makes the diff's impact understandable without
   relying on colour.
+- Group related review categories into five short bullets instead of listing
+  every possible bug class. Keep the detailed examples in "What gets reviewed",
+  where readers expect depth.
+- Name all five slash commands in one plain paragraph immediately before the
+  diagram so the interactive features remain visible.
 - Keep the source as inline Mermaid. The existing MkDocs renderer provides the
   actual visual output, keeps the example accessible as text, and avoids a new
   asset or dependency.
@@ -43,3 +51,5 @@ and unchanged immediate collaborators in one reviewable map.
 - [The homepage and how-to examples no longer match] → Treat the homepage as the
   showcase and retain the how-to's smaller example for explanation; both follow
   the same output contract.
+- [Shorter copy can hide capability] → Assert the category names and a 400-word
+  overview ceiling in the focused homepage test.

--- a/openspec/changes/improve-homepage-change-diagram-example/design.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The homepage currently uses the generator prompt's minimal Redis cache example.
+It contains four nodes and marks only one dependency as new. The example is
+technically correct, but it does not show how a change diagram can connect
+changed application code, new asynchronous infrastructure, an external service,
+and unchanged immediate collaborators in one reviewable map.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Demonstrate the breadth of a realistic change diagram at homepage scale.
+- Use only Mermaid C4 syntax and change labels supported by the current output
+  contract.
+- Keep the example readable on the documentation site's mobile and desktop
+  layouts.
+
+**Non-Goals:**
+
+- Change diagram generation, prompting, or rendering.
+- Redesign the homepage or add a binary screenshot.
+- Replace the smaller tutorial example in the detailed how-to guide.
+
+## Decisions
+
+- Show an asynchronous order-confirmation change: customer and storefront feed
+  an order API, which stores the order and publishes to a new queue; a new worker
+  calls an external email provider. This demonstrates people, containers, a
+  database, an external boundary, and synchronous and asynchronous relationships
+  in one plausible pull request.
+- Mark the API as `(changed)` and the queue and worker as `(new)`. This mirrors
+  the generator contract and makes the diff's impact understandable without
+  relying on colour.
+- Keep the source as inline Mermaid. The existing MkDocs renderer provides the
+  actual visual output, keeps the example accessible as text, and avoids a new
+  asset or dependency.
+
+## Risks / Trade-offs
+
+- [The richer graph is taller than the current example] → Limit it to the
+  touched containers and their immediate collaborators.
+- [The homepage and how-to examples no longer match] → Treat the homepage as the
+  showcase and retain the how-to's smaller example for explanation; both follow
+  the same output contract.

--- a/openspec/changes/improve-homepage-change-diagram-example/proposal.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/proposal.md
@@ -1,15 +1,19 @@
 ## Why
 
 The homepage's cache example proves that C4 diagrams render, but it undersells
-the feature by showing only one small infrastructure addition. A richer example
-will let visitors understand at a glance that lgtmaybe can map a change across
-multiple containers, relationship types, and system boundaries.
+the feature by showing only one small infrastructure addition. The long feature
+overview also delays the more useful commands, diagram, and getting-started
+links. A shorter overview and richer example will make the product easier to
+scan without hiding what it reviews.
 
 ## What Changes
 
 - Replace the homepage's Redis cache diagram with a compact pull-request example
   spanning a user-facing app, API, asynchronous worker, data store, and external
   service.
+- Cut the overview before "Start here" to roughly half its current length while
+  retaining every review category, the safety model, and the available slash
+  commands.
 - Mark both changed and newly added elements in the diagram labels, matching the
   generator's real output contract.
 - Keep the existing link to the detailed change-diagram guide and verify the
@@ -23,9 +27,8 @@ None.
 
 ### Modified Capabilities
 
-- `cli-and-local`: Make the homepage's representative change diagram demonstrate
-  the breadth of supported change mapping rather than only a single dependency
-  addition.
+- `cli-and-local`: Make the homepage easier to scan while preserving its review
+  categories and demonstrating the breadth of supported change mapping.
 
 ## Impact
 

--- a/openspec/changes/improve-homepage-change-diagram-example/proposal.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The homepage's cache example proves that C4 diagrams render, but it undersells
+the feature by showing only one small infrastructure addition. A richer example
+will let visitors understand at a glance that lgtmaybe can map a change across
+multiple containers, relationship types, and system boundaries.
+
+## What Changes
+
+- Replace the homepage's Redis cache diagram with a compact pull-request example
+  spanning a user-facing app, API, asynchronous worker, data store, and external
+  service.
+- Mark both changed and newly added elements in the diagram labels, matching the
+  generator's real output contract.
+- Keep the existing link to the detailed change-diagram guide and verify the
+  rendered Mermaid through the existing docs test and strict MkDocs build.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-and-local`: Make the homepage's representative change diagram demonstrate
+  the breadth of supported change mapping rather than only a single dependency
+  addition.
+
+## Impact
+
+- Documentation only: the homepage example, its generated `llms-full.txt`
+  mirror, the focused homepage test, and this OpenSpec change.
+- No runtime, API, dependency, configuration, or compatibility changes.

--- a/openspec/changes/improve-homepage-change-diagram-example/specs/cli-and-local/spec.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/specs/cli-and-local/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Homepage diagram conveys change breadth
+<!-- anchor: cli.docs-homepage-diagram-breadth -->
+
+The main documentation homepage SHALL use a representative C4-style Mermaid
+example that distinguishes changed and new elements and maps a change across
+multiple cooperating containers.
+
+#### Scenario: Visitor evaluates the diagram feature
+- **WHEN** a visitor views the homepage change-diagram example
+- **THEN** they can see changed and new elements connected across application,
+  asynchronous, data, and external-service boundaries

--- a/openspec/changes/improve-homepage-change-diagram-example/specs/cli-and-local/spec.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/specs/cli-and-local/spec.md
@@ -11,3 +11,14 @@ multiple cooperating containers.
 - **WHEN** a visitor views the homepage change-diagram example
 - **THEN** they can see changed and new elements connected across application,
   asynchronous, data, and external-service boundaries
+
+### Requirement: Homepage overview stays concise
+<!-- anchor: cli.docs-homepage-overview -->
+
+The main documentation homepage SHALL introduce every review category, its
+trust boundaries, and its pull-request commands in no more than 400 source words
+before the "Start here" section.
+
+#### Scenario: Visitor scans the homepage
+- **WHEN** a visitor reads from the hero to the "Start here" section
+- **THEN** they reach the commands and diagram without losing any review category

--- a/openspec/changes/improve-homepage-change-diagram-example/tasks.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/tasks.md
@@ -1,0 +1,14 @@
+## 1. Homepage example
+
+- [x] 1.1 Update the focused homepage test to require changed and new elements,
+  asynchronous infrastructure, and an external service; run it and confirm it
+  fails against the current cache example.
+- [x] 1.2 Replace the homepage Mermaid block with the compact asynchronous
+  order-confirmation example.
+- [x] 1.3 Regenerate the checked-in `docs/llms-full.txt` documentation mirror.
+
+## 2. Verification
+
+- [x] 2.1 Run the focused homepage test and the strict MkDocs build.
+- [x] 2.2 Inspect the rendered homepage at desktop and mobile widths.
+- [x] 2.3 Run the OpenSpec validation, anchor hygiene tests, and drift gate.

--- a/openspec/changes/improve-homepage-change-diagram-example/tasks.md
+++ b/openspec/changes/improve-homepage-change-diagram-example/tasks.md
@@ -12,3 +12,17 @@
 - [x] 2.1 Run the focused homepage test and the strict MkDocs build.
 - [x] 2.2 Inspect the rendered homepage at desktop and mobile widths.
 - [x] 2.3 Run the OpenSpec validation, anchor hygiene tests, and drift gate.
+
+## 3. Concise overview
+
+- [x] 3.1 Add a focused test for the 400-word overview ceiling and retained
+  review categories; run it and confirm it fails against the current homepage.
+- [x] 3.2 Rewrite the homepage overview in plain language and keep all review
+  categories, trust boundaries, and slash commands visible.
+- [x] 3.3 Regenerate the checked-in `docs/llms-full.txt` documentation mirror.
+
+## 4. Reverification
+
+- [x] 4.1 Run the docs tests, strict MkDocs build, OpenSpec validation, anchor
+  hygiene tests, and drift gate.
+- [x] 4.2 Inspect the shortened homepage at desktop and mobile widths.

--- a/tests/docs/test_homepage.py
+++ b/tests/docs/test_homepage.py
@@ -5,5 +5,9 @@ def test_homepage_shows_change_diagram_example() -> None:
     homepage = Path("docs/index.md").read_text(encoding="utf-8")
 
     assert "```mermaid\nC4Container" in homepage
+    assert "(changed)" in homepage
     assert "(new)" in homepage
+    assert 'Container(queue, "Order events"' in homepage
+    assert 'Container(worker, "Notification worker"' in homepage
+    assert 'System_Ext(email, "Email provider"' in homepage
     assert "how-to/generate-a-change-diagram.md" in homepage

--- a/tests/docs/test_homepage.py
+++ b/tests/docs/test_homepage.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -11,3 +12,22 @@ def test_homepage_shows_change_diagram_example() -> None:
     assert 'Container(worker, "Notification worker"' in homepage
     assert 'System_Ext(email, "Email provider"' in homepage
     assert "how-to/generate-a-change-diagram.md" in homepage
+
+
+def test_homepage_overview_is_concise_without_hiding_features() -> None:
+    homepage = Path("docs/index.md").read_text(encoding="utf-8")
+    overview = homepage.split("## Start here", 1)[0].casefold()
+
+    assert len(re.findall(r"\b[\w'-]+\b", overview)) <= 400
+    for feature in (
+        "correctness",
+        "security",
+        "performance",
+        "complexity",
+        "tests",
+        "documentation",
+        "deprecations",
+        "intent",
+        "ponytail",
+    ):
+        assert feature in overview


### PR DESCRIPTION
## Summary

- replace the homepage's minimal Redis cache diagram with a richer asynchronous order-confirmation example
- demonstrate changed and new components across a storefront, API, database, queue, worker, and external email provider
- cut the overview before "Start here" from 694 to 362 words while keeping every review category, trust boundary, and slash command visible
- rewrite the overview in shorter, more natural language so readers reach the commands and diagram sooner
- refresh the generated `llms-full.txt` mirror and strengthen the focused homepage regression test
- capture the change in a completed OpenSpec proposal

## Why

The previous four-node example proved that Mermaid rendered, but it did not show the breadth of the change-diagram feature. The surrounding copy also spent too long cataloguing individual bug classes before showing the product's commands and visual output.

The new page keeps the capabilities visible in five concise groups, surfaces all five PR commands, and makes system boundaries, synchronous and asynchronous relationships, and changed/new labels visible at a glance.

## Impact

Documentation only. There are no runtime, API, dependency, configuration, or compatibility changes.

## Validation

- `uv run pytest tests/docs -q`
- `uv run pytest tests/specs -q`
- `uv run mkdocs build --strict --site-dir <temporary-directory>`
- `openspec validate improve-homepage-change-diagram-example --strict`
- `uv run python scripts/check_spec_drift.py --base origin/main`
- visually inspected the rendered homepage at 1440px desktop and 390px mobile widths
