### PR TITLE
feat: generous timeout defaults for slow providers and auto diagrams by default

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           provider: openrouter
           model: deepseek/deepseek-v4-pro
-          auto_diagram: true
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}
           app_id: ${{ vars.LGTMAYBE_APP_ID }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -240,7 +240,7 @@ run; generated/binary files are skipped automatically.
 
 **Reliability** — provider retries with fallback (all attempts for one call
 share a 2.5×-timeout budget), provider-aware timeouts, a soft whole-review
-deadline (`max_review_seconds`, default 600s) that degrades an overrunning run
+deadline (`max_review_seconds`, default 1800s) that degrades an overrunning run
 to partial results with an explicit notice, a self-reflection pass to cut
 false positives (toggle with `--no-reflect`; its verdicts carry a 0–10
 confidence score, filtered by `min_confidence`), and loud failure surfacing (a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,8 +172,8 @@ pattern, event bus, plugin framework.
      when the Mermaid can't render; one structured call, `_mermaid_ok` prefix
      check, raw-text fallback) via `post_diagram_comment` — its own idempotent
      upsert with a disjoint marker family. `ReviewConfig.auto_diagram` (default
-     off; Action input `auto_diagram`) posts it automatically alongside
-     auto-describe. The local `lgtmaybe diagram` command prints the same body
+     **on**; Action input `auto_diagram`, set false to opt out) posts it
+     automatically on freshly opened/reopened PRs. The local `lgtmaybe diagram` command prints the same body
      (no GitHub) — a terminal can't render Mermaid, which is what the ASCII is
      for. **No D2:** GitHub doesn't render it in Markdown.
    - **Guards (in the engine):** generated/binary files skipped via
@@ -256,7 +256,7 @@ pattern, event bus, plugin framework.
      `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 8
      cloud, 1 ollama/openai-compatible), then the findings are **merged and
      de-duped** (`engine._dedupe`, keyed on path/line/side) before reflection.
-     A soft whole-review deadline (`max_review_seconds`, default 600s, 0 = off)
+     A soft whole-review deadline (`max_review_seconds`, default 1800s, 0 = off)
      skips still-queued calls once passed — partial results with a notice,
      never a silent LGTM. Every stage and call is timed
      (`engine/profiling.py`); `--profile` / Action input `profile` prints the

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     required: false
     default: ""
   timeout:
-    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama, openai-compatible and openrouter 900, cloud 60)."
+    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama, openai-compatible and openrouter 900, cloud 300)."
     required: false
     default: ""
   max_review_seconds:

--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,11 @@ inputs:
     required: false
     default: ""
   timeout:
-    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama and openai-compatible 300, cloud 60)."
+    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama, openai-compatible and openrouter 900, cloud 60)."
     required: false
     default: ""
   max_review_seconds:
-    description: "Soft wall-clock ceiling for the whole review, in seconds (default 600). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with an incomplete-results notice. Set 0 to disable."
+    description: "Soft wall-clock ceiling for the whole review, in seconds (default 1800). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with an incomplete-results notice. Set 0 to disable."
     required: false
     default: ""
   temperature:
@@ -99,7 +99,7 @@ inputs:
     required: false
     default: ""
   auto_diagram:
-    description: "On a freshly opened (or reopened) PR, post a C4-style change diagram comment — a Mermaid C4 diagram of the components the PR touches (rendered natively by GitHub), with an ASCII fallback — before the review runs, updated in place by later /diagram runs. Off by default."
+    description: "On a freshly opened (or reopened) PR, post a C4-style change diagram comment — a Mermaid C4 diagram of the components the PR touches (rendered natively by GitHub), with an ASCII fallback — before the review runs, updated in place by later /diagram runs. On by default; set to false to opt out."
     required: false
     default: ""
   answer_replies:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -176,14 +176,16 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 60s for hosted providers, 300s for local ones (ollama,
-  openai-compatible), overridable via `timeout` / `--timeout`. All attempts for
+  timeout: 60s for direct cloud providers, 900s for the ones that may front a
+  slow model — ollama and openai-compatible (local servers) and openrouter (a
+  gateway to arbitrary models, including slow reasoning ones) — overridable via
+  `timeout` / `--timeout`. All attempts for
   one call additionally share a wall-clock budget of **2.5× that timeout**, so
   a flaky model can't burn four full timeouts plus backoff per lens. The
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
   run can't hold a runner for GitHub's six-hour default.
 
-- **A whole-review deadline.** `max_review_seconds` (default 600, `0` disables)
+- **A whole-review deadline.** `max_review_seconds` (default 1800, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -176,7 +176,7 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 60s for direct cloud providers, 900s for the ones that may front a
+  timeout: 300s for direct cloud providers, 900s for the ones that may front a
   slow model — ollama and openai-compatible (local servers) and openrouter (a
   gateway to arbitrary models, including slow reasoning ones) — overridable via
   `timeout` / `--timeout`. All attempts for

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -281,7 +281,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
-| `max_review_seconds` | 600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
+| `max_review_seconds` | 1800 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
 | `min_severity` | `low` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`); `low` keeps everything except pure-`info` narration. |

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -228,14 +228,14 @@ Default: `true`.
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
 **provider-aware default**: **900 s for ollama, openai-compatible, and
 openrouter** (local models are slow, and openrouter can route to slow reasoning
-models) and 60 s for direct cloud providers. Set it explicitly to raise it for a
+models) and 300 s for direct cloud providers. Set it explicitly to raise it for a
 large local model.
 
 ```yaml
 timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 60 s). See
+Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 300 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -226,14 +226,16 @@ Default: `true`.
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
-**provider-aware default**: **300 s for ollama and openai-compatible** (local
-models are slow) and 60 s for cloud providers. Set it explicitly to raise it for a large local model.
+**provider-aware default**: **900 s for ollama, openai-compatible, and
+openrouter** (local models are slow, and openrouter can route to slow reasoning
+models) and 60 s for direct cloud providers. Set it explicitly to raise it for a
+large local model.
 
 ```yaml
-timeout: 900   # 15 minutes per call, e.g. for a big model on CPU
+timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible 300 s, cloud 60 s). See
+Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 60 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output

--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -80,30 +80,27 @@ Comment **`/diagram`** on a pull request to post (or update in place) the change
 diagram. Like `/describe`, it's an idempotent upsert — re-running edits the same
 comment instead of stacking new ones.
 
-The supplied starter workflows set `auto_diagram: true`, so new repositories
-post one automatically when a PR is opened or reopened. The underlying Action
-input remains off by default for backwards compatibility, and it never fires
-on a `synchronize` push. To enable it in an existing workflow:
+`auto_diagram` is **on by default** — no workflow input or `.lgtmaybe.yml`
+needed — so a diagram posts automatically when a PR is opened or reopened. It
+never fires on a `synchronize` push. To opt out, set it in your workflow:
 
 ```yaml
       - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
-          auto_diagram: "true"
+          auto_diagram: "false"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
-You can also set it in `.lgtmaybe.yml`:
+or in `.lgtmaybe.yml`:
 
 ```yaml
-auto_diagram: true
+auto_diagram: false
 ```
 
 The diagram is best-effort — a failure is logged and never blocks the review.
-To opt out of the starter-workflow default, remove `auto_diagram` or set it to
-`false`.
 
 ## Locally: `lgtmaybe diagram`
 

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -183,16 +183,16 @@ branch locally before opening a PR. See
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
-long default per-request timeout (300 seconds)** automatically — you don't need
-to set anything for a normal run. (Cloud providers default to 60 s.)
+long default per-request timeout (900 seconds)** automatically — you don't need
+to set anything for a normal run. (Direct cloud providers default to 60 s.)
 
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 300.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 900
+  --api-base http://localhost:11434 --timeout 1800
 ```
 
 ```yaml

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -184,7 +184,7 @@ branch locally before opening a PR. See
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
 long default per-request timeout (900 seconds)** automatically — you don't need
-to set anything for a normal run. (Direct cloud providers default to 60 s.)
+to set anything for a normal run. (Direct cloud providers default to 300 s.)
 
 If a big model still times out — you'll see
 `litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -66,7 +66,7 @@ The API key, when you do supply one, is read from the environment or `--api-key`
 and is **never persisted** to config.
 
 Because the endpoint might be a slow local model, `openai-compatible` defaults to
-the same generous **300s** per-call timeout as ollama. For a fast hosted endpoint
+the same generous **900s** per-call timeout as ollama. For a fast hosted endpoint
 like DeepSeek you can dial it down with `--timeout` (or `timeout:` in config).
 
 ## DeepSeek (hosted, keyed)

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -210,7 +210,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 300s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -17,9 +17,9 @@ below shows the complete shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
-They enable `auto_diagram`, so newly opened or reopened pull requests receive
-a C4-style change diagram automatically. Remove that input or set it to `false`
-if you do not want the extra model call.
+`auto_diagram` is on by default, so newly opened or reopened pull requests
+receive a C4-style change diagram automatically. Set it to `false` if you do
+not want the extra model call.
 ollama runs the model on your own machine, so it is local-only — use the
 [CLI](run-locally-with-ollama.md) rather than a posting workflow.
 
@@ -210,7 +210,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -220,14 +220,14 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `1800` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
-| `auto_diagram` | `false` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review |
+| `auto_diagram` | `true` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
 | `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -318,9 +318,9 @@ below shows the complete shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
-They enable `auto_diagram`, so newly opened or reopened pull requests receive
-a C4-style change diagram automatically. Remove that input or set it to `false`
-if you do not want the extra model call.
+`auto_diagram` is on by default, so newly opened or reopened pull requests
+receive a C4-style change diagram automatically. Set it to `false` if you do
+not want the extra model call.
 ollama runs the model on your own machine, so it is local-only — use the
 [CLI](run-locally-with-ollama.md) rather than a posting workflow.
 
@@ -511,7 +511,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible 300s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -521,14 +521,14 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `1800` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
-| `auto_diagram` | `false` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review |
+| `auto_diagram` | `true` | Post a C4-style Mermaid change diagram comment when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
 | `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |
@@ -1740,16 +1740,16 @@ branch locally before opening a PR. See
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
-long default per-request timeout (300 seconds)** automatically — you don't need
-to set anything for a normal run. (Cloud providers default to 60 s.)
+long default per-request timeout (900 seconds)** automatically — you don't need
+to set anything for a normal run. (Direct cloud providers default to 60 s.)
 
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 300.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 900
+  --api-base http://localhost:11434 --timeout 1800
 ```
 
 ```yaml
@@ -1903,7 +1903,7 @@ The API key, when you do supply one, is read from the environment or `--api-key`
 and is **never persisted** to config.
 
 Because the endpoint might be a slow local model, `openai-compatible` defaults to
-the same generous **300s** per-call timeout as ollama. For a fast hosted endpoint
+the same generous **900s** per-call timeout as ollama. For a fast hosted endpoint
 like DeepSeek you can dial it down with `--timeout` (or `timeout:` in config).
 
 ## DeepSeek (hosted, keyed)
@@ -2247,14 +2247,16 @@ Default: `true`.
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
-**provider-aware default**: **300 s for ollama and openai-compatible** (local
-models are slow) and 60 s for cloud providers. Set it explicitly to raise it for a large local model.
+**provider-aware default**: **900 s for ollama, openai-compatible, and
+openrouter** (local models are slow, and openrouter can route to slow reasoning
+models) and 60 s for direct cloud providers. Set it explicitly to raise it for a
+large local model.
 
 ```yaml
-timeout: 900   # 15 minutes per call, e.g. for a big model on CPU
+timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible 300 s, cloud 60 s). See
+Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 60 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output
@@ -2818,30 +2820,27 @@ Comment **`/diagram`** on a pull request to post (or update in place) the change
 diagram. Like `/describe`, it's an idempotent upsert — re-running edits the same
 comment instead of stacking new ones.
 
-The supplied starter workflows set `auto_diagram: true`, so new repositories
-post one automatically when a PR is opened or reopened. The underlying Action
-input remains off by default for backwards compatibility, and it never fires
-on a `synchronize` push. To enable it in an existing workflow:
+`auto_diagram` is **on by default** — no workflow input or `.lgtmaybe.yml`
+needed — so a diagram posts automatically when a PR is opened or reopened. It
+never fires on a `synchronize` push. To opt out, set it in your workflow:
 
 ```yaml
       - uses: MattJColes/lgtmaybe@v1
         with:
           provider: anthropic
           model: claude-sonnet-4-6
-          auto_diagram: "true"
+          auto_diagram: "false"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
-You can also set it in `.lgtmaybe.yml`:
+or in `.lgtmaybe.yml`:
 
 ```yaml
-auto_diagram: true
+auto_diagram: false
 ```
 
 The diagram is best-effort — a failure is logged and never blocks the review.
-To opt out of the starter-workflow default, remove `auto_diagram` or set it to
-`false`.
 
 ## Locally: `lgtmaybe diagram`
 
@@ -3079,7 +3078,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `answer_replies` | boolean | No | `True` | Answer Replies |
 | `api_base` | string / null | No | `null` | Api Base |
 | `auto_describe` | boolean | No | `False` | Auto Describe |
-| `auto_diagram` | boolean | No | `False` | Auto Diagram |
+| `auto_diagram` | boolean | No | `True` | Auto Diagram |
 | `categories` | list[`complexity` / `correctness` / `deprecation` / `documentation` / `intent` / `performance` / `ponytail` / `security` / `tests`] | No | `['security', 'correctness', 'deprecation', 'tests', 'documentation', 'performance', 'complexity', 'intent', 'ponytail']` | Categories |
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
@@ -3095,7 +3094,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
-| `max_review_seconds` | integer | No | `600` | Max Review Seconds |
+| `max_review_seconds` | integer | No | `1800` | Max Review Seconds |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -3597,7 +3596,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "boolean"
     },
     "auto_diagram": {
-      "default": false,
+      "default": true,
       "title": "Auto Diagram",
       "type": "boolean"
     },
@@ -3728,7 +3727,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 600,
+      "default": 1800,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"
@@ -4416,7 +4415,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
-| `max_review_seconds` | 600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
+| `max_review_seconds` | 1800 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
 | `min_severity` | `low` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`); `low` keeps everything except pure-`info` narration. |
@@ -4733,14 +4732,16 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 60s for hosted providers, 300s for local ones (ollama,
-  openai-compatible), overridable via `timeout` / `--timeout`. All attempts for
+  timeout: 60s for direct cloud providers, 900s for the ones that may front a
+  slow model — ollama and openai-compatible (local servers) and openrouter (a
+  gateway to arbitrary models, including slow reasoning ones) — overridable via
+  `timeout` / `--timeout`. All attempts for
   one call additionally share a wall-clock budget of **2.5× that timeout**, so
   a flaky model can't burn four full timeouts plus backoff per lens. The
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
   run can't hold a runner for GitHub's six-hour default.
 
-- **A whole-review deadline.** `max_review_seconds` (default 600, `0` disables)
+- **A whole-review deadline.** `max_review_seconds` (default 1800, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -511,7 +511,7 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 60s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 300s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -1741,7 +1741,7 @@ branch locally before opening a PR. See
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
 long default per-request timeout (900 seconds)** automatically — you don't need
-to set anything for a normal run. (Direct cloud providers default to 60 s.)
+to set anything for a normal run. (Direct cloud providers default to 300 s.)
 
 If a big model still times out — you'll see
 `litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:
@@ -2249,14 +2249,14 @@ Default: `true`.
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
 **provider-aware default**: **900 s for ollama, openai-compatible, and
 openrouter** (local models are slow, and openrouter can route to slow reasoning
-models) and 60 s for direct cloud providers. Set it explicitly to raise it for a
+models) and 300 s for direct cloud providers. Set it explicitly to raise it for a
 large local model.
 
 ```yaml
 timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 60 s). See
+Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 300 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output
@@ -4732,7 +4732,7 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 60s for direct cloud providers, 900s for the ones that may front a
+  timeout: 300s for direct cloud providers, 900s for the ones that may front a
   slow model — ollama and openai-compatible (local servers) and openrouter (a
   gateway to arbitrary models, including slow reasoning ones) — overridable via
   `timeout` / `--timeout`. All attempts for

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -19,7 +19,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `answer_replies` | boolean | No | `True` | Answer Replies |
 | `api_base` | string / null | No | `null` | Api Base |
 | `auto_describe` | boolean | No | `False` | Auto Describe |
-| `auto_diagram` | boolean | No | `False` | Auto Diagram |
+| `auto_diagram` | boolean | No | `True` | Auto Diagram |
 | `categories` | list[`complexity` / `correctness` / `deprecation` / `documentation` / `intent` / `performance` / `ponytail` / `security` / `tests`] | No | `['security', 'correctness', 'deprecation', 'tests', 'documentation', 'performance', 'complexity', 'intent', 'ponytail']` | Categories |
 | `context_lines` | integer | No | `20` | Context Lines |
 | `exclude_paths` | list[string] | No | `[]` | Exclude Paths |
@@ -35,7 +35,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
-| `max_review_seconds` | integer | No | `600` | Max Review Seconds |
+| `max_review_seconds` | integer | No | `1800` | Max Review Seconds |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -537,7 +537,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "boolean"
     },
     "auto_diagram": {
-      "default": false,
+      "default": true,
       "title": "Auto Diagram",
       "type": "boolean"
     },
@@ -668,7 +668,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 600,
+      "default": 1800,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"

--- a/evals/run.py
+++ b/evals/run.py
@@ -164,9 +164,9 @@ def _review(
         reflect=reflect,
         recursive=recursive,
         # Evals measure model quality, never wall-clock discipline: the
-        # production review deadline (max_review_seconds, default 600s) would
+        # production review deadline (max_review_seconds, default 1800s) would
         # skip calls mid-eval on a slow local model — a full-preset run on a
-        # big fixture easily exceeds 600s serially — and silently melt the
+        # big fixture can exceed it serially — and silently melt the
         # recall it exists to measure. Always off here.
         max_review_seconds=0,
         **cfg_overrides,

--- a/examples/workflows/review-anthropic.yml
+++ b/examples/workflows/review-anthropic.yml
@@ -38,5 +38,4 @@ jobs:
         with:
           provider: anthropic
           model: claude-sonnet-4-6
-          auto_diagram: true
           api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           provider: azure
           model: my-gpt-4o-deployment      # your Azure deployment name
-          auto_diagram: true
           api_base: ${{ secrets.AZURE_API_BASE }}  # https://<resource>.openai.azure.com
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: MattJColes/lgtmaybe@v1
         with:
           provider: bedrock
-          auto_diagram: true
           # Bedrock needs a Bedrock model id (Claude/Nova/Llama/…), not an
           # OpenAI/GPT id. Prefer the cross-region inference profile (us./eu./
           # apac.) — most current Claude models aren't available on-demand on the

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           provider: anthropic
           model: claude-sonnet-4-6
-          auto_diagram: true
           api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Post as the App identity instead of github-actions[bot].
           app_id: ${{ vars.LGTMAYBE_APP_ID }}

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           provider: openai-compatible
           model: deepseek-chat
-          auto_diagram: true
           api_base: https://api.deepseek.com/v1
           # Hosted endpoints need a key; omit api_key for keyless self-hosted servers.
           api_key: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}

--- a/examples/workflows/review-openai.yml
+++ b/examples/workflows/review-openai.yml
@@ -40,5 +40,4 @@ jobs:
         with:
           provider: openai
           model: gpt-5.5
-          auto_diagram: true
           api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/examples/workflows/review-openrouter.yml
+++ b/examples/workflows/review-openrouter.yml
@@ -38,5 +38,4 @@ jobs:
         with:
           provider: openrouter
           model: anthropic/claude-sonnet-4-6
-          auto_diagram: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/examples/workflows/review-vertex.yml
+++ b/examples/workflows/review-vertex.yml
@@ -42,6 +42,5 @@ jobs:
         with:
           provider: vertex
           model: gemini-3-pro
-          auto_diagram: true
           gcp_wif_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           provider: zai
           model: glm-4.6
-          auto_diagram: true
           api_key: ${{ secrets.ZAI_API_KEY }}
           # Optional: point at the China / coding-plan endpoint instead of the
           # international default.

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -51,11 +51,17 @@ the preamble-plus-diff from cache. Cache read/creation token counts land on
 
 ### Requirement: Defaults are provider-aware
 
-Timeouts SHALL default long for local providers (ollama/openai-compatible)
-and short for cloud; the litellm model string is derived per provider so users
-give bare model ids.
+Timeouts SHALL default long for providers that may front a slow model —
+local-capable ones (ollama/openai-compatible) and openrouter, a gateway to
+arbitrary models including slow reasoning ones — and short for direct cloud
+providers; the litellm model string is derived per provider so users give bare
+model ids.
 <!-- anchor: provider.defaults -->
 
 #### Scenario: no timeout configured
 - **WHEN** `timeout` is unset and the provider is ollama
-- **THEN** the local (long) default applies, not the cloud one
+- **THEN** the generous (long) default applies, not the cloud one
+
+#### Scenario: openrouter gets the generous default
+- **WHEN** `timeout` is unset and the provider is openrouter
+- **THEN** the generous (long) default applies, not the cloud one

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -238,7 +238,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "--max-review-seconds",
     default=None,
     type=click.IntRange(min=0),
-    help="Soft wall-clock ceiling for the whole review (default 600). Past it, "
+    help="Soft wall-clock ceiling for the whole review (default 1800). Past it, "
     "no further model calls are dispatched — in-flight calls finish and the "
     "review returns partial results with an incomplete-results notice. 0 disables",
 )

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -509,9 +509,9 @@ class ReviewConfig(_Strict):
     # languages or any ast-grep failure. Off = fixed-line padding only.
     function_context: bool = True
     # Per-request timeout (seconds) for each provider completion call. None means
-    # "auto": the factory picks a provider-aware default (ollama gets a long one,
-    # since local models are slow; cloud providers a short one). An explicit value
-    # always wins.
+    # "auto": the factory picks a provider-aware default (long for providers that
+    # may front a slow model — ollama, openai-compatible, openrouter — short for
+    # direct cloud providers). An explicit value always wins.
     timeout: int | None = None
     # Sampling temperature for completions. Defaults to 0.0 for deterministic,
     # reproducible reviews (and steadier instruction-following on small models).
@@ -565,8 +565,9 @@ class ReviewConfig(_Strict):
     # a Mermaid C4 diagram of the components the PR touches (with an ASCII
     # fallback), rendered natively in the comment — when a PR is opened or
     # reopened. Its own comment, updated in place on later /diagram runs.
-    # Best-effort; a diagram failure never blocks the review. Default off.
-    auto_diagram: bool = False
+    # Best-effort; a diagram failure never blocks the review. Default on —
+    # no yaml needed; set false to opt out.
+    auto_diagram: bool = True
     # Two-stage triage routing: when set, this cheap model runs FIRST over the
     # compressed per-file diffs, skipping files that plainly need no review
     # (pure formatting, trivial renames, generated content that slipped the
@@ -641,9 +642,10 @@ class ReviewConfig(_Strict):
     # findings post, and the summary carries the existing "results may be
     # incomplete" notice naming the skipped calls. It can never turn a total
     # failure into a silent LGTM — a run where every call failed or was
-    # skipped still fails loud. Generous by default (10 minutes); 0 disables
-    # the ceiling entirely.
-    max_review_seconds: int = Field(default=600, ge=0)
+    # skipped still fails loud. Generous by default (30 minutes — 2× the
+    # generous per-call timeout, so one slow gateway/local call can't eat the
+    # whole review budget); 0 disables the ceiling entirely.
+    max_review_seconds: int = Field(default=1800, ge=0)
     # Ceiling on concurrent review calls across the WHOLE fan-out (every
     # (batch, lens) task shares one pool). None means auto: 8 for hosted cloud
     # providers (their retry layer absorbs a capacity 429, and on bedrock cache

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -37,17 +37,18 @@ _PREFIXES: dict[Provider, str] = {
     Provider.zai: "zai",
 }
 
-# Default per-request timeout (seconds) when the caller doesn't set one. Local
-# models are slow — and the per-category fan-out runs them serially — so the
-# providers that can front a local server (ollama, and openai-compatible pointing
-# at llama.cpp / LM Studio / vLLM) get a generous default; cloud providers respond
-# fast. An explicit --timeout always wins, so a fast cloud openai-compatible
-# endpoint (e.g. DeepSeek) can dial it down.
-_LOCAL_TIMEOUT = 300
+# Default per-request timeout (seconds) when the caller doesn't set one. Some
+# providers can't be assumed fast: the ones that can front a slow local server
+# (ollama, and openai-compatible pointing at llama.cpp / LM Studio / vLLM), and
+# openrouter, a gateway to arbitrary third-party models — including reasoning
+# models that routinely think past 60s on a large diff. Those get a generous
+# default; direct cloud providers respond fast and keep the short one. An
+# explicit --timeout always wins, so a fast endpoint can dial it down.
+_SLOW_TIMEOUT = 900
 _CLOUD_TIMEOUT = 60
 
-# Providers whose endpoint may be a slow, locally hosted model.
-_LOCAL_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible})
+# Providers whose endpoint may be a slow model (local server or open gateway).
+_SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider.openrouter})
 
 # Ollama context window. Big enough to hold a real review prompt + diff + the
 # emitted findings; ollama's own default (~4k) truncates the output to a stub.
@@ -58,7 +59,7 @@ _OLLAMA_NUM_CTX = 32768
 
 def default_timeout_for(provider: Provider) -> int:
     """The auto timeout (seconds) for a provider when none is given explicitly."""
-    return _LOCAL_TIMEOUT if provider in _LOCAL_CAPABLE else _CLOUD_TIMEOUT
+    return _SLOW_TIMEOUT if provider in _SLOW_CAPABLE else _CLOUD_TIMEOUT
 
 
 def cheaper_reflect_sibling(provider: Provider, model: str) -> str | None:

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -41,11 +41,12 @@ _PREFIXES: dict[Provider, str] = {
 # providers can't be assumed fast: the ones that can front a slow local server
 # (ollama, and openai-compatible pointing at llama.cpp / LM Studio / vLLM), and
 # openrouter, a gateway to arbitrary third-party models — including reasoning
-# models that routinely think past 60s on a large diff. Those get a generous
-# default; direct cloud providers respond fast and keep the short one. An
-# explicit --timeout always wins, so a fast endpoint can dial it down.
+# models that routinely think slowly on a large diff. Those get a generous
+# default; direct cloud providers get a shorter one that still leaves room
+# for a reasoning model to think. An explicit --timeout always wins, so a
+# fast endpoint can dial it down.
 _SLOW_TIMEOUT = 900
-_CLOUD_TIMEOUT = 60
+_CLOUD_TIMEOUT = 300
 
 # Providers whose endpoint may be a slow model (local server or open gateway).
 _SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider.openrouter})

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -128,8 +128,12 @@ class TestActionRouting:
         called = self._run_diagram_gate(tmp_path, monkeypatch, action="synchronize", auto="true")
         assert called == []
 
-    def test_auto_diagram_off_by_default(self, tmp_path, monkeypatch):
+    def test_auto_diagram_on_by_default(self, tmp_path, monkeypatch):
         called = self._run_diagram_gate(tmp_path, monkeypatch, action="opened", auto="")
+        assert called == [True]
+
+    def test_auto_diagram_can_be_disabled(self, tmp_path, monkeypatch):
+        called = self._run_diagram_gate(tmp_path, monkeypatch, action="opened", auto="false")
         assert called == []
 
     def test_auto_extras_share_one_gateway_and_context_fetch(self, tmp_path, monkeypatch):

--- a/tests/cli/test_incremental_review.py
+++ b/tests/cli/test_incremental_review.py
@@ -256,7 +256,8 @@ def test_auto_diagram_only_on_open_events_when_enabled() -> None:
     assert should_auto_diagram(on, event_action="opened") is True
     assert should_auto_diagram(on, event_action="reopened") is True
     assert should_auto_diagram(on, event_action="synchronize") is False
-    assert should_auto_diagram(_cfg(), event_action="opened") is False  # default off
+    assert should_auto_diagram(_cfg(), event_action="opened") is True  # default on
+    assert should_auto_diagram(_cfg(auto_diagram=False), event_action="opened") is False
 
 
 def test_run_diagram_posts_via_the_idempotent_upsert() -> None:

--- a/tests/engine/test_deadline.py
+++ b/tests/engine/test_deadline.py
@@ -78,7 +78,9 @@ class TestReviewDeadline:
     def test_generous_default_never_trips_a_normal_run(self) -> None:
         provider = _SlowProvider(delay=0.0)
         cfg = _cfg()
-        assert cfg.max_review_seconds == 600
+        # 2× the generous per-call timeout (900s), so one slow gateway/local
+        # call can't eat the whole review budget on its own.
+        assert cfg.max_review_seconds == 1800
         _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
         assert len(provider.calls) == 3
         assert "deadline" not in summary

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -151,7 +151,7 @@ class TestBuildProvider:
 
     def test_cloud_gets_a_short_default_timeout_when_unset(self) -> None:
         provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")
-        assert provider.default_opts.get("timeout") == 60
+        assert provider.default_opts.get("timeout") == 300
 
     def test_explicit_timeout_overrides_the_provider_default(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", timeout=45)

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -121,7 +121,7 @@ class TestBuildProvider:
             api_key="sk-x",
             api_base="https://api.deepseek.com/v1",
         )
-        assert provider.default_opts.get("timeout") == 300
+        assert provider.default_opts.get("timeout") == 900
 
     def test_openai_compatible_timeout_is_overridable(self) -> None:
         provider = build_provider(
@@ -147,7 +147,7 @@ class TestBuildProvider:
 
     def test_ollama_gets_a_long_default_timeout_when_unset(self) -> None:
         provider = build_provider(Provider.ollama, "llama2")
-        assert provider.default_opts.get("timeout") == 300
+        assert provider.default_opts.get("timeout") == 900
 
     def test_cloud_gets_a_short_default_timeout_when_unset(self) -> None:
         provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")
@@ -196,6 +196,14 @@ class TestDefaultTimeout:
         assert default_timeout_for(Provider.openai_compatible) == default_timeout_for(
             Provider.ollama
         )
+
+    def test_openrouter_default_matches_ollama(self) -> None:
+        # openrouter is a gateway to arbitrary models, including reasoning models
+        # that routinely think past the 60s cloud default — it gets the generous
+        # default too.
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert default_timeout_for(Provider.openrouter) == default_timeout_for(Provider.ollama)
 
     def test_build_provider_threads_temperature_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", temperature=0.0)

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -212,7 +212,7 @@ class TestEngineBehaviourMatrix:
     def test_review_deadline_field_defaults_on_every_provider(self, provider: Provider) -> None:
         from lgtmaybe.core.models import ReviewConfig
 
-        assert ReviewConfig(provider=provider, model="m").max_review_seconds == 600
+        assert ReviewConfig(provider=provider, model="m").max_review_seconds == 1800
 
 
 _CUSTOM_BASE = "https://api.deepseek.com/v1"

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -395,7 +395,7 @@
       "type": "boolean"
     },
     "auto_diagram": {
-      "default": false,
+      "default": true,
       "title": "Auto Diagram",
       "type": "boolean"
     },
@@ -526,7 +526,7 @@
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 600,
+      "default": 1800,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -14,7 +14,9 @@ _ACTION_REF = f"MattJColes/lgtmaybe@v{_PROJECT_VERSION.split('.', maxsplit=1)[0]
 _STARTER_WORKFLOWS = _REPO_ROOT / "examples" / "workflows"
 
 
-def test_supplied_workflows_enable_auto_diagram() -> None:
+def test_supplied_workflows_rely_on_the_auto_diagram_default() -> None:
+    # auto_diagram defaults to on in ReviewConfig, so a workflow that sets it
+    # explicitly is redundant config that would mask a default regression.
     workflows = [_DOGFOOD_WORKFLOW, *_STARTER_WORKFLOWS.glob("*.yml")]
 
     for workflow in workflows:
@@ -25,8 +27,8 @@ def test_supplied_workflows_enable_auto_diagram() -> None:
             if step.get("uses") in {_ACTION_REF, "./"}
         ]
         assert action_steps, f"{workflow} has no lgtmaybe Action step"
-        assert all(step.get("with", {}).get("auto_diagram") is True for step in action_steps), (
-            f"{workflow} must enable automatic diagrams for new repositories"
+        assert all("auto_diagram" not in step.get("with", {}) for step in action_steps), (
+            f"{workflow} sets auto_diagram explicitly; the default already enables it"
         )
 
 


### PR DESCRIPTION
## What

Four default changes, prompted by a real review run failing with `⚠️ 2 of 4 review calls failed (TimeoutError: provider request exceeded 60s)` on `openrouter` / `deepseek/deepseek-v4-pro`:

- **openrouter gets the generous per-call timeout default.** It joins ollama and openai-compatible in the slow-capable tier (`providers/factory.py`): openrouter is a gateway to arbitrary models, including reasoning models that routinely think past the old 60s cloud default on a large diff. Retries can't rescue a too-short timeout — each attempt restarts under the same bound — so the default has to fit the route.
- **The generous tier rises from 300s to 900s**, covering big local models and slow reasoning gateways alike.
- **The direct-cloud default rises from 60s to 300s** — hosted reasoning models can think past 60s even on direct routes. An explicit `timeout` always wins on every tier.
- **`max_review_seconds` default raised 600s → 1800s** (2× the largest per-call timeout), so the whole-review soft deadline can't be eaten by a single slow call.
- **`auto_diagram` now defaults to on** — a C4-style change diagram posts on freshly opened/reopened PRs without any yaml. The starter and dogfood workflows drop the now-redundant explicit input (guarded by `test_workflow_examples.py` so it doesn't creep back); set `auto_diagram: false` to opt out.

## How

TDD red → green throughout: default assertions flipped first (`tests/providers/test_factory.py`, `tests/engine/test_deadline.py`, `tests/providers/test_provider_matrix.py`, `tests/cli/test_action.py`, `tests/cli/test_incremental_review.py`), then the code. The `provider.defaults` spec section gained an openrouter scenario; `docs/reference/config.md`, `docs/llms-full.txt`, and the `ReviewConfig` schema snapshot are regenerated, and the hand-written docs (`action.yml` descriptions, how-to pages, ARCHITECTURE/CLAUDE.md) updated to match.

## Verification

- `uv run pytest` — 1224 passed (plus evals/specs suites: 108 passed)
- `uv run ruff check .` / `ruff format --check .` — clean
- `openspec validate --specs` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsLuXJTHCeMC3aB4v6j9KP