### PR TITLE
ci: post dogfood reviews under the lgtmaybe GitHub App identity

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -2,6 +2,11 @@
 # Runs the in-repo action (./) so changes to action.yml are exercised too.
 # Add an OPENROUTER_API_KEY repo secret.
 #
+# Reviews post as lgtmaybe[bot] (name + avatar) via the GitHub App identity —
+# see docs/how-to/post-as-a-github-app.md. Set the LGTMAYBE_APP_ID repo
+# variable and LGTMAYBE_APP_PRIVATE_KEY secret; until they exist the action
+# falls back to the default workflow token (github-actions[bot]).
+#
 # Reviews run automatically on PRs from trusted authors (owner / member /
 # collaborator), and on demand via slash commands (/review, /improve, /ask,
 # /describe, /diagram) — a maintainer can opt an external PR in by commenting
@@ -55,3 +60,5 @@ jobs:
           auto_diagram: true
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          app_id: ${{ vars.LGTMAYBE_APP_ID }}
+          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Wires `app_id` / `app_private_key` into the dogfood workflow so reviews on this repo's own PRs post as **lgtmaybe[bot]** — the App's name and avatar — instead of `github-actions[bot]`.

The action already supports this (the `app_id` inputs and `docs/how-to/post-as-a-github-app.md` shipped earlier); this PR just makes the repo dogfood its own branded identity.

**Safe to merge before the App exists:** `${{ vars.LGTMAYBE_APP_ID }}` resolves to empty until the variable is set, which skips the token-mint step and falls back to the default workflow token — current behaviour, unchanged.

One-time setup to activate (maintainer, per the how-to doc):
1. Create a GitHub App named `lgtmaybe`, upload its avatar under Display information, grant **Pull requests: read/write** + **Contents: read** (+ **Issues: read/write** for `/ask`), no webhooks.
2. Install it on this repo.
3. Set the `LGTMAYBE_APP_ID` repository variable and `LGTMAYBE_APP_PRIVATE_KEY` secret (full PEM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn)_