### PR TITLE
fix: bound default review runtime

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -49,4 +49,5 @@ jobs:
           provider: openrouter
           model: deepseek/deepseek-v4-pro
           auto_diagram: true
+          profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,7 +140,7 @@ reviews need no static keys in GitHub secrets. The `LiteLLMProvider` adds retrie
 budget-scaled context → batch to token budget → fan out one call per review
 lens → parse → merge & dedupe → self-reflect → filter by severity →
 findings + summary`. The lens set follows the `preset` — `fast` (default)
-covers the nine categories in four calls, `full` runs one per category — and
+covers seven code-focused categories in three calls, `full` runs all nine — and
 every (batch, lens) call shares one pool (`max_concurrency`: 8 cloud, 1
 ollama/openai-compatible) with a cacheable preamble-plus-diff prompt prefix on
 anthropic/bedrock. A soft whole-review deadline (`max_review_seconds`) degrades
@@ -176,11 +176,11 @@ engine/provider.
 ## Features
 
 **Review intelligence** — nine review lenses, fanned out per the `preset`:
-`fast` (default) covers them in four concurrent calls — dedicated security and
-correctness calls (the stated intent folds into correctness), plus merged
-code-health and artefacts calls with per-finding category attribution — while
-`full` runs each lens as its own focused call with a lens-matched worked
-example. Findings from every call are merged & de-duped:
+`fast` (default) covers seven in three concurrent calls — dedicated security
+and correctness calls (the stated intent folds into correctness), plus merged
+code-health with per-finding category attribution — while `full` restores tests
+and documentation and runs each lens as its own focused call with a lens-matched
+worked example. Findings from every call are merged & de-duped:
 - **Security** — OWASP-aligned checklist: injection, XSS, CSRF/open redirect,
   hardcoded secrets, broken authn/authz (incl. JWT pitfalls), path traversal,
   unrestricted upload, SSRF, insecure deserialization/XXE, mass assignment, weak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,12 +244,13 @@ pattern, event bus, plugin framework.
    - **Per-lens fan-out (preset-shaped):** the prompt is composed per lens
      (`engine/prompt.py`) — each lens gets a **worked example** (with a real
      hunk header, teaching the line-number arithmetic). `ReviewConfig.preset`
-     picks the lens set: **`fast` (default)** covers the nine `ReviewCategory`
-     lenses in **four calls** (dedicated security + correctness — stated intent
-     folds into correctness with per-finding `category` attribution — plus
-     merged code-health and artefacts calls, `prompt.FAST_GROUPS`); **`full`**
-     runs one call per category. An explicit `categories` list overrides the
-     grouping. Every (batch, lens) call runs through **one global
+     picks the lens set: **`fast` (default)** covers security, correctness and
+     stated intent, performance, complexity, ponytail, and deprecation in
+     **three calls** (dedicated security + correctness — stated intent folds
+     into correctness with per-finding `category` attribution — plus merged
+     code-health, `prompt.FAST_GROUPS`); **`full`** restores tests and
+     documentation and runs one call per category. An explicit `categories`
+     list overrides the grouping. Every (batch, lens) call runs through **one global
      `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 8
      cloud, 1 ollama/openai-compatible), then the findings are **merged and
      de-duped** (`engine._dedupe`, keyed on path/line/side) before reflection.

--- a/README.md
+++ b/README.md
@@ -60,14 +60,13 @@ forged delimiter break-out attempts), and redacts a broad set of secret formats
 credentials in connection strings) before anything leaves your environment. See
 [Data and Privacy](docs/explanation/data-and-privacy.md).
 
-**Fast by default.** Reviews run the **`fast` preset** by default: the nine
-lenses are covered in **four model calls** instead of nine. Security and
-correctness keep dedicated calls (the stated intent folds into correctness when
-the PR states one), and the rest merge into a code-health call
-(performance/complexity/ponytail/deprecation) and an artefacts call
-(tests/documentation). That's roughly **half the calls and wall time**, trading
-some recall on the softer lenses; `--preset full` (or `preset: full` in
-`.lgtmaybe.yml`) restores the one-call-per-lens deep audit for release branches.
+**Fast by default.** Reviews run the **`fast` preset** by default: security,
+correctness (including stated intent), and code health
+(performance/complexity/ponytail/deprecation) run in **three model calls**.
+Tests and documentation are reserved for `--preset full` (or `preset: full` in
+`.lgtmaybe.yml`), which restores the one-call-per-lens deep audit for release
+branches. This keeps the everyday path focused on code defects while avoiding a
+low-yield call that can dominate wall time.
 On top of that, all calls across all batches share **one concurrency pool**
 (`max_concurrency`, default 8 on cloud providers) and share a **cached
 preamble-plus-diff prefix** on anthropic/bedrock, so the diff is processed once
@@ -77,7 +76,7 @@ the time and tokens went.
 **How the scope is bounded.** Every run is capped so a large PR can't blow up
 latency:
 
-- `preset` (default `fast`) — four grouped lens calls; `full` runs one call per lens.
+- `preset` (default `fast`) — three focused/grouped calls; `full` restores tests and documentation and runs one call per lens.
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
 - `max_concurrency` (default 8 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
   preset:
-    description: "Review preset. fast (the default) covers all nine lenses in four model calls: dedicated security and correctness calls (the stated intent folds into correctness), plus merged code-health (performance/complexity/ponytail/deprecation) and artefacts (tests/documentation) calls — roughly half the calls and wall time, trading some recall on the softer lenses. full runs one call per lens, for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
+    description: "Review preset. fast (the default) covers security, correctness/intent, performance, complexity, ponytail, and deprecation in three model calls. full restores tests/documentation and runs one call per lens for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
     required: false
     default: ""
   fallback_model:
@@ -39,7 +39,7 @@ inputs:
     required: false
     default: ""
   timeout:
-    description: "Per-request timeout in seconds for each model call. Leave empty for the provider default (ollama and openai-compatible 300, cloud 60)."
+    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama and openai-compatible 300, cloud 60)."
     required: false
     default: ""
   max_review_seconds:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -52,15 +52,13 @@ flowchart TD
     compress --> security["security lens"]
     compress --> correctness["correctness + intent lens"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
-    compress --> artefacts["artefacts lens<br/>tests · documentation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
     correctness --> anchor
     codehealth --> anchor
-    artefacts --> anchor
     anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The four lens calls shown are the `fast` preset's grouping; the `full` preset
+(The three lens calls shown are the `fast` preset's grouping; the `full` preset
 fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
@@ -80,11 +78,11 @@ fans out one call per category, and custom lenses join the same fan-out.)
 
 3. **prompt + parse** — this stage **fans out one model call per review
    lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   nine built-in categories in **four calls**: dedicated security and
+   seven code-focused categories in **three calls**: dedicated security and
    correctness calls (the stated intent folds into correctness when present),
    plus a merged code-health call (performance/complexity/ponytail/
-   deprecation) and an artefacts call (tests/documentation), each demanding a
-   per-finding `category`. `full` runs one call per category. Every
+   deprecation), each demanding a per-finding `category`. `full` restores tests
+   and documentation and runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -10,9 +10,9 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends one model call per review lens — four grouped calls under the
-default `fast` preset, one per category under `full`, fanned out concurrently —
-plus a self-reflection call. Each call contains some subset of:
+lgtmaybe sends three grouped model calls under the default `fast` preset, one
+per category under `full`, fanned out concurrently — plus a self-reflection
+call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after
   generated files, lockfiles, minified assets, and vendored code have been

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -277,7 +277,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` covers the nine lenses in four grouped model calls; `full` runs one call per lens for deep audits. |
+| `preset` | `fast` | `fast` covers seven code-focused lenses in three model calls; `full` restores tests/documentation and runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -307,15 +307,14 @@ Each finding has:
 | `body` | The explanation |
 | `suggestion` | Optional suggested replacement code |
 
-The nine review categories (security, correctness, deprecation, tests,
-documentation, performance, complexity, intent, ponytail) fan out as concurrent
-model calls per the `preset`. The default `fast` preset covers them in four
-calls: dedicated security and correctness calls (the stated intent folds into
-correctness), plus a merged code-health call
-(performance/complexity/ponytail/deprecation) and a merged artefacts call
-(tests/documentation), with each finding attributed to its category.
-`preset: full` runs each category as its own focused call with a worked example
-of its own finding type. Their findings are merged and de-duplicated. A
+The nine review categories are security, correctness, deprecation, tests,
+documentation, performance, complexity, intent, and ponytail. The default
+`fast` preset runs seven of them in three concurrent calls: dedicated security
+and correctness calls (the stated intent folds into correctness), plus a merged
+code-health call (performance/complexity/ponytail/deprecation). `preset: full`
+restores tests and documentation and runs each category as its own focused call
+with a worked example of its own finding type. Their findings are merged and
+de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence
 findings, so the model's first guesses are filtered before anything is posted.
 

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -145,14 +145,10 @@ Default: `100000`.
 
 ### preset
 
-How many model calls the review spends. `fast` (the default) covers all nine
-lenses in **four calls**: security and correctness keep dedicated calls (the
-stated intent folds into the correctness prompt when the PR states one), and
-the rest merge into a code-health call (performance, complexity, ponytail,
-deprecation) and an artefacts call (tests, documentation), with each finding
-attributed to its category. `full` runs one call per lens — more per-lens
-focus for release branches and deep audits, at roughly twice the calls and
-wall time.
+How many model calls the review spends. `fast` (the default) covers security,
+correctness and stated intent, performance, complexity, ponytail, and
+deprecation in **three calls**. `full` restores tests and documentation and
+runs one focused call per lens for release branches and deep audits.
 
 ```yaml
 preset: full

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -202,12 +202,12 @@ model: qwen3.6:35b
 timeout: 900
 ```
 
-The review fans out one call per lens — **four calls** under the default `fast`
-preset (nine under `--preset full`). lgtmaybe runs those **serially for
+The review fans out **three calls** under the default `fast` preset (nine under
+`--preset full`). lgtmaybe runs those **serially for
 ollama**: a single ollama instance serves one request at a time, so firing them
 concurrently would only make each wait and time out. The trade-off is
 wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — four serial calls instead of nine is the
+is exactly why `fast` is the default — three serial calls instead of nine is the
 single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -192,14 +192,14 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Per-request timeout in seconds for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | Lens grouping: `fast` covers all nine lenses in four model calls; `full` runs one call per lens (an explicit `categories` list in `.lgtmaybe.yml` overrides it) |
+| `preset` | `fast` | `fast` covers seven code-focused lenses in three calls; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -491,14 +491,14 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Per-request timeout in seconds for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | Lens grouping: `fast` covers all nine lenses in four model calls; `full` runs one call per lens (an explicit `categories` list in `.lgtmaybe.yml` overrides it) |
+| `preset` | `fast` | `fast` covers seven code-focused lenses in three calls; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
@@ -1693,12 +1693,12 @@ model: qwen3.6:35b
 timeout: 900
 ```
 
-The review fans out one call per lens — **four calls** under the default `fast`
-preset (nine under `--preset full`). lgtmaybe runs those **serially for
+The review fans out **three calls** under the default `fast` preset (nine under
+`--preset full`). lgtmaybe runs those **serially for
 ollama**: a single ollama instance serves one request at a time, so firing them
 concurrently would only make each wait and time out. The trade-off is
 wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — four serial calls instead of nine is the
+is exactly why `fast` is the default — three serial calls instead of nine is the
 single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
@@ -2098,14 +2098,10 @@ Default: `100000`.
 
 ### preset
 
-How many model calls the review spends. `fast` (the default) covers all nine
-lenses in **four calls**: security and correctness keep dedicated calls (the
-stated intent folds into the correctness prompt when the PR states one), and
-the rest merge into a code-health call (performance, complexity, ponytail,
-deprecation) and an artefacts call (tests, documentation), with each finding
-attributed to its category. `full` runs one call per lens — more per-lens
-focus for release branches and deep audits, at roughly twice the calls and
-wall time.
+How many model calls the review spends. `fast` (the default) covers security,
+correctness and stated intent, performance, complexity, ponytail, and
+deprecation in **three calls**. `full` restores tests and documentation and
+runs one focused call per lens for release branches and deep audits.
 
 ```yaml
 preset: full
@@ -3406,7 +3402,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in lenses in four calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while the remaining six\nfold into two combined calls \u2014 code health (performance, complexity,\nponytail, deprecation) and supporting artefacts (tests, documentation).\n``full`` runs each of the nine lenses as its own call \u2014 more per-lens\nfocus for release branches and deep audits, at ~2\u00d7 the calls and wall\ntime. An explicit ``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"
@@ -4287,7 +4283,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` covers the nine lenses in four grouped model calls; `full` runs one call per lens for deep audits. |
+| `preset` | `fast` | `fast` covers seven code-focused lenses in three model calls; `full` restores tests/documentation and runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -4317,15 +4313,14 @@ Each finding has:
 | `body` | The explanation |
 | `suggestion` | Optional suggested replacement code |
 
-The nine review categories (security, correctness, deprecation, tests,
-documentation, performance, complexity, intent, ponytail) fan out as concurrent
-model calls per the `preset`. The default `fast` preset covers them in four
-calls: dedicated security and correctness calls (the stated intent folds into
-correctness), plus a merged code-health call
-(performance/complexity/ponytail/deprecation) and a merged artefacts call
-(tests/documentation), with each finding attributed to its category.
-`preset: full` runs each category as its own focused call with a worked example
-of its own finding type. Their findings are merged and de-duplicated. A
+The nine review categories are security, correctness, deprecation, tests,
+documentation, performance, complexity, intent, and ponytail. The default
+`fast` preset runs seven of them in three concurrent calls: dedicated security
+and correctness calls (the stated intent folds into correctness), plus a merged
+code-health call (performance/complexity/ponytail/deprecation). `preset: full`
+restores tests and documentation and runs each category as its own focused call
+with a worked example of its own finding type. Their findings are merged and
+de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence
 findings, so the model's first guesses are filtered before anything is posted.
 
@@ -4484,15 +4479,13 @@ flowchart TD
     compress --> security["security lens"]
     compress --> correctness["correctness + intent lens"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
-    compress --> artefacts["artefacts lens<br/>tests · documentation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
     correctness --> anchor
     codehealth --> anchor
-    artefacts --> anchor
     anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The four lens calls shown are the `fast` preset's grouping; the `full` preset
+(The three lens calls shown are the `fast` preset's grouping; the `full` preset
 fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
@@ -4512,11 +4505,11 @@ fans out one call per category, and custom lenses join the same fan-out.)
 
 3. **prompt + parse** — this stage **fans out one model call per review
    lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   nine built-in categories in **four calls**: dedicated security and
+   seven code-focused categories in **three calls**: dedicated security and
    correctness calls (the stated intent folds into correctness when present),
    plus a merged code-health call (performance/complexity/ponytail/
-   deprecation) and an artefacts call (tests/documentation), each demanding a
-   per-finding `category`. `full` runs one call per category. Every
+   deprecation), each demanding a per-finding `category`. `full` restores tests
+   and documentation and runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
@@ -4774,9 +4767,9 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends one model call per review lens — four grouped calls under the
-default `fast` preset, one per category under `full`, fanned out concurrently —
-plus a self-reflection call. Each call contains some subset of:
+lgtmaybe sends three grouped model calls under the default `fast` preset, one
+per category under `full`, fanned out concurrently — plus a self-reflection
+call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after
   generated files, lockfiles, minified assets, and vendored code have been

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -424,7 +424,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in lenses in four calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while the remaining six\nfold into two combined calls \u2014 code health (performance, complexity,\nponytail, deprecation) and supporting artefacts (tests, documentation).\n``full`` runs each of the nine lenses as its own call \u2014 more per-lens\nfocus for release branches and deep audits, at ~2\u00d7 the calls and wall\ntime. An explicit ``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"

--- a/openspec/changes/reduce-default-review-time/.openspec.yaml
+++ b/openspec/changes/reduce-default-review-time/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/reduce-default-review-time/README.md
+++ b/openspec/changes/reduce-default-review-time/README.md
@@ -1,0 +1,3 @@
+# reduce-default-review-time
+
+Bound default review runtime while retaining mandatory C4 diagrams

--- a/openspec/changes/reduce-default-review-time/design.md
+++ b/openspec/changes/reduce-default-review-time/design.md
@@ -1,0 +1,51 @@
+## Context
+
+GitHub Actions run `lgtmaybe` with a 20-minute job timeout. The review engine
+already has a 600-second soft deadline, but it deliberately waits for in-flight
+calls. A real OpenRouter request exceeded the configured 60-second provider
+timeout and held the four-call executor open until GitHub cancelled the job.
+
+Recent run profiles also show that the combined tests/documentation call can be
+the slowest default lens: one 18-file run spent 129 seconds and 7,619 output
+tokens on it without producing a finding.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent one stuck provider request from consuming the whole GitHub job.
+- Reduce everyday model calls without weakening security or correctness.
+- Preserve full and explicitly selected review coverage.
+- Preserve automatic C4 diagrams in supplied workflows.
+- Make future dogfood latency easy to diagnose.
+
+**Non-Goals:**
+
+- Remove self-reflection or its false-positive protection.
+- Change local-provider timeout defaults.
+- Add a new preset or dependency.
+- Generate diagrams on every synchronize event.
+
+## Decisions
+
+- `fast` runs security, correctness/intent, and combined code-health calls.
+  Tests and documentation remain available through `full` or `categories`.
+- Wrap the synchronous LiteLLM request in a daemon thread and wait on its result
+  for the request timeout. This is the smallest adapter-level guard that works
+  even when an HTTP client's own timeout is not honored. Python cannot safely
+  stop the blocked transport thread, so it is allowed to finish as a daemon.
+- Keep the review deadline soft. The request guard makes in-flight duration
+  bounded without changing the existing partial-results semantics.
+- Set `profile: true` only in the dogfood workflow. Per-call structured timing
+  logs already exist for users; the readable summary is useful for maintainers
+  and costs no model calls.
+
+## Risks / Trade-offs
+
+- Default reviews no longer flag test or documentation gaps. Those are lower
+  risk than security/correctness defects and remain one setting away.
+- A timed-out request can continue consuming provider resources briefly in a
+  daemon thread. The alternative is a child process per request, which adds
+  substantial state and portability complexity.
+- Reducing calls may reduce recall on softer concerns. The deep `full` preset
+  and explicit categories remain unchanged.

--- a/openspec/changes/reduce-default-review-time/proposal.md
+++ b/openspec/changes/reduce-default-review-time/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A medium pull request can exhaust the dogfood workflow's 20-minute job limit.
+In the observed run, three review calls finished within 57 seconds while one
+provider call ignored the configured timeout and remained in flight until
+GitHub cancelled the job. The everyday preset also spends a separate call on
+tests and documentation, which has shown high latency and low yield.
+
+## What Changes
+
+- Reduce the default `fast` preset from four review calls to three by reserving
+  the tests and documentation lenses for `full` or explicit category runs.
+- Add a local wall-clock guard around each LiteLLM request so a provider call
+  cannot outlive its configured timeout even when the downstream client hangs.
+- Keep `full` and explicit categories as the opt-in paths for deeper scans.
+- Keep automatic C4 diagrams enabled in every supplied starter workflow and
+  the dogfood workflow.
+- Enable the existing timing profile in the dogfood workflow so future slow
+  runs retain a stage and call breakdown.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `review-pipeline`: Define the narrower everyday preset.
+- `prompt-and-lenses`: Reserve tests and documentation for deep or explicit
+  reviews.
+- `core-contracts`: Describe the three-call default and nine-lens full preset.
+- `provider-gateway`: Enforce the configured provider-call timeout.
+- `cli-and-local`: Preserve automatic C4 diagrams in supplied workflows while
+  documenting the faster default review.
+
+## Impact
+
+Default reviews make one fewer model call and no longer inspect missing tests
+or documentation unless the user selects `full` or those categories
+explicitly. Security, correctness, intent, performance, complexity, ponytail,
+and deprecation coverage remain on. One timed-out provider request may leave a
+daemon transport thread to finish in the background, but it no longer prevents
+the CLI process or GitHub job from completing.

--- a/openspec/changes/reduce-default-review-time/specs/cli-and-local/spec.md
+++ b/openspec/changes/reduce-default-review-time/specs/cli-and-local/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Starter workflows enable automatic diagrams
+<!-- anchor: cli.starter-workflow-diagrams -->
+
+The supplied GitHub Actions starter workflows SHALL opt in to automatic C4
+change diagrams and the dogfood workflow SHALL keep the same setting while
+using the faster default review preset.
+
+#### Scenario: New repository adopts a supplied workflow
+- **WHEN** a maintainer copies a supplied provider workflow into a repository
+- **THEN** the workflow passes `auto_diagram: true` to the lgtmaybe Action
+
+#### Scenario: Faster default is adopted
+- **WHEN** the supplied workflow runs a default review
+- **THEN** automatic C4 diagram generation remains enabled

--- a/openspec/changes/reduce-default-review-time/specs/core-contracts/spec.md
+++ b/openspec/changes/reduce-default-review-time/specs/core-contracts/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Nine built-in lenses, preset-shaped fan-out
+<!-- anchor: core.lenses -->
+
+`ReviewCategory` SHALL enumerate the nine built-in lenses (security,
+correctness, deprecation, tests, documentation, performance, complexity,
+intent, ponytail). `ReviewPreset` SHALL shape the fan-out: `fast` SHALL cover
+seven code-focused lenses in three calls, while `full` SHALL run all nine.
+
+#### Scenario: default preset batches the lenses
+- **WHEN** a review runs with no preset override
+- **THEN** seven lenses fan out as three concurrent calls
+
+#### Scenario: full preset restores artefact checks
+- **WHEN** a review runs with `preset: full`
+- **THEN** tests and documentation run alongside every other built-in lens

--- a/openspec/changes/reduce-default-review-time/specs/prompt-and-lenses/spec.md
+++ b/openspec/changes/reduce-default-review-time/specs/prompt-and-lenses/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Fast preset focuses seven lenses into three calls
+<!-- anchor: prompt.groups -->
+
+The default `fast` preset SHALL run dedicated security and correctness calls
+(with stated intent folded into correctness) plus one merged code-health call
+covering performance, complexity, ponytail, and deprecation. Tests and
+documentation SHALL remain available through `full` or explicit categories.
+
+#### Scenario: intent with no dedicated call
+- **WHEN** the fast preset runs and the PR states an intent
+- **THEN** intent findings come out of the correctness call, attributed to the
+  intent category
+
+#### Scenario: everyday review
+- **WHEN** the fast preset runs with no category override
+- **THEN** tests and documentation do not consume a model call

--- a/openspec/changes/reduce-default-review-time/specs/provider-gateway/spec.md
+++ b/openspec/changes/reduce-default-review-time/specs/provider-gateway/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Completion calls retry, fall back, cache, and time out
+<!-- anchor: provider.complete -->
+
+`LiteLLMProvider.complete` SHALL enforce the configured request timeout at the
+adapter boundary, retry transient failures within its bounded budget, switch to
+`fallback_model` when the primary is exhausted, and place explicit cache
+breakpoints on the shared prefix for supported routes. Cache usage SHALL land
+on `ProviderResult`.
+
+#### Scenario: provider SDK ignores its timeout
+- **WHEN** the underlying completion call remains blocked past the configured
+  timeout
+- **THEN** the adapter raises a timeout error and the existing bounded retry
+  policy decides whether to retry
+
+#### Scenario: primary model keeps failing
+- **WHEN** retries on the primary model are exhausted and a fallback is set
+- **THEN** the call completes on the fallback model instead of failing the
+  review

--- a/openspec/changes/reduce-default-review-time/specs/review-pipeline/spec.md
+++ b/openspec/changes/reduce-default-review-time/specs/review-pipeline/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Per-lens fan-out through one bounded executor
+<!-- anchor: engine.fan-out -->
+
+Every (batch, lens) call SHALL run through one global bounded executor sized by
+`max_concurrency` (auto: 8 cloud, 1 for ollama/openai-compatible). The default
+`fast` preset SHALL run three calls per batch: security, correctness with
+stated intent, and code health. The `full` preset and explicit categories SHALL
+retain tests and documentation coverage.
+
+#### Scenario: default medium pull request
+- **WHEN** a review uses the default `fast` preset
+- **THEN** each batch makes three review calls and does not run the tests or
+  documentation lenses
+
+#### Scenario: deep audit
+- **WHEN** a review uses the `full` preset
+- **THEN** every built-in category runs, including tests and documentation

--- a/openspec/changes/reduce-default-review-time/tasks.md
+++ b/openspec/changes/reduce-default-review-time/tasks.md
@@ -1,0 +1,24 @@
+## 1. Acceptance Coverage
+
+- [x] 1.1 Add a regression test proving a provider call cannot exceed its
+  configured wall-clock timeout when the underlying SDK hangs
+- [x] 1.2 Update preset tests to require three default calls and retain all
+  categories in `full`
+- [x] 1.3 Keep the supplied-workflow C4 assertion green
+
+## 2. Runtime Optimization
+
+- [x] 2.1 Enforce the configured timeout around each raw LiteLLM completion
+- [x] 2.2 Remove the tests/documentation call from the `fast` preset
+- [x] 2.3 Enable the existing profile summary in the dogfood workflow
+
+## 3. Documentation
+
+- [x] 3.1 Update user-facing preset and timeout descriptions
+- [x] 3.2 Regenerate derived configuration and LLM documentation
+
+## 4. Verification
+
+- [x] 4.1 Run focused timeout, preset, and workflow tests
+- [x] 4.2 Run the complete unit/integration suite, lint, and type checks
+- [x] 4.3 Run spec-anchor checks and validate the OpenSpec change

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -62,10 +62,9 @@ def _apply_static_analysis_flag(cfg: ReviewConfig, flag: bool | None) -> ReviewC
     "--preset",
     default=None,
     type=click.Choice(["fast", "full"]),
-    help="Review preset: fast (default) covers all nine lenses in four model "
-    "calls — dedicated security and correctness calls (stated intent folds "
-    "into correctness), plus merged code-health and artefacts calls; full runs "
-    "one call per lens for release branches and deep audits (~2x the calls)",
+    help="Review preset: fast (default) covers security, correctness/intent, "
+    "performance, complexity, ponytail, and deprecation in three calls; full "
+    "restores tests/documentation and runs one call per lens for deep audits",
 )
 @click.option(
     "--full",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -76,14 +76,13 @@ class ReviewCategory(StrEnum):
 class ReviewPreset(StrEnum):
     """How many model calls a review spends: the everyday path or the deep audit.
 
-    ``fast`` (the default) covers all nine built-in lenses in four calls:
+    ``fast`` (the default) covers seven built-in lenses in three calls:
     security and correctness keep dedicated calls (they earn it; the stated
-    intent, when present, merges into correctness), while the remaining six
-    fold into two combined calls — code health (performance, complexity,
-    ponytail, deprecation) and supporting artefacts (tests, documentation).
-    ``full`` runs each of the nine lenses as its own call — more per-lens
-    focus for release branches and deep audits, at ~2× the calls and wall
-    time. An explicit ``categories`` list always wins over the preset.
+    intent, when present, merges into correctness), while performance,
+    complexity, ponytail, and deprecation fold into one code-health call.
+    ``full`` restores tests and documentation and runs each of the nine lenses
+    as its own call for release branches and deep audits. An explicit
+    ``categories`` list always wins over the preset.
     """
 
     fast = "fast"
@@ -570,9 +569,9 @@ class ReviewConfig(_Strict):
     # replies and resolves the conversation. GitHub posting only — ignored by the
     # local CLI review, which has no conversations to resolve.
     resolve_fixed: bool = True
-    # Call-count preset (see ReviewPreset): `fast` (default) covers all nine
-    # built-in lenses in four calls; `full` runs one call per lens for release
-    # branches and deep audits. An explicit `categories` list overrides it.
+    # Call-count preset (see ReviewPreset): `fast` (default) covers seven
+    # built-in lenses in three calls; `full` restores tests/documentation and
+    # runs one call per lens. An explicit `categories` list overrides it.
     preset: ReviewPreset = ReviewPreset.fast
     # Review lenses to run. Each is asked in its own concurrent LLM call and the
     # findings are merged + deduped. Defaults to all of them (grouped per the

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -134,11 +134,11 @@ class _Lens:
 def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
     """All lenses to run: built-ins (grouped per the preset), then user lenses.
 
-    The fast preset groups the nine built-ins into four calls — but only when
+    The fast preset runs seven built-ins in three calls — but only when
     ``categories`` is the untouched default: a user who explicitly listed
     lenses asked for exactly those, so the preset never regroups them. The
-    full preset (and any explicit list) runs one call per category, skipping
-    the intent lens when nothing states an intent.
+    full preset runs every category; an explicit list runs exactly its selected
+    categories. Both skip intent when nothing states an intent.
     """
     fast = cfg.preset is ReviewPreset.fast and list(cfg.categories) == list(ReviewCategory)
     if fast:

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -499,7 +499,7 @@ keep this lens to "should this exist at all?" — leave readability nits to othe
 
 # ---------------------------------------------------------------------------
 # Fast-preset merged lenses. Written as integrated checklists (not a paste-up
-# of the per-lens sections): four calls must cover what nine did, so each
+# of the per-lens sections): three calls cover the everyday concerns, so each
 # merged prompt condenses its members to their high-signal items and demands
 # the per-finding `category` field so downstream rules/labels keep working.
 # ---------------------------------------------------------------------------
@@ -616,12 +616,10 @@ class LensGroup:
 # The fast preset's grouping (a judgement call the profile can't settle, so
 # here is the reasoning): security and correctness are the two lenses whose
 # recall is worth a dedicated, focused call — they find the merge-blocking
-# bugs. The other six split by what the reviewer is looking AT: code health
-# reads the changed code itself (how it performs, how complex it is, whether
-# it should exist, what it depends on), artefacts reads what should accompany
-# the code (tests, docs). Members that grade similarly and share framing merge
-# well; splitting differently (e.g. perf+tests) would force one call to switch
-# between unrelated rubrics.
+# bugs. Code health keeps the lower-cost concerns that inspect the changed code
+# itself. Tests and documentation are reserved for full/explicit reviews: the
+# default artefacts call was the slowest call in production while yielding no
+# findings, so it did not earn a place in the everyday path.
 CODE_HEALTH_GROUP = LensGroup(
     id="code-health",
     members=(
@@ -633,13 +631,7 @@ CODE_HEALTH_GROUP = LensGroup(
     section=_CODE_HEALTH_SECTION,
     example=_PERFORMANCE_EXAMPLE,
 )
-ARTEFACTS_GROUP = LensGroup(
-    id="artefacts",
-    members=(ReviewCategory.tests, ReviewCategory.documentation),
-    section=_ARTEFACTS_SECTION,
-    example=_TESTS_EXAMPLE,
-)
-FAST_GROUPS: tuple[LensGroup, ...] = (CODE_HEALTH_GROUP, ARTEFACTS_GROUP)
+FAST_GROUPS: tuple[LensGroup, ...] = (CODE_HEALTH_GROUP,)
 
 
 def build_group_prompt(group: LensGroup) -> str:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -6,6 +6,9 @@ optional fallback model.
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
 import litellm
@@ -238,14 +241,14 @@ class LiteLLMProvider(ProviderClient):
     ) -> ProviderResult:
         """One litellm call, with the temperature-value-rejection fallback applied."""
         try:
-            response = litellm.completion(model=model, messages=messages, **kwargs)
+            response = _completion_with_wall_timeout(model, messages, kwargs)
         except Exception as exc:
             if "temperature" not in kwargs or not _rejects_temperature(exc):
                 raise
             # Drop temperature for this and every subsequent retry, letting the
             # model use its only supported value (its default).
             kwargs.pop("temperature")
-            response = litellm.completion(model=model, messages=messages, **kwargs)
+            response = _completion_with_wall_timeout(model, messages, kwargs)
         return self._map_response(response, model)
 
     def _with_cache_control(self, messages: list[Message], model: str) -> list[Message]:
@@ -336,6 +339,26 @@ class LiteLLMProvider(ProviderClient):
 def _cache_block(text: str) -> dict[str, Any]:
     """A text content block carrying an ephemeral cache breakpoint."""
     return {"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}
+
+
+def _completion_with_wall_timeout(
+    model: str, messages: list[Message], kwargs: dict[str, Any]
+) -> Any:
+    """Call LiteLLM with a real wall-clock bound even if its transport hangs."""
+    timeout = float(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
+    future: Future[Any] = Future()
+
+    def complete() -> None:
+        try:
+            future.set_result(litellm.completion(model=model, messages=messages, **kwargs))
+        except BaseException as exc:
+            future.set_exception(exc)
+
+    threading.Thread(target=complete, name="lgtmaybe-provider", daemon=True).start()
+    try:
+        return future.result(timeout=timeout)
+    except FutureTimeoutError as exc:
+        raise TimeoutError(f"provider request exceeded {timeout:g}s") from exc
 
 
 def _trailing_user_run(messages: list[Message]) -> tuple[int, list[Message]]:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -391,7 +391,7 @@ def test_reflect_false_skips_the_reflection_pass() -> None:
 
     findings, _ = engine.review(_CTX, cfg)
 
-    assert [f.title for f in findings] == ["real bug"]  # 5 category copies deduped to one
+    assert [f.title for f in findings] == ["real bug"]  # 3 lens copies deduped to one
     assert _reflection_calls(provider) == []  # no reflection pass ran
 
 
@@ -403,8 +403,8 @@ def test_reflect_true_runs_the_reflection_pass() -> None:
     engine.review(_CTX, cfg)
 
     assert len(_reflection_calls(provider)) == 1  # exactly one reflection pass
-    # The default fast preset covers the nine lenses in four grouped calls.
-    assert len(_review_calls(provider)) == 4
+    # The default fast preset covers seven lenses in three grouped calls.
+    assert len(_review_calls(provider)) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -1009,8 +1009,8 @@ def test_review_logs_an_upfront_work_summary(engine_logs) -> None:
 
     starting = [r for r in engine_logs if "review starting" in r.getMessage()]
     assert starting, "expected an up-front 'review starting' log"
-    # The default fast preset queues four grouped lens calls.
-    assert getattr(starting[0], "lenses", None) == 4
+    # The default fast preset queues three grouped lens calls.
+    assert getattr(starting[0], "lenses", None) == 3
 
 
 def test_review_logs_a_heartbeat_as_each_lens_runs(engine_logs) -> None:
@@ -1080,9 +1080,9 @@ def test_custom_lens_runs_as_an_extra_review_call() -> None:
     findings, _ = engine.review(_CTX, cfg)
 
     review_calls = _review_calls(provider)
-    # The default fast preset runs four grouped built-in calls; the custom
+    # The default fast preset runs three grouped built-in calls; the custom
     # lens always adds its own focused call on top.
-    assert len(review_calls) == 4 + 1
+    assert len(review_calls) == 3 + 1
     assert any("Simplify or delete" in _all_text(c) for c in review_calls)
     assert findings  # the custom lens's finding survived the pipeline
 

--- a/tests/engine/test_preset.py
+++ b/tests/engine/test_preset.py
@@ -1,4 +1,4 @@
-"""Tests for the fast/full review presets (fast = 4 grouped calls, default)."""
+"""Tests for the fast/full review presets (fast = 3 calls, default)."""
 
 from __future__ import annotations
 
@@ -42,32 +42,36 @@ class TestFastLensGrouping:
     def test_default_preset_is_fast(self) -> None:
         assert _cfg().preset is ReviewPreset.fast
 
-    def test_fast_builds_four_lenses(self) -> None:
+    def test_fast_builds_three_lenses(self) -> None:
         lenses = _build_lenses(_cfg(), has_intent=False)
         assert [lens.id for lens in lenses] == [
             "security",
             "correctness",
             "code-health",
-            "artefacts",
         ]
 
-    def test_fast_covers_every_builtin_category(self) -> None:
-        """Four calls, nine lenses: every category is either a dedicated call
-        or a member of a merged one — nothing silently dropped."""
+    def test_fast_reserves_artefact_categories_for_deep_reviews(self) -> None:
         lenses = _build_lenses(_cfg(), has_intent=True)
         covered: set[str] = set()
         for lens in lenses:
             covered.add(lens.id)
             covered |= set(lens.allowed_categories or ())
-        assert covered >= {c.value for c in ReviewCategory}
+        assert covered >= {
+            "security",
+            "correctness",
+            "intent",
+            "performance",
+            "complexity",
+            "ponytail",
+            "deprecation",
+        }
+        assert covered.isdisjoint({"tests", "documentation"})
 
     def test_merged_prompts_name_their_member_categories(self) -> None:
         lenses = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=False)}
         code_health = lenses["code-health"].user_block
         for name in ("performance", "complexity", "ponytail", "deprecation"):
             assert f'"{name}"' in code_health
-        artefacts = lenses["artefacts"].user_block
-        assert '"tests"' in artefacts and '"documentation"' in artefacts
 
     def test_intent_folds_into_correctness_when_stated(self) -> None:
         lenses = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=True)}
@@ -83,6 +87,7 @@ class TestFastLensGrouping:
     def test_full_preset_builds_one_lens_per_category(self) -> None:
         lenses = _build_lenses(_cfg(preset="full"), has_intent=True)
         assert [lens.id for lens in lenses] == [c.value for c in ReviewCategory]
+        assert {"tests", "documentation"} <= {lens.id for lens in lenses}
 
     def test_full_preset_skips_intent_without_a_stated_intent(self) -> None:
         lenses = _build_lenses(_cfg(preset="full"), has_intent=False)
@@ -93,10 +98,10 @@ class TestFastLensGrouping:
         lenses = _build_lenses(cfg, has_intent=False)
         assert [lens.id for lens in lenses] == ["security", "performance"]
 
-    def test_fast_review_makes_four_calls(self) -> None:
+    def test_fast_review_makes_three_calls(self) -> None:
         provider = FakeProvider()
         LLMReviewEngine(provider).review(_CTX, _cfg())
-        assert len(provider.calls) == 4
+        assert len(provider.calls) == 3
 
 
 class TestMergedCategoryStamping:

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -189,7 +189,7 @@ class TestEngineBehaviourMatrix:
         assert _resolve_workers(cfg, task_count=99) == expected
 
     @pytest.mark.parametrize("provider", list(Provider))
-    def test_fast_preset_runs_four_calls_on_every_provider(self, provider: Provider) -> None:
+    def test_fast_preset_runs_three_calls_on_every_provider(self, provider: Provider) -> None:
         from lgtmaybe.core.models import PRContext, ReviewConfig
         from lgtmaybe.engine import LLMReviewEngine
         from tests.fakes import FakeProvider
@@ -205,7 +205,7 @@ class TestEngineBehaviourMatrix:
         cfg = ReviewConfig(provider=provider, model="m", reflect=False)
         fake = FakeProvider()
         LLMReviewEngine(fake).review(ctx, cfg)
-        assert len(fake.calls) == 4
+        assert len(fake.calls) == 3
 
     @pytest.mark.parametrize("provider", list(Provider))
     def test_review_deadline_field_defaults_on_every_provider(self, provider: Provider) -> None:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -21,6 +23,29 @@ def _fake_response(content: str = "ok") -> Any:
 
 
 class TestRetry:
+    def test_sdk_hang_cannot_exceed_the_request_timeout(self) -> None:
+        """The adapter timeout is a real wall-clock bound even if LiteLLM's
+        downstream transport never returns."""
+        release = threading.Event()
+
+        def hangs(*args: Any, **kwargs: Any) -> Any:
+            release.wait(timeout=5)
+            return _fake_response()
+
+        started = time.perf_counter()
+        try:
+            with (
+                patch("litellm.completion", side_effect=hangs),
+                patch("lgtmaybe.providers.litellm_provider._MAX_ATTEMPTS", 1),
+            ):
+                provider = LiteLLMProvider(timeout=0.05)
+                with pytest.raises(TimeoutError, match="exceeded 0.05"):
+                    provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+        finally:
+            release.set()
+
+        assert time.perf_counter() - started < 0.5
+
     def test_first_call_raises_then_retry_succeeds(self) -> None:
         """Provider retries on transient failure and returns the good result."""
         good_response = _fake_response("retried ok")
@@ -358,7 +383,7 @@ class TestFailFastOnPermanentErrors:
 
         with patch("litellm.completion", side_effect=slow_transient):
             provider = LiteLLMProvider(timeout=0.05)
-            with pytest.raises(RuntimeError):
+            with pytest.raises(TimeoutError, match="exceeded 0.05"):
                 provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
 
         assert calls < _MAX_ATTEMPTS

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -287,7 +287,7 @@
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in lenses in four calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while the remaining six\nfold into two combined calls \u2014 code health (performance, complexity,\nponytail, deprecation) and supporting artefacts (tests, documentation).\n``full`` runs each of the nine lenses as its own call \u2014 more per-lens\nfocus for release branches and deep audits, at ~2\u00d7 the calls and wall\ntime. An explicit ``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -23,3 +23,14 @@ def test_supplied_workflows_enable_auto_diagram() -> None:
         assert all(step.get("with", {}).get("auto_diagram") is True for step in action_steps), (
             f"{workflow} must enable automatic diagrams for new repositories"
         )
+
+
+def test_dogfood_workflow_prints_the_timing_profile() -> None:
+    workflow = yaml.safe_load(_DOGFOOD_WORKFLOW.read_text(encoding="utf-8"))
+    [action_step] = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("uses") == "./"
+    ]
+    assert action_step.get("with", {}).get("profile") is True


### PR DESCRIPTION
## What changed

- reduce the default `fast` preset from four review calls to three by reserving
  the tests/documentation artefacts lens for `full` or explicit category runs
- enforce each LiteLLM request's configured timeout at the adapter boundary,
  even when the downstream SDK/transport hangs
- keep `auto_diagram: true` in every supplied workflow and retain its regression
  guard
- enable the existing timing profile in the dogfood workflow
- update the OpenSpec change, user docs, generated config reference, and LLM
  docs mirror

## Why

A real medium PR exhausted the dogfood workflow's 20-minute job limit. Its
Action log showed three lens calls completing in 26s, 31s, and 57s while the
fourth call never returned. The existing 600s review deadline could not help
because all four calls were already in flight, and the provider's nominal 60s
timeout was not acting as a hard wall-clock bound.

The separate artefacts call was also the slowest call in a recent successful
18-file run: 129s and 7,619 output tokens with no finding. Security,
correctness/intent, performance, complexity, ponytail, and deprecation remain
in the everyday preset; `full` still runs all nine lenses.

## Impact

Default reviews make 25% fewer review calls per batch and a stuck provider
request can no longer hold the worker indefinitely. Tests/documentation gap
checks move to the deep-review path. Automatic C4 diagrams remain enabled in
the supplied setup.

## Validation

- `uv run pytest -q` — 1,195 passed, 3 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- focused post-rebase docs/runtime/spec suite — 47 passed
- `openspec validate reduce-default-review-time --strict`
- `uv run pytest -q tests/specs` — 17 passed
- `uv run python scripts/check_spec_drift.py --base origin/main` — no drift
- `uv run lgtmaybe --help`
