### PR TITLE
fix(diagram): keep C4 relationship lines readable in GitHub dark mode

### DIFF
--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -27,7 +27,10 @@ One model call returns two renderings of the same graph:
   terminal and serves as the fallback if the Mermaid can't be rendered.
 
 Changed elements are marked in the labels (`(new)` / `(changed)`), and the
-diagram stays honest about the diff being only a slice of the codebase —
+relationship lines are restyled in a mid-grey that stays readable on both
+GitHub themes — Mermaid's C4 renderer defaults them to a near-black that
+disappears in dark mode. The diagram also stays honest about the diff being
+only a slice of the codebase —
 relationships it infers from imports rather than the diff itself are called out
 in the notes rather than asserted as fact.
 
@@ -47,6 +50,9 @@ C4Container
     Rel(client, api, "GET /users/{id}")
     Rel(api, cache, "check cache (new)")
     Rel(api, db, "on miss, query")
+    UpdateRelStyle(client, api, $textColor="#767676", $lineColor="#767676")
+    UpdateRelStyle(api, cache, $textColor="#767676", $lineColor="#767676")
+    UpdateRelStyle(api, db, $textColor="#767676", $lineColor="#767676")
 ```
 
 <details>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2699,7 +2699,10 @@ One model call returns two renderings of the same graph:
   terminal and serves as the fallback if the Mermaid can't be rendered.
 
 Changed elements are marked in the labels (`(new)` / `(changed)`), and the
-diagram stays honest about the diff being only a slice of the codebase —
+relationship lines are restyled in a mid-grey that stays readable on both
+GitHub themes — Mermaid's C4 renderer defaults them to a near-black that
+disappears in dark mode. The diagram also stays honest about the diff being
+only a slice of the codebase —
 relationships it infers from imports rather than the diff itself are called out
 in the notes rather than asserted as fact.
 
@@ -2719,6 +2722,9 @@ C4Container
     Rel(client, api, "GET /users/{id}")
     Rel(api, cache, "check cache (new)")
     Rel(api, db, "on miss, query")
+    UpdateRelStyle(client, api, $textColor="#767676", $lineColor="#767676")
+    UpdateRelStyle(api, cache, $textColor="#767676", $lineColor="#767676")
+    UpdateRelStyle(api, db, $textColor="#767676", $lineColor="#767676")
 ```
 
 <details>

--- a/src/lgtmaybe/engine/diagram.py
+++ b/src/lgtmaybe/engine/diagram.py
@@ -12,6 +12,11 @@ since a terminal can't render Mermaid). If the Mermaid fails a cheap validity
 check the comment shows the ASCII alone — a reviewer never sees GitHub's red
 "unable to render" box.
 
+C4 output is post-processed for dark mode: Mermaid's C4 renderer draws
+relationship lines and labels in a hardcoded near-black that disappears on
+GitHub's dark theme, so ``_restyle_rels`` appends an ``UpdateRelStyle`` per
+relationship in a mid-grey legible on both themes.
+
 Like describe, the diff and stated intent are untrusted: both are redacted
 before egress and the diff enters its own neutralised block with a
 diagram-specific task statement (never ``wrap_diff``'s findings-JSON
@@ -78,6 +83,40 @@ _MERMAID_START = re.compile(
     r"^(C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|flowchart|graph)\b"
 )
 
+# A C4 relationship call — Rel, BiRel, and the directional/back variants — whose
+# first two arguments are the endpoint aliases.
+_REL_CALL = re.compile(r"^\s*(?:Bi)?Rel(?:_\w+)?\(\s*([^,()\s]+)\s*,\s*([^,()\s]+)\s*,")
+_REL_STYLE = re.compile(r"^\s*UpdateRelStyle\(\s*([^,()\s]+)\s*,\s*([^,()\s]+)\s*[,)]")
+
+# Mermaid's C4 renderer hardcodes near-black relationship lines and labels
+# regardless of theme, so they vanish on GitHub's dark background. This
+# mid-grey keeps ≥4:1 contrast on both GitHub themes (#ffffff and #0d1117).
+_REL_COLOR = "#767676"
+
+
+def _restyle_rels(mermaid: str) -> str:
+    """Append an ``UpdateRelStyle`` per C4 relationship so it survives dark mode.
+
+    Best-effort and additive: pairs the model already styled are left alone,
+    each pair is styled once, and non-C4 diagrams (which GitHub themes
+    properly) pass through untouched.
+    """
+    lines = mermaid.splitlines()
+    first = next((line.strip() for line in lines if line.strip()), "")
+    if not first.startswith("C4"):
+        return mermaid
+
+    styled = {m.groups() for line in lines if (m := _REL_STYLE.match(line))}
+    additions = []
+    for line in lines:
+        if (m := _REL_CALL.match(line)) and m.groups() not in styled:
+            styled.add(m.groups())
+            additions.append(
+                f"    UpdateRelStyle({m[1]}, {m[2]}, "
+                f'$textColor="{_REL_COLOR}", $lineColor="{_REL_COLOR}")'
+            )
+    return "\n".join(lines + additions)
+
 
 def build_diagram(ctx: PRContext, cfg: ReviewConfig, provider: ProviderClient) -> str:
     """One provider call → the Markdown body of the change-diagram comment.
@@ -138,7 +177,7 @@ def _render(diagram: DiagramResult) -> str:
     ascii_art = diagram.ascii.strip()
 
     if _mermaid_ok(mermaid):
-        lines += _fenced(mermaid, "mermaid")
+        lines += _fenced(_restyle_rels(mermaid), "mermaid")
         if ascii_art:
             # Collapsed so the rendered diagram leads; expandable text fallback.
             lines += ["", "<details><summary>Text version</summary>", ""]

--- a/tests/engine/test_diagram.py
+++ b/tests/engine/test_diagram.py
@@ -9,6 +9,9 @@ rendering and renders them as a Markdown comment. Contracts:
 - invalid Mermaid (not a diagram) drops to an ASCII-only plain fence — never a
   broken Mermaid block;
 - unparseable model output falls back to the raw text;
+- C4 relationship lines get an ``UpdateRelStyle`` in a mid-grey readable on
+  both GitHub themes (the renderer's near-black default vanishes in dark mode),
+  without duplicating styles the model already emitted;
 - the diff is redacted before it leaves, and wrapped as untrusted data;
 - the intent block is sent only when the PR states an intent;
 - the diagram prompt carries no findings-JSON task restatement.
@@ -88,6 +91,56 @@ def test_invalid_mermaid_falls_back_to_ascii_only() -> None:
     assert "```mermaid" not in body
     assert "<details>" not in body
     assert "[Client] --> [App] (changed)" in body
+
+
+def test_c4_rels_get_dark_mode_safe_styles() -> None:
+    mermaid = (
+        "C4Container\n"
+        '    Container(api, "API")\n'
+        '    ContainerDb(db, "DB")\n'
+        '    Rel(client, api, "GET /users")\n'
+        '    BiRel_D(api, db, "query")\n'
+    )
+    body = build_diagram(_CTX, _CFG, _structured_provider(mermaid=mermaid))
+
+    assert 'UpdateRelStyle(client, api, $textColor="#767676", $lineColor="#767676")' in body
+    assert 'UpdateRelStyle(api, db, $textColor="#767676", $lineColor="#767676")' in body
+
+
+def test_rel_styles_land_inside_the_mermaid_fence() -> None:
+    mermaid = 'C4Container\n    Rel(a, b, "calls")'
+    body = build_diagram(_CTX, _CFG, _structured_provider(mermaid=mermaid))
+
+    fence = body.split("```mermaid\n", 1)[1].split("\n```", 1)[0]
+    assert "UpdateRelStyle(a, b," in fence
+
+
+def test_model_supplied_rel_style_is_not_duplicated() -> None:
+    mermaid = (
+        "C4Container\n"
+        '    Rel(a, b, "calls")\n'
+        '    Rel(b, c, "calls")\n'
+        '    UpdateRelStyle(a, b, $textColor="red", $lineColor="red")\n'
+    )
+    body = build_diagram(_CTX, _CFG, _structured_provider(mermaid=mermaid))
+
+    # The model's own style for (a, b) is kept; only (b, c) gets ours.
+    assert body.count("UpdateRelStyle(a, b,") == 1
+    assert '$textColor="red"' in body
+    assert 'UpdateRelStyle(b, c, $textColor="#767676"' in body
+
+
+def test_repeated_rel_pair_styled_once() -> None:
+    mermaid = 'C4Container\n    Rel(a, b, "calls")\n    Rel(a, b, "calls again")'
+    body = build_diagram(_CTX, _CFG, _structured_provider(mermaid=mermaid))
+
+    assert body.count("UpdateRelStyle(a, b,") == 1
+
+
+def test_non_c4_mermaid_is_left_unstyled() -> None:
+    body = build_diagram(_CTX, _CFG, _structured_provider(mermaid="flowchart LR\n    a --> b"))
+
+    assert "UpdateRelStyle" not in body
 
 
 def test_unparseable_output_falls_back_to_raw_text() -> None:


### PR DESCRIPTION
## What

Mermaid's C4 renderer hardcodes near-black relationship lines and labels regardless of theme, so `/diagram` comments were hard to read on GitHub's dark theme — the arrows and their labels all but disappear against the `#0d1117` background. (The element boxes themselves are fine: white text on C4's blue fills reads on both themes.)

## How

`_render` now post-processes validated C4 Mermaid through a new `_restyle_rels` step that appends an `UpdateRelStyle(from, to, $textColor="#767676", $lineColor="#767676")` per unique relationship pair — Mermaid's documented mechanism for styling C4 relationships. `#767676` keeps ≥4:1 contrast on both GitHub backgrounds (`#ffffff` and `#0d1117`), so light-mode readability is preserved.

Deterministic post-processing rather than prompting, in line with the project's "don't trust the model with mechanics" stance:

- covers `Rel`, `BiRel`, and the directional/back variants;
- a pair the model already styled with its own `UpdateRelStyle` is left alone;
- repeated pairs are styled once;
- non-C4 diagrams (`flowchart`/`graph`, which GitHub themes properly) pass through untouched;
- purely additive at the end of the source, so a bad match can't corrupt the diagram body.

## Tests

TDD red → green: five new tests in `tests/engine/test_diagram.py` cover the styling, fence placement, model-supplied-style dedupe, repeated-pair dedupe, and the non-C4 pass-through. Full suite green (1249 passed), ruff check/format clean, `docs/llms-full.txt` regenerated for the doc update in `docs/how-to/generate-a-change-diagram.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3wipq3ko7ybkbcVHPkk6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3wipq3ko7ybkbcVHPkk6r)_