### PR TITLE
fix: support Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,25 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.13"
+    env:
+      PYTHONWARNDEFAULTENCODING: "1"
     steps:
+      - name: Disable autocrlf
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --global core.autocrlf input
+
       - uses: actions/checkout@v7
 
       - name: Install uv

--- a/evals/ab.py
+++ b/evals/ab.py
@@ -126,7 +126,15 @@ def _run_json(
         "--json",
         *extra_args,
     ]
-    proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, env=env)
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
     if proc.returncode != 0 and not proc.stdout.strip():
         raise RuntimeError(f"eval leg in {cwd} broke:\n{proc.stderr}")
     payload = json.loads(proc.stdout.strip().splitlines()[-1])
@@ -151,6 +159,8 @@ def _baseline_leg(
             check=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         try:
             scores = _run_json(
@@ -167,6 +177,8 @@ def _baseline_leg(
                 check=False,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
     return _pool_legs(ref, scores)
 

--- a/evals/persist.py
+++ b/evals/persist.py
@@ -38,5 +38,5 @@ def write_run_record(record: RunRecord, results_dir: Path) -> Path:
     """
     results_dir.mkdir(parents=True, exist_ok=True)
     path = results_dir / f"{record.sha}.json"
-    path.write_text(record.model_dump_json(indent=2) + "\n")
+    path.write_text(record.model_dump_json(indent=2) + "\n", encoding="utf-8")
     return path

--- a/evals/run.py
+++ b/evals/run.py
@@ -49,6 +49,8 @@ def _head_sha() -> str:
             ["git", "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=True,
         )
         return out.stdout.strip() or "unknown"
@@ -59,8 +61,8 @@ def _head_sha() -> str:
 def _load_fixtures() -> list[tuple[str, Fixture]]:
     out: list[tuple[str, Fixture]] = []
     for d in sorted(p for p in _FIXTURES.iterdir() if p.is_dir()):
-        diff = (d / "diff.txt").read_text()
-        manifest = Fixture.model_validate_json((d / "expected.json").read_text())
+        diff = (d / "diff.txt").read_text(encoding="utf-8")
+        manifest = Fixture.model_validate_json((d / "expected.json").read_text(encoding="utf-8"))
         # A `repo/` subdir is the fixture's on-disk corpus of unshown files — the
         # ones a cross-file deferral needs to verify. When present, the harness
         # roots a read-only reader + symbol resolver here (see `_review`).

--- a/evals/scorer.py
+++ b/evals/scorer.py
@@ -224,7 +224,7 @@ def _eval_ctx(diff: str, manifest: Fixture) -> PRContext:
         # the GitHub gateway fetches — feeding static analysis, context
         # expansion, and boundary padding during an eval run.
         file_contents = {
-            str(p.relative_to(manifest.head_root)): p.read_text()
+            str(p.relative_to(manifest.head_root)): p.read_text(encoding="utf-8")
             for p in sorted(manifest.head_root.rglob("*"))
             if p.is_file()
         }

--- a/openspec/changes/add-windows-support-and-winget/.openspec.yaml
+++ b/openspec/changes/add-windows-support-and-winget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/add-windows-support-and-winget/design.md
+++ b/openspec/changes/add-windows-support-and-winget/design.md
@@ -1,0 +1,160 @@
+## Context
+
+lgtmaybe has no POSIX-only imports or shell-dependent subprocess calls, but it
+is not Windows-clean at its trust boundaries. Locale-default text I/O can fail
+on non-ASCII source, Windows paths do not join the forward-slash path namespace
+used by GitHub diffs, the static-analysis subprocess environment omits Windows
+runtime variables, gcloud ADC is probed in the Unix location, and read-only
+temporary trees can leak. The current Ubuntu-only CI matrix cannot observe
+these failures.
+
+The release pipeline publishes PyPI, Homebrew, and GHCR artifacts from the
+release-please workflow. A Windows executable and winget update must join that
+same release graph because releases created with `GITHUB_TOKEN` do not emit a
+second `release: published` event to other workflows.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Run the full test suite on the supported Python floor and executable Python
+  version under real Windows locale, path, and filesystem semantics.
+- Make all owned text boundaries deterministic UTF-8 without hiding malformed
+  configuration, while tolerating undecodable output from external processes.
+- Preserve forward-slash, case-sensitive git path semantics on every host.
+- Preserve static-analysis isolation and ambient Vertex authentication on
+  Windows.
+- Publish a smoke-tested portable executable on every release and update the
+  existing winget package from the second release onward.
+- Deliver the work as two reviewable PRs: compatibility and CI first, packaging
+  and distribution second.
+
+**Non-Goals:**
+
+- Bundle boto3, google-auth, or azure-identity in the executable; pip remains
+  the installation path for keyless cloud authentication.
+- Add semgrep support on Windows when upstream provides no Windows build.
+- Replace the provider, engine, or Click CLI architecture.
+- Automate the first moderated winget package submission.
+- Build ARM64 Windows artifacts in this change.
+
+## Decisions
+
+### Add two focused Windows CI legs before compatibility fixes
+
+The main test job will use an `include` matrix so Ubuntu retains Python
+3.11-3.14 while Windows runs 3.11 and 3.13. Windows 3.11 protects the supported
+floor and 3.13 matches the executable build; a Windows 3.14 leg adds little
+coverage while litellm is constrained there. `PYTHONWARNDEFAULTENCODING=1`
+turns implicit text encodings into a CI gate without `PYTHONUTF8=1` masking
+cp1252 behavior. Windows disables `core.autocrlf` before checkout.
+
+Alternative: a full OS-by-Python cross-product. Rejected because it doubles
+expensive coverage without adding distinct boundary behavior.
+
+### Fix encoding at the boundary and enforce it mechanically
+
+Owned files use `encoding="utf-8"`. Text-mode subprocesses also use UTF-8 but
+set `errors="replace"` because external output is untrusted and a decode error
+must not erase an otherwise useful review. Config and files written by
+lgtmaybe remain strict. A subprocess-driven quality test runs representative
+call sites under `-X warn_default_encoding -W error::EncodingWarning`, and
+pytest treats `EncodingWarning` as an error.
+
+The Click group configures stdout and stderr once through a small,
+exception-suppressed `reconfigure(encoding="utf-8", errors="replace")`
+boundary. This avoids editing every emoji call site and remains compatible
+with test streams that do not support reconfiguration.
+
+Alternative: set `PYTHONUTF8=1`. Rejected because it masks missing boundary
+declarations and does not control users' launch environments.
+
+### Canonicalise repository paths at producers
+
+Static-analysis tool paths pass through one `_posix_rel` helper that handles
+absolute paths, `./`, and Windows-style backslashes even when tested on POSIX.
+The ast-grep adapter emits `Path.as_posix()`. Consumers continue comparing the
+canonical forward-slash strings they already receive. Git path globbing uses
+`fnmatchcase`, because repository paths must not inherit host filesystem case
+rules.
+
+Alternative: normalise at every consumer. Rejected because multiple consumers
+would duplicate the same guard and new consumers could silently regress.
+
+### Preserve the Windows static-analysis sandbox explicitly
+
+The scrubbed environment stays an exact minimal mapping on POSIX. On Windows it
+passes through only process-critical `SystemRoot`, `COMSPEC`, `PATHEXT`, `TEMP`,
+and `TMP`, while pinning `HOME`, `USERPROFILE`, `APPDATA`, and `LOCALAPPDATA` to
+the analysis root. A patchable module-level `_WINDOWS` flag keeps both branches
+testable on Linux without weakening the guarantee that cloud credentials do
+not leak.
+
+Alternative: inherit `os.environ` and remove known credential keys. Rejected
+because denylisting cannot provide the existing sandbox guarantee.
+
+### Use platform-native cleanup and credential locations
+
+Temporary checkout cleanup retries after clearing read-only attributes. Python
+3.12+ uses `shutil.rmtree(onexc=...)`; Python 3.11 uses `onerror=...` to avoid
+the newer deprecation warning. `TemporaryDirectory` users opt into ignored
+cleanup errors where static analysis is already best-effort. Vertex credential
+probing checks `CLOUDSDK_CONFIG` first, then `%APPDATA%\gcloud` on Windows and
+`~/.config/gcloud` elsewhere.
+
+### Build one portable executable and gate it before publishing
+
+PyInstaller builds a one-file console executable on `windows-latest` with
+Python 3.13. The spec collects lgtmaybe and litellm data, includes tiktoken's
+registry imports, and bundles ast-grep with a runtime hook that places the
+temporary extraction directory on `PATH`. The workflow exercises `--help`,
+`config path`, and `help review` before attaching a versioned x86_64 asset to
+the existing GitHub release.
+
+Alternative: onedir plus zip. Deferred unless measured one-file size or cold
+start is unacceptable; winget supports either shape.
+
+### Sequence release, executable, then winget
+
+Both new workflows support `workflow_call` and recovery via
+`workflow_dispatch`. release-please calls the executable workflow after the
+release exists, then calls winget only after the asset exists. The winget job
+polls the public asset and runs `wingetcreate update` with `WINGET_TOKEN`.
+Maintainers perform the first `wingetcreate new` submission manually because
+it establishes portable installer metadata and enters Microsoft moderation.
+
+## Risks / Trade-offs
+
+- [One-file size and extraction latency may be high] → Print artifact size in
+  CI and retain onedir-plus-zip as the measured fallback.
+- [PyInstaller misses a lazy litellm import] → Run real executable smoke
+  commands before upload and widen hidden imports only when the gate proves it
+  necessary.
+- [First winget moderation takes days or weeks] → Document that delay and keep
+  PyPI plus the GitHub release asset available immediately.
+- [Read-only cleanup semantics differ by Python version] → Test the shared
+  helper and keep the `onerror`/`onexc` split until Python 3.11 is dropped.
+- [Bundled ast-grep increases artifact size] → Measure the release artifact;
+  remove it only through an explicit quality-versus-size decision.
+
+## Migration Plan
+
+1. PR 1 adds the Windows CI legs as the first commit so existing failures are
+   observable, then lands each test-first compatibility fix and targeted living
+   spec update until all Linux and Windows checks pass.
+2. PR 2 adds the PyInstaller acceptance test and spec, executable workflow,
+   winget workflow, release graph wiring, docs, and distribution spec.
+3. Dispatch the executable workflow against a current tag to validate the asset
+   and smoke gate.
+4. Create and moderate the first winget manifest manually, then dispatch the
+   winget workflow to validate automated updates.
+
+Rollback removes the two reusable release jobs without affecting PyPI,
+Homebrew, or GHCR publishing. The compatibility fixes are host-neutral and do
+not require data migration.
+
+## Open Questions
+
+- What measured executable size or cold-start time should trigger the
+  onedir-plus-zip fallback? The workflow will expose the data before that
+  decision is needed.

--- a/openspec/changes/add-windows-support-and-winget/proposal.md
+++ b/openspec/changes/add-windows-support-and-winget/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+lgtmaybe is advertised for Windows but is not tested there and still fails or
+silently degrades under Windows locale, path, environment, and filesystem
+semantics. Releases also lack a Windows-native executable and package-manager
+installation path.
+
+## What Changes
+
+- Add focused Windows 3.11 and 3.13 legs to the main CI matrix while retaining
+  the existing Ubuntu coverage and stable fan-in check.
+- Make file and subprocess text handling explicitly UTF-8, configure CLI stdio
+  safely, and enforce the rule with tests and encoding warnings.
+- Normalise repository paths to forward slashes and keep git path matching
+  case-sensitive on every host.
+- Preserve the static-analysis sandbox on Windows, discover gcloud ADC in the
+  Windows config location, and reliably remove read-only temporary trees.
+- Build and smoke-test a portable Windows executable for each release, attach
+  it to the GitHub release, and submit subsequent versions to winget as
+  `MattJColes.lgtmaybe`.
+- Document Windows installation, release automation, bundled tooling, and the
+  one-time winget publisher setup.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-distribution`: Windows CI coverage, the portable executable release
+  artifact, winget publishing, and their release gates.
+
+### Modified Capabilities
+
+- `cli-and-local`: CLI, config, git, and subprocess text boundaries become
+  deterministic UTF-8 and CLI output remains safe under legacy Windows
+  redirected-stdio encodings.
+- `review-pipeline`: Static-analysis paths and sandbox environment become
+  Windows-safe, and repository path filters remain case-sensitive on every
+  host.
+- `provider-gateway`: Ambient Vertex credentials are discovered from the
+  platform-appropriate gcloud configuration directory.
+
+## Impact
+
+The change affects the main CI workflow, CLI/config/local text boundaries,
+static-analysis and ast-grep adapters, git path filtering, provider credential
+probing, temporary checkout cleanup, packaging metadata, release workflows,
+release and installation documentation, and the corresponding living specs.
+PyInstaller is added only to the packaging dependency group; cloud-provider
+extras remain exclusive to the pip distribution.

--- a/openspec/changes/add-windows-support-and-winget/specs/cli-and-local/spec.md
+++ b/openspec/changes/add-windows-support-and-winget/specs/cli-and-local/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Text boundaries are deterministic across host locales
+<!-- anchor: cli.utf8-boundaries -->
+
+The CLI, local git adapter, and configuration store SHALL read and write owned
+text as UTF-8 on every host. External subprocess output MUST decode as UTF-8
+with undecodable bytes replaced, and CLI stdout and stderr MUST emit safely
+when the inherited stream uses a legacy Windows encoding.
+
+#### Scenario: configuration contains non-Latin text
+- **WHEN** a user stores and reloads non-Latin configuration values on Windows
+- **THEN** the values round-trip as UTF-8 without locale-dependent corruption
+
+#### Scenario: a clean review writes an emoji to redirected output
+- **WHEN** stdout is redirected through a cp1252 text stream
+- **THEN** the CLI emits the summary without raising `UnicodeEncodeError`
+
+#### Scenario: git emits an undecodable byte
+- **WHEN** the local git subprocess returns output that is not valid UTF-8
+- **THEN** the command retains the decodable output and replaces only the
+  malformed byte sequence

--- a/openspec/changes/add-windows-support-and-winget/specs/provider-gateway/spec.md
+++ b/openspec/changes/add-windows-support-and-winget/specs/provider-gateway/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Credentials resolve by chain, fail with instructions
+<!-- anchor: provider.credentials -->
+
+Resolution SHALL try the chosen provider's native mode first (ambient cloud
+creds for bedrock/vertex/azure), then an API key from flag/env; ollama needs
+neither; openai-compatible needs an `api_base` with the key optional
+(placeholder when absent). Vertex ambient credential probing MUST prefer
+`CLOUDSDK_CONFIG`, then use `%APPDATA%\gcloud` on Windows or
+`~/.config/gcloud` on POSIX. Static cloud keys (AWS keys, service-account JSON)
+are never accepted or required; exhaustion fails with a clear
+"how to auth this provider" message.
+
+#### Scenario: nothing resolves
+- **WHEN** a provider has neither ambient creds nor a key
+- **THEN** the run fails naming exactly how to authenticate that provider
+
+#### Scenario: Vertex uses the default Windows gcloud location
+- **WHEN** a Windows user has ADC under `%APPDATA%\gcloud` and
+  `CLOUDSDK_CONFIG` is unset
+- **THEN** ambient Vertex authentication is detected
+
+#### Scenario: Vertex uses an explicit gcloud location
+- **WHEN** `CLOUDSDK_CONFIG` is set
+- **THEN** that directory is checked before the platform default

--- a/openspec/changes/add-windows-support-and-winget/specs/review-pipeline/spec.md
+++ b/openspec/changes/add-windows-support-and-winget/specs/review-pipeline/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Path filters apply after the skip filter
+<!-- anchor: engine.path-filters -->
+
+The user's `include_paths` allowlist and `exclude_paths` denylist SHALL apply
+right after generated/binary skipping; exclude wins, `**/`-prefixed patterns
+also match at the repo root, and matching repository paths is case-sensitive
+on every host.
+
+#### Scenario: a file is both included and excluded
+- **WHEN** a path matches `include_paths` and `exclude_paths`
+- **THEN** it is excluded
+
+#### Scenario: path case differs from the configured glob
+- **WHEN** a repository path differs from a configured include or exclude glob
+  only by letter case
+- **THEN** the path does not match on Windows or POSIX hosts
+
+### Requirement: Static analysis grounds, never posts
+<!-- anchor: engine.static-analysis -->
+
+Installed tools SHALL run sandboxed when static analysis is enabled - ruff,
+bandit, and semgrep with local rules only; scrubbed env, no network, hard
+timeout, temp dir, never a checkout - and their findings enter the prompt only
+as an untrusted HINTS block ("confirm, contextualise, or discard"). Paths MUST
+be canonical forward-slash repository paths. On Windows the scrubbed
+environment MUST pass through process-critical system variables while pinning
+user config and profile directories to the temp root. Raw tool findings are
+never posted; a missing tool is skipped silently.
+
+#### Scenario: semgrep has no local rules
+- **WHEN** static analysis runs without `semgrep_rules` configured
+- **THEN** semgrep does not run at all (never `--config auto`)
+
+#### Scenario: a Windows tool reports a backslash path
+- **WHEN** static analysis reports `.\src\app.py`
+- **THEN** the hint is associated with the canonical diff path `src/app.py`
+
+#### Scenario: static analysis runs on Windows
+- **WHEN** a child analyzer starts under Windows
+- **THEN** it receives the minimal process-critical system variables and temp-
+  rooted user directories without inheriting cloud credentials

--- a/openspec/changes/add-windows-support-and-winget/specs/windows-distribution/spec.md
+++ b/openspec/changes/add-windows-support-and-winget/specs/windows-distribution/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Supported Windows versions run the full CI gate
+<!-- anchor: windows.ci -->
+
+The main CI workflow SHALL run the same test, lint, format, and type-check gate
+on Windows with Python 3.11 and 3.13 while retaining Ubuntu coverage for every
+supported Python version. The Windows jobs MUST exercise locale-default
+encoding behavior rather than forcing Python UTF-8 mode.
+
+#### Scenario: a change breaks only under Windows path semantics
+- **WHEN** the pull request test matrix runs
+- **THEN** a Windows job fails before the shared required check can pass
+
+### Requirement: Releases include a smoke-tested portable executable
+<!-- anchor: windows.executable -->
+
+Each release SHALL build a Windows x86_64 portable `lgtmaybe.exe` with Python
+3.13, bundle the package and litellm data needed at runtime plus ast-grep, and
+attach the versioned artifact only after CLI smoke commands pass. The
+executable MUST NOT bundle optional cloud authentication dependencies.
+
+#### Scenario: a lazy import is absent from the bundle
+- **WHEN** the built executable cannot run the required CLI smoke commands
+- **THEN** the workflow fails without uploading the release asset
+
+### Requirement: winget updates follow executable publication
+<!-- anchor: windows.winget -->
+
+After the executable asset is published, the release workflow SHALL submit an
+update for `MattJColes.lgtmaybe` through winget using the versioned asset URL.
+The reusable workflow MUST also support a manually dispatched recovery run.
+
+#### Scenario: release automation publishes a new version
+- **WHEN** release-please creates a release and the executable workflow succeeds
+- **THEN** the winget workflow submits the new version, URL, and checksum to the
+  existing portable package
+
+#### Scenario: the initial package does not exist
+- **WHEN** maintainers prepare the first winget release
+- **THEN** they create the portable manifest manually before automated update
+  submissions begin

--- a/openspec/changes/add-windows-support-and-winget/tasks.md
+++ b/openspec/changes/add-windows-support-and-winget/tasks.md
@@ -1,0 +1,50 @@
+## 1. PR 1 - Windows CI first
+
+- [x] 1.1 Re-run the `engine.static-analysis`, `engine.path-filters`, and `provider.credentials` anchors against the files PR 1 will touch and confirm each resolves exactly once.
+- [x] 1.2 Add Windows 3.11 and 3.13 `include` entries to `.github/workflows/ci.yml`, set `PYTHONWARNDEFAULTENCODING=1`, disable `core.autocrlf` before checkout on Windows, and retain the existing `check` fan-in.
+- [x] 1.3 Land the CI matrix as PR 1's first conventional commit so the compatibility failures are observable before their fixes.
+
+## 2. PR 1 - UTF-8 boundaries
+
+- [x] 2.1 Add the subprocess-based `test_no_default_encoding_io` quality gate and configure pytest to fail on `EncodingWarning`; run it red against the current implicit call sites.
+- [x] 2.2 Add explicit UTF-8 to owned `read_text`/`write_text` calls and UTF-8 with replacement only to external subprocess output in static analysis, boundaries, config, CLI commands, local git, and ast-grep; run the encoding gate green.
+- [x] 2.3 Add and run red-to-green byte-level tests proving non-Latin config values round-trip as UTF-8 and the static-analysis corpus is written as UTF-8.
+- [x] 2.4 Add and run a red-to-green `_utf8_stdio` CLI boundary test using a cp1252 `TextIOWrapper`, then invoke the guarded stream reconfiguration from the root Click group.
+
+## 3. PR 1 - Path, sandbox, credentials, and cleanup
+
+- [x] 3.1 Add failing coverage for Windows, dotted, and POSIX analyzer paths, implement one `_posix_rel` producer helper, and make ast-grep emit forward-slash paths.
+- [x] 3.2 Add cross-host case-sensitivity regression tests for review path filters and generated-file skip globs, then replace host-normalising glob matches with `fnmatchcase`.
+- [x] 3.3 Add Linux-runnable tests for both `_scrubbed_env` branches, then pass through only required Windows process variables and pin all Windows user/profile directories to the analysis root while preserving the exact POSIX environment.
+- [x] 3.4 Add failing Windows ADC location and override-precedence tests, then resolve Vertex ADC from `CLOUDSDK_CONFIG`, `%APPDATA%\gcloud`, or `~/.config/gcloud` in that order by platform.
+- [x] 3.5 Add failing read-only tree cleanup coverage, implement the Python 3.11 `onerror` and Python 3.12+ `onexc` cleanup helper, and replace both silent checkout cleanup calls.
+- [x] 3.6 Assert `ignore_cleanup_errors=True` at the best-effort `TemporaryDirectory` boundaries in static analysis and boundaries, then make the tests green.
+- [x] 3.7 Resolve any Windows-only line-ending fixture failures without weakening format checks, preferring a repository-wide LF rule if the CI leg proves one is needed.
+
+## 4. PR 1 - Specs and verification
+
+- [x] 4.1 Update the `cli-and-local`, `review-pipeline`, and `provider-gateway` living requirements plus anchor sidecars for UTF-8 boundaries, case-sensitive path filters, Windows static-analysis isolation, and Windows gcloud ADC discovery.
+- [x] 4.2 Run the focused new tests, full pytest suite, ruff check, ruff format check, mypy, living-spec tests, OpenSpec spec validation, and the spec drift check.
+- [ ] 4.3 Confirm both Windows CI legs pass under locale defaults, then prepare PR 1 with a conventional title and no packaging/distribution changes.
+
+## 5. PR 2 - Portable executable
+
+- [ ] 5.1 Add a failing packaging test that requires lgtmaybe and litellm data collection plus tiktoken registry hidden imports in the PyInstaller spec.
+- [ ] 5.2 Add the packaging dependency group and lockfile update for PyInstaller, then create the executable entrypoint, one-file spec, ast-grep binary collection, and runtime PATH hook needed to satisfy the test.
+- [ ] 5.3 Add reusable and dispatchable `.github/workflows/windows-exe.yml` automation that normalises the version, skips an existing asset unless forced, checks out the tag, builds with Python 3.13, and smoke-tests `--help`, `config path`, and `help review` before upload.
+- [ ] 5.4 Name and attach the versioned x86_64 executable to the existing GitHub release and print its measured size in the smoke job.
+
+## 6. PR 2 - winget release chain
+
+- [ ] 6.1 Add reusable and dispatchable `.github/workflows/winget.yml` automation that normalises the version, polls for the executable asset, and runs `wingetcreate update MattJColes.lgtmaybe` with `WINGET_TOKEN`.
+- [ ] 6.2 Wire release-please to call the executable workflow after release creation and the winget workflow only after the executable succeeds, preserving the existing PyPI, Homebrew, and GHCR release jobs.
+- [ ] 6.3 Add workflow-structure tests that assert the executable smoke gate, release sequencing, asset URL, portable package ID, and secret wiring.
+
+## 7. PR 2 - Documentation, specs, and verification
+
+- [ ] 7.1 Document `winget install MattJColes.lgtmaybe`, pip-on-Windows support, bundled ast-grep, and the executable's excluded cloud extras in the CLI installation guide and README.
+- [ ] 7.2 Document the one-time winget fork, classic `public_repo` PAT, `WINGET_TOKEN`, initial portable manifest submission, and moderation expectations beside the existing release setup.
+- [ ] 7.3 Update `CLAUDE.md` with the Windows distribution variant and CI legs, and add the `windows-distribution` living spec with exact-one-match anchors for its CI, executable, and winget requirements.
+- [ ] 7.4 Run packaging and workflow tests, the full local quality gate, living-spec tests, OpenSpec spec validation, and the spec drift check.
+- [ ] 7.5 Dispatch the executable workflow against a current tag and verify the smoke-tested asset; after the first winget manifest is moderated, dispatch the winget workflow and verify its update PR.
+- [ ] 7.6 Prepare PR 2 with a conventional title, measured executable size noted, and no unresolved release-gate failures.

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -43,3 +43,9 @@ cli.config:
       kind: function_definition
       has: { field: name, regex: '^set_key$' }
     files: [src/lgtmaybe/config/**/*.py]
+
+cli.utf8-boundaries:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_utf8_stdio$' }
+  files: [src/lgtmaybe/cli/**/*.py]

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -91,3 +91,24 @@ defaults; the default `.lgtmaybe.yml` probe stays lenient when absent.
 #### Scenario: user tries to persist a key
 - **WHEN** `lgtmaybe config set` targets an API key
 - **THEN** it is refused; keys are read from env/flags at run time only
+
+### Requirement: Text boundaries are deterministic across host locales
+
+The CLI, local git adapter, and configuration store SHALL read and write owned
+text as UTF-8 on every host. External subprocess output MUST decode as UTF-8
+with undecodable bytes replaced, and CLI stdout and stderr MUST emit safely
+when the inherited stream uses a legacy Windows encoding.
+<!-- anchor: cli.utf8-boundaries -->
+
+#### Scenario: configuration contains non-Latin text
+- **WHEN** a user stores and reloads non-Latin configuration values on Windows
+- **THEN** the values round-trip as UTF-8 without locale-dependent corruption
+
+#### Scenario: a clean review writes an emoji to redirected output
+- **WHEN** stdout is redirected through a cp1252 text stream
+- **THEN** the CLI emits the summary without raising `UnicodeEncodeError`
+
+#### Scenario: git emits an undecodable byte
+- **WHEN** the local git subprocess returns output that is not valid UTF-8
+- **THEN** the command retains the decodable output and replaces only the
+  malformed byte sequence

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -27,14 +27,25 @@ set of credentials.
 Resolution SHALL try the chosen provider's native mode first (ambient cloud
 creds for bedrock/vertex/azure), then an API key from flag/env; ollama needs
 neither; openai-compatible needs an `api_base` with the key optional
-(placeholder when absent). Static cloud keys (AWS keys, service-account JSON)
-are never accepted or required; exhaustion fails with a clear
-"how to auth this provider" message.
+(placeholder when absent). Vertex ambient credential probing MUST prefer
+`CLOUDSDK_CONFIG`, then use `%APPDATA%\gcloud` on Windows or
+`~/.config/gcloud` on POSIX. Static cloud keys (AWS keys, service-account JSON)
+are never accepted or required; exhaustion fails with a clear "how to auth
+this provider" message.
 <!-- anchor: provider.credentials -->
 
 #### Scenario: nothing resolves
 - **WHEN** a provider has neither ambient creds nor a key
 - **THEN** the run fails naming exactly how to authenticate that provider
+
+#### Scenario: Vertex uses the default Windows gcloud location
+- **WHEN** a Windows user has ADC under `%APPDATA%\gcloud` and
+  `CLOUDSDK_CONFIG` is unset
+- **THEN** ambient Vertex authentication is detected
+
+#### Scenario: Vertex uses an explicit gcloud location
+- **WHEN** `CLOUDSDK_CONFIG` is set
+- **THEN** that directory is checked before the platform default
 
 ### Requirement: Completion calls retry, fall back, and cache
 

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -58,13 +58,19 @@ posting on a wrong line.
 ### Requirement: Path filters apply after the skip filter
 
 The user's `include_paths` allowlist and `exclude_paths` denylist SHALL apply
-right after generated/binary skipping; exclude wins, and `**/`-prefixed
-patterns also match at the repo root.
+right after generated/binary skipping; exclude wins, `**/`-prefixed patterns
+also match at the repo root, and matching repository paths is case-sensitive
+on every host.
 <!-- anchor: engine.path-filters -->
 
 #### Scenario: a file is both included and excluded
 - **WHEN** a path matches `include_paths` and `exclude_paths`
 - **THEN** it is excluded
+
+#### Scenario: path case differs from the configured glob
+- **WHEN** a repository path differs from a configured include or exclude glob
+  only by letter case
+- **THEN** the path does not match on Windows or POSIX hosts
 
 ### Requirement: Over-budget files walk hunk-by-hunk
 
@@ -108,10 +114,22 @@ any triage failure reviews everything, and skips are named in the summary.
 Installed tools SHALL run sandboxed when static analysis is enabled — ruff,
 bandit, and semgrep with local rules only; scrubbed env, no network, hard
 timeout, temp dir, never a checkout — and their findings enter the prompt only
-as an untrusted HINTS block ("confirm, contextualise, or discard"). Raw tool
-findings are never posted; a missing tool is skipped silently.
+as an untrusted HINTS block ("confirm, contextualise, or discard"). Paths MUST
+be canonical forward-slash repository paths. On Windows the scrubbed
+environment MUST pass through process-critical system variables while pinning
+user config and profile directories to the temp root. Raw tool findings are
+never posted; a missing tool is skipped silently.
 <!-- anchor: engine.static-analysis -->
 
 #### Scenario: semgrep has no local rules
 - **WHEN** static analysis runs without `semgrep_rules` configured
 - **THEN** semgrep does not run at all (never `--config auto`)
+
+#### Scenario: a Windows tool reports a backslash path
+- **WHEN** static analysis reports `.\src\app.py`
+- **THEN** the hint is associated with the canonical diff path `src/app.py`
+
+#### Scenario: static analysis runs on Windows
+- **WHEN** a child analyzer starts under Windows
+- **THEN** it receives the minimal process-critical system variables and temp-
+  rooted user directories without inheriting cloud credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,10 @@ markers = [
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
+    "error::EncodingWarning",
+    "ignore::EncodingWarning:litellm",
+    "ignore::EncodingWarning:regex",
+    "ignore::EncodingWarning:tests",
 ]
 
 [tool.mypy]

--- a/scripts/check_spec_drift.py
+++ b/scripts/check_spec_drift.py
@@ -140,6 +140,8 @@ def run_scan(binary: str, inline_rules: str, cwd: Path) -> dict[str, list[Match]
         cwd=cwd,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=True,
         timeout=120,
     )
@@ -257,7 +259,13 @@ def classify(
 
 def _git(root: Path, *args: str) -> str:
     return subprocess.run(
-        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+        ["git", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
     ).stdout.strip()
 
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from collections import Counter
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -784,9 +786,19 @@ Docs: https://lgtmaybe.coles.codes/
 """
 
 
+def _utf8_stdio() -> None:
+    """Keep redirected Windows output safe for summaries containing Unicode."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            with suppress(Exception):
+                reconfigure(encoding="utf-8", errors="replace")
+
+
 @click.group(epilog=_EPILOG)
 def main() -> None:
     """lgtmaybe — provider-agnostic PR reviewer."""
+    _utf8_stdio()
 
 
 @main.group(name="config")

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -507,7 +507,7 @@ def comment(
     config_path: str | None,
 ) -> None:
     """Handle an issue_comment event: route a /slash command to the engine."""
-    event = json.loads(Path(event_path).read_text())
+    event = json.loads(Path(event_path).read_text(encoding="utf-8"))
     cfg = _load_cfg(config_path, provider=provider, model=model)
     runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
     execute_comment(event, cfg, runtime)
@@ -556,7 +556,7 @@ def action() -> None:
         profile=bool(_parse_bool(inputs["profile"])),
     )
 
-    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")
 
     if event_name == "issue_comment":

--- a/src/lgtmaybe/config/loader.py
+++ b/src/lgtmaybe/config/loader.py
@@ -85,7 +85,7 @@ def _load_lens_files(lens_paths: Any) -> list[dict[str, Any]]:
         else:
             files = [path]
         for file in files:
-            parsed = yaml.safe_load(file.read_text())
+            parsed = yaml.safe_load(file.read_text(encoding="utf-8"))
             if isinstance(parsed, list):
                 lenses.extend(item for item in parsed if isinstance(item, dict))
             elif isinstance(parsed, dict):
@@ -136,7 +136,7 @@ def _load_file(
             raise ValueError(f"config file not found: {config_path}")
         return {}
 
-    raw = config_path.read_text()
+    raw = config_path.read_text(encoding="utf-8")
     if not raw.strip():
         return {}
 

--- a/src/lgtmaybe/config/store.py
+++ b/src/lgtmaybe/config/store.py
@@ -33,7 +33,7 @@ def load(path: Path | None = None) -> dict[str, Any]:
     path = path or user_config_path()
     if not path.exists():
         return {}
-    parsed = yaml.safe_load(path.read_text())
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
     return parsed if isinstance(parsed, dict) else {}
 
 
@@ -41,7 +41,7 @@ def save(data: dict[str, Any], path: Path | None = None) -> None:
     """Write the config dict as YAML, creating parent directories as needed."""
     path = path or user_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(data, sort_keys=True))
+    path.write_text(yaml.safe_dump(data, sort_keys=True), encoding="utf-8")
 
 
 def as_yaml(path: Path | None = None) -> str:

--- a/src/lgtmaybe/engine/astgrep.py
+++ b/src/lgtmaybe/engine/astgrep.py
@@ -168,6 +168,8 @@ def _default_runner(binary: str, rule_yaml: str, target: Path) -> str:
             [binary, "scan", "--inline-rules", rule_yaml, "--json=compact", str(target)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_SCAN_TIMEOUT,
             check=False,
         )
@@ -208,7 +210,7 @@ def _parse_paths(stdout: str, root: Path) -> list[str]:
             rel = Path(file).resolve().relative_to(root)
         except ValueError:
             continue
-        out.append(str(rel))
+        out.append(rel.as_posix())
     return out
 
 

--- a/src/lgtmaybe/engine/boundaries.py
+++ b/src/lgtmaybe/engine/boundaries.py
@@ -73,9 +73,9 @@ def definition_starts(
     kinds_flow = ", ".join(f"{{kind: {k}}}" for k in kinds)
     rule = f"id: lgtmaybe-boundaries\nlanguage: {language}\nrule: {{any: [{kinds_flow}]}}\n"
     run = runner if runner is not None else _default_runner
-    with tempfile.TemporaryDirectory(prefix="lgtmaybe-bounds-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="lgtmaybe-bounds-", ignore_cleanup_errors=True) as tmp:
         target = Path(tmp) / f"file{Path(path).suffix.lower()}"
-        target.write_text(text)
+        target.write_text(text, encoding="utf-8")
         stdout = run(binary, rule, target)
     return _parse_starts(stdout)
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from functools import partial
 
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
@@ -793,9 +793,9 @@ def passes_path_filters(path: str, *, include: list[str], exclude: list[str]) ->
 
 
 def _matches_glob(path: str, pattern: str) -> bool:
-    if fnmatch(path, pattern):
+    if fnmatchcase(path, pattern):
         return True
-    return pattern.startswith("**/") and fnmatch(path, pattern[3:])
+    return pattern.startswith("**/") and fnmatchcase(path, pattern[3:])
 
 
 def _intent_text(ctx: PRContext) -> str:

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -11,9 +11,9 @@ Sandboxing posture:
 
 - tools are external binaries discovered on PATH — a missing tool is skipped
   silently, so a minimal install degrades to no hints;
-- subprocesses get a **scrubbed environment** (only PATH; no proxy vars or
-  cloud credentials to phone home with; HOME pinned inside the sandbox so
-  user-level tool config can't leak in) and a hard timeout;
+- subprocesses get a **scrubbed environment** (PATH plus process-critical
+  Windows variables when applicable; no proxy vars or cloud credentials;
+  user profile/config roots pinned inside the sandbox) and a hard timeout;
 - semgrep runs only with locally configured rules — its registry configs
   (``--config auto``) fetch over the network, which is forbidden here;
 - tool output is untrusted text: the engine redacts it and wraps it in a
@@ -36,6 +36,7 @@ from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import ReviewConfig, Severity, StaticAnalysisTool
 
 _log = get_logger(__name__)
+_WINDOWS = os.name == "nt"
 
 # Hard per-tool wall-clock cap: a hung linter must never hang the review.
 _TOOL_TIMEOUT = 60
@@ -83,7 +84,7 @@ def run_static_analysis(file_contents: dict[str, str], cfg: ReviewConfig) -> lis
         return []
 
     findings: list[ToolFinding] = []
-    with tempfile.TemporaryDirectory(prefix="lgtmaybe-sa-") as tmp:
+    with tempfile.TemporaryDirectory(prefix="lgtmaybe-sa-", ignore_cleanup_errors=True) as tmp:
         root = Path(tmp)
         written = _write_corpus(root, file_contents)
         if not written:
@@ -131,12 +132,12 @@ def _write_corpus(root: Path, file_contents: dict[str, str]) -> list[str]:
     written: list[str] = []
     for path, text in file_contents.items():
         rel = Path(path)
-        if rel.is_absolute() or ".." in rel.parts:
+        if rel.anchor or ".." in rel.parts:
             _log.warning("skipping unsafe static-analysis path", extra={"path": path})
             continue
         target = root / rel
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(text)
+        target.write_text(text, encoding="utf-8")
         written.append(path)
     return written
 
@@ -178,6 +179,8 @@ def _run_tool(tool: StaticAnalysisTool, root: Path, cfg: ReviewConfig) -> list[T
             env=_scrubbed_env(root),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_TOOL_TIMEOUT,
         )
         return _parse_output(tool, result.stdout, root)
@@ -192,17 +195,36 @@ def _run_tool(tool: StaticAnalysisTool, root: Path, cfg: ReviewConfig) -> list[T
 def _scrubbed_env(root: Path) -> dict[str, str]:
     """A minimal subprocess environment: nothing to phone home with.
 
-    Only PATH survives from the parent (to find the binary's own deps); proxy
-    variables, cloud credentials, and tokens are all dropped, and HOME is
-    pinned inside the sandbox so user-level tool config can't alter behaviour.
+    POSIX retains only PATH. Windows also needs a small set of process-critical
+    system variables; user profile/config roots stay pinned inside the sandbox.
+    Proxy variables, cloud credentials, and tokens are always dropped.
     """
-    return {
+    env = {
         "PATH": os.environ.get("PATH", ""),
         "HOME": str(root),
         "NO_COLOR": "1",
         # Belt and braces for semgrep even with --metrics=off.
         "SEMGREP_SEND_METRICS": "off",
     }
+    if not _WINDOWS:
+        return env
+
+    system_vars = {
+        "SystemRoot": os.environ.get("SystemRoot", os.environ.get("SYSTEMROOT")),
+        "COMSPEC": os.environ.get("COMSPEC"),
+        "PATHEXT": os.environ.get("PATHEXT"),
+        "TEMP": os.environ.get("TEMP"),
+        "TMP": os.environ.get("TMP"),
+    }
+    env.update({key: value for key, value in system_vars.items() if value is not None})
+    env.update(
+        {
+            "USERPROFILE": str(root),
+            "APPDATA": str(root),
+            "LOCALAPPDATA": str(root),
+        }
+    )
+    return env
 
 
 def _parse_output(tool: StaticAnalysisTool, stdout: str, root: Path) -> list[ToolFinding]:
@@ -214,20 +236,21 @@ def _parse_output(tool: StaticAnalysisTool, stdout: str, root: Path) -> list[Too
     return [_semgrep_finding(item) for item in data.get("results", [])]
 
 
-def _relativise(path: str, root: Path) -> str:
-    """Map a tool-reported path back to the repo-relative form."""
+def _posix_rel(path: str, root: Path | None = None) -> str:
+    """Map a tool-reported path into the canonical repository path form."""
     p = Path(path)
-    try:
-        return str(p.relative_to(root))
-    except ValueError:
-        # Already relative (bandit reports ./src/x.py; semgrep src/x.py).
-        return str(p).removeprefix("./")
+    if root is not None:
+        try:
+            p = p.relative_to(root)
+        except ValueError:
+            pass
+    return p.as_posix().replace("\\", "/").removeprefix("./")
 
 
 def _ruff_finding(item: dict[str, Any], root: Path) -> ToolFinding:
     return ToolFinding(
         tool="ruff",
-        path=_relativise(str(item.get("filename", "")), root),
+        path=_posix_rel(str(item.get("filename", "")), root),
         line=int(item.get("location", {}).get("row", 1)),
         rule=str(item.get("code") or ""),
         message=str(item.get("message", "")),
@@ -239,7 +262,7 @@ def _ruff_finding(item: dict[str, Any], root: Path) -> ToolFinding:
 def _bandit_finding(item: dict[str, Any]) -> ToolFinding:
     return ToolFinding(
         tool="bandit",
-        path=str(item.get("filename", "")).removeprefix("./"),
+        path=_posix_rel(str(item.get("filename", ""))),
         line=int(item.get("line_number", 1)),
         rule=str(item.get("test_id", "")),
         message=str(item.get("issue_text", "")),
@@ -251,7 +274,7 @@ def _semgrep_finding(item: dict[str, Any]) -> ToolFinding:
     extra = item.get("extra", {})
     return ToolFinding(
         tool="semgrep",
-        path=str(item.get("path", "")).removeprefix("./"),
+        path=_posix_rel(str(item.get("path", ""))),
         line=int(item.get("start", {}).get("line", 1)),
         rule=str(item.get("check_id", "")),
         message=str(extra.get("message", "")),

--- a/src/lgtmaybe/github/checkout.py
+++ b/src/lgtmaybe/github/checkout.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import atexit
 import base64
 import shutil
+import stat
 import subprocess
+import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
@@ -32,6 +34,42 @@ _CLONE_TIMEOUT = 120
 # Injected so tests don't shell out to real git. Mirrors subprocess.run's surface
 # for the args we pass.
 Runner = Callable[..., Any]
+
+
+def _rmtree_force(path: Path) -> None:
+    """Remove a tree, making Windows read-only entries writable when needed."""
+    root = path.resolve()
+
+    def retry(function: Callable[..., Any], failed_path: str, _error: Any) -> None:
+        target = Path(failed_path)
+        candidates = [target]
+        try:
+            target.parent.resolve().relative_to(root)
+        except ValueError:
+            pass
+        else:
+            candidates.append(target.parent)
+        for candidate in candidates:
+            try:
+                candidate.chmod(candidate.stat().st_mode | stat.S_IWRITE | stat.S_IEXEC)
+            except OSError:
+                pass
+        function(failed_path)
+
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=retry)
+    else:
+        shutil.rmtree(path, onerror=retry)
+
+
+def _cleanup_base_tree(path: Path) -> None:
+    try:
+        _rmtree_force(path)
+    except OSError as exc:
+        _log.warning(
+            "could not remove temporary base tree",
+            extra={"path": str(path), "error": str(exc)},
+        )
 
 
 def clone_base_tree(
@@ -81,8 +119,8 @@ def clone_base_tree(
             check=True,
         )
     except (OSError, subprocess.SubprocessError):
-        shutil.rmtree(dest, ignore_errors=True)
+        _cleanup_base_tree(dest)
         return None
-    atexit.register(shutil.rmtree, dest, ignore_errors=True)
+    atexit.register(_cleanup_base_tree, dest)
     _log.info("cloned base tree for symbol resolution", extra={"repo": repo, "ref": ref})
     return dest

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -15,7 +15,7 @@ review to save tokens and avoid noise.
 
 from __future__ import annotations
 
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 
 from lgtmaybe.core.diffparse import FILE_HEADER_RE, parse_hunk_header
 
@@ -231,7 +231,7 @@ def is_reviewable(path: str) -> bool:
 
     # Glob pattern check on the full path
     for pattern in _SKIP_GLOB_PATTERNS:
-        if fnmatch(path, pattern) or fnmatch(filename, pattern):
+        if fnmatchcase(path, pattern) or fnmatchcase(filename, pattern):
             return False
 
     return True

--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -113,6 +113,8 @@ def _git(cwd: Path | None, *args: str) -> str:
             check=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_TIMEOUT,
         )
     except FileNotFoundError as exc:

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -20,6 +20,8 @@ from lgtmaybe.providers.constants import (
     OPENAI_COMPATIBLE_PLACEHOLDER_KEY,
 )
 
+_WINDOWS = os.name == "nt"
+
 
 @dataclass(frozen=True)
 class AuthConfig:
@@ -80,8 +82,15 @@ def _default_gcp_probe() -> bool:
     ):
         return True
 
-    config_dir = os.environ.get("CLOUDSDK_CONFIG") or str(Path.home() / ".config" / "gcloud")
-    return (Path(config_dir) / "application_default_credentials.json").is_file()
+    configured = os.environ.get("CLOUDSDK_CONFIG")
+    if configured:
+        config_dir = Path(configured)
+    elif _WINDOWS:
+        appdata = os.environ.get("APPDATA")
+        config_dir = (Path(appdata) if appdata else Path.home() / "AppData" / "Roaming") / "gcloud"
+    else:
+        config_dir = Path.home() / ".config" / "gcloud"
+    return (config_dir / "application_default_credentials.json").is_file()
 
 
 def _default_azure_token() -> str | None:

--- a/tests/cli/test_stdio.py
+++ b/tests/cli/test_stdio.py
@@ -1,0 +1,20 @@
+"""CLI stdio is safe when Windows redirects output through a legacy codec."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import lgtmaybe.cli as cli
+
+
+def test_utf8_stdio_reconfigures_legacy_windows_stream(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="cp1252")
+    monkeypatch.setattr(sys, "stdout", stream)
+
+    cli._utf8_stdio()
+    print("👍 LGTM!", end="")
+    stream.flush()
+
+    assert raw.getvalue().decode("utf-8") == "👍 LGTM!"

--- a/tests/config/test_store.py
+++ b/tests/config/test_store.py
@@ -27,6 +27,15 @@ def test_set_then_get_round_trips(cfg_home: Path) -> None:
     assert store.get_key("model") == "qwen3:27b"
 
 
+def test_store_roundtrips_non_latin_values_as_utf8(tmp_path: Path) -> None:
+    path = tmp_path / "config.yml"
+
+    store.save({"model": "模型-Привет-👍"}, path)
+
+    assert store.load(path)["model"] == "模型-Привет-👍"
+    assert path.read_bytes().decode("utf-8")
+
+
 def test_set_coerces_to_field_type(cfg_home: Path) -> None:
     store.set_key("max_files", "25")
 

--- a/tests/engine/test_astgrep.py
+++ b/tests/engine/test_astgrep.py
@@ -14,10 +14,11 @@ from pathlib import Path
 import pytest
 
 from lgtmaybe.engine.astgrep import (
-    _rule_yaml as rule_yaml,
+    _parse_paths,
+    build_symbol_resolver,
 )
 from lgtmaybe.engine.astgrep import (
-    build_symbol_resolver,
+    _rule_yaml as rule_yaml,
 )
 
 _HAVE_BINARY = "ast-grep"  # any non-None string stands in for "binary present"
@@ -70,6 +71,12 @@ def test_resolver_parses_and_dedupes_paths(tmp_path: Path) -> None:
     assert resolve is not None
     # Returned as a repo-relative path, de-duplicated across the match array.
     assert resolve("already_applied") == ["ledger.py"]
+
+
+def test_parse_paths_emits_posix_separators(tmp_path: Path) -> None:
+    output = json.dumps([{"file": str(tmp_path / "src" / "app.py")}])
+
+    assert _parse_paths(output, tmp_path.resolve()) == ["src/app.py"]
 
 
 def test_resolver_uses_last_dotted_segment(tmp_path: Path) -> None:

--- a/tests/engine/test_boundaries.py
+++ b/tests/engine/test_boundaries.py
@@ -10,6 +10,7 @@ failure returns [] and the caller keeps the fixed-line pad.
 
 from __future__ import annotations
 
+import lgtmaybe.engine.boundaries as boundaries
 from lgtmaybe.engine.boundaries import definition_starts
 
 _PY = """\
@@ -52,3 +53,23 @@ def test_runner_failure_returns_nothing() -> None:
     assert (
         definition_starts(_PY, "src/sample.py", runner=lambda binary, rule, path: "not json") == []
     )
+
+
+def test_boundaries_temp_directory_ignores_cleanup_errors(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+    temporary_directory = boundaries.tempfile.TemporaryDirectory
+
+    def recording_temp_directory(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return temporary_directory(*args, **kwargs)
+
+    monkeypatch.setattr(boundaries.tempfile, "TemporaryDirectory", recording_temp_directory)
+
+    definition_starts(
+        _PY,
+        "src/sample.py",
+        runner=lambda *_args: "[]",
+        find_binary=lambda: "ast-grep",
+    )
+
+    assert captured["ignore_cleanup_errors"] is True

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1443,6 +1443,11 @@ def test_passes_path_filters_matches_root_level_with_leading_globstar() -> None:
     assert passes_path_filters("deep/nested/file.py", include=["**/*.py"], exclude=[])
 
 
+def test_path_filters_match_case_sensitively() -> None:
+    assert not passes_path_filters("src/App.py", include=["src/app.py"], exclude=[])
+    assert passes_path_filters("src/App.py", include=[], exclude=["src/app.py"])
+
+
 # ---------------------------------------------------------------------------
 # static-analysis fusion: hints enter the prompt as untrusted grounding
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -25,8 +25,14 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import lgtmaybe.engine.static_analysis as static_analysis
 from lgtmaybe.core.models import Provider, ReviewConfig, Severity, StaticAnalysisTool
-from lgtmaybe.engine.static_analysis import ToolFinding, format_hints, run_static_analysis
+from lgtmaybe.engine.static_analysis import (
+    ToolFinding,
+    _write_corpus,
+    format_hints,
+    run_static_analysis,
+)
 
 FILES = {"src/app.py": "import os\nx = eval(input())\n"}
 
@@ -104,6 +110,40 @@ def test_missing_tool_is_skipped_silently(monkeypatch) -> None:  # type: ignore[
     assert run.calls == []
 
 
+def test_static_analysis_temp_directory_ignores_cleanup_errors(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+    temporary_directory = static_analysis.tempfile.TemporaryDirectory
+
+    def recording_temp_directory(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return temporary_directory(*args, **kwargs)
+
+    monkeypatch.setattr(static_analysis.tempfile, "TemporaryDirectory", recording_temp_directory)
+    _patch_tools(monkeypatch, _FakeRun(), present=set())
+
+    run_static_analysis(FILES, _cfg())
+
+    assert captured["ignore_cleanup_errors"] is True
+
+
+def test_corpus_written_utf8(tmp_path: Path) -> None:
+    source = "print('你好, мир, 👍')\n"
+
+    assert _write_corpus(tmp_path, {"src/app.py": source}) == ["src/app.py"]
+    assert (tmp_path / "src" / "app.py").read_bytes().decode("utf-8").splitlines() == [
+        source.rstrip()
+    ]
+
+
+def test_relativise_returns_forward_slash_paths(tmp_path: Path) -> None:
+    absolute = tmp_path / "src" / "app.py"
+
+    assert static_analysis._posix_rel(str(absolute), tmp_path) == "src/app.py"
+    assert static_analysis._posix_rel(r"src\app.py", tmp_path) == "src/app.py"
+    assert static_analysis._posix_rel(r".\src\app.py") == "src/app.py"
+    assert static_analysis._posix_rel("./src/app.py") == "src/app.py"
+
+
 def test_ruff_findings_parsed_and_relativised(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     captured_root: dict[str, str] = {}
 
@@ -173,6 +213,40 @@ def test_subprocess_env_is_scrubbed_of_proxies_and_home(monkeypatch) -> None:  #
     assert run.calls[0]["timeout"]
 
 
+def test_scrubbed_env_windows_passes_system_vars(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(static_analysis, "_WINDOWS", True, raising=False)
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+    monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT")
+    monkeypatch.setenv("TEMP", r"C:\Temp")
+    monkeypatch.setenv("TMP", r"C:\Tmp")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "must-not-leak")
+
+    env = static_analysis._scrubbed_env(tmp_path)
+
+    assert env["SystemRoot"] == r"C:\Windows"
+    assert env["COMSPEC"] == r"C:\Windows\System32\cmd.exe"
+    assert env["PATHEXT"] == ".COM;.EXE;.BAT"
+    assert env["TEMP"] == r"C:\Temp"
+    assert env["TMP"] == r"C:\Tmp"
+    for key in ("HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA"):
+        assert env[key] == str(tmp_path)
+    assert "AWS_ACCESS_KEY_ID" not in env
+
+
+def test_scrubbed_env_posix_stays_minimal(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(static_analysis, "_WINDOWS", False, raising=False)
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "must-not-leak")
+
+    assert static_analysis._scrubbed_env(tmp_path) == {
+        "PATH": static_analysis.os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        "NO_COLOR": "1",
+        "SEMGREP_SEND_METRICS": "off",
+    }
+
+
 def test_semgrep_skipped_without_local_rules(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """semgrep with no --config would need the network registry — never run it
     unless the user configured local rules."""
@@ -235,14 +309,15 @@ def test_escaping_paths_are_never_written(monkeypatch, tmp_path) -> None:  # typ
     """A malicious PR path must not be written outside the sandbox dir."""
     run = _FakeRun()
     _patch_tools(monkeypatch, run, present=set())
-    evil = {"../evil.py": "x = 1", "/abs/evil.py": "x = 1"}
     sentinel = tmp_path / "evil.py"
+    absolute_sentinel = tmp_path / "absolute-evil.py"
+    evil = {"../evil.py": "x = 1", str(absolute_sentinel): "x = 1"}
 
     monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
     run_static_analysis(evil, _cfg())
 
     assert not sentinel.exists()
-    assert not Path("/abs/evil.py").exists()
+    assert not absolute_sentinel.exists()
 
 
 def test_format_hints_renders_tool_rule_path_line() -> None:

--- a/tests/github/test_checkout.py
+++ b/tests/github/test_checkout.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+import lgtmaybe.github.checkout as checkout
 from lgtmaybe.github.checkout import clone_base_tree
 
 
@@ -74,6 +75,22 @@ def test_clone_failure_returns_none_and_cleans_up(tmp_path: Path) -> None:
     assert created and not Path(created[0]).exists()
 
 
+def test_clone_failure_stays_best_effort_when_cleanup_fails(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    dest = tmp_path / "clone"
+    dest.mkdir()
+    monkeypatch.setattr(checkout.tempfile, "mkdtemp", lambda **_kwargs: str(dest))
+
+    def fail_cleanup(_path: Path) -> None:
+        raise OSError("locked")
+
+    monkeypatch.setattr(checkout, "_rmtree_force", fail_cleanup)
+
+    def runner(cmd: list[str], **kwargs: Any) -> Any:
+        raise subprocess.CalledProcessError(128, cmd)
+
+    assert clone_base_tree("owner/repo", "main", "tok", runner=runner) is None
+
+
 def test_clone_token_not_in_returned_path() -> None:
     def runner(cmd: list[str], **kwargs: Any) -> Any:
         return subprocess.CompletedProcess(cmd, 0)
@@ -82,3 +99,15 @@ def test_clone_token_not_in_returned_path() -> None:
 
     assert dest is not None
     assert "supersecret" not in str(dest)
+
+
+def test_rmtree_force_removes_read_only_tree(tmp_path: Path) -> None:
+    tree = tmp_path / "tree"
+    child = tree / "child"
+    child.mkdir(parents=True)
+    (child / "file.txt").write_text("content", encoding="utf-8")
+    child.chmod(0o500)
+
+    checkout._rmtree_force(tree)
+
+    assert not tree.exists()

--- a/tests/github/test_diff.py
+++ b/tests/github/test_diff.py
@@ -167,6 +167,11 @@ def test_is_reviewable_rejects_generated_globs() -> None:
     assert not is_reviewable("__generated__/foo.py")
 
 
+def test_skip_globs_are_case_sensitive() -> None:
+    assert is_reviewable("api/service.PB.go")
+    assert is_reviewable("types/models.D.TS")
+
+
 def test_is_reviewable_rejects_nested_generated_dirs() -> None:
     """A __generated__ tree is skipped anywhere in the path, not just at the
     repo root — fnmatch("src/__generated__/api.ts", "__generated__/*") is False,

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+import lgtmaybe.providers.credentials as credentials
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.credentials import (
     _default_aws_probe,
@@ -328,8 +329,9 @@ _AWS_ENV_VARS = (
 def _clear(monkeypatch: pytest.MonkeyPatch, names: tuple[str, ...], home: str) -> None:
     for name in names:
         monkeypatch.delenv(name, raising=False)
-    # Redirect HOME so a real ~/.config/gcloud or ~/.aws on the dev box can't leak in.
+    # Redirect both host conventions so real local cloud config can't leak in.
     monkeypatch.setenv("HOME", home)
+    monkeypatch.setenv("USERPROFILE", home)
 
 
 class TestDefaultGcpProbe:
@@ -356,9 +358,36 @@ class TestDefaultGcpProbe:
         _clear(monkeypatch, _GCP_ENV_VARS, str(tmp_path))
         gcloud_dir = tmp_path / "gcloud"
         gcloud_dir.mkdir()
-        (gcloud_dir / "application_default_credentials.json").write_text("{}")
+        (gcloud_dir / "application_default_credentials.json").write_text("{}", encoding="utf-8")
         monkeypatch.setenv("CLOUDSDK_CONFIG", str(gcloud_dir))
         assert _default_gcp_probe() is True
+
+    def test_gcp_probe_finds_adc_under_appdata_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        _clear(monkeypatch, _GCP_ENV_VARS, str(tmp_path))
+        monkeypatch.setattr(credentials, "_WINDOWS", True, raising=False)
+        appdata = tmp_path / "AppData" / "Roaming"
+        gcloud_dir = appdata / "gcloud"
+        gcloud_dir.mkdir(parents=True)
+        (gcloud_dir / "application_default_credentials.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("APPDATA", str(appdata))
+
+        assert _default_gcp_probe() is True
+
+    def test_gcp_probe_prefers_cloudsdk_config_over_appdata(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        _clear(monkeypatch, _GCP_ENV_VARS, str(tmp_path))
+        monkeypatch.setattr(credentials, "_WINDOWS", True, raising=False)
+        appdata = tmp_path / "AppData" / "Roaming"
+        gcloud_dir = appdata / "gcloud"
+        gcloud_dir.mkdir(parents=True)
+        (gcloud_dir / "application_default_credentials.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("CLOUDSDK_CONFIG", str(tmp_path / "explicit-empty"))
+
+        assert _default_gcp_probe() is False
 
     def test_no_creds_anywhere_is_absent(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         _clear(monkeypatch, _GCP_ENV_VARS, str(tmp_path))

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+import subprocess
+import sys
+import textwrap
 import tomllib
 import warnings
 from pathlib import Path
@@ -49,7 +52,111 @@ def test_module_imports_without_deprecation_warnings(module_name: str) -> None:
 
 def test_deprecation_gate_is_configured() -> None:
     """The pyproject deprecation gate must stay in place (don't silently drop it)."""
-    cfg = tomllib.loads(_PYPROJECT.read_text())
+    cfg = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
     filters = cfg["tool"]["pytest"]["ini_options"]["filterwarnings"]
     assert "error::DeprecationWarning" in filters
     assert "error::PendingDeprecationWarning" in filters
+    assert "error::EncodingWarning" in filters
+
+
+def test_no_default_encoding_io() -> None:
+    """Owned text boundaries must not depend on the host locale."""
+    script = textwrap.dedent(
+        """
+        import subprocess
+        import sys
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from lgtmaybe.cli import main
+        from lgtmaybe.config.loader import load_config
+        from lgtmaybe.config.store import load, save
+        from lgtmaybe.core.models import ReviewConfig, StaticAnalysisTool
+        from lgtmaybe.engine.astgrep import _default_runner
+        from lgtmaybe.engine.boundaries import definition_starts
+        from lgtmaybe.engine.static_analysis import _run_tool, _write_corpus
+        from lgtmaybe.local import _git
+        from scripts.check_spec_drift import run_scan
+
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            root = Path(tmp)
+            config = root / "config.yml"
+            save({"model": "模型"}, config)
+            assert load(config)["model"] == "模型"
+
+            lens = root / "lens.yml"
+            lens.write_text(
+                "id: windows\\ninstructions: Проверить код.\\n",
+                encoding="utf-8",
+            )
+            config.write_text(
+                f"provider: ollama\\nmodel: llama3\\nlens_paths:\\n  - {lens}\\n",
+                encoding="utf-8",
+            )
+            load_config(config_path=config)
+
+            _write_corpus(root / "corpus", {"src/app.py": "print('👍')\\n"})
+            definition_starts(
+                "def f():\\n    pass\\n",
+                "src/app.py",
+                runner=lambda *_args: "[]",
+                find_binary=lambda: "ast-grep",
+            )
+
+            event = root / "event.json"
+            event.write_text("{}", encoding="utf-8")
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["comment", "--event-path", str(event), "--config", str(config)],
+            )
+            assert result.exit_code == 0, result.output
+            result = runner.invoke(
+                main,
+                ["action"],
+                env={
+                    "GITHUB_EVENT_NAME": "issue_comment",
+                    "GITHUB_EVENT_PATH": str(event),
+                    "INPUT_CONFIG_PATH": str(config),
+                },
+            )
+            assert result.exit_code == 0, result.output
+
+            _git(root, "--version")
+            _default_runner(sys.executable, "", root)
+            with patch(
+                "lgtmaybe.engine.static_analysis.shutil.which",
+                return_value=sys.executable,
+            ):
+                _run_tool(
+                    StaticAnalysisTool.ruff,
+                    root,
+                    ReviewConfig(provider="ollama", model="llama3"),
+                )
+            try:
+                run_scan(sys.executable, "", root)
+            except subprocess.CalledProcessError:
+                pass
+        """
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            "-c",
+            script,
+        ],
+        cwd=_PYPROJECT.parent,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What changed

- add Windows 3.11 and 3.13 legs to the shared CI matrix, before the compatibility fixes
- make owned text I/O and subprocess output explicitly UTF-8
- normalize analyzer and ast-grep paths to repository-style forward slashes
- preserve the minimal static-analysis sandbox while supplying required Windows process variables
- make CLI output, path globs, Vertex ADC discovery, and temporary-directory cleanup Windows-safe
- update the living specs and anchor coverage for the changed behavior

## Why

The CLI was close to Windows-compatible, but locale-default encoding, backslash paths, Windows subprocess requirements, and read-only cleanup could either terminate a review or silently disable findings. Ubuntu-only CI did not exercise those paths.

## Impact

Windows becomes a tested CLI platform. The same full gate now runs on Windows under locale-default encoding without forcing Python UTF-8 mode, while Linux behavior remains unchanged.

## Validation

- `1204 passed, 3 deselected`
- `ruff check .`
- `ruff format --check .`
- `mypy`
- living-spec tests and OpenSpec validation
- spec-anchor drift check

The new hosted Windows CI legs are the final platform validation for this PR.
