### PR TITLE
docs: move docs site to lgtmaybe.coles.codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Provider-agnostic PR reviewer. Seven hosted providers, local ollama, and any
 OpenAI-compatible endpoint — one flag, no static keys for cloud providers. Posts
 inline review comments and a summary.
 
-📖 **Full documentation:** <https://mattjcoles.github.io/lgtmaybe/>
+📖 **Full documentation:** <https://lgtmaybe.coles.codes/>
 
 ## What it reviews
 
@@ -165,10 +165,10 @@ reviews on real pull requests, wire up the
 
 ## Documentation
 
-Browse the rendered docs at <https://mattjcoles.github.io/lgtmaybe/>, or read the
+Browse the rendered docs at <https://lgtmaybe.coles.codes/>, or read the
 Markdown sources below. For LLM agents, a curated
-[`llms.txt`](https://mattjcoles.github.io/lgtmaybe/llms.txt) index (and a
-whole-corpus [`llms-full.txt`](https://mattjcoles.github.io/lgtmaybe/llms-full.txt))
+[`llms.txt`](https://lgtmaybe.coles.codes/llms.txt) index (and a
+whole-corpus [`llms-full.txt`](https://lgtmaybe.coles.codes/llms-full.txt))
 are published at the docs root.
 
 **Tutorial** — learn by doing

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+lgtmaybe.coles.codes

--- a/docs/generate_llms_txt.py
+++ b/docs/generate_llms_txt.py
@@ -27,7 +27,7 @@ MKDOCS_PATH = DOCS.parent / "mkdocs.yml"
 LLMS_PATH = DOCS / "llms.txt"
 LLMS_FULL_PATH = DOCS / "llms-full.txt"
 
-SITE_URL = "https://mattjcoles.github.io/lgtmaybe/"
+SITE_URL = "https://lgtmaybe.coles.codes/"
 
 SUMMARY = (
     "Provider-agnostic AI pull-request reviewer. It posts inline review comments "

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,11 +2,11 @@
 
 > Provider-agnostic AI pull-request reviewer. It posts inline review comments and a summary onto a GitHub pull request, or prints findings locally from your git diff. Seven hosted providers, local ollama, and any OpenAI-compatible endpoint — one flag, and keyless OIDC/WIF auth for cloud providers (no static keys in secrets).
 
-Source: https://mattjcoles.github.io/lgtmaybe/ — generated from the docs/ tree.
+Source: https://lgtmaybe.coles.codes/ — generated from the docs/ tree.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/ -->
+<!-- Source: https://lgtmaybe.coles.codes/ -->
 
 <div class="hero" markdown>
 
@@ -94,7 +94,7 @@ coding agents.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/tutorial/getting-started/ -->
+<!-- Source: https://lgtmaybe.coles.codes/tutorial/getting-started/ -->
 
 # Getting Started with lgtmaybe
 
@@ -211,7 +211,7 @@ lgtmaybe ran its pipeline over your local diff:
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/install-the-cli/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/install-the-cli/ -->
 
 # Install the CLI
 
@@ -299,7 +299,7 @@ bundles all three and wires up the OIDC/WIF auth for you.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/use-as-github-action/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/use-as-github-action/ -->
 
 # Use lgtmaybe as a GitHub Action
 
@@ -591,7 +591,7 @@ uses: MattJColes/lgtmaybe@v1.0.0
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/post-as-a-github-app/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/ -->
 
 # Post reviews as a GitHub App
 
@@ -751,7 +751,7 @@ including the `-----BEGIN...-----` / `-----END...-----` lines. Paste the whole
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-openai/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-openai/ -->
 
 # Review with OpenAI
 
@@ -825,7 +825,7 @@ With that file in place, `lgtmaybe review` needs no flags. See
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-anthropic/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-anthropic/ -->
 
 # Review with Claude (Anthropic)
 
@@ -906,7 +906,7 @@ With that file in place, `lgtmaybe review` needs no flags. See
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-openrouter/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-openrouter/ -->
 
 # Review with OpenRouter
 
@@ -984,7 +984,7 @@ With that file in place, `lgtmaybe review` needs no flags. See
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-zai/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-zai/ -->
 
 # Review with z.ai (GLM)
 
@@ -1071,7 +1071,7 @@ With that file in place, `lgtmaybe review` needs no flags. See
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-bedrock-oidc/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-bedrock-oidc/ -->
 
 # Review with AWS Bedrock (keyless OIDC)
 
@@ -1244,7 +1244,7 @@ needs a cross-region inference profile — prefix with `us.`/`eu.`/`apac.` (e.g.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-vertex-wif/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-vertex-wif/ -->
 
 # Review with Google Vertex AI (keyless WIF)
 
@@ -1377,7 +1377,7 @@ region. Check the [Vertex AI model garden](https://console.cloud.google.com/vert
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/review-with-azure/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-azure/ -->
 
 # Review with Azure OpenAI (keyless OIDC)
 
@@ -1537,7 +1537,7 @@ resource that `api_base` points at, not the upstream OpenAI model id.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/run-locally-with-ollama/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/run-locally-with-ollama/ -->
 
 # Run Locally with ollama
 
@@ -1817,7 +1817,7 @@ window. Add a path filter in `.lgtmaybe.yml` to reduce diff size, or set
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/use-a-custom-openai-compatible-endpoint/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/use-a-custom-openai-compatible-endpoint/ -->
 
 # Local Models & other OpenAI providers
 
@@ -2001,7 +2001,7 @@ Persist it as `structured_output: false` in `.lgtmaybe.yml`, or set the
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/configure-lgtmaybe-yml/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/configure-lgtmaybe-yml/ -->
 
 # Configure .lgtmaybe.yml
 
@@ -2560,7 +2560,7 @@ Flags take precedence over `.lgtmaybe.yml`.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/add-a-custom-lens/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/add-a-custom-lens/ -->
 
 # Add a custom review lens (BYO skills)
 
@@ -2718,7 +2718,7 @@ your lenses.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/generate-a-change-diagram/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/ -->
 
 # Generate a change diagram
 
@@ -2859,7 +2859,7 @@ used: GitHub doesn't render D2 in Markdown, so it would show as source anyway.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/fix-findings-with-an-ai-agent/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/fix-findings-with-an-ai-agent/ -->
 
 # Fix findings with an AI agent
 
@@ -2945,7 +2945,7 @@ you are happy, then open your PR. To post reviews on the PR itself, wire up the
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/how-to/releasing/ -->
+<!-- Source: https://lgtmaybe.coles.codes/how-to/releasing/ -->
 
 # Releasing lgtmaybe (maintainers)
 
@@ -3034,7 +3034,7 @@ The only human-only pieces:
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/reference/config/ -->
+<!-- Source: https://lgtmaybe.coles.codes/reference/config/ -->
 
 <!-- DO NOT EDIT — this file is generated by docs/generate_reference.py.
      Run `uv run python docs/generate_reference.py` to regenerate.
@@ -4109,7 +4109,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/explanation/what-gets-reviewed/ -->
+<!-- Source: https://lgtmaybe.coles.codes/explanation/what-gets-reviewed/ -->
 
 # What gets reviewed
 
@@ -4531,7 +4531,7 @@ coding agent can read and apply — a local review-and-fix loop. See
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/explanation/architecture/ -->
+<!-- Source: https://lgtmaybe.coles.codes/explanation/architecture/ -->
 
 # Architecture
 
@@ -4746,7 +4746,7 @@ requirement arises.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/explanation/auth-model/ -->
+<!-- Source: https://lgtmaybe.coles.codes/explanation/auth-model/ -->
 
 # Auth Model
 
@@ -4865,7 +4865,7 @@ display key values.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/explanation/data-and-privacy/ -->
+<!-- Source: https://lgtmaybe.coles.codes/explanation/data-and-privacy/ -->
 
 # Data and Privacy
 
@@ -5015,7 +5015,7 @@ malicious PR from gaining access to repository secrets.
 
 ---
 
-<!-- Source: https://mattjcoles.github.io/lgtmaybe/explanation/trust-and-cost/ -->
+<!-- Source: https://lgtmaybe.coles.codes/explanation/trust-and-cost/ -->
 
 # Trust and Cost
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,36 +4,36 @@
 
 ## Tutorial
 
-- [Getting started](https://mattjcoles.github.io/lgtmaybe/tutorial/getting-started/): Run your first lgtmaybe pull-request review locally with ollama — no API keys, no GitHub token, and no pull request required.
+- [Getting started](https://lgtmaybe.coles.codes/tutorial/getting-started/): Run your first lgtmaybe pull-request review locally with ollama — no API keys, no GitHub token, and no pull request required.
 
 ## How-to
 
-- [Install the CLI](https://mattjcoles.github.io/lgtmaybe/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS) or Homebrew (macOS/Linuxbrew), and add the cloud extras for keyless Bedrock/Vertex/Azure.
-- [Use as a GitHub Action](https://mattjcoles.github.io/lgtmaybe/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
-- [Post reviews as a GitHub App](https://mattjcoles.github.io/lgtmaybe/how-to/post-as-a-github-app/): Post lgtmaybe reviews under your own branded GitHub App identity (lgtmaybe[bot]) with higher API rate limits, instead of the default github-actions[bot].
-- [Review with OpenAI](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
-- [Review with Claude (Anthropic)](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
-- [Review with OpenRouter](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.
-- [Review with z.ai (GLM)](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-zai/): Configure lgtmaybe to review pull requests with z.ai GLM models through litellm's native zai route.
-- [Review with Bedrock OIDC](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-bedrock-oidc/): Run lgtmaybe on AWS Bedrock with keyless GitHub OIDC — no static AWS credentials stored in repository secrets.
-- [Review with Vertex WIF](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-vertex-wif/): Run lgtmaybe on Google Vertex AI with keyless Workload Identity Federation — no service-account JSON in secrets.
-- [Review with Azure OpenAI](https://mattjcoles.github.io/lgtmaybe/how-to/review-with-azure/): Review pull requests with Azure OpenAI in lgtmaybe using keyless GitHub OIDC federated to Entra, or an API key.
-- [Run locally with ollama](https://mattjcoles.github.io/lgtmaybe/how-to/run-locally-with-ollama/): Run lgtmaybe entirely locally with an ollama model — zero API cost, zero egress, no keys, and code never leaves your machine.
-- [Other OpenAI-compatible servers](https://mattjcoles.github.io/lgtmaybe/how-to/use-a-custom-openai-compatible-endpoint/): Point lgtmaybe at any OpenAI-compatible server — vLLM, llama.cpp, LM Studio, DeepSeek — with --api-base; the key is optional.
-- [Configure .lgtmaybe.yml](https://mattjcoles.github.io/lgtmaybe/how-to/configure-lgtmaybe-yml/): Configure lgtmaybe with a .lgtmaybe.yml file — provider, model, severity floor, lenses, caps, and other non-secret defaults.
-- [Add a custom review lens](https://mattjcoles.github.io/lgtmaybe/how-to/add-a-custom-lens/): Add a custom review lens to lgtmaybe — a bring-your-own skill file that runs alongside the nine built-in lenses.
-- [Generate a change diagram](https://mattjcoles.github.io/lgtmaybe/how-to/generate-a-change-diagram/): Post a C4-style Mermaid diagram of a pull request's changes as a GitHub comment, or print one from the CLI.
-- [Fix findings with an AI agent](https://mattjcoles.github.io/lgtmaybe/how-to/fix-findings-with-an-ai-agent/): Turn lgtmaybe findings into instructions an AI coding agent can apply, for a local review-and-fix loop before you push.
-- [Releasing](https://mattjcoles.github.io/lgtmaybe/how-to/releasing/): Maintainer guide to cutting and publishing a new lgtmaybe release with release-please, PyPI trusted publishing, and GHCR.
+- [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS) or Homebrew (macOS/Linuxbrew), and add the cloud extras for keyless Bedrock/Vertex/Azure.
+- [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
+- [Post reviews as a GitHub App](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews under your own branded GitHub App identity (lgtmaybe[bot]) with higher API rate limits, instead of the default github-actions[bot].
+- [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
+- [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
+- [Review with OpenRouter](https://lgtmaybe.coles.codes/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.
+- [Review with z.ai (GLM)](https://lgtmaybe.coles.codes/how-to/review-with-zai/): Configure lgtmaybe to review pull requests with z.ai GLM models through litellm's native zai route.
+- [Review with Bedrock OIDC](https://lgtmaybe.coles.codes/how-to/review-with-bedrock-oidc/): Run lgtmaybe on AWS Bedrock with keyless GitHub OIDC — no static AWS credentials stored in repository secrets.
+- [Review with Vertex WIF](https://lgtmaybe.coles.codes/how-to/review-with-vertex-wif/): Run lgtmaybe on Google Vertex AI with keyless Workload Identity Federation — no service-account JSON in secrets.
+- [Review with Azure OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-azure/): Review pull requests with Azure OpenAI in lgtmaybe using keyless GitHub OIDC federated to Entra, or an API key.
+- [Run locally with ollama](https://lgtmaybe.coles.codes/how-to/run-locally-with-ollama/): Run lgtmaybe entirely locally with an ollama model — zero API cost, zero egress, no keys, and code never leaves your machine.
+- [Other OpenAI-compatible servers](https://lgtmaybe.coles.codes/how-to/use-a-custom-openai-compatible-endpoint/): Point lgtmaybe at any OpenAI-compatible server — vLLM, llama.cpp, LM Studio, DeepSeek — with --api-base; the key is optional.
+- [Configure .lgtmaybe.yml](https://lgtmaybe.coles.codes/how-to/configure-lgtmaybe-yml/): Configure lgtmaybe with a .lgtmaybe.yml file — provider, model, severity floor, lenses, caps, and other non-secret defaults.
+- [Add a custom review lens](https://lgtmaybe.coles.codes/how-to/add-a-custom-lens/): Add a custom review lens to lgtmaybe — a bring-your-own skill file that runs alongside the nine built-in lenses.
+- [Generate a change diagram](https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/): Post a C4-style Mermaid diagram of a pull request's changes as a GitHub comment, or print one from the CLI.
+- [Fix findings with an AI agent](https://lgtmaybe.coles.codes/how-to/fix-findings-with-an-ai-agent/): Turn lgtmaybe findings into instructions an AI coding agent can apply, for a local review-and-fix loop before you push.
+- [Releasing](https://lgtmaybe.coles.codes/how-to/releasing/): Maintainer guide to cutting and publishing a new lgtmaybe release with release-please, PyPI trusted publishing, and GHCR.
 
 ## Reference
 
-- [Configuration](https://mattjcoles.github.io/lgtmaybe/reference/config/): Complete lgtmaybe configuration reference — every ReviewConfig field, enum, and JSON schema, generated from the pydantic models.
+- [Configuration](https://lgtmaybe.coles.codes/reference/config/): Complete lgtmaybe configuration reference — every ReviewConfig field, enum, and JSON schema, generated from the pydantic models.
 
 ## Explanation
 
-- [What gets reviewed](https://mattjcoles.github.io/lgtmaybe/explanation/what-gets-reviewed/): What lgtmaybe reviews and how it bounds the work — only changed lines, padded with surrounding context, never your whole repo.
-- [Architecture](https://mattjcoles.github.io/lgtmaybe/explanation/architecture/): lgtmaybe's hexagonal ports-and-adapters architecture, the review pipeline stages, and the per-category lens fan-out.
-- [Auth model](https://mattjcoles.github.io/lgtmaybe/explanation/auth-model/): How lgtmaybe authenticates to each provider — keyless OIDC/WIF for cloud, ambient credentials, API keys only where unavoidable.
-- [Data and privacy](https://mattjcoles.github.io/lgtmaybe/explanation/data-and-privacy/): Exactly what data lgtmaybe sends where — diffs only, secret redaction before egress, no code checkout, fully local with ollama.
-- [Trust and cost](https://mattjcoles.github.io/lgtmaybe/explanation/trust-and-cost/): How lgtmaybe's trigger gate and cost model work — who can start a review, and why opening it wide is a cost not a security choice.
+- [What gets reviewed](https://lgtmaybe.coles.codes/explanation/what-gets-reviewed/): What lgtmaybe reviews and how it bounds the work — only changed lines, padded with surrounding context, never your whole repo.
+- [Architecture](https://lgtmaybe.coles.codes/explanation/architecture/): lgtmaybe's hexagonal ports-and-adapters architecture, the review pipeline stages, and the per-category lens fan-out.
+- [Auth model](https://lgtmaybe.coles.codes/explanation/auth-model/): How lgtmaybe authenticates to each provider — keyless OIDC/WIF for cloud, ambient credentials, API keys only where unavoidable.
+- [Data and privacy](https://lgtmaybe.coles.codes/explanation/data-and-privacy/): Exactly what data lgtmaybe sends where — diffs only, secret redaction before egress, no code checkout, fully local with ollama.
+- [Trust and cost](https://lgtmaybe.coles.codes/explanation/trust-and-cost/): How lgtmaybe's trigger gate and cost model work — who can start a review, and why opening it wide is a cost not a security choice.

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -8,7 +8,7 @@
 #
 # One-time setup (create the App, grant it pull-requests:write + contents:read,
 # install it, store the ID + private key): see
-# https://mattjcoles.github.io/lgtmaybe/how-to/post-as-a-github-app/
+# https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/
 #
 # Secrets/variables to add:
 #   ANTHROPIC_API_KEY        (secret)   — your model provider key

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: lgtmaybe
 site_description: Provider-agnostic AI PR reviewer — OpenAI, Claude, Bedrock, Vertex, Azure, ollama and more. One flag, keyless OIDC/WIF for cloud, no keys in secrets. GitHub Action + CLI.
-site_url: https://mattjcoles.github.io/lgtmaybe/
+site_url: https://lgtmaybe.coles.codes/
 repo_url: https://github.com/MattJColes/lgtmaybe
 repo_name: MattJColes/lgtmaybe
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ static-analysis = [
 lgtmaybe = "lgtmaybe.cli:main"
 
 [project.urls]
-Homepage = "https://mattjcoles.github.io/lgtmaybe/"
+Homepage = "https://lgtmaybe.coles.codes/"
 Repository = "https://github.com/MattJColes/lgtmaybe"
 
 [dependency-groups]

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -64,7 +64,7 @@ class Lgtmaybe < Formula
   include Language::Python::Virtualenv
 
   desc "Provider-agnostic pull request reviewer with keyless cloud auth"
-  homepage "https://mattjcoles.github.io/lgtmaybe/"
+  homepage "https://lgtmaybe.coles.codes/"
   url "${SDIST_URL}"
   sha256 "${SDIST_SHA}"
   license "MIT"

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -780,7 +780,7 @@ Examples:
   lgtmaybe config init                     One-time provider/model setup
   lgtmaybe help COMMAND                    Detailed help for any command
 \b
-Docs: https://mattjcoles.github.io/lgtmaybe/
+Docs: https://lgtmaybe.coles.codes/
 """
 
 

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -16,7 +16,7 @@ def test_help_lists_commands_and_examples() -> None:
         assert command in result.output
     assert "Examples:" in result.output
     assert "lgtmaybe review" in result.output
-    assert "https://mattjcoles.github.io/lgtmaybe/" in result.output
+    assert "https://lgtmaybe.coles.codes/" in result.output
 
 
 def test_help_command_matches_dash_dash_help() -> None:


### PR DESCRIPTION
Moves the GitHub Pages docs site from `mattjcoles.github.io/lgtmaybe/` to the custom domain **`lgtmaybe.coles.codes`**.

## What changed

- **`docs/CNAME`** (new) — the site deploys from a GitHub Actions artifact, so the custom domain must ship inside the build output on every deploy; a settings-committed `CNAME` alone would be wiped by the next build. MkDocs copies the file verbatim into `site/`.
- **`mkdocs.yml`** — `site_url` now `https://lgtmaybe.coles.codes/` (drives canonical URLs + sitemap; internal links are relative, so the subpath→root move needs nothing else).
- **`docs/generate_llms_txt.py`** — `SITE_URL` updated, and `docs/llms.txt` / `docs/llms-full.txt` regenerated (byte-for-byte freshness gated by `tests/docs/test_llms_txt_fresh.py`).
- **URL sweep** — README, `pyproject.toml` Homepage, the CLI help epilog (+ its assertion in `tests/cli/test_help.py`), the Homebrew formula `homepage`, and the GitHub App example workflow link.

## Verified locally

- `uv run pytest tests/docs tests/cli/test_help.py tests/specs -q` — all pass
- `uv run --group docs mkdocs build --strict` — clean, and `site/CNAME` contains the domain
- `grep -ri mattjcoles.github.io` — no old URLs remain
- DNS is already live: `lgtmaybe.coles.codes` CNAMEs to `mattjcoles.github.io` and resolves to GitHub's Pages IPs

## After merging (manual, repo settings)

1. Wait for the `docs` workflow to deploy (triggers on this merge).
2. Settings → Pages → Custom domain → `lgtmaybe.coles.codes` → Save; tick **Enforce HTTPS** once the certificate provisions.
3. Optional: verify `coles.codes` under account Settings → Pages → Verified domains, and add the new domain in Google Search Console (a verification file is already served at the docs root).

Old `mattjcoles.github.io/lgtmaybe/` URLs will 301-redirect to the new domain once the custom domain is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xGGrDoVCBUsJWB94EXty9

---
_Generated by [Claude Code](https://claude.ai/code/session_013xGGrDoVCBUsJWB94EXty9)_