### PR TITLE
feat(diagram): light-green relationship lines and labels in C4 diagrams

### DIFF
--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -30,9 +30,9 @@ One model call returns two renderings of the same graph:
 
 Changed elements are marked in the labels (`(new)` / `(changed)`) **and get a
 green border**, so the PR's footprint stands out from the untouched
-collaborators at a glance; the relationship lines are restyled in a mid-grey
-that stays readable on every GitHub theme — Mermaid's C4 renderer defaults
-them to a near-black that disappears in dark mode — and the layout is loosened
+collaborators at a glance; the relationship lines and labels are restyled in a
+light green that stays readable on every GitHub theme — Mermaid's C4 renderer
+defaults them to a near-black that disappears in dark mode — and the layout is loosened
 to three cards per row so the renderer's fixed-width cards don't overlap. The diagram also stays
 honest about the diff being only a slice of the codebase —
 relationships it infers from imports rather than the diff itself are called out
@@ -54,9 +54,9 @@ C4Container
     Rel(client, api, "GET /users/{id}")
     Rel(api, cache, "check cache (new)")
     Rel(api, db, "on miss, query")
-    UpdateRelStyle(client, api, $textColor="#808080", $lineColor="#808080")
-    UpdateRelStyle(api, cache, $textColor="#808080", $lineColor="#808080")
-    UpdateRelStyle(api, db, $textColor="#808080", $lineColor="#808080")
+    UpdateRelStyle(client, api, $textColor="#34a862", $lineColor="#34a862")
+    UpdateRelStyle(api, cache, $textColor="#34a862", $lineColor="#34a862")
+    UpdateRelStyle(api, db, $textColor="#34a862", $lineColor="#34a862")
     UpdateElementStyle(cache, $borderColor="#54d090")
     UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2768,9 +2768,9 @@ One model call returns two renderings of the same graph:
 
 Changed elements are marked in the labels (`(new)` / `(changed)`) **and get a
 green border**, so the PR's footprint stands out from the untouched
-collaborators at a glance; the relationship lines are restyled in a mid-grey
-that stays readable on every GitHub theme — Mermaid's C4 renderer defaults
-them to a near-black that disappears in dark mode — and the layout is loosened
+collaborators at a glance; the relationship lines and labels are restyled in a
+light green that stays readable on every GitHub theme — Mermaid's C4 renderer
+defaults them to a near-black that disappears in dark mode — and the layout is loosened
 to three cards per row so the renderer's fixed-width cards don't overlap. The diagram also stays
 honest about the diff being only a slice of the codebase —
 relationships it infers from imports rather than the diff itself are called out
@@ -2792,9 +2792,9 @@ C4Container
     Rel(client, api, "GET /users/{id}")
     Rel(api, cache, "check cache (new)")
     Rel(api, db, "on miss, query")
-    UpdateRelStyle(client, api, $textColor="#808080", $lineColor="#808080")
-    UpdateRelStyle(api, cache, $textColor="#808080", $lineColor="#808080")
-    UpdateRelStyle(api, db, $textColor="#808080", $lineColor="#808080")
+    UpdateRelStyle(client, api, $textColor="#34a862", $lineColor="#34a862")
+    UpdateRelStyle(api, cache, $textColor="#34a862", $lineColor="#34a862")
+    UpdateRelStyle(api, db, $textColor="#34a862", $lineColor="#34a862")
     UpdateElementStyle(cache, $borderColor="#54d090")
     UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 ```

--- a/src/lgtmaybe/engine/diagram.py
+++ b/src/lgtmaybe/engine/diagram.py
@@ -15,7 +15,7 @@ check the comment shows the ASCII alone — a reviewer never sees GitHub's red
 C4 output is post-processed for GitHub's renderer (``_polish_c4``): Mermaid's
 C4 renderer draws relationship lines and labels in a hardcoded near-black that
 disappears on GitHub's dark theme, so every relationship gets an
-``UpdateRelStyle`` in a mid-grey legible on every theme; elements whose label
+``UpdateRelStyle`` in a light green legible on every theme; elements whose label
 carries the ``(new)``/``(changed)`` marker get an ``UpdateElementStyle`` green
 border so the PR's footprint stands out at a glance; and its default layout
 packs four fixed-width cards per row, which overlap once labels grow, so an
@@ -126,10 +126,12 @@ _CHANGED_MARKER = re.compile(r"\((?:new|changed)\)")
 _ELEMENT_COLOR = "#54d090"
 
 # Mermaid's C4 renderer hardcodes near-black relationship lines and labels
-# regardless of theme, so they vanish on GitHub's dark background. #808080
-# maximises the minimum contrast across GitHub's themes: ~4:1 on light
-# (#ffffff) and dark-dimmed (#22272e), ~4.8:1 on dark (#0d1117).
-_REL_COLOR = "#808080"
+# regardless of theme, so they vanish on GitHub's dark background. A light
+# brand-green ties the connectors to the green element borders; #34a862 is the
+# lightest green that still clears the 3:1 graphics-contrast bar on every
+# GitHub theme (3.0:1 on light #ffffff, 6.2:1 on dark #0d1117, 5.0:1 on
+# dark-dimmed #22272e) — the brand's #54d090 itself drops to 1.9:1 on light.
+_REL_COLOR = "#34a862"
 
 # The C4 renderer's default grid packs 4 fixed-width shapes per row (with
 # boundaries side by side), so cards and relationship labels overlap once
@@ -140,7 +142,7 @@ _LAYOUT = 'UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")'
 def _polish_c4(mermaid: str) -> str:
     """Post-process a C4 diagram so it stays legible on GitHub.
 
-    Appends an ``UpdateRelStyle`` per relationship (dark-mode-safe grey), an
+    Appends an ``UpdateRelStyle`` per relationship (theme-safe light green), an
     ``UpdateElementStyle`` green border per element whose label carries the
     ``(new)``/``(changed)`` marker (so the PR's footprint stands out), and an
     overlap-loosening ``UpdateLayoutConfig``. Best-effort and additive: pairs

--- a/tests/engine/test_diagram.py
+++ b/tests/engine/test_diagram.py
@@ -9,7 +9,7 @@ rendering and renders them as a Markdown comment. Contracts:
 - invalid Mermaid (not a diagram) drops to an ASCII-only plain fence — never a
   broken Mermaid block;
 - unparseable model output falls back to the raw text;
-- C4 relationship lines get an ``UpdateRelStyle`` in a mid-grey readable on
+- C4 relationship lines get an ``UpdateRelStyle`` in a light green readable on
   every GitHub theme (the renderer's near-black default vanishes in dark mode),
   without duplicating styles the model already emitted;
 - C4 diagrams get an ``UpdateLayoutConfig`` loosening the default 4-per-row
@@ -108,8 +108,8 @@ def test_c4_rels_get_dark_mode_safe_styles() -> None:
     )
     body = build_diagram(_CTX, _CFG, _structured_provider(mermaid=mermaid))
 
-    assert 'UpdateRelStyle(client, api, $textColor="#808080", $lineColor="#808080")' in body
-    assert 'UpdateRelStyle(api, db, $textColor="#808080", $lineColor="#808080")' in body
+    assert 'UpdateRelStyle(client, api, $textColor="#34a862", $lineColor="#34a862")' in body
+    assert 'UpdateRelStyle(api, db, $textColor="#34a862", $lineColor="#34a862")' in body
 
 
 def test_rel_styles_land_inside_the_mermaid_fence() -> None:
@@ -132,7 +132,7 @@ def test_model_supplied_rel_style_is_not_duplicated() -> None:
     # The model's own style for (a, b) is kept; only (b, c) gets ours.
     assert body.count("UpdateRelStyle(a, b,") == 1
     assert '$textColor="red"' in body
-    assert 'UpdateRelStyle(b, c, $textColor="#808080"' in body
+    assert 'UpdateRelStyle(b, c, $textColor="#34a862"' in body
 
 
 def test_repeated_rel_pair_styled_once() -> None:


### PR DESCRIPTION
Makes the C4 change-diagram connectors (relationship lines and their label text) light green, tying them to the green `(new)`/`(changed)` element borders.

Colour choice: `#34a862` is the lightest green that clears the 3:1 graphics-contrast bar on **every** GitHub theme — 3.0:1 on light (`#ffffff`), 6.2:1 on dark (`#0d1117`), 5.0:1 on dark-dimmed (`#22272e`). The brand's `#54d090` itself was measured at 1.9:1 on the light theme (unreadable for label text), so the thick element borders keep the bright brand green while the finer lines and text take the darker shade.

TDD: rel-style test expectations updated first (red), then `_REL_COLOR` changed (green). Docs example + prose and `llms-full.txt` regenerated; diagram, docs, and spec suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpcabeioAQN3CAdq6WgsZn)_