### PR TITLE
fix: align action with v1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: "The released tag to build and publish (e.g. lgtmaybe-v0.1.0)."
+        description: "The released tag to build and publish (e.g. lgtmaybe-v1.0.0)."
         required: true
         type: string
   # Manual path: (re)publish the image + (re)move the clean v-tags for an
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to build and publish (e.g. lgtmaybe-v0.1.0)."
+        description: "Existing release tag to build and publish (e.g. lgtmaybe-v1.0.0)."
         required: true
         type: string
 
@@ -38,16 +38,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # release-please cuts component-prefixed tags (lgtmaybe-v0.1.0); strip the
-      # prefix to a clean semver so the metadata/git tags are v0 / 0.1.0, not the
+      # release-please cuts component-prefixed tags (lgtmaybe-v1.0.0); strip the
+      # prefix to a clean semver so the metadata/git tags are v1 / 1.0.0, not the
       # prefixed form (which semver can't parse).
       - name: Clean version from tag
         id: ver
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag }}"   # e.g. lgtmaybe-v0.1.0
-          v="${tag##*-}"            # v0.1.0  (everything after the last '-')
-          v="${v#v}"                # 0.1.0
+          tag="${{ inputs.tag }}"   # e.g. lgtmaybe-v1.0.0
+          v="${tag##*-}"            # v1.0.0  (everything after the last '-')
+          v="${v#v}"                # 1.0.0
           echo "version=$v" >> "$GITHUB_OUTPUT"
       - name: Image metadata
         id: meta
@@ -67,10 +67,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # Publish clean v-prefixed git tags consumers can use in `uses:` — the exact
-  # alias (v0.1.0), the floating major (v0), and the component-prefixed floating
-  # major (lgtmaybe-v0) — all pointing at the released commit. release-please owns
-  # the canonical lgtmaybe-v0.1.0 tag + GitHub release; these are the
-  # Action-friendly aliases (the image uses the same v0 / 0.1.0 scheme).
+  # alias (v1.0.0), the floating major (v1), and the component-prefixed floating
+  # major (lgtmaybe-v1) — all pointing at the released commit. release-please owns
+  # the canonical lgtmaybe-v1.0.0 tag + GitHub release; these are the
+  # Action-friendly aliases (the image uses the same v1 / 1.0.0 scheme).
   floating-tag:
     needs: [ghcr]
     runs-on: ubuntu-latest
@@ -83,17 +83,17 @@ jobs:
       - name: Tag clean exact + floating-major v-tags
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag }}"   # e.g. lgtmaybe-v0.1.0
-          ver="${tag##*-}"          # v0.1.0  (everything after the last '-')
-          major="${ver%%.*}"        # v0
+          tag="${{ inputs.tag }}"   # e.g. lgtmaybe-v1.0.0
+          ver="${tag##*-}"          # v1.0.0  (everything after the last '-')
+          major="${ver%%.*}"        # v1
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -f "$ver" "$tag"
           git push -f origin "refs/tags/$ver"
           git tag -f "$major" "$tag"
           git push -f origin "refs/tags/$major"
-          # Also keep the component-prefixed floating major (lgtmaybe-v0) in sync.
-          # Some consumers pin `uses: MattJColes/lgtmaybe@lgtmaybe-v0`; without this
+          # Also keep the component-prefixed floating major (lgtmaybe-v1) in sync.
+          # Some consumers pin `uses: MattJColes/lgtmaybe@lgtmaybe-v1`; without this
           # it stays frozen at an old commit whose action.yml points at a stale image.
           git tag -f "lgtmaybe-$major" "$tag"
           git push -f origin "refs/tags/lgtmaybe-$major"

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openai
           model: gpt-5.5
@@ -252,7 +252,7 @@ only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instea
 - **CLI (PyPI)** — `pip install lgtmaybe`
 - **CLI (Homebrew)** — `brew tap MattJColes/lgtmaybe && brew trust MattJColes/lgtmaybe && brew install lgtmaybe`
   ([details](docs/how-to/install-the-cli.md) — the `brew trust` step is required for third-party taps)
-- **GitHub Action** — `uses: MattJColes/lgtmaybe@v0`
+- **GitHub Action** — `uses: MattJColes/lgtmaybe@v1`
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ inputs:
   image:
     description: "Override the container image (advanced; defaults to the released GHCR image)."
     required: false
-    default: "ghcr.io/mattjcoles/lgtmaybe:v0"
+    default: "ghcr.io/mattjcoles/lgtmaybe:v1"
   github_token:
     description: "Token used to fetch the diff and post the review. Defaults to the workflow token."
     required: false

--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -74,7 +74,7 @@ input remains off by default for backwards compatibility, and it never fires
 on a `synchronize` push. To enable it in an existing workflow:
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -104,7 +104,7 @@ review PRs across a monorepo or several repos in an org, set `app_owner` (and
 optionally `app_repositories`):
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -133,7 +133,7 @@ steps:
         with:
           app-id: ${{ vars.LGTMAYBE_APP_ID }}
           private-key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -11,7 +11,7 @@ It reads the **conventional commits** merged to `main` and keeps a "Release PR"
 open that bumps the version and regenerates `CHANGELOG.md`. **Merging that PR** is
 the release: it cuts the tag and the GitHub release, then the same run publishes —
 **PyPI** via trusted publishing (OIDC) and the **GHCR image** + floating major
-tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml`
+tag (`v{major}`, currently `v1`) via the reusable `.github/workflows/release.yml`
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew

--- a/docs/how-to/review-with-anthropic.md
+++ b/docs/how-to/review-with-anthropic.md
@@ -28,7 +28,7 @@ Copy [`examples/workflows/review-anthropic.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6

--- a/docs/how-to/review-with-azure.md
+++ b/docs/how-to/review-with-azure.md
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: azure
           model: my-gpt-4o-deployment            # your deployment name
@@ -123,7 +123,7 @@ If you would rather use a resource key, set `AZURE_API_KEY` and `AZURE_API_BASE`
 extra is not required in this mode.
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: azure
           model: my-gpt-4o-deployment

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: bedrock
           model: us.anthropic.claude-sonnet-4-6

--- a/docs/how-to/review-with-openai.md
+++ b/docs/how-to/review-with-openai.md
@@ -27,7 +27,7 @@ Copy [`examples/workflows/review-openai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openai
     model: gpt-5.5

--- a/docs/how-to/review-with-openrouter.md
+++ b/docs/how-to/review-with-openrouter.md
@@ -28,7 +28,7 @@ Copy [`examples/workflows/review-openrouter.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6

--- a/docs/how-to/review-with-vertex-wif.md
+++ b/docs/how-to/review-with-vertex-wif.md
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: vertex
           model: gemini-3-pro

--- a/docs/how-to/review-with-zai.md
+++ b/docs/how-to/review-with-zai.md
@@ -31,7 +31,7 @@ Copy [`examples/workflows/review-zai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: zai
     model: glm-4.6

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openai
           model: gpt-5.5
@@ -121,21 +121,21 @@ Swap the `provider`, `model`, and `api_key` inputs:
 
 ```yaml
 # anthropic
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6
     api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # openrouter
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
     api_key: ${{ secrets.OPENROUTER_API_KEY }}
 
 # zai (GLM / Zhipu AI)
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: zai
     model: glm-4.6
@@ -168,7 +168,7 @@ purely the *posting identity* — the keyless cloud model is unchanged and
 everything still runs in your own CI.
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6
@@ -224,7 +224,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `app_private_key` | — | Private key (PEM) of the App named by `app_id`; wire a secret to it. Mints a short-lived, auto-revoked installation token |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
-| `image` | `ghcr.io/mattjcoles/lgtmaybe:v0` | Override the container image (advanced) |
+| `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
@@ -237,9 +237,9 @@ filters, and cost caps. See
 
 ## Pin to a specific version
 
-`@v0` is a floating tag that tracks the latest `v0.x.x` release. To pin exactly,
+`@v1` is a floating tag that tracks the latest `v1.x.x` release. To pin exactly,
 use a full version tag:
 
 ```yaml
-uses: MattJColes/lgtmaybe@v0.1.0
+uses: MattJColes/lgtmaybe@v1.0.0
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -406,7 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openai
           model: gpt-5.5
@@ -420,21 +420,21 @@ Swap the `provider`, `model`, and `api_key` inputs:
 
 ```yaml
 # anthropic
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6
     api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # openrouter
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
     api_key: ${{ secrets.OPENROUTER_API_KEY }}
 
 # zai (GLM / Zhipu AI)
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: zai
     model: glm-4.6
@@ -467,7 +467,7 @@ purely the *posting identity* — the keyless cloud model is unchanged and
 everything still runs in your own CI.
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6
@@ -523,7 +523,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `app_private_key` | — | Private key (PEM) of the App named by `app_id`; wire a secret to it. Mints a short-lived, auto-revoked installation token |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
-| `image` | `ghcr.io/mattjcoles/lgtmaybe:v0` | Override the container image (advanced) |
+| `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
@@ -536,11 +536,11 @@ filters, and cost caps. See
 
 ## Pin to a specific version
 
-`@v0` is a floating tag that tracks the latest `v0.x.x` release. To pin exactly,
+`@v1` is a floating tag that tracks the latest `v1.x.x` release. To pin exactly,
 use a full version tag:
 
 ```yaml
-uses: MattJColes/lgtmaybe@v0.1.0
+uses: MattJColes/lgtmaybe@v1.0.0
 ```
 
 ---
@@ -629,7 +629,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -649,7 +649,7 @@ review PRs across a monorepo or several repos in an org, set `app_owner` (and
 optionally `app_repositories`):
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -678,7 +678,7 @@ steps:
         with:
           app-id: ${{ vars.LGTMAYBE_APP_ID }}
           private-key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -732,7 +732,7 @@ Copy [`examples/workflows/review-openai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openai
     model: gpt-5.5
@@ -807,7 +807,7 @@ Copy [`examples/workflows/review-anthropic.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: anthropic
     model: claude-sonnet-4-6
@@ -888,7 +888,7 @@ Copy [`examples/workflows/review-openrouter.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
@@ -969,7 +969,7 @@ Copy [`examples/workflows/review-zai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v0
+- uses: MattJColes/lgtmaybe@v1
   with:
     provider: zai
     model: glm-4.6
@@ -1123,7 +1123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: bedrock
           model: us.anthropic.claude-sonnet-4-6
@@ -1268,7 +1268,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: vertex
           model: gemini-3-pro
@@ -1412,7 +1412,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: azure
           model: my-gpt-4o-deployment            # your deployment name
@@ -1454,7 +1454,7 @@ If you would rather use a resource key, set `AZURE_API_KEY` and `AZURE_API_BASE`
 extra is not required in this mode.
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: azure
           model: my-gpt-4o-deployment
@@ -2742,7 +2742,7 @@ input remains off by default for backwards compatibility, and it never fires
 on a `synchronize` push. To enable it in an existing workflow:
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
@@ -2898,7 +2898,7 @@ It reads the **conventional commits** merged to `main` and keeps a "Release PR"
 open that bumps the version and regenerates `CHANGELOG.md`. **Merging that PR** is
 the release: it cuts the tag and the GitHub release, then the same run publishes —
 **PyPI** via trusted publishing (OIDC) and the **GHCR image** + floating major
-tag (`v{major}`, currently `v0`) via the reusable `.github/workflows/release.yml`
+tag (`v{major}`, currently `v1`) via the reusable `.github/workflows/release.yml`
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew

--- a/examples/workflows/review-anthropic.yml
+++ b/examples/workflows/review-anthropic.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: azure
           model: my-gpt-4o-deployment      # your Azure deployment name

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: bedrock
           auto_diagram: true

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openai-compatible
           model: deepseek-chat

--- a/examples/workflows/review-openai.yml
+++ b/examples/workflows/review-openai.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openai
           model: gpt-5.5

--- a/examples/workflows/review-openrouter.yml
+++ b/examples/workflows/review-openrouter.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: openrouter
           model: anthropic/claude-sonnet-4-6

--- a/examples/workflows/review-vertex.yml
+++ b/examples/workflows/review-vertex.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: vertex
           model: gemini-3-pro

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v0
+      - uses: MattJColes/lgtmaybe@v1
         with:
           provider: zai
           model: glm-4.6

--- a/openspec/changes/align-action-release-major/.openspec.yaml
+++ b/openspec/changes/align-action-release-major/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/align-action-release-major/README.md
+++ b/openspec/changes/align-action-release-major/README.md
@@ -1,0 +1,3 @@
+# align-action-release-major
+
+Keep the published Action, container image, and release automation on the package major

--- a/openspec/changes/align-action-release-major/design.md
+++ b/openspec/changes/align-action-release-major/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The composite Action launches the image named by its `image` input. That input
+is a literal major tag, while the package major is stored separately in
+`pyproject.toml`. The v1 release advanced the package and published a v1 image,
+but left the Action default and copy-paste workflows on v0. A one-time
+release-please `release-as` override also remained after 1.0.0 was cut.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `uses: ...@v1` launch the v1 image by default.
+- Make supplied workflows and documentation adopt the supported v1 line.
+- Let release-please calculate the next patch normally.
+- Fail CI if the package major and default Action image diverge again.
+
+**Non-Goals:**
+
+- Change review concurrency, timeouts, or provider behavior.
+- Remove the supported v0 image or floating tags.
+- Automate edits to every major-version reference during a future major bump.
+
+## Decisions
+
+1. Keep a literal floating-major image in `action.yml`. GitHub Action metadata
+   cannot derive its input default from `pyproject.toml`, and a floating major
+   is the existing compatibility contract.
+2. Derive the expected major in the test. This leaves the runtime metadata
+   simple while making future drift an immediate deterministic failure.
+3. Move starter workflows and current documentation to `@v1`; users explicitly
+   pinned to v0 remain unaffected.
+4. Delete `release-as` after its one-time use so conventional commits drive
+   subsequent releases.
+
+## Risks / Trade-offs
+
+- [A future major bump still needs a small metadata edit] -> The alignment test
+  fails in the same change that bumps `pyproject.toml`.
+- [Existing v0 users do not receive this fix automatically] -> Preserve v0 as a
+  compatibility line and move all maintained onboarding surfaces to v1.

--- a/openspec/changes/align-action-release-major/proposal.md
+++ b/openspec/changes/align-action-release-major/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+lgtmaybe 1.0.0 is published, but the v1 Action metadata still defaults to the
+v0 container and the supplied workflows still pin `@v0`. The committed
+release-please override also keeps proposing 1.0.0 instead of the next patch.
+Users therefore miss fixes already merged to the v1 code line.
+
+## What Changes
+
+- Point the Action's default image and supplied workflow examples at major v1.
+- Update the public setup documentation to recommend the v1 floating tag.
+- Remove the consumed one-time `release-as: 1.0.0` override.
+- Add a deterministic test that derives the expected image tag from the package
+  version so the Action cannot silently drift across another major release.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-and-local`: Keep GitHub Action distribution metadata aligned with the
+  package's released major version.
+
+## Impact
+
+The change affects only distribution metadata, supplied examples,
+documentation, and its regression test. Runtime review behavior and provider
+configuration are unchanged.

--- a/openspec/changes/align-action-release-major/specs/cli-and-local/spec.md
+++ b/openspec/changes/align-action-release-major/specs/cli-and-local/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Action distribution major alignment
+<!-- anchor: distribution.action-major -->
+
+The GitHub Action SHALL default to the GHCR image whose floating major matches
+the package major, and maintained workflow examples SHALL use that same Action
+major.
+
+#### Scenario: package major is released
+- **WHEN** the package version belongs to major v1
+- **THEN** the Action defaults to the v1 image and maintained workflows use
+  `MattJColes/lgtmaybe@v1`
+
+#### Scenario: a future major changes
+- **WHEN** the package major changes without updating the Action image default
+- **THEN** the deterministic distribution alignment test fails

--- a/openspec/changes/align-action-release-major/tasks.md
+++ b/openspec/changes/align-action-release-major/tasks.md
@@ -1,0 +1,17 @@
+## 1. Acceptance Test
+
+- [x] 1.1 Add a test deriving the expected GHCR major from `pyproject.toml` and
+  confirm it fails against the v0 Action default.
+
+## 2. Distribution Alignment
+
+- [x] 2.1 Change the Action's default container image to v1.
+- [x] 2.2 Update supplied workflows and public documentation from v0 to v1.
+- [x] 2.3 Remove the consumed `release-as: 1.0.0` override.
+
+## 3. Verification and Release
+
+- [x] 3.1 Regenerate derived documentation and validate the OpenSpec change.
+- [x] 3.2 Run focused tests, the full test/lint/type/spec gates, and the local
+  Action image smoke path.
+- [x] 3.3 Review the final diff and publish the fix PR.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,7 @@
       "package-name": "lgtmaybe",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
-      "bump-minor-pre-major": true,
-      "release-as": "1.0.0"
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -11,11 +11,15 @@ a refactor of the YAML can't silently drop the fallback or the gate.
 
 from __future__ import annotations
 
+import json
+import tomllib
 from pathlib import Path
 
 import yaml
 
 _ACTION_YML = Path(__file__).parent.parent / "action.yml"
+_PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+_RELEASE_PLEASE_CONFIG = Path(__file__).parent.parent / "release-please-config.json"
 _README = Path(__file__).parent.parent / "README.md"
 
 # The container reads GITHUB_TOKEN; prefer the minted App token, else the default
@@ -90,3 +94,16 @@ def test_mint_step_is_pinned_and_gated_on_app_id() -> None:
 
 def test_container_token_prefers_the_minted_app_token() -> None:
     assert _run_lgtmaybe_step()["env"]["GITHUB_TOKEN"] == _TOKEN_EXPR
+
+
+def test_default_container_image_tracks_package_major() -> None:
+    version = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+    major = version.split(".", maxsplit=1)[0]
+
+    assert _action()["inputs"]["image"]["default"] == f"ghcr.io/mattjcoles/lgtmaybe:v{major}"
+
+
+def test_release_please_is_not_pinned_to_a_consumed_version() -> None:
+    config = json.loads(_RELEASE_PLEASE_CONFIG.read_text(encoding="utf-8"))
+
+    assert "release-as" not in config["packages"]["."]

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -1,11 +1,16 @@
 """Structural guards for the supplied lgtmaybe workflows."""
 
+import tomllib
 from pathlib import Path
 
 import yaml
 
 _REPO_ROOT = Path(__file__).parent.parent
 _DOGFOOD_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "lgtmaybe.yml"
+_PROJECT_VERSION = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+    "project"
+]["version"]
+_ACTION_REF = f"MattJColes/lgtmaybe@v{_PROJECT_VERSION.split('.', maxsplit=1)[0]}"
 _STARTER_WORKFLOWS = _REPO_ROOT / "examples" / "workflows"
 
 
@@ -17,7 +22,7 @@ def test_supplied_workflows_enable_auto_diagram() -> None:
             step
             for job in yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"].values()
             for step in job["steps"]
-            if str(step.get("uses", "")).endswith("lgtmaybe@v0") or step.get("uses") == "./"
+            if step.get("uses") in {_ACTION_REF, "./"}
         ]
         assert action_steps, f"{workflow} has no lgtmaybe Action step"
         assert all(step.get("with", {}).get("auto_diagram") is True for step in action_steps), (


### PR DESCRIPTION
## What changed

- default the composite Action to `ghcr.io/mattjcoles/lgtmaybe:v1`
- move maintained workflow examples and setup documentation from `@v0` to `@v1`
- remove the consumed `release-as: 1.0.0` override so release-please can propose the next patch
- add deterministic package-major alignment guards for the Action image and supplied workflows

## Why

The package and v1 image were released, but the v1 Action metadata still launched the v0 container and maintained starter workflows still selected the v0 Action. The stale release override also kept the release PR at 1.0.0. Users therefore could not receive the default-runtime fixes already merged on the v1 line.

## Impact

Current Action adopters and new workflow copies use the supported v1 release line. Existing consumers explicitly pinned to v0 remain unchanged.

## Validation

- `uv run pytest -q` — 1,198 passed, 3 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest tests/specs -q`
- `uv run openspec validate align-action-release-major --strict`
- `uv run python scripts/check_spec_drift.py --base origin/main`
- `uv run mkdocs build --strict`
- built the Docker image and ran its packaged CLI help successfully