### PR TITLE
feat: parallelise correctness review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,8 +140,9 @@ reviews need no static keys in GitHub secrets. The `LiteLLMProvider` adds retrie
 budget-scaled context → batch to token budget → fan out one call per review
 lens → parse → merge & dedupe → self-reflect → filter by severity →
 findings + summary`. The lens set follows the `preset` — `fast` (default)
-covers seven code-focused categories in three calls, `full` runs all nine — and
-every (batch, lens) call shares one pool (`max_concurrency`: 8 cloud, 1
+covers seven code-focused categories in four calls when the pool can overlap
+work, or three combined calls with one worker; `full` runs all nine — and every
+(batch, lens) call shares one pool (`max_concurrency`: 8 cloud, 1
 ollama/openai-compatible) with a cacheable preamble-plus-diff prompt prefix on
 anthropic/bedrock. A soft whole-review deadline (`max_review_seconds`) degrades
 an overrunning review to partial-with-a-notice, and every stage and model call
@@ -176,11 +177,12 @@ engine/provider.
 ## Features
 
 **Review intelligence** — nine review lenses, fanned out per the `preset`:
-`fast` (default) covers seven in three concurrent calls — dedicated security
-and correctness calls (the stated intent folds into correctness), plus merged
-code-health with per-finding category attribution — while `full` restores tests
-and documentation and runs each lens as its own focused call with a lens-matched
-worked example. Findings from every call are merged & de-duped:
+`fast` (default) covers seven in four concurrent calls when parallelism is
+available — security, correctness flow/intent, correctness state/lifecycle, and
+merged code health — while a single-worker provider keeps correctness combined
+for three calls. `full` restores tests and documentation and runs each lens as
+its own focused call with a lens-matched worked example. Findings from every
+call are merged & de-duped:
 - **Security** — OWASP-aligned checklist: injection, XSS, CSRF/open redirect,
   hardcoded secrets, broken authn/authz (incl. JWT pitfalls), path traversal,
   unrestricted upload, SSRF, insecure deserialization/XXE, mass assignment, weak

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ credentials in connection strings) before anything leaves your environment. See
 
 **Fast by default.** Reviews run the **`fast` preset** by default: security,
 correctness (including stated intent), and code health
-(performance/complexity/ponytail/deprecation) run in **three model calls**.
+(performance/complexity/ponytail/deprecation) run in **four parallel model
+calls** when more than one worker is available: correctness is split into
+focused flow and state/lifecycle checks so one oversized task cannot set the
+critical path. Single-worker configurations keep the combined **three-call**
+shape.
 Tests and documentation are reserved for `--preset full` (or `preset: full` in
 `.lgtmaybe.yml`), which restores the one-call-per-lens deep audit for release
 branches. This keeps the everyday path focused on code defects while avoiding a
@@ -76,7 +80,7 @@ the time and tokens went.
 **How the scope is bounded.** Every run is capped so a large PR can't blow up
 latency:
 
-- `preset` (default `fast`) — three focused/grouped calls; `full` restores tests and documentation and runs one call per lens.
+- `preset` (default `fast`) — four focused/grouped calls when concurrency is available, three with one worker; `full` restores tests and documentation and runs one call per lens.
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
 - `max_concurrency` (default 8 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
   preset:
-    description: "Review preset. fast (the default) covers security, correctness/intent, performance, complexity, ponytail, and deprecation in three model calls. full restores tests/documentation and runs one call per lens for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
+    description: "Review preset. fast (the default) covers security, correctness/intent, performance, complexity, ponytail, and deprecation in four model calls when parallelism is available, or three with one worker. full restores tests/documentation and runs one call per lens for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
     required: false
     default: ""
   fallback_model:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -50,16 +50,19 @@ call per review lens — before the findings funnel back into a single stream:
 flowchart TD
     fetch["fetch<br/>diff via API — never a checkout"] --> compress["compress<br/>skip generated files · pad context · batch to budget"]
     compress --> security["security lens"]
-    compress --> correctness["correctness + intent lens"]
+    compress --> correctnessflow["correctness flow + intent lens"]
+    compress --> correctnessstate["correctness state/lifecycle lens"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
-    correctness --> anchor
+    correctnessflow --> anchor
+    correctnessstate --> anchor
     codehealth --> anchor
     anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The three lens calls shown are the `fast` preset's grouping; the `full` preset
-fans out one call per category, and custom lenses join the same fan-out.)
+(The four lens calls shown are the parallel-capable `fast` grouping. A
+single-worker configuration combines the two correctness calls; the `full`
+preset fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
    metadata from the GitHub REST API. No PR code is checked out or executed.
@@ -78,11 +81,12 @@ fans out one call per category, and custom lenses join the same fan-out.)
 
 3. **prompt + parse** — this stage **fans out one model call per review
    lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   seven code-focused categories in **three calls**: dedicated security and
-   correctness calls (the stated intent folds into correctness when present),
-   plus a merged code-health call (performance/complexity/ponytail/
-   deprecation), each demanding a per-finding `category`. `full` restores tests
-   and documentation and runs one call per category. Every
+   seven code-focused categories in **four calls** when parallelism is
+   available: security, correctness flow (with stated intent when present),
+   correctness state/lifecycle, and merged code health (performance/
+   complexity/ponytail/deprecation). With one worker the two correctness tasks
+   stay combined, keeping the three-call serial path. `full` restores tests and
+   documentation and runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -10,9 +10,10 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends three grouped model calls under the default `fast` preset, one
-per category under `full`, fanned out concurrently — plus a self-reflection
-call. Each call contains some subset of:
+lgtmaybe sends four grouped model calls under the default `fast` preset when
+the provider can overlap work, or three combined calls with one worker. `full`
+sends one per category. The review calls fan out through one bounded pool and
+are followed by a self-reflection call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after
   generated files, lockfiles, minified assets, and vendored code have been
@@ -30,9 +31,10 @@ call. Each call contains some subset of:
   each commit message (on the CLI: the commit names from your local `git log`).
   This feeds the **intent lens** ("does the PR do what it says?"). It is
   redacted exactly like the diff, wrapped as untrusted data, and sent **only on
-  the single lens call that carries the intent** (the correctness call under
-  the default `fast` preset, or the dedicated intent lens under `full`) — drop
-  `intent` from `categories` in `.lgtmaybe.yml` and it is never sent at all.
+  the single lens call that carries the intent** (the correctness-flow or
+  combined correctness call under the default `fast` preset, or the dedicated
+  intent lens under `full`) — drop `intent` from `categories` in
+  `.lgtmaybe.yml` and it is never sent at all.
 - A **system prompt** — the fixed instructions that tell the model to return
   structured JSON findings.
 

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -277,7 +277,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` covers seven code-focused lenses in three model calls; `full` restores tests/documentation and runs one call per lens. |
+| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -309,12 +309,13 @@ Each finding has:
 
 The nine review categories are security, correctness, deprecation, tests,
 documentation, performance, complexity, intent, and ponytail. The default
-`fast` preset runs seven of them in three concurrent calls: dedicated security
-and correctness calls (the stated intent folds into correctness), plus a merged
-code-health call (performance/complexity/ponytail/deprecation). `preset: full`
-restores tests and documentation and runs each category as its own focused call
-with a worked example of its own finding type. Their findings are merged and
-de-duplicated. A
+`fast` preset covers seven of them in four concurrent calls when parallelism is
+available: security, correctness flow/intent, correctness state/lifecycle, and
+merged code health (performance/complexity/ponytail/deprecation). With one
+worker, correctness stays combined and the preset uses three calls.
+`preset: full` restores tests and documentation and runs each category as its
+own focused call with a worked example of its own finding type. Their findings
+are merged and de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence
 findings, so the model's first guesses are filtered before anything is posted.
 

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -147,8 +147,10 @@ Default: `100000`.
 
 How many model calls the review spends. `fast` (the default) covers security,
 correctness and stated intent, performance, complexity, ponytail, and
-deprecation in **three calls**. `full` restores tests and documentation and
-runs one focused call per lens for release branches and deep audits.
+deprecation in **four calls when parallelism is available**: correctness splits
+into flow/intent and state/lifecycle tasks. With one worker it stays combined
+for three calls. `full` restores tests and documentation and runs one focused
+call per lens for release branches and deep audits.
 
 ```yaml
 preset: full

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -214,8 +214,10 @@ To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
 `OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match — by default lgtmaybe issues ollama calls one at a time. Add `--profile`
-to any run to see the per-call breakdown.
+match. With more than one worker, lgtmaybe splits correctness into focused flow
+and state/lifecycle calls, making four parallel fast-preset tasks instead of
+three combined serial tasks. By default lgtmaybe issues ollama calls one at a
+time. Add `--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -199,7 +199,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | `fast` covers seven code-focused lenses in three calls; `full` restores tests/documentation and runs one call per lens |
+| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -498,7 +498,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | `fast` covers seven code-focused lenses in three calls; `full` restores tests/documentation and runs one call per lens |
+| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
@@ -1705,8 +1705,10 @@ To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
 `OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match — by default lgtmaybe issues ollama calls one at a time. Add `--profile`
-to any run to see the per-call breakdown.
+match. With more than one worker, lgtmaybe splits correctness into focused flow
+and state/lifecycle calls, making four parallel fast-preset tasks instead of
+three combined serial tasks. By default lgtmaybe issues ollama calls one at a
+time. Add `--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 
@@ -2100,8 +2102,10 @@ Default: `100000`.
 
 How many model calls the review spends. `fast` (the default) covers security,
 correctness and stated intent, performance, complexity, ponytail, and
-deprecation in **three calls**. `full` restores tests and documentation and
-runs one focused call per lens for release branches and deep audits.
+deprecation in **four calls when parallelism is available**: correctness splits
+into flow/intent and state/lifecycle tasks. With one worker it stays combined
+for three calls. `full` restores tests and documentation and runs one focused
+call per lens for release branches and deep audits.
 
 ```yaml
 preset: full
@@ -3402,7 +3406,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"
@@ -4283,7 +4287,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` covers seven code-focused lenses in three model calls; `full` restores tests/documentation and runs one call per lens. |
+| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -4315,12 +4319,13 @@ Each finding has:
 
 The nine review categories are security, correctness, deprecation, tests,
 documentation, performance, complexity, intent, and ponytail. The default
-`fast` preset runs seven of them in three concurrent calls: dedicated security
-and correctness calls (the stated intent folds into correctness), plus a merged
-code-health call (performance/complexity/ponytail/deprecation). `preset: full`
-restores tests and documentation and runs each category as its own focused call
-with a worked example of its own finding type. Their findings are merged and
-de-duplicated. A
+`fast` preset covers seven of them in four concurrent calls when parallelism is
+available: security, correctness flow/intent, correctness state/lifecycle, and
+merged code health (performance/complexity/ponytail/deprecation). With one
+worker, correctness stays combined and the preset uses three calls.
+`preset: full` restores tests and documentation and runs each category as its
+own focused call with a worked example of its own finding type. Their findings
+are merged and de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence
 findings, so the model's first guesses are filtered before anything is posted.
 
@@ -4477,16 +4482,19 @@ call per review lens — before the findings funnel back into a single stream:
 flowchart TD
     fetch["fetch<br/>diff via API — never a checkout"] --> compress["compress<br/>skip generated files · pad context · batch to budget"]
     compress --> security["security lens"]
-    compress --> correctness["correctness + intent lens"]
+    compress --> correctnessflow["correctness flow + intent lens"]
+    compress --> correctnessstate["correctness state/lifecycle lens"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
-    correctness --> anchor
+    correctnessflow --> anchor
+    correctnessstate --> anchor
     codehealth --> anchor
     anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The three lens calls shown are the `fast` preset's grouping; the `full` preset
-fans out one call per category, and custom lenses join the same fan-out.)
+(The four lens calls shown are the parallel-capable `fast` grouping. A
+single-worker configuration combines the two correctness calls; the `full`
+preset fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
    metadata from the GitHub REST API. No PR code is checked out or executed.
@@ -4505,11 +4513,12 @@ fans out one call per category, and custom lenses join the same fan-out.)
 
 3. **prompt + parse** — this stage **fans out one model call per review
    lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   seven code-focused categories in **three calls**: dedicated security and
-   correctness calls (the stated intent folds into correctness when present),
-   plus a merged code-health call (performance/complexity/ponytail/
-   deprecation), each demanding a per-finding `category`. `full` restores tests
-   and documentation and runs one call per category. Every
+   seven code-focused categories in **four calls** when parallelism is
+   available: security, correctness flow (with stated intent when present),
+   correctness state/lifecycle, and merged code health (performance/
+   complexity/ponytail/deprecation). With one worker the two correctness tasks
+   stay combined, keeping the three-call serial path. `full` restores tests and
+   documentation and runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
@@ -4767,9 +4776,10 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends three grouped model calls under the default `fast` preset, one
-per category under `full`, fanned out concurrently — plus a self-reflection
-call. Each call contains some subset of:
+lgtmaybe sends four grouped model calls under the default `fast` preset when
+the provider can overlap work, or three combined calls with one worker. `full`
+sends one per category. The review calls fan out through one bounded pool and
+are followed by a self-reflection call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after
   generated files, lockfiles, minified assets, and vendored code have been
@@ -4787,9 +4797,10 @@ call. Each call contains some subset of:
   each commit message (on the CLI: the commit names from your local `git log`).
   This feeds the **intent lens** ("does the PR do what it says?"). It is
   redacted exactly like the diff, wrapped as untrusted data, and sent **only on
-  the single lens call that carries the intent** (the correctness call under
-  the default `fast` preset, or the dedicated intent lens under `full`) — drop
-  `intent` from `categories` in `.lgtmaybe.yml` and it is never sent at all.
+  the single lens call that carries the intent** (the correctness-flow or
+  combined correctness call under the default `fast` preset, or the dedicated
+  intent lens under `full`) — drop `intent` from `categories` in
+  `.lgtmaybe.yml` and it is never sent at all.
 - A **system prompt** — the fixed instructions that tell the model to return
   structured JSON findings.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -424,7 +424,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"

--- a/openspec/changes/parallelise-correctness-review/.openspec.yaml
+++ b/openspec/changes/parallelise-correctness-review/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/parallelise-correctness-review/README.md
+++ b/openspec/changes/parallelise-correctness-review/README.md
@@ -1,0 +1,4 @@
+# parallelise-correctness-review
+
+Split the default correctness review into narrower concurrent work only when the
+configured provider has more than one review worker.

--- a/openspec/changes/parallelise-correctness-review/design.md
+++ b/openspec/changes/parallelise-correctness-review/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The engine already flattens every `(batch, lens)` task into one bounded thread
+pool. The default fast preset now contributes only three tasks per batch:
+security, correctness (with intent), and code health. Increasing the pool above
+three cannot improve a one-batch review.
+
+The production straggler is the correctness task itself. It owns ten distinct
+bug classes and can spend far more reasoning/output tokens than the other
+lenses. Decomposing that task creates useful parallel work; increasing the
+executor size does not.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Shorten the fast review's critical path on parallel-capable providers.
+- Keep all existing correctness and intent coverage.
+- Preserve one global concurrency bound and deterministic merge order.
+- Avoid increasing serial-provider latency or request count.
+
+**Non-Goals:**
+
+- Raise the default cloud concurrency above eight.
+- Parallelise reflection, which depends on the merged review findings.
+- Change the full preset or explicitly selected categories.
+- Add another concurrency setting or dependency.
+
+## Decisions
+
+1. Split correctness into `correctness-flow` (nulls, boundaries, ranges, error
+   paths, conditionals, numeric/validation errors) and `correctness-state`
+   (resource ordering, races/async, time, and aliasing/mutation).
+2. Fold stated-intent checking into `correctness-flow` only, so PR-authored
+   prose still reaches one review call rather than widening its injection and
+   token surface.
+3. Attribute findings from both tasks to the existing `correctness` category.
+   Their distinct task labels remain visible in profiling.
+4. Select the split only when the configured effective concurrency can exceed
+   one: cloud auto mode or an explicit `max_concurrency > 1`. An explicit cap
+   of one and single-stream provider defaults keep the combined prompt.
+5. Reuse the current `_fan_out` executor, ordering, deadline, cache warm-up, and
+   dedupe behavior. No second pool or unbounded task submission is introduced.
+
+## Risks / Trade-offs
+
+- The parallel path repeats the diff in one additional request. Prompt caching
+  offsets this where supported; elsewhere the speed-up costs more input tokens.
+- Two focused calls may overlap in what they flag. Existing deterministic
+  dedupe removes duplicate comments.
+- A provider may still make either task a straggler. The dogfood timing profile
+  will show both labels separately so the split can be tightened or reverted
+  using evidence.
+- Provider-aware call counts are less uniform. Tests will pin both the
+  parallel-capable and single-worker paths.

--- a/openspec/changes/parallelise-correctness-review/proposal.md
+++ b/openspec/changes/parallelise-correctness-review/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Raising the cloud worker ceiling does not shorten the current default review:
+the three fast-preset calls already start together. In the observed dogfood
+profile, the correctness call took 513 seconds and emitted 32,768 output tokens
+while the other calls completed within 66 seconds. The wall clock is therefore
+set by one oversized task, not by queued work.
+
+## What Changes
+
+- On configurations with more than one effective review worker, split the
+  default correctness checklist into two focused calls: control/data-flow
+  correctness and state/lifecycle correctness.
+- Run both calls through the existing bounded fan-out pool and merge their
+  findings back into the `correctness` category.
+- Keep the current combined correctness call when effective concurrency is one,
+  so Ollama and single-slot OpenAI-compatible servers do not pay for another
+  serial request.
+- Keep the cloud concurrency default at eight and retain the explicit
+  `max_concurrency` override.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `review-pipeline`: Make the fast fan-out shape depend on whether the bounded
+  executor can run more than one call.
+- `prompt-and-lenses`: Split the correctness checklist into two focused prompts
+  for parallel-capable reviews while preserving the combined serial prompt.
+- `core-contracts`: Define the provider-aware fast-preset call shape.
+
+## Impact
+
+Parallel-capable fast reviews make four calls per batch instead of three, with
+the two correctness calls overlapping. Single-worker reviews remain at three
+calls. This trades one additional cloud request and repeated input tokens for a
+shorter critical path and a narrower output task; full and explicitly selected
+category reviews are unchanged.

--- a/openspec/changes/parallelise-correctness-review/specs/core-contracts/spec.md
+++ b/openspec/changes/parallelise-correctness-review/specs/core-contracts/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Nine built-in lenses, provider-aware preset fan-out
+
+`ReviewCategory` SHALL enumerate the nine built-in lenses. `ReviewPreset` SHALL
+shape their fan-out: `fast` uses four focused calls when more than one worker is
+available and three combined calls for a single-worker configuration; `full`
+runs one call per selected built-in category.
+<!-- anchor: core.lenses -->
+
+#### Scenario: parallel-capable default
+- **WHEN** a fast review has effective concurrency greater than one
+- **THEN** correctness is split into two concurrent tasks without creating a
+  new public review category
+
+#### Scenario: serial default
+- **WHEN** a fast review has effective concurrency of one
+- **THEN** correctness remains one combined task

--- a/openspec/changes/parallelise-correctness-review/specs/prompt-and-lenses/spec.md
+++ b/openspec/changes/parallelise-correctness-review/specs/prompt-and-lenses/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Fast preset splits correctness only when it can overlap
+
+The default `fast` preset SHALL run security and code-health tasks plus
+provider-aware correctness tasks. A parallel-capable configuration SHALL split
+correctness into focused flow and state/lifecycle calls, both attributed to the
+`correctness` category; a single-worker configuration SHALL keep one combined
+correctness call. Stated intent SHALL remain attached to one correctness task.
+Tests and documentation SHALL remain reserved for `full` or explicit category
+reviews.
+<!-- anchor: prompt.groups -->
+
+#### Scenario: cloud default
+- **WHEN** `fast` uses a cloud provider with auto-concurrency
+- **THEN** its four calls are security, correctness-flow, correctness-state,
+  and code health
+
+#### Scenario: local single-slot default
+- **WHEN** `fast` uses Ollama with auto-concurrency
+- **THEN** its three calls are security, combined correctness, and code health

--- a/openspec/changes/parallelise-correctness-review/specs/review-pipeline/spec.md
+++ b/openspec/changes/parallelise-correctness-review/specs/review-pipeline/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Per-lens fan-out through one bounded executor
+
+Every `(batch, lens)` call SHALL run through one global bounded executor sized
+by `max_concurrency` (auto: eight cloud, one for Ollama/OpenAI-compatible).
+When the effective executor can run more than one call, the default fast preset
+SHALL submit separate correctness-flow and correctness-state tasks; when it is
+single-worker, it SHALL submit the existing combined correctness task.
+<!-- anchor: engine.fan-out -->
+
+#### Scenario: parallel-capable default review
+- **WHEN** a fast review uses cloud auto-concurrency
+- **THEN** security, correctness-flow, correctness-state, and code-health calls
+  share the existing bounded executor and may overlap
+
+#### Scenario: single-worker default review
+- **WHEN** a fast review uses Ollama auto-concurrency or `max_concurrency: 1`
+- **THEN** security, combined correctness, and code-health run within the
+  single-worker pool without an additional serial request

--- a/openspec/changes/parallelise-correctness-review/tasks.md
+++ b/openspec/changes/parallelise-correctness-review/tasks.md
@@ -1,0 +1,24 @@
+## 1. Acceptance Tests
+
+- [x] 1.1 Add a failing test that a parallel-capable fast review builds separate
+  `correctness-flow` and `correctness-state` tasks and runs them concurrently.
+- [x] 1.2 Add a failing test that an auto-configured Ollama review and an
+  explicit `max_concurrency: 1` review keep one combined correctness task.
+- [x] 1.3 Pin both correctness tasks' findings to the public `correctness`
+  category and verify cross-task duplicates collapse.
+
+## 2. Focused Parallelism
+
+- [x] 2.1 Split the correctness checklist into focused flow and state prompt
+  sections while retaining the current combined form.
+- [x] 2.2 Select the split from effective provider concurrency and feed both
+  tasks through the existing global fan-out pool.
+- [x] 2.3 Update maintained configuration/reference documentation with the
+  provider-aware fast-preset call shape.
+
+## 3. Verification
+
+- [x] 3.1 Run focused preset, prompt, concurrency, and eval tests.
+- [x] 3.2 Run the full test, lint, type, OpenSpec, anchor, drift, and docs gates.
+- [ ] 3.3 Compare the dogfood profile's correctness critical path and total
+  tokens before deciding whether the split should ship.

--- a/openspec/specs/prompt-and-lenses/anchors.yml
+++ b/openspec/specs/prompt-and-lenses/anchors.yml
@@ -19,7 +19,7 @@ prompt.custom-lens:
     files: [src/lgtmaybe/engine/**/*.py]
   - rule:
       kind: function_definition
-      has: { field: name, regex: '^_build_lenses$' }
+      has: { field: name, regex: '^build_custom_lens_block$' }
     files: [src/lgtmaybe/engine/**/*.py]
 
 prompt.groups:
@@ -30,4 +30,8 @@ prompt.groups:
   - rule:
       kind: function_definition
       has: { field: name, regex: '^build_correctness_prompt$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_build_lenses$' }
     files: [src/lgtmaybe/engine/**/*.py]

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -63,8 +63,9 @@ def _apply_static_analysis_flag(cfg: ReviewConfig, flag: bool | None) -> ReviewC
     default=None,
     type=click.Choice(["fast", "full"]),
     help="Review preset: fast (default) covers security, correctness/intent, "
-    "performance, complexity, ponytail, and deprecation in three calls; full "
-    "restores tests/documentation and runs one call per lens for deep audits",
+    "performance, complexity, ponytail, and deprecation in four calls when "
+    "parallelism is available, or three with one worker; full restores "
+    "tests/documentation and runs one call per lens for deep audits",
 )
 @click.option(
     "--full",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -76,10 +76,10 @@ class ReviewCategory(StrEnum):
 class ReviewPreset(StrEnum):
     """How many model calls a review spends: the everyday path or the deep audit.
 
-    ``fast`` (the default) covers seven built-in lenses in three calls:
-    security and correctness keep dedicated calls (they earn it; the stated
-    intent, when present, merges into correctness), while performance,
-    complexity, ponytail, and deprecation fold into one code-health call.
+    ``fast`` (the default) covers seven built-in lenses in four calls when the
+    provider can overlap work: security, correctness flow/intent, correctness
+    state/lifecycle, and code health. With one worker, correctness stays
+    combined for three calls.
     ``full`` restores tests and documentation and runs each of the nine lenses
     as its own call for release branches and deep audits. An explicit
     ``categories`` list always wins over the preset.

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -42,7 +42,11 @@ from .profiling import profiler
 from .prompt import (
     FAST_GROUPS,
     build_correctness_block,
+    build_correctness_flow_block,
+    build_correctness_flow_prompt,
     build_correctness_prompt,
+    build_correctness_state_block,
+    build_correctness_state_prompt,
     build_custom_lens_block,
     build_group_block,
     build_group_prompt,
@@ -129,16 +133,27 @@ class _Lens:
     # and falls back to the lens id otherwise; None (a focused lens) means the
     # lens id is always stamped — the model's value is ignored, as before.
     allowed_categories: frozenset[str] | None = None
+    # A split task can keep a distinct profiler label while attributing its
+    # findings to an existing public category.
+    finding_category: str | None = None
+
+
+def _parallel_fast_enabled(cfg: ReviewConfig) -> bool:
+    """Whether the fast preset can overlap its two correctness tasks."""
+    if cfg.max_concurrency is not None:
+        return cfg.max_concurrency > 1
+    return cfg.provider not in _SINGLE_STREAM_PROVIDERS
 
 
 def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
     """All lenses to run: built-ins (grouped per the preset), then user lenses.
 
-    The fast preset runs seven built-ins in three calls — but only when
-    ``categories`` is the untouched default: a user who explicitly listed
-    lenses asked for exactly those, so the preset never regroups them. The
-    full preset runs every category; an explicit list runs exactly its selected
-    categories. Both skip intent when nothing states an intent.
+    The fast preset runs seven built-ins in four calls when the provider can
+    overlap work, or three combined calls with one worker. This grouping applies
+    only when ``categories`` is the untouched default: a user who explicitly
+    listed lenses asked for exactly those, so the preset never regroups them.
+    The full preset runs every category; an explicit list runs exactly its
+    selected categories. Both skip intent when nothing states an intent.
     """
     fast = cfg.preset is ReviewPreset.fast and list(cfg.categories) == list(ReviewCategory)
     if fast:
@@ -148,18 +163,40 @@ def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
                 system_prompt=build_system_prompt(ReviewCategory.security),
                 user_block=build_lens_block(ReviewCategory.security),
             ),
-            _Lens(
-                id=ReviewCategory.correctness.value,
-                system_prompt=build_correctness_prompt(has_intent),
-                user_block=build_correctness_block(has_intent),
-                carries_intent=has_intent,
-                allowed_categories=(
-                    frozenset({ReviewCategory.correctness.value, ReviewCategory.intent.value})
-                    if has_intent
-                    else None
-                ),
-            ),
         ]
+        correctness_categories = (
+            frozenset({ReviewCategory.correctness.value, ReviewCategory.intent.value})
+            if has_intent
+            else frozenset({ReviewCategory.correctness.value})
+        )
+        if _parallel_fast_enabled(cfg):
+            lenses += [
+                _Lens(
+                    id="correctness-flow",
+                    system_prompt=build_correctness_flow_prompt(has_intent),
+                    user_block=build_correctness_flow_block(has_intent),
+                    carries_intent=has_intent,
+                    allowed_categories=correctness_categories,
+                    finding_category=ReviewCategory.correctness.value,
+                ),
+                _Lens(
+                    id="correctness-state",
+                    system_prompt=build_correctness_state_prompt(),
+                    user_block=build_correctness_state_block(),
+                    allowed_categories=frozenset({ReviewCategory.correctness.value}),
+                    finding_category=ReviewCategory.correctness.value,
+                ),
+            ]
+        else:
+            lenses.append(
+                _Lens(
+                    id=ReviewCategory.correctness.value,
+                    system_prompt=build_correctness_prompt(has_intent),
+                    user_block=build_correctness_block(has_intent),
+                    carries_intent=has_intent,
+                    allowed_categories=correctness_categories if has_intent else None,
+                )
+            )
         lenses += [
             _Lens(
                 id=group.id,
@@ -699,11 +736,14 @@ class LLMReviewEngine(ReviewEngine):
         # value from its member set is kept and anything else falls back to
         # the lens id.
         allowed = lens.allowed_categories
+        fallback_category = lens.finding_category or lens.id
         findings = [
             f.model_copy(
                 update={
                     "category": (
-                        f.category if allowed is not None and f.category in allowed else lens.id
+                        f.category
+                        if allowed is not None and f.category in allowed
+                        else fallback_category
                     )
                 }
             )

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -126,6 +126,26 @@ _CORRECTNESS_EXAMPLE = _example_block(
     },
 )
 
+_CORRECTNESS_STATE_EXAMPLE = _example_block(
+    "--- a/cache.py\n"
+    "+++ b/cache.py\n"
+    "@@ -8,1 +8,3 @@\n"
+    " def get_or_create(key):\n"
+    "+    if key not in cache:\n"
+    "+        cache[key] = create_value(key)\n",
+    {
+        "path": "cache.py",
+        "line": 9,
+        "side": "RIGHT",
+        "severity": "high",
+        "title": "Check-then-act race can create the value twice",
+        "body": "Concurrent callers can both observe a missing key and run create_value. "
+        "Protect the read-modify-write sequence or use an atomic cache operation.",
+        "suggestion": None,
+        "anchor": "    if key not in cache:",
+    },
+)
+
 _DEPRECATION_EXAMPLE = _example_block(
     "--- a/clock.py\n"
     "+++ b/clock.py\n"
@@ -271,12 +291,11 @@ _INTENT_EXAMPLE = _example_block(
 # The monolithic (no-category) prompt keeps a single generic example.
 _GENERIC_EXAMPLE = _SECURITY_EXAMPLE
 
-_CORRECTNESS_SECTION = """\
-## Correctness & logic (the substance of the change)
-
+_CORRECTNESS_INTRO = """\
 Actively hunt for bugs the change introduces — these are high-value findings,
-graded `high` or `critical` when they cause wrong results, crashes, or data loss:
+graded `high` or `critical` when they cause wrong results, crashes, or data loss."""
 
+_CORRECTNESS_FLOW_CHECKS = """\
 - **Null / None dereferences** — a value that can be `null`/`None`/undefined used
   without a guard; an Optional unwrapped on a path where it may be empty.
 - **Off-by-one & boundary errors** — `<` vs `<=`, fencepost mistakes, indexing
@@ -287,20 +306,44 @@ graded `high` or `critical` when they cause wrong results, crashes, or data loss
   swallowed, a result/error left unchecked, a path that leaves state half-updated.
 - **Incorrect conditionals** — inverted booleans, `and`/`or` mix-ups, missing
   branches, comparisons against the wrong variable.
+- **Numeric errors** — integer overflow or truncation, float equality
+  comparisons, division by zero, money handled in binary floats, precision loss.
+- **Wrong validation anchoring** — a regex anchored with `match` where full-match
+  semantics are needed, letting bad input through."""
+
+_CORRECTNESS_STATE_CHECKS = """\
 - **Resource leaks & ordering** — handles/locks/connections not released,
   use-after-close, or operations sequenced so a concurrent caller sees a bad state.
 - **Races & concurrency** — check-then-act (TOCTOU) sequences, shared mutable
   state read or written without synchronisation, non-atomic read-modify-write,
   and async mistakes: a coroutine called without `await`, blocking calls inside
   an async path.
-- **Numeric errors** — integer overflow or truncation, float equality
-  comparisons, division by zero, money handled in binary floats, precision loss.
 - **Date & time bugs** — timezone-naive datetimes mixed with aware ones,
   seconds/milliseconds epoch confusion, DST-unsafe date arithmetic.
 - **Aliasing & mutation** — mutable default arguments, storing a mutable value
-  the caller still owns, mutating a collection while iterating over it.
-- **Wrong validation anchoring** — a regex anchored with `match` where full-match
-  semantics are needed, letting bad input through."""
+  the caller still owns, mutating a collection while iterating over it."""
+
+_CORRECTNESS_FLOW_SECTION = f"""\
+## Correctness & control/data flow
+
+{_CORRECTNESS_INTRO}
+
+{_CORRECTNESS_FLOW_CHECKS}"""
+
+_CORRECTNESS_STATE_SECTION = f"""\
+## Correctness & state/lifecycle
+
+{_CORRECTNESS_INTRO}
+
+{_CORRECTNESS_STATE_CHECKS}"""
+
+_CORRECTNESS_SECTION = f"""\
+## Correctness & logic (the substance of the change)
+
+{_CORRECTNESS_INTRO}
+
+{_CORRECTNESS_FLOW_CHECKS}
+{_CORRECTNESS_STATE_CHECKS}"""
 
 _SECURITY_SECTION = """\
 ## Security review (be thorough — these are high-value findings)
@@ -499,9 +542,10 @@ keep this lens to "should this exist at all?" — leave readability nits to othe
 
 # ---------------------------------------------------------------------------
 # Fast-preset merged lenses. Written as integrated checklists (not a paste-up
-# of the per-lens sections): three calls cover the everyday concerns, so each
-# merged prompt condenses its members to their high-signal items and demands
-# the per-finding `category` field so downstream rules/labels keep working.
+# of the per-lens sections): the bounded pool runs four calls when parallelism
+# is available, or three combined calls with one worker. Each merged prompt
+# condenses its members to their high-signal items and demands the per-finding
+# `category` field so downstream rules/labels keep working.
 # ---------------------------------------------------------------------------
 
 _CODE_HEALTH_SECTION = """\
@@ -663,6 +707,40 @@ def build_correctness_prompt(include_intent: bool) -> str:
 def build_correctness_block(include_intent: bool) -> str:
     """The fast preset's correctness call, user-block (split) shape."""
     return f"{_LENS_LEAD_IN}\n\n{_correctness_section(include_intent)}\n\n{_CORRECTNESS_EXAMPLE}"
+
+
+@lru_cache(maxsize=2)
+def _correctness_flow_section(include_intent: bool) -> str:
+    """The parallel fast preset's flow section, optionally carrying intent."""
+    if not include_intent:
+        return _CORRECTNESS_FLOW_SECTION
+    return f"{_CORRECTNESS_INTENT_PREFIX}\n{_CORRECTNESS_FLOW_SECTION}\n\n{_INTENT_SECTION}"
+
+
+def build_correctness_flow_prompt(include_intent: bool) -> str:
+    """The parallel fast preset's correctness-flow system prompt."""
+    section = _correctness_flow_section(include_intent)
+    return f"{_SHARED_HEADER}\n{_CORRECTNESS_EXAMPLE}\n\n{section}\n\n{_SHARED_RULES}\n"
+
+
+def build_correctness_flow_block(include_intent: bool) -> str:
+    """The parallel fast preset's correctness-flow split block."""
+    return (
+        f"{_LENS_LEAD_IN}\n\n{_correctness_flow_section(include_intent)}\n\n{_CORRECTNESS_EXAMPLE}"
+    )
+
+
+def build_correctness_state_prompt() -> str:
+    """The parallel fast preset's correctness-state system prompt."""
+    return (
+        f"{_SHARED_HEADER}\n{_CORRECTNESS_STATE_EXAMPLE}\n\n"
+        f"{_CORRECTNESS_STATE_SECTION}\n\n{_SHARED_RULES}\n"
+    )
+
+
+def build_correctness_state_block() -> str:
+    """The parallel fast preset's correctness-state split block."""
+    return f"{_LENS_LEAD_IN}\n\n{_CORRECTNESS_STATE_SECTION}\n\n{_CORRECTNESS_STATE_EXAMPLE}"
 
 
 _CATEGORY_SECTIONS: dict[ReviewCategory, str] = {

--- a/tests/engine/test_concurrency.py
+++ b/tests/engine/test_concurrency.py
@@ -90,6 +90,14 @@ def _multi_file_ctx(n_files: int, lines_per_file: int = 40) -> PRContext:
 
 
 class TestFlattenedFanOut:
+    def test_parallel_fast_correctness_tasks_overlap(self) -> None:
+        cfg = ReviewConfig(provider=Provider.openai, model="m", reflect=False)
+        provider = _ConcurrencyTrackingProvider()
+
+        LLMReviewEngine(provider).review(_multi_file_ctx(1), cfg)
+
+        assert provider.max_in_flight == 4
+
     def test_calls_from_different_batches_run_concurrently(self) -> None:
         """The old per-batch pool serialised batches; the flat pool must not.
 

--- a/tests/engine/test_preset.py
+++ b/tests/engine/test_preset.py
@@ -1,4 +1,4 @@
-"""Tests for the fast/full review presets (fast = 3 calls, default)."""
+"""Tests for the provider-aware fast/full review presets."""
 
 from __future__ import annotations
 
@@ -42,11 +42,39 @@ class TestFastLensGrouping:
     def test_default_preset_is_fast(self) -> None:
         assert _cfg().preset is ReviewPreset.fast
 
-    def test_fast_builds_three_lenses(self) -> None:
+    def test_single_worker_fast_builds_three_lenses(self) -> None:
         lenses = _build_lenses(_cfg(), has_intent=False)
         assert [lens.id for lens in lenses] == [
             "security",
             "correctness",
+            "code-health",
+        ]
+
+    def test_parallel_fast_splits_correctness_into_two_lenses(self) -> None:
+        lenses = _build_lenses(
+            _cfg(provider=Provider.openai, max_concurrency=None), has_intent=False
+        )
+        assert [lens.id for lens in lenses] == [
+            "security",
+            "correctness-flow",
+            "correctness-state",
+            "code-health",
+        ]
+
+    def test_explicit_single_worker_keeps_combined_correctness(self) -> None:
+        lenses = _build_lenses(_cfg(provider=Provider.openai, max_concurrency=1), has_intent=False)
+        assert [lens.id for lens in lenses] == [
+            "security",
+            "correctness",
+            "code-health",
+        ]
+
+    def test_explicit_parallel_local_provider_splits_correctness(self) -> None:
+        lenses = _build_lenses(_cfg(max_concurrency=2), has_intent=False)
+        assert [lens.id for lens in lenses] == [
+            "security",
+            "correctness-flow",
+            "correctness-state",
             "code-health",
         ]
 
@@ -73,7 +101,7 @@ class TestFastLensGrouping:
         for name in ("performance", "complexity", "ponytail", "deprecation"):
             assert f'"{name}"' in code_health
 
-    def test_intent_folds_into_correctness_when_stated(self) -> None:
+    def test_intent_folds_into_combined_correctness_when_stated(self) -> None:
         lenses = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=True)}
         correctness = lenses["correctness"]
         assert correctness.carries_intent
@@ -83,6 +111,15 @@ class TestFastLensGrouping:
         plain = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=False)}
         assert not plain["correctness"].carries_intent
         assert "stated intent" not in plain["correctness"].user_block
+
+    def test_parallel_intent_reaches_only_correctness_flow(self) -> None:
+        lenses = {
+            lens.id: lens for lens in _build_lenses(_cfg(provider=Provider.openai), has_intent=True)
+        }
+        assert lenses["correctness-flow"].carries_intent
+        assert "stated intent" in lenses["correctness-flow"].user_block
+        assert not lenses["correctness-state"].carries_intent
+        assert "stated intent" not in lenses["correctness-state"].user_block
 
     def test_full_preset_builds_one_lens_per_category(self) -> None:
         lenses = _build_lenses(_cfg(preset="full"), has_intent=True)
@@ -102,6 +139,38 @@ class TestFastLensGrouping:
         provider = FakeProvider()
         LLMReviewEngine(provider).review(_CTX, _cfg())
         assert len(provider.calls) == 3
+
+    def test_parallel_fast_review_makes_four_calls(self) -> None:
+        provider = FakeProvider()
+        LLMReviewEngine(provider).review(_CTX, _cfg(provider=Provider.openai))
+        assert len(provider.calls) == 4
+
+
+class TestSplitCorrectnessAttribution:
+    def test_split_findings_are_correctness_and_deduplicated(self) -> None:
+        finding = ReviewFinding(
+            path="a.py",
+            line=1,
+            severity=Severity.high,
+            title="shared bug",
+            body="x",
+        )
+        finding_text = json.dumps([finding.model_dump(mode="json")])
+
+        class _BothCorrectnessTasks(FakeProvider):
+            def complete(self, messages, model, **opts):  # type: ignore[override]
+                self.calls.append({"messages": messages, "model": model, "opts": opts})
+                prompt = "\n".join(str(m.get("content", "")) for m in messages)
+                if "Correctness &" in prompt:
+                    return ProviderResult(text=finding_text, input_tokens=1, output_tokens=1)
+                return ProviderResult(text='{"findings": []}', input_tokens=1, output_tokens=1)
+
+        findings, _ = LLMReviewEngine(_BothCorrectnessTasks()).review(
+            _CTX, _cfg(provider=Provider.openai, min_severity="info")
+        )
+
+        assert len(findings) == 1
+        assert findings[0].category == "correctness"
 
 
 class TestMergedCategoryStamping:

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -189,7 +189,7 @@ class TestEngineBehaviourMatrix:
         assert _resolve_workers(cfg, task_count=99) == expected
 
     @pytest.mark.parametrize("provider", list(Provider))
-    def test_fast_preset_runs_three_calls_on_every_provider(self, provider: Provider) -> None:
+    def test_fast_preset_call_count_is_provider_aware(self, provider: Provider) -> None:
         from lgtmaybe.core.models import PRContext, ReviewConfig
         from lgtmaybe.engine import LLMReviewEngine
         from tests.fakes import FakeProvider
@@ -205,7 +205,8 @@ class TestEngineBehaviourMatrix:
         cfg = ReviewConfig(provider=provider, model="m", reflect=False)
         fake = FakeProvider()
         LLMReviewEngine(fake).review(ctx, cfg)
-        assert len(fake.calls) == 3
+        expected = 3 if provider in self.SINGLE_STREAM else 4
+        assert len(fake.calls) == expected
 
     @pytest.mark.parametrize("provider", list(Provider))
     def test_review_deadline_field_defaults_on_every_provider(self, provider: Provider) -> None:

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -287,7 +287,7 @@
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in three calls:\nsecurity and correctness keep dedicated calls (they earn it; the stated\nintent, when present, merges into correctness), while performance,\ncomplexity, ponytail, and deprecation fold into one code-health call.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
       "enum": [
         "fast",
         "full"


### PR DESCRIPTION
## Summary

- split the default fast-preset correctness review into focused flow/intent and state/lifecycle tasks when effective concurrency is greater than one
- preserve the existing combined three-call path for Ollama, OpenAI-compatible defaults, and explicit `max_concurrency: 1`
- keep both split tasks attributed to the public `correctness` category and merge them through the existing bounded executor and dedupe pipeline
- update OpenSpec, anchor ownership, configuration text, architecture diagrams, and generated documentation

## Why

Increasing the worker ceiling cannot shorten the current one-batch review because its fast-preset tasks already start together. In the observed pre-v1.1 dogfood profile, correctness took 513 seconds and emitted 32,768 output tokens while the other calls completed within 66 seconds. Splitting that oversized task creates useful work for the existing pool without raising the cloud concurrency default above eight or making single-worker providers slower.

## Impact

Parallel-capable fast reviews make four calls per batch instead of three. Single-worker reviews remain at three calls. Full and explicitly selected category reviews are unchanged.

## Validation

- `uv run pytest -q` — 1,205 passed, 3 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run --group docs mkdocs build --strict`
- `uv build`
- CLI help smoke checks
- strict OpenSpec validation and anchor hygiene
- PR CI green across Python 3.11–3.14, commitlint, Ruff, and drift checks

The advisory `core.lenses` drift notice is expected while this active OpenSpec change remains unarchived; the matching specification delta is included in this PR.

## Dogfood profile

The PR's dogfood check passed in 3m41s with a 149.0s lgtmaybe profile. The published v1 baseline recorded correctness at 123.48s (three attempts, 8 output tokens), reflection at 22.17s, code health at 7.86s, and security at 2.45s.

This is **not** a benchmark of the branch implementation: the security-sensitive `pull_request_target` workflow intentionally checks out the base repository and runs the released `ghcr.io/mattjcoles/lgtmaybe:v1` image. Its log therefore shows the current three tasks (`security`, `correctness`, `code-health`), not the new four-task split. The remaining OpenSpec benchmark task must be completed after publishing the change or with a separate safe benchmark credential path.
