### PR TITLE
feat: gate merges on findings via a GitHub Check Run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,10 @@ inputs:
     description: "On a re-run, suppress a finding a human reacted 👎 (thumbs-down) to on its inline comment last time. The reactions live on GitHub and are re-read each run — no new persistence. Resolving a thread is NOT a suppress signal (that means fixed). On by default; set to false to disable."
     required: false
     default: ""
+  fail_on:
+    description: "Merge-gate threshold (info/low/medium/high/critical). When set, after posting the review a GitHub Check Run named 'lgtmaybe' is created with conclusion failure if any finding is at or above this severity, else success — make it a required check in branch protection to block merges. Enforcement rides the Check Run, never PR approval state. Off by default (no check run)."
+    required: false
+    default: ""
   profile:
     description: "Print a timing profile at the end of the run in the Action log: total wall time, per-stage and per-call tables (with token and prompt-cache usage), and cache hit totals. Off by default."
     required: false
@@ -248,6 +252,7 @@ runs:
         INPUT_AUTO_DIAGRAM: ${{ inputs.auto_diagram }}
         INPUT_PR_LABELS: ${{ inputs.pr_labels }}
         INPUT_LEARN_FEEDBACK: ${{ inputs.learn_feedback }}
+        INPUT_FAIL_ON: ${{ inputs.fail_on }}
         INPUT_PROFILE: ${{ inputs.profile }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         LGTMAYBE_IMAGE: ${{ inputs.image }}
@@ -270,7 +275,7 @@ runs:
           -e INPUT_RECURSIVE -e INPUT_STRUCTURED_OUTPUT -e INPUT_SYMBOL_RESOLUTION \
           -e INPUT_PROMPT_CACHE -e INPUT_INCREMENTAL -e INPUT_STATIC_ANALYSIS \
           -e INPUT_AUTO_DESCRIBE -e INPUT_AUTO_DIAGRAM -e INPUT_PR_LABELS \
-          -e INPUT_LEARN_FEEDBACK -e INPUT_PROFILE \
+          -e INPUT_LEARN_FEEDBACK -e INPUT_FAIL_ON -e INPUT_PROFILE \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_GHA_CREDS_PATH \

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -211,6 +211,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
 | `auto_diagram` | `false` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
+| `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |
 | `profile` | `false` | Print a timing profile (per-stage and per-call tables, token and cache usage) in the Action log |
 | `aws_role_arn` | — | IAM role ARN to assume via OIDC for bedrock (keyless) |
 | `aws_region` | `us-east-1` | AWS region for bedrock |
@@ -228,6 +229,36 @@ App, grant those permissions, install it, and store the ID and key) is in
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
+
+## Gate merges on findings
+
+Set `fail_on` to a severity to turn the review into a merge gate. After posting
+the review, lgtmaybe creates a **Check Run** named `lgtmaybe` whose conclusion is
+`failure` when any surviving finding is at or above that severity, and `success`
+otherwise. Enforcement rides the Check Run — lgtmaybe never sets PR approval
+state, so a clean review stays comment-only.
+
+```yaml
+- uses: MattJColes/lgtmaybe@v1
+  with:
+    provider: openai
+    model: gpt-4o
+    api_key: ${{ secrets.OPENAI_API_KEY }}
+    fail_on: high   # block merge on any high/critical finding
+```
+
+To make it block merges, mark the check as required in **branch protection**:
+
+1. Open **Settings → Branches → Branch protection rules** (or a ruleset) for the
+   target branch.
+2. Enable **Require status checks to pass before merging**.
+3. Search for and add the **`lgtmaybe`** check. It appears in the list once the
+   Action has run at least once with `fail_on` set on a PR against that branch.
+
+A PR with a finding at or above the threshold then shows a failing `lgtmaybe`
+check and cannot merge until the finding is resolved (or `fail_on` is lowered).
+Leave `fail_on` unset to keep reviews advisory (the default) — no check run is
+created.
 
 ## Adding a config file
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -510,6 +510,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
 | `auto_diagram` | `false` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
+| `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |
 | `profile` | `false` | Print a timing profile (per-stage and per-call tables, token and cache usage) in the Action log |
 | `aws_role_arn` | — | IAM role ARN to assume via OIDC for bedrock (keyless) |
 | `aws_region` | `us-east-1` | AWS region for bedrock |
@@ -527,6 +528,36 @@ App, grant those permissions, install it, and store the ID and key) is in
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
+
+## Gate merges on findings
+
+Set `fail_on` to a severity to turn the review into a merge gate. After posting
+the review, lgtmaybe creates a **Check Run** named `lgtmaybe` whose conclusion is
+`failure` when any surviving finding is at or above that severity, and `success`
+otherwise. Enforcement rides the Check Run — lgtmaybe never sets PR approval
+state, so a clean review stays comment-only.
+
+```yaml
+- uses: MattJColes/lgtmaybe@v1
+  with:
+    provider: openai
+    model: gpt-4o
+    api_key: ${{ secrets.OPENAI_API_KEY }}
+    fail_on: high   # block merge on any high/critical finding
+```
+
+To make it block merges, mark the check as required in **branch protection**:
+
+1. Open **Settings → Branches → Branch protection rules** (or a ruleset) for the
+   target branch.
+2. Enable **Require status checks to pass before merging**.
+3. Search for and add the **`lgtmaybe`** check. It appears in the list once the
+   Action has run at least once with `fail_on` set on a PR against that branch.
+
+A PR with a finding at or above the threshold then shows a failing `lgtmaybe`
+check and cannot merge until the finding is resolved (or `fail_on` is lowered).
+Leave `fail_on` unset to keep reviews advisory (the default) — no check run is
+created.
 
 ## Adding a config file
 
@@ -3011,6 +3042,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
+| `fail_on` | `critical` / `high` / `info` / `low` / `medium` / null | No | `null` |  |
 | `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
 | `function_context` | boolean | No | `True` | Function Context |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
@@ -3557,6 +3589,17 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Extra Lenses",
       "type": "array"
+    },
+    "fail_on": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Severity"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "finding_rules": {
       "items": {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,6 +23,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
 | `extra_lenses` | list[CustomLens] | No | `[]` | Extra Lenses |
+| `fail_on` | `critical` / `high` / `info` / `low` / `medium` / null | No | `null` |  |
 | `finding_rules` | list[FindingRule] | No | `[]` | Finding Rules |
 | `function_context` | boolean | No | `True` | Function Context |
 | `ignore_fingerprints` | list[string] | No | `[]` | Ignore Fingerprints |
@@ -569,6 +570,17 @@ The canonical machine-readable schemas. These are the source of truth for provid
       },
       "title": "Extra Lenses",
       "type": "array"
+    },
+    "fail_on": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Severity"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "finding_rules": {
       "items": {

--- a/openspec/specs/core-contracts/spec.md
+++ b/openspec/specs/core-contracts/spec.md
@@ -63,12 +63,18 @@ is never parsed.
 
 `ReviewConfig` SHALL be the single knob surface for a review (provider, model,
 filters, caps, toggles like `learn_feedback`); `Severity` SHALL order `info <
-low < medium < high < critical` so floors like `min_severity` compare with `>=`.
+low < medium < high < critical` so floors like `min_severity` and `fail_on`
+compare with `>=`. `fail_on` is an optional `Severity` (default `None` = off)
+driving the merge-gate Check Run.
 <!-- anchor: core.config -->
 
 #### Scenario: severity floor filters findings
 - **WHEN** `min_severity` is `medium`
 - **THEN** `low` and `info` findings are dropped before posting
+
+#### Scenario: merge-gate threshold is off by default
+- **WHEN** a `ReviewConfig` is built without `fail_on`
+- **THEN** `fail_on` is `None` and no check run is created
 
 ### Requirement: Nine built-in lenses, preset-shaped fan-out
 

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -69,3 +69,13 @@ github.labels:
       kind: function_definition
       has: { field: name, regex: '^apply_pr_labels$' }
     files: [src/lgtmaybe/github/**/*.py]
+
+github.check-run:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^create_check_run$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^RestGitHubGateway$' }
+      stopBy: end
+  files: [src/lgtmaybe/github/**/*.py]

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -114,3 +114,20 @@ best-effort, never failing the review.
 #### Scenario: repo has unrelated labels
 - **WHEN** labels are reconciled
 - **THEN** labels outside lgtmaybe's families are never added or removed
+
+### Requirement: Merge-gate rides a Check Run, never approval state
+
+With `fail_on` set, after posting the review the adapter SHALL create a
+completed Check Run on the PR head SHA whose conclusion is `failure` when any
+surviving finding is at or above `fail_on`, else `success` — so teams can make
+it a required check in branch protection. Enforcement rides the Check Run;
+approval state is never set. `fail_on` unset (default) creates no check run.
+<!-- anchor: github.check-run -->
+
+#### Scenario: a blocking finding is present
+- **WHEN** `fail_on` is `high` and a finding is `high` or above
+- **THEN** the Check Run is created with conclusion `failure`
+
+#### Scenario: no finding meets the threshold
+- **WHEN** `fail_on` is set and no surviving finding reaches it
+- **THEN** the Check Run is created with conclusion `success`

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
@@ -32,6 +33,7 @@ from lgtmaybe.core.models import (
     ReviewConfig,
     ReviewFinding,
     ReviewPreset,
+    Severity,
 )
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
 from lgtmaybe.engine import FileFetcher, LLMReviewEngine, SymbolResolver, build_symbol_resolver
@@ -341,8 +343,39 @@ def run_review(
                 from lgtmaybe.engine.labels import compute_labels
 
                 apply_labels(compute_labels(findings, ctx))
+        if cfg.fail_on is not None:
+            # Merge-gate: create a Check Run so branch protection can require it.
+            # Enforcement rides the Check Run, never PR approval state. Best-effort
+            # and only on gateways that support it (fakes/plain gateways don't).
+            create_check_run = getattr(github, "create_check_run", None)
+            if create_check_run is not None:
+                conclusion, title, check_summary = _fail_on_check(findings, cfg.fail_on)
+                create_check_run(ctx.head_sha, conclusion, title, check_summary)
 
     return findings, summary
+
+
+def _fail_on_check(findings: list[ReviewFinding], fail_on: Severity) -> tuple[str, str, str]:
+    """Build the (conclusion, title, summary) for the merge-gate Check Run.
+
+    ``failure`` when any surviving finding is at or above ``fail_on`` (the
+    findings are already the severity-floor-filtered set), else ``success``.
+    The summary carries the count at/above the threshold plus a per-severity
+    breakdown so the check page explains the verdict.
+    """
+    failing = [f for f in findings if f.severity >= fail_on]
+    conclusion = "failure" if failing else "success"
+    counts = Counter(f.severity for f in findings)
+    breakdown = ", ".join(f"{counts[s]} {s.value}" for s in Severity if counts[s]) or "none"
+    if failing:
+        title = f"{len(failing)} finding(s) at or above {fail_on.value}"
+    else:
+        title = f"No findings at or above {fail_on.value}"
+    summary = (
+        f"{len(failing)} of {len(findings)} finding(s) are at or above the "
+        f"`{fail_on.value}` threshold.\n\nFindings by severity: {breakdown}."
+    )
+    return conclusion, title, summary
 
 
 def _incremental_context(
@@ -631,6 +664,7 @@ def action_inputs() -> dict[str, str | None]:
         "auto_diagram": get("AUTO_DIAGRAM"),
         "pr_labels": get("PR_LABELS"),
         "learn_feedback": get("LEARN_FEEDBACK"),
+        "fail_on": get("FAIL_ON"),
         "profile": get("PROFILE"),
         "config_path": get("CONFIG_PATH"),
     }

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -141,6 +141,14 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     help="Minimum severity to report",
 )
 @click.option(
+    "--fail-on",
+    default=None,
+    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    help="Merge-gate threshold: on the GitHub Action, create a Check Run that "
+    "fails when any finding is at or above this severity (make it a required "
+    "check in branch protection). Default off",
+)
+@click.option(
     "--unanchored-min-severity",
     default=None,
     type=click.Choice(["info", "low", "medium", "high", "critical"]),
@@ -312,6 +320,7 @@ def review(
     api_key: str | None,
     api_base: str | None,
     min_severity: str | None,
+    fail_on: str | None,
     unanchored_min_severity: str | None,
     max_files: int | None,
     max_input_tokens: int | None,
@@ -351,6 +360,7 @@ def review(
         reflect_model=reflect_model,
         triage_model=triage_model,
         min_severity=min_severity,
+        fail_on=fail_on,
         unanchored_min_severity=unanchored_min_severity,
         max_files=max_files,
         max_input_tokens=max_input_tokens,
@@ -524,6 +534,7 @@ def action() -> None:
         auto_diagram=inputs["auto_diagram"],
         pr_labels=inputs["pr_labels"],
         learn_feedback=inputs["learn_feedback"],
+        fail_on=inputs["fail_on"],
     )
     cfg = _apply_static_analysis_flag(cfg, _parse_bool(inputs["static_analysis"]))
     runtime = RuntimeOptions(

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -470,6 +470,13 @@ class ReviewConfig(_Strict):
     # high/critical guess is worth surfacing (demoted to the review body, never
     # posted on a line we can't stand behind); anything weaker is dropped.
     unanchored_min_severity: Severity = Severity.high
+    # Merge-gate threshold. When set, after posting the review the GitHub adapter
+    # creates a Check Run whose conclusion is `failure` if any surviving finding
+    # is at or above this severity, else `success` — so a team can make lgtmaybe a
+    # required check in branch protection. Enforcement rides the Check Run, never
+    # PR approval state (lgtmaybe never sets approval state). None (default) = off,
+    # non-breaking: no check run is created.
+    fail_on: Severity | None = None
     include_paths: list[str] = Field(default_factory=list)
     exclude_paths: list[str] = Field(default_factory=list)
     max_files: int = 50

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -39,6 +39,10 @@ _TIMEOUT = httpx.Timeout(30.0)
 _MARKER = "<!-- lgtmaybe -->"
 _GRAPHQL_URL = "https://api.github.com/graphql"
 
+# Stable name for the merge-gate Check Run (`fail_on`). Teams mark this exact
+# name as a required status check in branch protection, so it must not change.
+_CHECK_RUN_NAME = "lgtmaybe"
+
 # Hidden marker stamped into every inline comment so a later run can match an
 # existing review conversation back to the finding that opened it. The capture
 # group is the finding fingerprint.
@@ -490,6 +494,29 @@ class RestGitHubGateway(GitHubGateway):
                 resp.raise_for_status()
         except Exception as exc:  # noqa: BLE001 — labels are auxiliary, never fatal
             _log.warning("applying PR labels failed: %s", exc)
+
+    def create_check_run(self, head_sha: str, conclusion: str, title: str, summary: str) -> None:
+        """Create a completed Check Run on *head_sha* — the merge-gate (`fail_on`).
+
+        POSTs a `completed` check run whose *conclusion* (`failure`/`success`)
+        a team can require in branch protection, so a blocking finding stops the
+        merge. Enforcement rides the Check Run, never PR approval state (lgtmaybe
+        never sets approval state). Adapter-only, beyond the frozen port.
+        """
+        url = f"https://api.github.com/repos/{self._repo}/check-runs"
+        resp = self._client.post(
+            url,
+            headers={**self._headers, "Accept": "application/vnd.github+json"},
+            json={
+                "name": _CHECK_RUN_NAME,
+                "head_sha": head_sha,
+                "status": "completed",
+                "conclusion": conclusion,
+                "output": {"title": title, "summary": summary},
+            },
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
 
     # ------------------------------------------------------------------
     # Incremental review (adapter-only methods, beyond the frozen port)

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -300,6 +300,33 @@ class TestActionRouting:
         assert result.exit_code == 0, result.output
         assert captured == {"reflect_model": "bigger-judge"}
 
+    def test_fail_on_input_reaches_config(self, tmp_path, monkeypatch):
+        """INPUT_FAIL_ON sets the merge-gate threshold from the Action."""
+        captured: dict[str, object] = {}
+
+        import lgtmaybe.cli as cli_module
+
+        def fake_build(cfg, runtime):
+            captured["fail_on"] = cfg.fail_on
+            return FakeGitHub(), FakeEngine(FakeProvider()), FakeProvider()
+
+        monkeypatch.setattr(cli_module, "build_review_context", fake_build)
+
+        event = _write_event(
+            tmp_path,
+            {"repository": {"full_name": "org/repo"}, "pull_request": {"number": 1}},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "ollama")
+        monkeypatch.setenv("INPUT_MODEL", "llama3")
+        monkeypatch.setenv("INPUT_FAIL_ON", "high")
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert captured == {"fail_on": "high"}
+
     def test_num_ctx_and_max_input_tokens_inputs_reach_config(self, tmp_path, monkeypatch):
         """INPUT_NUM_CTX / INPUT_MAX_INPUT_TOKENS tune a big-diff run from the Action."""
         captured: dict[str, object] = {}

--- a/tests/cli/test_merge_gate.py
+++ b/tests/cli/test_merge_gate.py
@@ -1,0 +1,123 @@
+"""Merge-gate via a Check Run (fail_on) — wiring in run_review.
+
+With ``cfg.fail_on`` set, after posting the review ``run_review`` creates a
+GitHub Check Run whose conclusion is ``failure`` when any surviving finding is
+at or above the threshold, else ``success``. Off by default (fail_on=None): no
+check run is created. Enforcement rides the check run, never PR approval state.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.cli import run_review
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ReviewConfig,
+    ReviewFinding,
+    Severity,
+)
+from lgtmaybe.core.ports import GitHubGateway, ReviewEngine
+from tests.fakes import FakeGitHub
+
+CTX = PRContext(
+    diff="diff --git a/src/app.py b/src/app.py\n@@ -1 +1,2 @@\n old\n+new\n",
+    changed_files=["src/app.py"],
+    base_sha="base0000",
+    head_sha="head2222",
+    repo="org/repo",
+    pr_number=5,
+)
+
+
+def _cfg(**overrides: object) -> ReviewConfig:
+    return ReviewConfig(provider=Provider.ollama, model="llama3", **overrides)  # type: ignore[arg-type]
+
+
+def _finding(severity: Severity) -> ReviewFinding:
+    return ReviewFinding(
+        path="src/app.py", line=2, side="RIGHT", severity=severity, title="t", body="b"
+    )
+
+
+class CannedEngine(ReviewEngine):
+    def __init__(self, findings: list[ReviewFinding]) -> None:
+        self._findings = findings
+
+    def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
+        return list(self._findings), "summary"
+
+
+def test_check_run_fails_when_a_finding_meets_the_threshold() -> None:
+    github = FakeGitHub(CTX)
+    engine = CannedEngine([_finding(Severity.high), _finding(Severity.low)])
+
+    run_review(github=github, engine=engine, cfg=_cfg(fail_on=Severity.high), dry_run=False)
+
+    assert len(github.check_runs) == 1
+    run = github.check_runs[0]
+    assert run["conclusion"] == "failure"
+    assert run["head_sha"] == CTX.head_sha
+
+
+def test_check_run_succeeds_when_all_findings_are_below_the_threshold() -> None:
+    github = FakeGitHub(CTX)
+    engine = CannedEngine([_finding(Severity.low), _finding(Severity.medium)])
+
+    run_review(github=github, engine=engine, cfg=_cfg(fail_on=Severity.high), dry_run=False)
+
+    assert len(github.check_runs) == 1
+    assert github.check_runs[0]["conclusion"] == "success"
+
+
+def test_check_run_succeeds_on_a_clean_review() -> None:
+    github = FakeGitHub(CTX)
+    engine = CannedEngine([])
+
+    run_review(github=github, engine=engine, cfg=_cfg(fail_on=Severity.high), dry_run=False)
+
+    assert github.check_runs[0]["conclusion"] == "success"
+
+
+def test_no_check_run_when_fail_on_is_none() -> None:
+    github = FakeGitHub(CTX)
+    engine = CannedEngine([_finding(Severity.critical)])
+
+    run_review(github=github, engine=engine, cfg=_cfg(), dry_run=False)  # fail_on defaults to None
+
+    assert github.check_runs == []
+
+
+def test_no_check_run_on_dry_run() -> None:
+    github = FakeGitHub(CTX)
+    engine = CannedEngine([_finding(Severity.critical)])
+
+    run_review(github=github, engine=engine, cfg=_cfg(fail_on=Severity.high), dry_run=True)
+
+    assert github.check_runs == []
+
+
+class _PortOnlyGateway(GitHubGateway):
+    """A gateway implementing only the frozen port — no create_check_run."""
+
+    def __init__(self, ctx: PRContext) -> None:
+        self._ctx = ctx
+        self.posted: list[tuple[list[ReviewFinding], str]] = []
+
+    def get_pr_context(self) -> PRContext:
+        return self._ctx
+
+    def post_review(self, findings, summary, diff=None) -> None:
+        self.posted.append((findings, summary))
+
+    def post_issue_comment(self, body: str) -> None:  # pragma: no cover - unused
+        pass
+
+
+def test_check_run_skipped_on_gateway_without_the_method() -> None:
+    """A gateway lacking create_check_run must not crash the review."""
+    github = _PortOnlyGateway(CTX)
+    engine = CannedEngine([_finding(Severity.critical)])
+
+    run_review(github=github, engine=engine, cfg=_cfg(fail_on=Severity.high), dry_run=False)
+
+    assert len(github.posted) == 1

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -69,6 +69,25 @@ def test_learn_feedback_round_trips_from_file(tmp_path):
     assert load_config(config_path=cfg_file, learn_feedback=False).learn_feedback is False
 
 
+def test_fail_on_round_trips_from_file_and_cli(tmp_path):
+    """fail_on can be set in .lgtmaybe.yml and overridden via a CLI input."""
+    cfg_file = tmp_path / ".lgtmaybe.yml"
+    cfg_file.write_text("provider: openai\nmodel: gpt-4o\nfail_on: high\n")
+    cfg = load_config(config_path=cfg_file)
+    assert cfg.fail_on == "high"
+
+    cfg = load_config(config_path=cfg_file, fail_on="critical")
+    assert cfg.fail_on == "critical"
+
+
+def test_fail_on_defaults_off(tmp_path):
+    """With nothing set, the merge-gate stays off (fail_on is None)."""
+    cfg_file = tmp_path / ".lgtmaybe.yml"
+    cfg_file.write_text("provider: openai\nmodel: gpt-4o\n")
+    cfg = load_config(config_path=cfg_file)
+    assert cfg.fail_on is None
+
+
 def test_reflect_model_round_trips_from_file_and_cli(tmp_path):
     """reflect_model can be set in .lgtmaybe.yml and overridden via a CLI input."""
     cfg_file = tmp_path / ".lgtmaybe.yml"

--- a/tests/config/test_store.py
+++ b/tests/config/test_store.py
@@ -33,6 +33,13 @@ def test_set_coerces_to_field_type(cfg_home: Path) -> None:
     assert store.get_key("max_files") == 25  # int, not "25"
 
 
+def test_set_fail_on_round_trips(cfg_home: Path) -> None:
+    # A nullable-Severity field coerces the string to the enum's plain value.
+    store.set_key("fail_on", "high")
+
+    assert store.get_key("fail_on") == "high"
+
+
 def test_set_validates_enum_value(cfg_home: Path) -> None:
     with pytest.raises(ValueError):
         store.set_key("provider", "not-a-provider")

--- a/tests/fakes/github.py
+++ b/tests/fakes/github.py
@@ -25,6 +25,7 @@ class FakeGitHub(GitHubGateway):
         self.comments: list[str] = []
         self.described: list[str] = []
         self.diagrams: list[str] = []
+        self.check_runs: list[dict[str, str]] = []
 
     def get_pr_context(self) -> PRContext:
         return self._ctx
@@ -46,3 +47,14 @@ class FakeGitHub(GitHubGateway):
     def post_diagram_comment(self, body: str) -> None:
         """Idempotent change-diagram upsert — beyond the frozen port."""
         self.diagrams.append(body)
+
+    def create_check_run(self, head_sha: str, conclusion: str, title: str, summary: str) -> None:
+        """Merge-gate Check Run (fail_on) — beyond the frozen port."""
+        self.check_runs.append(
+            {
+                "head_sha": head_sha,
+                "conclusion": conclusion,
+                "title": title,
+                "summary": summary,
+            }
+        )

--- a/tests/github/test_check_run.py
+++ b/tests/github/test_check_run.py
@@ -1,0 +1,85 @@
+"""Tests for RestGitHubGateway.create_check_run — the merge-gate check run.
+
+The adapter POSTs a completed Check Run to the check-runs endpoint; branch
+protection can then require it. Adapter-only, beyond the frozen port.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+
+from lgtmaybe.github import RestGitHubGateway
+
+REPO = "owner/repo"
+PR_NUMBER = 42
+TOKEN = "ghp_test"
+
+BASE_URL = "https://api.github.com"
+CHECK_RUNS_URL = f"{BASE_URL}/repos/{REPO}/check-runs"
+
+
+@respx.mock
+def test_create_check_run_posts_completed_run_with_conclusion() -> None:
+    """create_check_run POSTs a completed run with the head sha, conclusion,
+    and output, carrying the auth + API-version headers."""
+    posted: list[dict[str, object]] = []
+    seen_headers: list[httpx.Headers] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        posted.append(json.loads(request.content))
+        seen_headers.append(request.headers)
+        return httpx.Response(201, json={"id": 7})
+
+    respx.route(method="POST", url=CHECK_RUNS_URL).mock(side_effect=capture)
+
+    client = httpx.Client()
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=client)
+    gw.create_check_run(
+        head_sha="deadbeef",
+        conclusion="failure",
+        title="1 finding at or above high",
+        summary="Blocking findings present.",
+    )
+
+    assert len(posted) == 1
+    body = posted[0]
+    assert body["head_sha"] == "deadbeef"
+    assert body["status"] == "completed"
+    assert body["conclusion"] == "failure"
+    assert body["output"] == {
+        "title": "1 finding at or above high",
+        "summary": "Blocking findings present.",
+    }
+    assert isinstance(body["name"], str) and body["name"]
+
+    headers = seen_headers[0]
+    assert headers["Authorization"] == f"Bearer {TOKEN}"
+    assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+    assert headers["Accept"] == "application/vnd.github+json"
+
+
+@respx.mock
+def test_create_check_run_success_conclusion() -> None:
+    """A success conclusion posts through the same endpoint."""
+    posted: list[dict[str, object]] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        posted.append(json.loads(request.content))
+        return httpx.Response(201, json={"id": 8})
+
+    respx.route(method="POST", url=CHECK_RUNS_URL).mock(side_effect=capture)
+
+    client = httpx.Client()
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=client)
+    gw.create_check_run(
+        head_sha="cafe1234",
+        conclusion="success",
+        title="No findings at or above high",
+        summary="Clean.",
+    )
+
+    assert posted[0]["conclusion"] == "success"
+    assert posted[0]["head_sha"] == "cafe1234"

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -431,6 +431,17 @@
       "title": "Extra Lenses",
       "type": "array"
     },
+    "fail_on": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Severity"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
     "finding_rules": {
       "items": {
         "$ref": "#/$defs/FindingRule"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,6 +155,20 @@ def test_review_config_unanchored_min_severity_defaults_to_high() -> None:
     assert cfg.unanchored_min_severity is Severity.high
 
 
+def test_review_config_fail_on_defaults_none() -> None:
+    # The merge-gate is off by default (non-breaking): no check run is created.
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+    assert cfg.fail_on is None
+
+
+def test_review_config_accepts_fail_on() -> None:
+    # A plain severity string coerces to the ordered Severity enum, so the gate
+    # can compare `finding.severity >= cfg.fail_on`.
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", fail_on="high")
+    restored = ReviewConfig.model_validate_json(cfg.model_dump_json())
+    assert restored.fail_on is Severity.high
+
+
 def test_review_finding_broad_defaults_false() -> None:
     # `broad` is engine-set (like `anchored`); a fresh finding is not broad.
     f = ReviewFinding(path="x.py", line=1, severity=Severity.high, title="t", body="b")


### PR DESCRIPTION
## What

Adds an optional `fail_on` severity threshold that turns a review into a **merge gate**. When set, after posting the review the reviewer creates a GitHub **Check Run** named `lgtmaybe` whose conclusion is:

- `failure` — if any surviving finding is at or above `fail_on`
- `success` — otherwise

Teams can mark that check **required** in branch protection to block merges on blocking findings.

Default is **off** (`fail_on = None`) and fully non-breaking. Enforcement rides the Check Run — lgtmaybe deliberately **never sets PR approval state**, so clean reviews stay comment-only.

## Why

Reviews were advisory only. A team that wants "no high-severity finding merges" had no first-class way to enforce it. A Check Run is the right primitive: it plugs into branch-protection required checks without touching approval state (which lgtmaybe intentionally leaves alone).

## How

- **Config:** `ReviewConfig.fail_on: Severity | None = None` (`core/models.py`). The loader/store are reflection-based, so it's a valid `.lgtmaybe.yml` key and `config set fail_on high` value automatically. `Severity`'s ordered `__ge__` drives the gate (`f.severity >= cfg.fail_on`).
- **CLI:** `--fail-on {info,low,medium,high,critical}` on `review`, mirroring `--min-severity` end-to-end into `load_config`.
- **Action:** `fail_on` input wired through `action.yml` (`inputs`, `INPUT_FAIL_ON` env, `-e` passthrough), `action_inputs()`, and `action()` → `load_config`.
- **Adapter:** adapter-only `RestGitHubGateway.create_check_run(head_sha, conclusion, title, summary)` — `POST /repos/{repo}/check-runs`, same injected `httpx.Client` + auth headers as the existing reviews/labels POSTs. Not added to the frozen port; invoked via `getattr`, exactly like `apply_pr_labels` / `mark_reviewed`.
- **Wiring:** in `run_review`, after `post_review`, a getattr-guarded block mirroring `apply_pr_labels` — computes the failing set from the already-severity-floor-filtered findings, picks the conclusion, builds a per-severity summary, and creates the check run on `ctx.head_sha`.

## Tests (TDD: red → green)

- `tests/cli/test_merge_gate.py` (new) — drives `run_review` with a fake: high finding → `failure` + `head_sha`, low-only → `success`, clean → `success`, `fail_on=None` → not called, dry-run → not called, port-only gateway → no crash.
- `tests/github/test_check_run.py` (new, respx) — `create_check_run` POSTs to `/check-runs` with the expected body (`head_sha`/`status`/`conclusion`/`output`/`name`) and auth headers.
- `tests/test_models.py`, `tests/config/test_loader.py`, `tests/config/test_store.py` — `fail_on` default-off + `.lgtmaybe.yml` / `config set` round-trips.
- `tests/cli/test_action.py` — `INPUT_FAIL_ON` reaches config.
- `tests/fakes/github.py` — `create_check_run` recorder.

## Specs & docs

- New requirement + anchor `github.check-run` in `openspec/specs/github-posting/` (binds `create_check_run`); `core.config` updated for the new field. `uv run pytest tests/specs` green, `openspec validate --specs` passes.
- Regenerated `docs/reference/config.md`, `docs/llms*.txt`, and `tests/snapshots/ReviewConfig.json`.
- Added a "Gate merges on findings" how-to section (branch-protection required-check steps) to `docs/how-to/use-as-github-action.md`.

## Verification

- `uv run pytest -q` → `1219 passed, 3 deselected`
- `uv run ruff check` → clean
- `uv lock --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j3CsYnZxhs5jQZA87vU4v

---
_Generated by [Claude Code](https://claude.ai/code/session_011j3CsYnZxhs5jQZA87vU4v)_