### PR TITLE
docs: simplify Marketplace Action setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,12 @@ are published at the docs root.
 
 ## Use as a GitHub Action
 
-Install from the [GitHub Marketplace](https://github.com/marketplace/actions/lgtmaybe):
-it copies the Action syntax into a workflow; it does not choose
-an LLM service or model for you. In `.github/workflows/lgtmaybe.yml`, set
-`provider`, `model`, and the matching authentication input in the step's `with:`
-block. This complete example uses OpenAI:
+Use lgtmaybe from the
+[GitHub Marketplace](https://github.com/marketplace/actions/lgtmaybe). It is a
+GitHub Action, so its settings live in your workflow. In
+`.github/workflows/lgtmaybe.yml`, set `provider`, `model`, and the matching
+authentication input in the step's `with:` block. This complete example uses
+OpenAI:
 
 ```yaml
 name: lgtmaybe

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: lgtmaybe
-description: Provider-agnostic PR reviewer. After Marketplace install, choose the provider, model, and authentication in your workflow.
+description: Provider-agnostic PR reviewer. Choose the provider, model, and authentication in your GitHub Actions workflow.
 author: Matt Coles
 branding:
   icon: check-circle
@@ -159,11 +159,11 @@ inputs:
     required: false
     default: ${{ github.token }}
   app_id:
-    description: "GitHub App ID. Set it (with app_private_key) to post reviews as your own branded App identity — e.g. lgtmaybe[bot] with an avatar, plus higher API rate limits — instead of the default github-actions[bot]. The App needs `pull requests: write` + `contents: read`. Left empty, the default workflow token is used."
+    description: "Advanced: ID of an existing GitHub App used with app_private_key. Most users should leave this empty and use the default workflow token."
     required: false
     default: ""
   app_private_key:
-    description: "Private key (PEM) of the GitHub App named by app_id. Wire a repository secret to it. Used only to mint a short-lived installation token, which is auto-revoked at the end of the job — no static key is stored."
+    description: "Advanced: private key (PEM) of the existing GitHub App named by app_id. Most users should leave this empty."
     required: false
     default: ""
   app_owner:

--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -1,173 +1,20 @@
 ---
-description: Post lgtmaybe reviews under your own branded GitHub App identity (lgtmaybe[bot]) with higher API rate limits, instead of the default github-actions[bot].
+description: lgtmaybe is a GitHub Marketplace Action and uses GitHub Actions' built-in token; no separate GitHub App setup is required.
 ---
 
-# Post reviews as a GitHub App
+# No GitHub App setup required
 
-!!! note "This is optional branding on top of the Marketplace action — not a second install"
-    lgtmaybe itself is installed from the
-    [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe)
-    as an Action in your workflow — see
-    [Use as a GitHub Action](use-as-github-action.md). The GitHub App on this
-    page is **one you create yourself** so reviews post under **your** bot
-    identity; there is no shared lgtmaybe App to install, because lgtmaybe has
-    no hosted backend — a shared App would need its private key distributed,
-    which is exactly what this design avoids.
+lgtmaybe is published to GitHub Marketplace as a **GitHub Action**. Add the
+Action to your workflow and GitHub Actions supplies the short-lived,
+repository-scoped token it needs. Reviews post as `github-actions[bot]` by
+default.
 
-By default lgtmaybe posts reviews as `github-actions[bot]` using the workflow's
-built-in token. The **recommended setup** is to point it at a **GitHub App** you
-own so reviews post under that App's identity instead — a branded
-`lgtmaybe[bot]` name and avatar, a higher API rate limit, and optional access
-across several repositories. The default token still works and every workflow
-falls back to it when the App inputs are empty, but the App identity is worth
-the one-time setup: reviews are clearly attributed, and busy repos don't share
-the workflow token's rate limit.
+You do not need to create or install a separate GitHub App, manage a private
+key, or run a hosted lgtmaybe service. Choose the model provider and
+authentication method in the workflow instead.
 
-This changes only the **posting identity**. The action still runs in your own CI,
-still fetches the diff via the API without checking out PR code, and the keyless
-cloud auth (Bedrock/Vertex/Azure) is untouched. There is no hosted service — you
-are not sending your code or keys anywhere new.
+[Use lgtmaybe as a GitHub Action](./use-as-github-action.md)
 
-## Contents
-
-- [How it works](#how-it-works)
-- [One-time GitHub App setup](#one-time-github-app-setup)
-- [Workflow example](#workflow-example)
-- [Reviewing across several repositories](#reviewing-across-several-repositories)
-- [Without the built-in inputs](#without-the-built-in-inputs)
-- [Troubleshooting](#troubleshooting)
-
-## How it works
-
-You pass the App's ID and private key as action inputs. The action mints a
-**short-lived installation token** with
-[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token),
-uses it to read the PR and post the review, and revokes it in a post step at the
-end of the job. Nothing long-lived is stored, and the token's scope is only what
-the App is installed for.
-
-## One-time GitHub App setup
-
-This is the human-only part — do it once:
-
-1. Create a **GitHub App** (Settings → Developer settings → GitHub Apps → New, at
-   the personal or organisation level). Name it — the name becomes the `[bot]`
-   identity on the review, e.g. `lgtmaybe`.
-2. Under **Repository permissions**, grant:
-   - **Pull requests: Read and write** — to post the review and inline comments.
-   - **Contents: Read-only** — to read the config and files.
-   - (Optional) **Issues: Read and write** if you use `/ask`, which replies on the
-     PR conversation.
-3. You do **not** need to subscribe to any webhook events — the App is used only
-   to mint a token; the review is still triggered by your workflow.
-4. **Install** the App on the repositories you want reviewed (the App's page →
-   Install App).
-5. Note the **App ID** (on the App's General page) and **generate a private key**
-   (same page → Private keys → Generate). The key downloads as a `.pem` file.
-6. Store them in the repo (or org):
-   - **App ID** as a repository variable, e.g. `LGTMAYBE_APP_ID` (Settings →
-     Secrets and variables → Actions → Variables).
-   - **Private key** as a secret, e.g. `LGTMAYBE_APP_PRIVATE_KEY` (paste the whole
-     `.pem` contents).
-
-## Workflow example
-
-Add `app_id` and `app_private_key` to any provider workflow. Everything else is
-unchanged — this example is the anthropic workflow with the App identity added:
-
-```yaml
-name: lgtmaybe
-
-on:
-  pull_request_target:
-  issue_comment:
-    types: [created]
-
-permissions:
-  contents: read           # still needed for the actions/checkout of .lgtmaybe.yml
-  pull-requests: write
-
-jobs:
-  review:
-    # Only trusted authors can trigger a review (see "Who can trigger a review").
-    if: >-
-      (github.event_name == 'pull_request_target' &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
-      (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          app_id: ${{ vars.LGTMAYBE_APP_ID }}
-          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-```
-
-The App's **installation** permissions govern what the review can post; the
-workflow `permissions:` block still applies to the default token that
-`actions/checkout` uses to read `.lgtmaybe.yml`.
-
-## Reviewing across several repositories
-
-By default the minted token is scoped to the current repository. To let one App
-review PRs across a monorepo or several repos in an org, set `app_owner` (and
-optionally `app_repositories`):
-
-```yaml
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          app_id: ${{ vars.LGTMAYBE_APP_ID }}
-          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-          app_owner: my-org
-          app_repositories: |
-            service-a
-            service-b
-```
-
-With `app_owner` set and `app_repositories` empty, the token covers every repo
-the App is installed on under that owner.
-
-## Without the built-in inputs
-
-The `app_id` / `app_private_key` inputs are a convenience — because `github_token`
-is already a pass-through input, you can mint the token yourself and pass it in.
-This is useful if you already run `actions/create-github-app-token` for other
-steps:
-
-```yaml
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.LGTMAYBE_APP_ID }}
-          private-key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
-```
-
-## Troubleshooting
-
-**Reviews still post as `github-actions[bot]`** — `app_id` is empty, so the action
-fell back to the default token. Check that the `LGTMAYBE_APP_ID` variable and
-`LGTMAYBE_APP_PRIVATE_KEY` secret are set and referenced correctly (a variable is
-`${{ vars.* }}`, a secret is `${{ secrets.* }}`).
-
-**`RequestError [HttpError]: Not Found` / `Resource not accessible by
-integration`** — the App is not installed on the repository, or lacks a required
-permission. Install it on the repo and confirm **Pull requests: write** +
-**Contents: read** under the App's Repository permissions (re-accept the
-permission change on the installation if you edited it after installing).
-
-**`private key ... failed to parse`** — the secret must contain the full PEM,
-including the `-----BEGIN...-----` / `-----END...-----` lines. Paste the whole
-`.pem` file contents.
+If your organisation already operates a GitHub App, the advanced `github_token`
+input can use a token minted elsewhere. This is optional and is not part of the
+standard setup.

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -7,13 +7,13 @@ description: Add lgtmaybe as a GitHub Action to review every pull request automa
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
-Install from the
-[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe) —
-it copies the Action syntax into your workflow. Provider and
-model selection happens in that workflow, not on a separate Marketplace
-settings screen: add a `with:` block containing `provider`, `model`, and the
-matching authentication input. The [minimal OpenAI workflow](#minimal-workflow-openai)
-below shows the complete shape.
+Use lgtmaybe from the
+[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
+It is a **GitHub Action**, not a hosted GitHub App. Its provider, model, and
+authentication settings live in the workflow's `with:` block. GitHub Actions
+supplies the repository token, so there is no separate App to install. The
+[minimal OpenAI workflow](#minimal-workflow-openai) below shows the complete
+shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
@@ -30,7 +30,6 @@ ollama runs the model on your own machine, so it is local-only — use the
 - [Minimal workflow — openai](#minimal-workflow-openai)
 - [Other key-based providers](#other-key-based-providers)
 - [Keyless cloud workflows](#keyless-cloud-workflows)
-- [Post reviews as a GitHub App](#post-reviews-as-a-github-app)
 - [Action inputs](#action-inputs)
 - [Adding a config file](#adding-a-config-file)
 - [Pin to a specific version](#pin-to-a-specific-version)
@@ -173,34 +172,6 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 - [Review with Vertex WIF](./review-with-vertex-wif.md)
 - [Review with Azure OpenAI](./review-with-azure.md)
 
-## Post reviews as a GitHub App (recommended)
-
-By default reviews post as `github-actions[bot]` using the workflow token. The
-**recommended setup** is to post as **your own branded identity** — e.g.
-`lgtmaybe[bot]` with an avatar — with higher API rate limits (and optional
-cross-repo reach): pass `app_id` and `app_private_key`. It costs a one-time
-five-minute App setup, and reviews are clearly attributed to the reviewer
-rather than blending into every other `github-actions[bot]` comment. The action mints a short-lived installation token, uses it to
-fetch the diff and post the review, and revokes it at the end of the job. This is
-purely the *posting identity* — the keyless cloud model is unchanged and
-everything still runs in your own CI.
-
-```yaml
-- uses: MattJColes/lgtmaybe@v1
-  with:
-    provider: anthropic
-    model: claude-sonnet-4-6
-    api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    app_id: ${{ vars.LGTMAYBE_APP_ID }}
-    app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-```
-
-The App's own installation permissions (`pull requests: write`, `contents: read`)
-govern what the review can post — but keep the workflow `permissions:` block for
-the `actions/checkout` of your `.lgtmaybe.yml`. The one-time setup (create the
-App, grant those permissions, install it, and store the ID and key) is in
-[Post reviews as a GitHub App](./post-as-a-github-app.md).
-
 ## Action inputs
 
 | Input | Default | Description |
@@ -240,8 +211,8 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `azure_tenant_id` | — | Entra (Azure AD) tenant ID for keyless azure |
 | `config_path` | `.lgtmaybe.yml` | Path to the config file, relative to repo root |
 | `github_token` | `${{ github.token }}` | Token for reading the PR and posting the review |
-| `app_id` | — | GitHub App ID — post as a branded App identity (with `app_private_key`) instead of `github-actions[bot]`, with higher rate limits. [Setup](./post-as-a-github-app.md) |
-| `app_private_key` | — | Private key (PEM) of the App named by `app_id`; wire a secret to it. Mints a short-lived, auto-revoked installation token |
+| `app_id` | — | Advanced: ID of an existing GitHub App used with `app_private_key`; most users should leave this empty |
+| `app_private_key` | — | Advanced: private key of the existing App named by `app_id`; most users should leave this empty |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
 | `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -308,13 +308,13 @@ bundles all three and wires up the OIDC/WIF auth for you.
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
-Install from the
-[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe) —
-it copies the Action syntax into your workflow. Provider and
-model selection happens in that workflow, not on a separate Marketplace
-settings screen: add a `with:` block containing `provider`, `model`, and the
-matching authentication input. The [minimal OpenAI workflow](#minimal-workflow-openai)
-below shows the complete shape.
+Use lgtmaybe from the
+[GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
+It is a **GitHub Action**, not a hosted GitHub App. Its provider, model, and
+authentication settings live in the workflow's `with:` block. GitHub Actions
+supplies the repository token, so there is no separate App to install. The
+[minimal OpenAI workflow](#minimal-workflow-openai) below shows the complete
+shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
@@ -331,7 +331,6 @@ ollama runs the model on your own machine, so it is local-only — use the
 - [Minimal workflow — openai](#minimal-workflow-openai)
 - [Other key-based providers](#other-key-based-providers)
 - [Keyless cloud workflows](#keyless-cloud-workflows)
-- [Post reviews as a GitHub App](#post-reviews-as-a-github-app)
 - [Action inputs](#action-inputs)
 - [Adding a config file](#adding-a-config-file)
 - [Pin to a specific version](#pin-to-a-specific-version)
@@ -474,34 +473,6 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 - [Review with Vertex WIF](./review-with-vertex-wif.md)
 - [Review with Azure OpenAI](./review-with-azure.md)
 
-## Post reviews as a GitHub App (recommended)
-
-By default reviews post as `github-actions[bot]` using the workflow token. The
-**recommended setup** is to post as **your own branded identity** — e.g.
-`lgtmaybe[bot]` with an avatar — with higher API rate limits (and optional
-cross-repo reach): pass `app_id` and `app_private_key`. It costs a one-time
-five-minute App setup, and reviews are clearly attributed to the reviewer
-rather than blending into every other `github-actions[bot]` comment. The action mints a short-lived installation token, uses it to
-fetch the diff and post the review, and revokes it at the end of the job. This is
-purely the *posting identity* — the keyless cloud model is unchanged and
-everything still runs in your own CI.
-
-```yaml
-- uses: MattJColes/lgtmaybe@v1
-  with:
-    provider: anthropic
-    model: claude-sonnet-4-6
-    api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    app_id: ${{ vars.LGTMAYBE_APP_ID }}
-    app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-```
-
-The App's own installation permissions (`pull requests: write`, `contents: read`)
-govern what the review can post — but keep the workflow `permissions:` block for
-the `actions/checkout` of your `.lgtmaybe.yml`. The one-time setup (create the
-App, grant those permissions, install it, and store the ID and key) is in
-[Post reviews as a GitHub App](./post-as-a-github-app.md).
-
 ## Action inputs
 
 | Input | Default | Description |
@@ -541,8 +512,8 @@ App, grant those permissions, install it, and store the ID and key) is in
 | `azure_tenant_id` | — | Entra (Azure AD) tenant ID for keyless azure |
 | `config_path` | `.lgtmaybe.yml` | Path to the config file, relative to repo root |
 | `github_token` | `${{ github.token }}` | Token for reading the PR and posting the review |
-| `app_id` | — | GitHub App ID — post as a branded App identity (with `app_private_key`) instead of `github-actions[bot]`, with higher rate limits. [Setup](./post-as-a-github-app.md) |
-| `app_private_key` | — | Private key (PEM) of the App named by `app_id`; wire a secret to it. Mints a short-lived, auto-revoked installation token |
+| `app_id` | — | Advanced: ID of an existing GitHub App used with `app_private_key`; most users should leave this empty |
+| `app_private_key` | — | Advanced: private key of the existing App named by `app_id`; most users should leave this empty |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
 | `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
@@ -594,180 +565,6 @@ use a full version tag:
 ```yaml
 uses: MattJColes/lgtmaybe@v1.0.0
 ```
-
----
-
-<!-- Source: https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/ -->
-
-# Post reviews as a GitHub App
-
-!!! note "This is optional branding on top of the Marketplace action — not a second install"
-    lgtmaybe itself is installed from the
-    [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe)
-    as an Action in your workflow — see
-    [Use as a GitHub Action](use-as-github-action.md). The GitHub App on this
-    page is **one you create yourself** so reviews post under **your** bot
-    identity; there is no shared lgtmaybe App to install, because lgtmaybe has
-    no hosted backend — a shared App would need its private key distributed,
-    which is exactly what this design avoids.
-
-By default lgtmaybe posts reviews as `github-actions[bot]` using the workflow's
-built-in token. The **recommended setup** is to point it at a **GitHub App** you
-own so reviews post under that App's identity instead — a branded
-`lgtmaybe[bot]` name and avatar, a higher API rate limit, and optional access
-across several repositories. The default token still works and every workflow
-falls back to it when the App inputs are empty, but the App identity is worth
-the one-time setup: reviews are clearly attributed, and busy repos don't share
-the workflow token's rate limit.
-
-This changes only the **posting identity**. The action still runs in your own CI,
-still fetches the diff via the API without checking out PR code, and the keyless
-cloud auth (Bedrock/Vertex/Azure) is untouched. There is no hosted service — you
-are not sending your code or keys anywhere new.
-
-## Contents
-
-- [How it works](#how-it-works)
-- [One-time GitHub App setup](#one-time-github-app-setup)
-- [Workflow example](#workflow-example)
-- [Reviewing across several repositories](#reviewing-across-several-repositories)
-- [Without the built-in inputs](#without-the-built-in-inputs)
-- [Troubleshooting](#troubleshooting)
-
-## How it works
-
-You pass the App's ID and private key as action inputs. The action mints a
-**short-lived installation token** with
-[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token),
-uses it to read the PR and post the review, and revokes it in a post step at the
-end of the job. Nothing long-lived is stored, and the token's scope is only what
-the App is installed for.
-
-## One-time GitHub App setup
-
-This is the human-only part — do it once:
-
-1. Create a **GitHub App** (Settings → Developer settings → GitHub Apps → New, at
-   the personal or organisation level). Name it — the name becomes the `[bot]`
-   identity on the review, e.g. `lgtmaybe`.
-2. Under **Repository permissions**, grant:
-   - **Pull requests: Read and write** — to post the review and inline comments.
-   - **Contents: Read-only** — to read the config and files.
-   - (Optional) **Issues: Read and write** if you use `/ask`, which replies on the
-     PR conversation.
-3. You do **not** need to subscribe to any webhook events — the App is used only
-   to mint a token; the review is still triggered by your workflow.
-4. **Install** the App on the repositories you want reviewed (the App's page →
-   Install App).
-5. Note the **App ID** (on the App's General page) and **generate a private key**
-   (same page → Private keys → Generate). The key downloads as a `.pem` file.
-6. Store them in the repo (or org):
-   - **App ID** as a repository variable, e.g. `LGTMAYBE_APP_ID` (Settings →
-     Secrets and variables → Actions → Variables).
-   - **Private key** as a secret, e.g. `LGTMAYBE_APP_PRIVATE_KEY` (paste the whole
-     `.pem` contents).
-
-## Workflow example
-
-Add `app_id` and `app_private_key` to any provider workflow. Everything else is
-unchanged — this example is the anthropic workflow with the App identity added:
-
-```yaml
-name: lgtmaybe
-
-on:
-  pull_request_target:
-  issue_comment:
-    types: [created]
-
-permissions:
-  contents: read           # still needed for the actions/checkout of .lgtmaybe.yml
-  pull-requests: write
-
-jobs:
-  review:
-    # Only trusted authors can trigger a review (see "Who can trigger a review").
-    if: >-
-      (github.event_name == 'pull_request_target' &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
-      (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          app_id: ${{ vars.LGTMAYBE_APP_ID }}
-          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-```
-
-The App's **installation** permissions govern what the review can post; the
-workflow `permissions:` block still applies to the default token that
-`actions/checkout` uses to read `.lgtmaybe.yml`.
-
-## Reviewing across several repositories
-
-By default the minted token is scoped to the current repository. To let one App
-review PRs across a monorepo or several repos in an org, set `app_owner` (and
-optionally `app_repositories`):
-
-```yaml
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          app_id: ${{ vars.LGTMAYBE_APP_ID }}
-          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-          app_owner: my-org
-          app_repositories: |
-            service-a
-            service-b
-```
-
-With `app_owner` set and `app_repositories` empty, the token covers every repo
-the App is installed on under that owner.
-
-## Without the built-in inputs
-
-The `app_id` / `app_private_key` inputs are a convenience — because `github_token`
-is already a pass-through input, you can mint the token yourself and pass it in.
-This is useful if you already run `actions/create-github-app-token` for other
-steps:
-
-```yaml
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.LGTMAYBE_APP_ID }}
-          private-key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
-      - uses: MattJColes/lgtmaybe@v1
-        with:
-          provider: anthropic
-          model: claude-sonnet-4-6
-          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
-```
-
-## Troubleshooting
-
-**Reviews still post as `github-actions[bot]`** — `app_id` is empty, so the action
-fell back to the default token. Check that the `LGTMAYBE_APP_ID` variable and
-`LGTMAYBE_APP_PRIVATE_KEY` secret are set and referenced correctly (a variable is
-`${{ vars.* }}`, a secret is `${{ secrets.* }}`).
-
-**`RequestError [HttpError]: Not Found` / `Resource not accessible by
-integration`** — the App is not installed on the repository, or lacks a required
-permission. Install it on the repo and confirm **Pull requests: write** +
-**Contents: read** under the App's Repository permissions (re-accept the
-permission change on the installation if you edited it after installing).
-
-**`private key ... failed to parse`** — the secret must contain the full PEM,
-including the `-----BEGIN...-----` / `-----END...-----` lines. Paste the whole
-`.pem` file contents.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,6 @@
 
 - [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS) or Homebrew (macOS/Linuxbrew), and add the cloud extras for keyless Bedrock/Vertex/Azure.
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
-- [Post reviews as a GitHub App](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews under your own branded GitHub App identity (lgtmaybe[bot]) with higher API rate limits, instead of the default github-actions[bot].
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
 - [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
 - [Review with OpenRouter](https://lgtmaybe.coles.codes/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -1,14 +1,10 @@
 # Copy into your repo at .github/workflows/lgtmaybe.yml
 #
-# Post reviews under your own branded GitHub App identity (e.g. lgtmaybe[bot])
-# instead of the default github-actions[bot], with higher API rate limits.
+# Advanced: use this only if your organisation already operates a GitHub App
+# and wants reviews posted under that identity instead of github-actions[bot].
 #
 # This example uses Anthropic for the model, but the app_id / app_private_key
 # inputs work with ANY provider — add them to any of the other example workflows.
-#
-# One-time setup (create the App, grant it pull-requests:write + contents:read,
-# install it, store the ID + private key): see
-# https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/
 #
 # Secrets/variables to add:
 #   ANTHROPIC_API_KEY        (secret)   — your model provider key

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,6 @@ nav:
       - Install & run:
           - Install the CLI: how-to/install-the-cli.md
           - Use as a GitHub Action: how-to/use-as-github-action.md
-          - Post reviews as a GitHub App: how-to/post-as-a-github-app.md
       - Cloud providers (API key):
           - Review with OpenAI: how-to/review-with-openai.md
           - Review with Claude (Anthropic): how-to/review-with-anthropic.md

--- a/openspec/changes/clarify-marketplace-provider-setup/design.md
+++ b/openspec/changes/clarify-marketplace-provider-setup/design.md
@@ -24,6 +24,7 @@ lgtmaybe is published to GitHub Marketplace as an Action. GitHub's Marketplace f
 2. Lead with one complete OpenAI example and link to the existing provider-specific workflows. A single working path is easier to scan, while the examples already encode the different keyless and key-based authentication shapes.
 3. Clarify the setup through `action.yml`, the README's GitHub Action section, and the focused how-to guide. These are the surfaces a Marketplace visitor and a repository adopter encounter.
 4. Add a small documentation acceptance test that asserts the quick-start example includes `provider`, `model`, and `api_key`. This protects the essential handoff without testing prose formatting.
+5. Do not promote creation of a separate GitHub App. GitHub Actions already supplies the default token, so the old App guide becomes a short compatibility page outside the navigation.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/clarify-marketplace-provider-setup/proposal.md
+++ b/openspec/changes/clarify-marketplace-provider-setup/proposal.md
@@ -7,6 +7,7 @@ GitHub Marketplace can add the lgtmaybe Action to a workflow, but it cannot pres
 - Make the Marketplace-facing Action metadata state where provider and model selection happens.
 - Add a short Marketplace setup path that shows the minimum working `with:` block and credential secret.
 - Link directly to the provider-specific workflow examples for users who need Bedrock, Vertex, Azure, OpenRouter, z.ai, or an OpenAI-compatible endpoint.
+- Remove the separate GitHub App setup from the default journey and make the old URL clarify that the Marketplace listing is an Action.
 - Add a documentation acceptance check so the Marketplace setup cannot regress to an unconfigured `uses:` example.
 
 ## Capabilities
@@ -21,4 +22,4 @@ None.
 
 ## Impact
 
-The change is limited to Marketplace-facing Action metadata, setup documentation, and documentation tests. It does not change provider routing, authentication behavior, runtime defaults, dependencies, or the GitHub permissions model.
+The change is limited to Marketplace-facing Action metadata, setup documentation, navigation, and documentation tests. It does not change provider routing, authentication behavior, runtime defaults, dependencies, or the GitHub permissions model.

--- a/openspec/changes/clarify-marketplace-provider-setup/specs/provider-gateway/spec.md
+++ b/openspec/changes/clarify-marketplace-provider-setup/specs/provider-gateway/spec.md
@@ -8,7 +8,8 @@ to a configured client - provider strategy selection lives here, not in the
 engine. All model slots (triage, review, reflect) share one provider and one
 set of credentials. The GitHub Action setup SHALL show that Marketplace users
 select the provider, model, and matching authentication inputs in workflow
-configuration.
+configuration. It SHALL also state that the Action uses GitHub Actions' built-in
+token and does not require a separate GitHub App.
 
 #### Scenario: user picks a provider
 - **WHEN** `--provider bedrock` is given
@@ -19,3 +20,7 @@ configuration.
 - **WHEN** a user adopts lgtmaybe from GitHub Marketplace
 - **THEN** the setup guidance shows a workflow `with:` block containing a
   provider, model, and matching authentication input
+
+#### Scenario: Marketplace user authenticates to GitHub
+- **WHEN** a user runs lgtmaybe as a GitHub Action
+- **THEN** the setup guidance says no separate GitHub App installation is required

--- a/openspec/changes/clarify-marketplace-provider-setup/tasks.md
+++ b/openspec/changes/clarify-marketplace-provider-setup/tasks.md
@@ -7,9 +7,11 @@
 - [x] 2.1 Update `action.yml` descriptions so the Marketplace input list explains that provider and model are selected in the workflow `with:` block.
 - [x] 2.2 Add a concise Marketplace setup section to the README with one complete example and a direct link to all provider workflow examples.
 - [x] 2.3 Update the GitHub Action how-to so its opening explains the Marketplace limitation and the workflow-based selection step.
+- [x] 2.4 Replace the separate GitHub App setup guide with a Marketplace Action clarification and remove it from the default navigation.
 
 ## 3. Verification
 
 - [x] 3.1 Regenerate the derived `llms.txt` documentation after changing the how-to guide.
 - [x] 3.2 Run the focused Action/documentation tests, the rendered documentation build, and `uv run pytest tests/specs -q`.
 - [x] 3.3 Re-run the relevant spec anchors and confirm the provider factory anchor still resolves exactly once.
+- [x] 3.4 Regenerate derived documentation and re-run the focused tests, documentation build, and spec checks after simplifying the App guidance.

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -21,9 +21,7 @@ _ACTION_YML = Path(__file__).parent.parent / "action.yml"
 _PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
 _RELEASE_PLEASE_CONFIG = Path(__file__).parent.parent / "release-please-config.json"
 _README = Path(__file__).parent.parent / "README.md"
-_GITHUB_APP_GUIDE = (
-    Path(__file__).parent.parent / "docs" / "how-to" / "post-as-a-github-app.md"
-)
+_GITHUB_APP_GUIDE = Path(__file__).parent.parent / "docs" / "how-to" / "post-as-a-github-app.md"
 _MKDOCS = Path(__file__).parent.parent / "mkdocs.yml"
 
 # The container reads GITHUB_TOKEN; prefer the minted App token, else the default

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -21,6 +21,10 @@ _ACTION_YML = Path(__file__).parent.parent / "action.yml"
 _PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
 _RELEASE_PLEASE_CONFIG = Path(__file__).parent.parent / "release-please-config.json"
 _README = Path(__file__).parent.parent / "README.md"
+_GITHUB_APP_GUIDE = (
+    Path(__file__).parent.parent / "docs" / "how-to" / "post-as-a-github-app.md"
+)
+_MKDOCS = Path(__file__).parent.parent / "mkdocs.yml"
 
 # The container reads GITHUB_TOKEN; prefer the minted App token, else the default
 # workflow token. A skipped mint step yields an empty output, so ``||`` falls
@@ -77,6 +81,13 @@ def test_marketplace_setup_explains_workflow_configuration() -> None:
     assert "GitHub Marketplace" in action_section
     for input_name in ("provider:", "model:", "api_key:"):
         assert input_name in action_section
+
+
+def test_marketplace_setup_does_not_require_a_separate_github_app() -> None:
+    guide = _GITHUB_APP_GUIDE.read_text(encoding="utf-8")
+    assert "do not need to create or install a separate GitHub App" in guide
+    assert "[Use lgtmaybe as a GitHub Action](./use-as-github-action.md)" in guide
+    assert "Post reviews as a GitHub App" not in _MKDOCS.read_text(encoding="utf-8")
 
 
 def test_mint_step_is_pinned_and_gated_on_app_id() -> None:


### PR DESCRIPTION
## Summary

- clarify that lgtmaybe's Marketplace listing is a GitHub Action and uses GitHub Actions' built-in repository token
- remove the separate GitHub App setup from navigation and the default Action guide, while keeping the old URL as a short compatibility clarification
- label the existing GitHub App inputs and example as advanced, then regenerate the derived LLM documentation
- update the OpenSpec change and add an acceptance check for the no-separate-App setup

## Why

The documentation promoted a user-created GitHub App as the recommended setup even though GitHub Actions already supplies the token lgtmaybe needs. That added private-key and permission-management work for a mostly cosmetic posting identity.

## Checks

- `.venv/Scripts/pytest.exe tests/test_action_yml.py tests/docs/test_llms_txt_fresh.py -q` (9 passed)
- `.venv/Scripts/mkdocs.exe build --strict`
- `.venv/Scripts/pytest.exe tests/specs -q` (17 passed)
- `openspec validate clarify-marketplace-provider-setup --type change --strict --no-interactive`
- `openspec validate --specs --strict --no-interactive`
