### PR TITLE
docs: link the Marketplace listing and feature the branded screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,16 @@ everywhere:
 - **On a GitHub PR** — an inline comment on the exact changed line for each finding, plus one summary comment naming the model used. Re-running updates the same comments instead of duplicating them, auto-resolves a conversation once its finding is fixed, and a clean PR gets a 👍 **LGTM!**.
 - **On the CLI** — `lgtmaybe review` reads your local `git` diff and prints the findings (a readable listing, a JSON array with `--json`, or `--format agent` for an AI coding agent to read and apply); nothing is posted to GitHub.
 
-Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **C4-style change diagram** — a Mermaid diagram of the components the PR touches, rendered natively in the comment, with an ASCII fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
+Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **C4-style change diagram** — a Mermaid diagram of the components the PR touches, with what the PR changes highlighted in green, rendered natively in the comment, with an ASCII fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
+
+<p align="center">
+  <img src="docs/assets/marketplace/marketplace-screenshot-4.png" alt="A /diagram comment posted by lgtmaybe: a C4 diagram of a Stripe webhook change, with the changed Checkout API and new Orders DB and Billing worker components highlighted with green borders and NEW/CHANGED badges" width="640">
+</p>
 
 On re-runs and big PRs the review stays cheap: a `synchronize` push triggers an **incremental review** of just the new commits, an optional cheap **triage model** (`triage_model`) skips plainly-non-substantive files before the strong model runs, and optional **static-analysis fusion** (`static_analysis`) feeds ruff/bandit/semgrep hints into the review as untrusted context.
 
 <p align="center">
-  <img src="docs/assets/review-sql-injection.png" alt="An inline lgtmaybe review comment on a GitHub pull request flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a suggested parameterized-query fix" width="640">
+  <img src="docs/assets/marketplace/marketplace-screenshot-1.png" alt="An inline lgtmaybe review comment on a GitHub pull request flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a suggested parameterized-query fix" width="640">
 </p>
 
 <p align="center"><em>On a GitHub PR — an inline comment on the changed line. The same findings on the CLI:</em></p>
@@ -204,7 +208,8 @@ are published at the docs root.
 
 ## Use as a GitHub Action
 
-GitHub Marketplace copies the Action syntax into a workflow; it does not choose
+Install from the [GitHub Marketplace](https://github.com/marketplace/actions/lgtmaybe):
+it copies the Action syntax into a workflow; it does not choose
 an LLM service or model for you. In `.github/workflows/lgtmaybe.yml`, set
 `provider`, `model`, and the matching authentication input in the step's `with:`
 block. This complete example uses OpenAI:

--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -9,6 +9,8 @@ containers and components the PR touches plus their immediate relationships — 
 a reviewer gets a visual overview before they read the diff. It's a separate
 concern from the review and the description: enable any of them independently.
 
+![A /diagram comment posted by lgtmaybe: a C4 diagram of a Stripe webhook change, with the changed Checkout API and new Orders DB and Billing worker components highlighted with green borders](../assets/marketplace/marketplace-screenshot-4.png){ width="720" }
+
 ## Contents
 
 - [What you get](#what-you-get)

--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -4,6 +4,16 @@ description: Post lgtmaybe reviews under your own branded GitHub App identity (l
 
 # Post reviews as a GitHub App
 
+!!! note "This is optional branding on top of the Marketplace action — not a second install"
+    lgtmaybe itself is installed from the
+    [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe)
+    as an Action in your workflow — see
+    [Use as a GitHub Action](use-as-github-action.md). The GitHub App on this
+    page is **one you create yourself** so reviews post under **your** bot
+    identity; there is no shared lgtmaybe App to install, because lgtmaybe has
+    no hosted backend — a shared App would need its private key distributed,
+    which is exactly what this design avoids.
+
 By default lgtmaybe posts reviews as `github-actions[bot]` using the workflow's
 built-in token. The **recommended setup** is to point it at a **GitHub App** you
 own so reviews post under that App's identity instead — a branded

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -7,7 +7,9 @@ description: Add lgtmaybe as a GitHub Action to review every pull request automa
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
-GitHub Marketplace copies the Action syntax into your workflow. Provider and
+Install from the
+[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe) —
+it copies the Action syntax into your workflow. Provider and
 model selection happens in that workflow, not on a separate Marketplace
 settings screen: add a `with:` block containing `provider`, `model`, and the
 matching authentication input. The [minimal OpenAI workflow](#minimal-workflow-openai)

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ It checks for:
 Findings are graded from `info` to `critical` and land on the exact changed
 line. A clean change just gets a 👍 **LGTM!**.
 
+![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a committable parameterized-query suggestion](assets/marketplace/marketplace-screenshot-1.png){ width="720" }
+
 Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
 **`/describe`** writes a structured overview, **`/diagram`** draws a
 [C4-style map of the change](how-to/generate-a-change-diagram.md), and

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -37,6 +37,8 @@ It checks for:
 Findings are graded from `info` to `critical` and land on the exact changed
 line. A clean change just gets a 👍 **LGTM!**.
 
+![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a committable parameterized-query suggestion](assets/marketplace/marketplace-screenshot-1.png){ width="720" }
+
 Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
 **`/describe`** writes a structured overview, **`/diagram`** draws a
 [C4-style map of the change](how-to/generate-a-change-diagram.md), and
@@ -306,7 +308,9 @@ bundles all three and wires up the OIDC/WIF auth for you.
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
-GitHub Marketplace copies the Action syntax into your workflow. Provider and
+Install from the
+[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe) —
+it copies the Action syntax into your workflow. Provider and
 model selection happens in that workflow, not on a separate Marketplace
 settings screen: add a `with:` block containing `provider`, `model`, and the
 matching authentication input. The [minimal OpenAI workflow](#minimal-workflow-openai)
@@ -596,6 +600,16 @@ uses: MattJColes/lgtmaybe@v1.0.0
 <!-- Source: https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/ -->
 
 # Post reviews as a GitHub App
+
+!!! note "This is optional branding on top of the Marketplace action — not a second install"
+    lgtmaybe itself is installed from the
+    [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe)
+    as an Action in your workflow — see
+    [Use as a GitHub Action](use-as-github-action.md). The GitHub App on this
+    page is **one you create yourself** so reviews post under **your** bot
+    identity; there is no shared lgtmaybe App to install, because lgtmaybe has
+    no hosted backend — a shared App would need its private key distributed,
+    which is exactly what this design avoids.
 
 By default lgtmaybe posts reviews as `github-actions[bot]` using the workflow's
 built-in token. The **recommended setup** is to point it at a **GitHub App** you
@@ -2732,6 +2746,8 @@ lgtmaybe can post a **C4-style diagram of what a pull request changes** — the
 containers and components the PR touches plus their immediate relationships — so
 a reviewer gets a visual overview before they read the diff. It's a separate
 concern from the review and the description: enable any of them independently.
+
+![A /diagram comment posted by lgtmaybe: a C4 diagram of a Stripe webhook change, with the changed Checkout API and new Orders DB and Billing worker components highlighted with green borders](../assets/marketplace/marketplace-screenshot-4.png){ width="720" }
 
 ## Contents
 


### PR DESCRIPTION
Fixes the gap where the docs never mentioned the [Marketplace listing](https://github.com/marketplace/actions/lgtmaybe), and puts the new branded screenshots to work:

- **README**, the **Action how-to**, and the docs describe the Marketplace listing as the install path.
- **`post-as-a-github-app.md`** now opens with a note clarifying the App is optional branding you create yourself on top of the Marketplace action — not a second install. lgtmaybe has no hosted backend, so there is no shared App to install (that would require distributing its private key).
- The branded `lgtmaybe[bot]` review screenshot replaces the README hero image and lands on the docs homepage; the C4 change-diagram screenshot lands in the README and the diagram how-to.

`docs/llms-full.txt` regenerated; docs + spec test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn)_