### PR TITLE
feat: add Windows executable and winget distribution

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,7 +93,6 @@ jobs:
       version: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write
-    secrets: inherit
 
   winget:
     needs: [release-please, windows-exe]
@@ -101,4 +100,5 @@ jobs:
     uses: ./.github/workflows/winget.yml
     with:
       version: ${{ needs.release-please.outputs.tag_name }}
-    secrets: inherit
+    secrets:
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,3 +84,21 @@ jobs:
     with:
       version: ${{ needs.release-please.outputs.tag_name }}
     secrets: inherit
+
+  windows-exe:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/windows-exe.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+    secrets: inherit
+
+  winget:
+    needs: [release-please, windows-exe]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/winget.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -106,3 +106,6 @@ jobs:
         run: |
           gh release upload "${{ steps.ver.outputs.tag }}" `
             "${{ steps.ver.outputs.asset }}" --clobber
+          if ($LASTEXITCODE -ne 0) {
+            throw "gh release upload failed with exit code $LASTEXITCODE"
+          }

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -1,0 +1,108 @@
+name: windows executable
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version or tag to build, e.g. 1.0.0 or lgtmaybe-v1.0.0."
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version or tag to build, e.g. 1.0.0 or lgtmaybe-v1.0.0."
+        required: true
+        type: string
+      force:
+        description: "Replace the release asset when it already exists."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Resolve version
+        id: ver
+        shell: pwsh
+        run: |
+          $v = "${{ inputs.version }}" -replace '^lgtmaybe-v', '' -replace '^v', ''
+          if (-not $v) {
+            throw "version is required"
+          }
+          "version=$v" >> $env:GITHUB_OUTPUT
+          "tag=lgtmaybe-v$v" >> $env:GITHUB_OUTPUT
+          "asset=lgtmaybe-$v-windows-x86_64.exe" >> $env:GITHUB_OUTPUT
+
+      - name: Skip if the release asset already exists
+        id: idem
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $assets = gh release view "${{ steps.ver.outputs.tag }}" --json assets --jq '.assets[].name'
+          if ($LASTEXITCODE -ne 0) {
+            throw "release ${{ steps.ver.outputs.tag }} does not exist"
+          }
+          $exists = $assets -contains "${{ steps.ver.outputs.asset }}"
+          $force = "${{ inputs.force }}" -eq "true"
+          if ($exists -and -not $force) {
+            "skip=true" >> $env:GITHUB_OUTPUT
+            Write-Output "Release asset already exists; nothing to do."
+          }
+
+      - uses: actions/checkout@v7
+        if: steps.idem.outputs.skip != 'true'
+        with:
+          ref: ${{ steps.ver.outputs.tag }}
+
+      - name: Install uv
+        if: steps.idem.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Sync locked packaging environment
+        if: steps.idem.outputs.skip != 'true'
+        run: uv sync --frozen --no-dev --group packaging
+
+      - name: Build executable
+        if: steps.idem.outputs.skip != 'true'
+        run: uv run pyinstaller packaging/pyinstaller/lgtmaybe.spec
+
+      - name: Smoke-test executable
+        id: smoke
+        if: steps.idem.outputs.skip != 'true'
+        shell: pwsh
+        run: |
+          $exe = Resolve-Path ".\dist\lgtmaybe.exe"
+          $help = & $exe --help
+          if ($LASTEXITCODE -ne 0 -or -not ($help | Select-String -Quiet "Usage")) {
+            throw "lgtmaybe.exe --help failed"
+          }
+          $configPath = & $exe config path
+          if ($LASTEXITCODE -ne 0 -or -not $configPath) {
+            throw "lgtmaybe.exe config path failed"
+          }
+          $reviewHelp = & $exe help review
+          if ($LASTEXITCODE -ne 0 -or -not ($reviewHelp | Select-String -Quiet "Usage")) {
+            throw "lgtmaybe.exe help review failed"
+          }
+
+          $size = (Get-Item $exe).Length
+          Write-Output "Executable size: $size bytes ($([math]::Round($size / 1MB, 1)) MiB)"
+          Copy-Item $exe "${{ steps.ver.outputs.asset }}"
+
+      - name: Upload release asset
+        if: steps.idem.outputs.skip != 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.ver.outputs.tag }}" `
+            "${{ steps.ver.outputs.asset }}" --clobber

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,71 @@
+name: winget
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version or tag to submit, e.g. 1.0.0 or lgtmaybe-v1.0.0."
+        required: true
+        type: string
+    secrets:
+      WINGET_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version or tag to submit, e.g. 1.0.0 or lgtmaybe-v1.0.0."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Resolve version
+        id: ver
+        shell: pwsh
+        run: |
+          $v = "${{ inputs.version }}" -replace '^lgtmaybe-v', '' -replace '^v', ''
+          if (-not $v) {
+            throw "version is required"
+          }
+          $asset = "lgtmaybe-$v-windows-x86_64.exe"
+          "version=$v" >> $env:GITHUB_OUTPUT
+          "asset_url=https://github.com/MattJColes/lgtmaybe/releases/download/lgtmaybe-v$v/$asset" >> $env:GITHUB_OUTPUT
+
+      - name: Wait for the release asset
+        shell: pwsh
+        run: |
+          $url = "${{ steps.ver.outputs.asset_url }}"
+          for ($attempt = 1; $attempt -le 60; $attempt++) {
+            try {
+              Invoke-WebRequest -Uri $url -Method Head -TimeoutSec 30 | Out-Null
+              Write-Output "Release asset is available: $url"
+              exit 0
+            } catch {
+              if ($attempt -eq 60) {
+                throw "Release asset did not become available within 10 minutes: $url"
+              }
+              Start-Sleep -Seconds 10
+            }
+          }
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          winget install --id Microsoft.WingetCreate --exact `
+            --accept-package-agreements --accept-source-agreements `
+            --disable-interactivity
+
+      - name: Submit winget update
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          wingetcreate update MattJColes.lgtmaybe `
+            --version "${{ steps.ver.outputs.version }}" `
+            --urls "${{ steps.ver.outputs.asset_url }}" `
+            --submit --token $env:WINGET_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #   before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!packaging/pyinstaller/lgtmaybe.spec
 
 # Installer logs
 pip-log.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Read this before writing code. It encodes decisions that are **made, not options
 
 A PR reviewer that posts inline review comments + a summary. The user picks the
 LLM backend with a `--provider` flag, drops a key into GitHub secrets (or wires
-OIDC/WIF for cloud providers), and gets a review. One core, three distribution
+OIDC/WIF for cloud providers), and gets a review. One core, four distribution
 variants:
 
 - **PyPI CLI** — `pip install lgtmaybe`
@@ -28,6 +28,11 @@ variants:
   published` event isn't delivered for a `GITHUB_TOKEN` release), **actually
   `brew install`s it as a gate** (so a broken formula is never published), then
   commits to the tap; a daily schedule + `force` dispatch are the safety nets
+- **Windows CLI** — `winget install MattJColes.lgtmaybe`. Each release builds a
+  one-file Python 3.13 executable, smoke-tests the Click command tree, attaches
+  it to the GitHub release, then submits `MattJColes.lgtmaybe` to winget. The
+  executable bundles ast-grep but not the optional cloud-auth SDKs; use pip for
+  keyless Bedrock, Vertex, or Azure.
 - **GitHub Action** — composite action (`action.yml`) that does keyless OIDC/WIF
   auth, then runs a GHCR image via the `action` entrypoint
 
@@ -37,6 +42,10 @@ cloud. We win on auth + simplicity. An `openai-compatible` provider is the escap
 hatch for anything else that speaks the OpenAI `/v1` wire format (DeepSeek's API,
 llama.cpp, LM Studio, vLLM) — you bring the `--api-base`, the key is optional —
 so the provider list is never a cage.
+
+The main CI matrix runs Ubuntu on Python 3.11–3.14 and Windows on Python 3.11
+and 3.13. Windows runs with locale-default encoding behavior and disables
+autocrlf before checkout.
 
 ## Non-negotiables
 
@@ -344,7 +353,7 @@ pattern, event bus, plugin framework.
      gateway reconciles only lgtmaybe's own label families, best-effort.
    - **Clean review:** zero findings on a fully-reviewed PR posts `👍 LGTM!`
      (comment only — no GitHub approval state) — still naming the model.
-4. **Packaging (sequential, last) — DONE:** the two distribution variants over
+4. **Packaging (sequential, last) — DONE:** the four distribution variants over
    one core. Delivered in this step:
    - **`action` entrypoint** — the container command. Routes by
      `GITHUB_EVENT_NAME` (`issue_comment` → slash command, else → full review with
@@ -376,6 +385,10 @@ pattern, event bus, plugin framework.
      pushes with the `HOMEBREW_TAP_TOKEN` PAT). Regenerated wholesale each release
      so dep bumps flow through — never hand-edited. Maintainer setup (tap repo +
      PAT) is in `docs/how-to/releasing.md`.
+   - **Windows executable + winget** — `.github/workflows/windows-exe.yml`
+     builds and smoke-tests the portable x86_64 executable before attaching it
+     to the release; `.github/workflows/winget.yml` then submits the versioned
+     asset to `MattJColes.lgtmaybe`.
    - **`examples/workflows/`** — one per posting provider (cloud + API-key);
      `id-token: write` for cloud. ollama is local-only (CLI), not a workflow.
    - **Model IDs in docs are kept current** per platform (litellm-native form).

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instea
 - **CLI (PyPI)** — `pip install lgtmaybe`
 - **CLI (Homebrew)** — `brew tap MattJColes/lgtmaybe && brew trust MattJColes/lgtmaybe && brew install lgtmaybe`
   ([details](docs/how-to/install-the-cli.md) — the `brew trust` step is required for third-party taps)
+- **CLI (winget)** — `winget install MattJColes.lgtmaybe`
 - **GitHub Action** — `uses: MattJColes/lgtmaybe@v1`
 
 ## Contributing

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -1,5 +1,5 @@
 ---
-description: Install the lgtmaybe CLI with pip (any OS) or Homebrew (macOS/Linuxbrew), and add the cloud extras for keyless Bedrock/Vertex/Azure.
+description: Install the lgtmaybe CLI with pip (any OS), Homebrew (macOS/Linuxbrew), or winget (Windows), and add cloud extras for keyless Bedrock/Vertex/Azure.
 ---
 
 # Install the CLI
@@ -27,6 +27,19 @@ That prints the command list with usage examples; `lgtmaybe help <command>`
 (e.g. `lgtmaybe help review`) shows the full option reference for one command.
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
+
+## Install on Windows (winget)
+
+Install the portable Windows executable from winget:
+
+```powershell
+winget install MattJColes.lgtmaybe
+```
+
+The executable bundles ast-grep for cross-file symbol resolution, but it does
+not bundle the optional cloud SDKs used by keyless Bedrock, Vertex, or Azure
+authentication. Use the pip install with the matching extra for those providers.
+The regular `pip install lgtmaybe` path also works on Windows.
 
 ## Install on macOS (Homebrew)
 
@@ -62,7 +75,8 @@ resolution during review.
 
 ## Cloud providers need extras
 
-The base install (either method) covers every **API-key** and **local** provider:
+The base pip install, Homebrew formula, and Windows executable cover every
+**API-key** and **local** provider:
 
 | Providers | Covered by base install? |
 |---|---|
@@ -70,8 +84,8 @@ The base install (either method) covers every **API-key** and **local** provider
 | `ollama`, `openai-compatible` — fully local, point `--api-base` at the server | ✅ Yes |
 | `bedrock`, `vertex`, `azure` — keyless cloud (OIDC/WIF) | ❌ Needs an extra |
 
-The **keyless cloud** providers need extra cloud SDKs that the base install (and
-the Homebrew formula) does not bundle. Install the CLI from PyPI with the matching
+The **keyless cloud** providers need extra cloud SDKs that the Homebrew formula
+and Windows executable do not bundle. Install the CLI from PyPI with the matching
 extra:
 
 ```bash

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -1,5 +1,5 @@
 ---
-description: Maintainer guide to cutting and publishing a new lgtmaybe release with release-please, PyPI trusted publishing, and GHCR.
+description: Maintainer guide to publishing lgtmaybe with release-please, PyPI, GHCR, Homebrew, a Windows executable, and winget.
 search:
   exclude: true
 ---
@@ -25,6 +25,11 @@ source is a dead end — the wheels work. The formula declares **`preserve_rpath
 so Homebrew keeps the wheels' `@rpath` extension-dylib ids instead of failing to
 rewrite them ("Failed to fix install linkage"). It's a plain source formula —
 no bottle — so it installs on any architecture and macOS version.
+
+The release run also calls `.github/workflows/windows-exe.yml` to build and
+smoke-test a portable Windows executable, then `.github/workflows/winget.yml`
+to submit the new asset to winget. The executable must exist before the winget
+job starts; both workflows are manually dispatchable for recovery.
 
 The workflow:
 
@@ -72,6 +77,14 @@ The only human-only pieces:
   with `contents: write` on the tap repo (the default `GITHUB_TOKEN` cannot push
   to another repository). To seed or verify the formula by hand on a Mac, run
   `scripts/update-homebrew-formula.sh <version> path/to/homebrew-lgtmaybe/Formula/lgtmaybe.rb`.
+- **winget:** fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+  Create a classic GitHub PAT with the `public_repo` scope and add it to this
+  repo as **`WINGET_TOKEN`**. For the first release, build/upload the Windows
+  asset and run `wingetcreate new <asset-url>` manually with package id
+  `MattJColes.lgtmaybe`, installer type `portable`, command alias `lgtmaybe`,
+  and MIT licence metadata. Microsoft moderates a new package before it exists;
+  this can take days or weeks. Once that first manifest is accepted, the release
+  workflow uses `wingetcreate update` for every later version.
 
 ## Each release
 
@@ -81,6 +94,8 @@ The only human-only pieces:
    proposed version + changelog, then **merge it** to publish.
 3. To (re)publish an existing tag to PyPI without a new release, run the
    `release-please` workflow via **workflow_dispatch** with the tag name.
+4. If Windows publication needs recovery, dispatch `windows-exe` for the tag,
+   then dispatch `winget` after the release asset is visible.
 
 ## Before going public
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -241,6 +241,19 @@ That prints the command list with usage examples; `lgtmaybe help <command>`
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 
+## Install on Windows (winget)
+
+Install the portable Windows executable from winget:
+
+```powershell
+winget install MattJColes.lgtmaybe
+```
+
+The executable bundles ast-grep for cross-file symbol resolution, but it does
+not bundle the optional cloud SDKs used by keyless Bedrock, Vertex, or Azure
+authentication. Use the pip install with the matching extra for those providers.
+The regular `pip install lgtmaybe` path also works on Windows.
+
 ## Install on macOS (Homebrew)
 
 On macOS (and Linuxbrew) you can install from the project's
@@ -275,7 +288,8 @@ resolution during review.
 
 ## Cloud providers need extras
 
-The base install (either method) covers every **API-key** and **local** provider:
+The base pip install, Homebrew formula, and Windows executable cover every
+**API-key** and **local** provider:
 
 | Providers | Covered by base install? |
 |---|---|
@@ -283,8 +297,8 @@ The base install (either method) covers every **API-key** and **local** provider
 | `ollama`, `openai-compatible` — fully local, point `--api-base` at the server | ✅ Yes |
 | `bedrock`, `vertex`, `azure` — keyless cloud (OIDC/WIF) | ❌ Needs an extra |
 
-The **keyless cloud** providers need extra cloud SDKs that the base install (and
-the Homebrew formula) does not bundle. Install the CLI from PyPI with the matching
+The **keyless cloud** providers need extra cloud SDKs that the Homebrew formula
+and Windows executable do not bundle. Install the CLI from PyPI with the matching
 extra:
 
 ```bash
@@ -2801,6 +2815,11 @@ so Homebrew keeps the wheels' `@rpath` extension-dylib ids instead of failing to
 rewrite them ("Failed to fix install linkage"). It's a plain source formula —
 no bottle — so it installs on any architecture and macOS version.
 
+The release run also calls `.github/workflows/windows-exe.yml` to build and
+smoke-test a portable Windows executable, then `.github/workflows/winget.yml`
+to submit the new asset to winget. The executable must exist before the winget
+job starts; both workflows are manually dispatchable for recovery.
+
 The workflow:
 
 - Is **called** by `release-please.yml` (`workflow_call`) right after a release,
@@ -2847,6 +2866,14 @@ The only human-only pieces:
   with `contents: write` on the tap repo (the default `GITHUB_TOKEN` cannot push
   to another repository). To seed or verify the formula by hand on a Mac, run
   `scripts/update-homebrew-formula.sh <version> path/to/homebrew-lgtmaybe/Formula/lgtmaybe.rb`.
+- **winget:** fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+  Create a classic GitHub PAT with the `public_repo` scope and add it to this
+  repo as **`WINGET_TOKEN`**. For the first release, build/upload the Windows
+  asset and run `wingetcreate new <asset-url>` manually with package id
+  `MattJColes.lgtmaybe`, installer type `portable`, command alias `lgtmaybe`,
+  and MIT licence metadata. Microsoft moderates a new package before it exists;
+  this can take days or weeks. Once that first manifest is accepted, the release
+  workflow uses `wingetcreate update` for every later version.
 
 ## Each release
 
@@ -2856,6 +2883,8 @@ The only human-only pieces:
    proposed version + changelog, then **merge it** to publish.
 3. To (re)publish an existing tag to PyPI without a new release, run the
    `release-please` workflow via **workflow_dispatch** with the tag name.
+4. If Windows publication needs recovery, dispatch `windows-exe` for the tag,
+   then dispatch `winget` after the release asset is visible.
 
 ## Before going public
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,7 +8,7 @@
 
 ## How-to
 
-- [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS) or Homebrew (macOS/Linuxbrew), and add the cloud extras for keyless Bedrock/Vertex/Azure.
+- [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS), Homebrew (macOS/Linuxbrew), or winget (Windows), and add cloud extras for keyless Bedrock/Vertex/Azure.
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
 - [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
@@ -23,7 +23,7 @@
 - [Add a custom review lens](https://lgtmaybe.coles.codes/how-to/add-a-custom-lens/): Add a custom review lens to lgtmaybe — a bring-your-own skill file that runs alongside the nine built-in lenses.
 - [Generate a change diagram](https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/): Post a C4-style Mermaid diagram of a pull request's changes as a GitHub comment, or print one from the CLI.
 - [Fix findings with an AI agent](https://lgtmaybe.coles.codes/how-to/fix-findings-with-an-ai-agent/): Turn lgtmaybe findings into instructions an AI coding agent can apply, for a local review-and-fix loop before you push.
-- [Releasing](https://lgtmaybe.coles.codes/how-to/releasing/): Maintainer guide to cutting and publishing a new lgtmaybe release with release-please, PyPI trusted publishing, and GHCR.
+- [Releasing](https://lgtmaybe.coles.codes/how-to/releasing/): Maintainer guide to publishing lgtmaybe with release-please, PyPI, GHCR, Homebrew, a Windows executable, and winget.
 
 ## Reference
 

--- a/openspec/changes/add-windows-support-and-winget/tasks.md
+++ b/openspec/changes/add-windows-support-and-winget/tasks.md
@@ -29,22 +29,22 @@
 
 ## 5. PR 2 - Portable executable
 
-- [ ] 5.1 Add a failing packaging test that requires lgtmaybe and litellm data collection plus tiktoken registry hidden imports in the PyInstaller spec.
-- [ ] 5.2 Add the packaging dependency group and lockfile update for PyInstaller, then create the executable entrypoint, one-file spec, ast-grep binary collection, and runtime PATH hook needed to satisfy the test.
-- [ ] 5.3 Add reusable and dispatchable `.github/workflows/windows-exe.yml` automation that normalises the version, skips an existing asset unless forced, checks out the tag, builds with Python 3.13, and smoke-tests `--help`, `config path`, and `help review` before upload.
-- [ ] 5.4 Name and attach the versioned x86_64 executable to the existing GitHub release and print its measured size in the smoke job.
+- [x] 5.1 Add a failing packaging test that requires lgtmaybe and litellm data collection plus tiktoken registry hidden imports in the PyInstaller spec.
+- [x] 5.2 Add the packaging dependency group and lockfile update for PyInstaller, then create the executable entrypoint, one-file spec, ast-grep binary collection, and runtime PATH hook needed to satisfy the test.
+- [x] 5.3 Add reusable and dispatchable `.github/workflows/windows-exe.yml` automation that normalises the version, skips an existing asset unless forced, checks out the tag, builds with Python 3.13, and smoke-tests `--help`, `config path`, and `help review` before upload.
+- [x] 5.4 Name and attach the versioned x86_64 executable to the existing GitHub release and print its measured size in the smoke job.
 
 ## 6. PR 2 - winget release chain
 
-- [ ] 6.1 Add reusable and dispatchable `.github/workflows/winget.yml` automation that normalises the version, polls for the executable asset, and runs `wingetcreate update MattJColes.lgtmaybe` with `WINGET_TOKEN`.
-- [ ] 6.2 Wire release-please to call the executable workflow after release creation and the winget workflow only after the executable succeeds, preserving the existing PyPI, Homebrew, and GHCR release jobs.
-- [ ] 6.3 Add workflow-structure tests that assert the executable smoke gate, release sequencing, asset URL, portable package ID, and secret wiring.
+- [x] 6.1 Add reusable and dispatchable `.github/workflows/winget.yml` automation that normalises the version, polls for the executable asset, and runs `wingetcreate update MattJColes.lgtmaybe` with `WINGET_TOKEN`.
+- [x] 6.2 Wire release-please to call the executable workflow after release creation and the winget workflow only after the executable succeeds, preserving the existing PyPI, Homebrew, and GHCR release jobs.
+- [x] 6.3 Add workflow-structure tests that assert the executable smoke gate, release sequencing, asset URL, portable package ID, and secret wiring.
 
 ## 7. PR 2 - Documentation, specs, and verification
 
-- [ ] 7.1 Document `winget install MattJColes.lgtmaybe`, pip-on-Windows support, bundled ast-grep, and the executable's excluded cloud extras in the CLI installation guide and README.
-- [ ] 7.2 Document the one-time winget fork, classic `public_repo` PAT, `WINGET_TOKEN`, initial portable manifest submission, and moderation expectations beside the existing release setup.
-- [ ] 7.3 Update `CLAUDE.md` with the Windows distribution variant and CI legs, and add the `windows-distribution` living spec with exact-one-match anchors for its CI, executable, and winget requirements.
-- [ ] 7.4 Run packaging and workflow tests, the full local quality gate, living-spec tests, OpenSpec spec validation, and the spec drift check.
+- [x] 7.1 Document `winget install MattJColes.lgtmaybe`, pip-on-Windows support, bundled ast-grep, and the executable's excluded cloud extras in the CLI installation guide and README.
+- [x] 7.2 Document the one-time winget fork, classic `public_repo` PAT, `WINGET_TOKEN`, initial portable manifest submission, and moderation expectations beside the existing release setup.
+- [x] 7.3 Update `CLAUDE.md` with the Windows distribution variant and CI legs, and add the `windows-distribution` living spec with exact-one-match anchors for its CI, executable, and winget requirements.
+- [x] 7.4 Run packaging and workflow tests, the full local quality gate, living-spec tests, OpenSpec spec validation, and the spec drift check.
 - [ ] 7.5 Dispatch the executable workflow against a current tag and verify the smoke-tested asset; after the first winget manifest is moderated, dispatch the winget workflow and verify its update PR.
 - [ ] 7.6 Prepare PR 2 with a conventional title, measured executable size noted, and no unresolved release-gate failures.

--- a/openspec/specs/windows-distribution/anchors.yml
+++ b/openspec/specs/windows-distribution/anchors.yml
@@ -1,0 +1,22 @@
+# ast-grep anchors for Windows distribution workflows.
+
+windows.ci:
+  rule:
+    kind: block_mapping_pair
+    has: { field: key, regex: '^test$' }
+  language: yaml
+  files: [.github/workflows/ci.yml]
+
+windows.executable:
+  rule:
+    kind: block_mapping_pair
+    has: { field: key, regex: '^windows-exe$' }
+  language: yaml
+  files: [.github/workflows/release-please.yml]
+
+windows.winget:
+  rule:
+    kind: block_mapping_pair
+    has: { field: key, regex: '^winget$' }
+  language: yaml
+  files: [.github/workflows/release-please.yml]

--- a/openspec/specs/windows-distribution/spec.md
+++ b/openspec/specs/windows-distribution/spec.md
@@ -1,0 +1,49 @@
+# windows-distribution Specification
+
+## Purpose
+
+Windows compatibility coverage and the release chain that builds, verifies,
+publishes, and distributes the portable CLI executable.
+
+## Requirements
+
+### Requirement: Supported Windows versions run the full CI gate
+
+The main CI workflow SHALL run the same test, lint, format, and type-check gate
+on Windows with Python 3.11 and 3.13 while retaining Ubuntu coverage for every
+supported Python version. The Windows jobs MUST exercise locale-default
+encoding behavior rather than forcing Python UTF-8 mode.
+<!-- anchor: windows.ci -->
+
+#### Scenario: a change breaks only under Windows path semantics
+- **WHEN** the pull request test matrix runs
+- **THEN** a Windows job fails before the shared required check can pass
+
+### Requirement: Releases include a smoke-tested portable executable
+
+Each release SHALL build a Windows x86_64 portable `lgtmaybe.exe` with Python
+3.13, bundle the package and litellm data needed at runtime plus ast-grep, and
+attach the versioned artifact only after CLI smoke commands pass. The
+executable MUST NOT bundle optional cloud authentication dependencies.
+<!-- anchor: windows.executable -->
+
+#### Scenario: a lazy import is absent from the bundle
+- **WHEN** the built executable cannot run the required CLI smoke commands
+- **THEN** the workflow fails without uploading the release asset
+
+### Requirement: winget updates follow executable publication
+
+After the executable asset is published, the release workflow SHALL submit an
+update for `MattJColes.lgtmaybe` through winget using the versioned asset URL.
+The reusable workflow MUST also support a manually dispatched recovery run.
+<!-- anchor: windows.winget -->
+
+#### Scenario: release automation publishes a new version
+- **WHEN** release-please creates a release and the executable workflow succeeds
+- **THEN** the winget workflow submits the new version, URL, and checksum to the
+  existing portable package
+
+#### Scenario: the initial package does not exist
+- **WHEN** maintainers prepare the first winget release
+- **THEN** they create the portable manifest manually before automated update
+  submissions begin

--- a/packaging/pyinstaller/entry.py
+++ b/packaging/pyinstaller/entry.py
@@ -1,0 +1,3 @@
+from lgtmaybe.cli import main
+
+main()

--- a/packaging/pyinstaller/lgtmaybe.spec
+++ b/packaging/pyinstaller/lgtmaybe.spec
@@ -1,0 +1,51 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+import shutil
+
+from PyInstaller.utils.hooks import collect_data_files
+
+project_root = Path(SPECPATH).parents[1]
+ast_grep = shutil.which("ast-grep")
+
+datas = collect_data_files("lgtmaybe") + collect_data_files("litellm")
+binaries = [(ast_grep, ".")] if ast_grep else []
+hiddenimports = ["tiktoken_ext", "tiktoken_ext.openai_public"]
+
+analysis = Analysis(
+    [str(project_root / "packaging" / "pyinstaller" / "entry.py")],
+    pathex=[str(project_root / "src")],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[
+        str(project_root / "packaging" / "pyinstaller" / "runtime_path.py")
+    ],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    analysis.binaries,
+    analysis.datas,
+    [],
+    name="lgtmaybe",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/packaging/pyinstaller/runtime_path.py
+++ b/packaging/pyinstaller/runtime_path.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import os
+import sys
+
+bundle_dir = getattr(sys, "_MEIPASS", None)
+if bundle_dir is not None:
+    os.environ["PATH"] = os.pathsep.join((bundle_dir, os.environ.get("PATH", "")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dev = [
 docs = [
     "mkdocs-material>=9.5",
 ]
+packaging = [
+    "pyinstaller>=6.11",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/check_spec_drift.py
+++ b/scripts/check_spec_drift.py
@@ -38,7 +38,7 @@ import yaml
 from lgtmaybe.core.diffparse import changed_line_index
 
 ANCHOR_RE = re.compile(r"^<!-- anchor: (?P<id>[a-z0-9.-]+) -->$")
-SCAN_TARGET = "src/"
+SCAN_TARGETS = ("src/", ".github/workflows/")
 
 
 @dataclass(frozen=True)
@@ -50,6 +50,7 @@ class AnchorRule:
     rule: dict[str, object]
     files: list[str]
     sidecar: str  # repo-relative posix path of the anchors.yml it came from
+    language: str = "python"
 
 
 @dataclass(frozen=True)
@@ -101,6 +102,7 @@ def load_anchors(root: Path) -> list[AnchorRule]:
                         rule=item["rule"],
                         files=list(item["files"]),
                         sidecar=rel,
+                        language=str(item.get("language", "python")),
                     )
                 )
     return rules
@@ -112,7 +114,7 @@ def to_inline_rules(rules: list[AnchorRule]) -> str:
     for r in rules:
         docs.append(
             yaml.safe_dump(
-                {"id": r.rule_id, "language": "python", "files": r.files, "rule": r.rule},
+                {"id": r.rule_id, "language": r.language, "files": r.files, "rule": r.rule},
                 sort_keys=False,
             )
         )
@@ -134,9 +136,9 @@ def parse_scan_output(json_text: str) -> dict[str, list[Match]]:
 
 
 def run_scan(binary: str, inline_rules: str, cwd: Path) -> dict[str, list[Match]]:
-    """Run one ast-grep scan from *cwd* (so files: globs resolve) over src/."""
+    """Run ast-grep from *cwd* so each rule's files glob resolves consistently."""
     result = subprocess.run(
-        [binary, "scan", "--inline-rules", inline_rules, "--json", SCAN_TARGET],
+        [binary, "scan", "--inline-rules", inline_rules, "--json", *SCAN_TARGETS],
         cwd=cwd,
         capture_output=True,
         text=True,

--- a/tests/specs/test_spec_drift.py
+++ b/tests/specs/test_spec_drift.py
@@ -104,6 +104,7 @@ def test_to_inline_rules_emits_one_scan_document_per_rule() -> None:
             rule={"kind": "class_definition"},
             files=["src/**"],
             sidecar="openspec/specs/y/anchors.yml",
+            language="yaml",
         ),
     ]
     text = to_inline_rules(rules)
@@ -111,6 +112,7 @@ def test_to_inline_rules_emits_one_scan_document_per_rule() -> None:
     assert len(docs) == 2
     assert "id: a.b__0" in docs[0]
     assert "language: python" in docs[0]
+    assert "language: yaml" in docs[1]
     assert "kind: class_definition" in docs[1]
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -17,6 +17,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).parent.parent
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _DOCKERFILE = _REPO_ROOT / "Dockerfile"
+_PYINSTALLER_SPEC = _REPO_ROOT / "packaging" / "pyinstaller" / "lgtmaybe.spec"
 
 # provider extra -> the import-name of the package its keyless path needs.
 _CLOUD_EXTRAS = {
@@ -49,3 +50,12 @@ def test_dockerfile_bundles_every_cloud_extra() -> None:
             f"Dockerfile must `uv sync ... --extra {extra}` so the image can run "
             f"keyless {extra} reviews"
         )
+
+
+def test_pyinstaller_spec_collects_data_trees() -> None:
+    spec = _PYINSTALLER_SPEC.read_text(encoding="utf-8")
+
+    assert 'collect_data_files("lgtmaybe")' in spec
+    assert 'collect_data_files("litellm")' in spec
+    assert '"tiktoken_ext"' in spec
+    assert '"tiktoken_ext.openai_public"' in spec

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -27,6 +27,7 @@ def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
     for command in ("--help", "config path", "help review"):
         assert command in runs
     assert "gh release upload" in runs
+    assert "gh release upload failed with exit code $LASTEXITCODE" in runs
     assert "windows-x86_64.exe" in runs
     assert ".Length" in runs
 
@@ -51,7 +52,9 @@ def test_release_please_sequences_windows_exe_before_winget() -> None:
 
     assert jobs["windows-exe"]["needs"] == "release-please"
     assert jobs["windows-exe"]["uses"] == "./.github/workflows/windows-exe.yml"
-    assert jobs["windows-exe"]["secrets"] == "inherit"
+    assert "secrets" not in jobs["windows-exe"]
     assert jobs["winget"]["needs"] == ["release-please", "windows-exe"]
     assert jobs["winget"]["uses"] == "./.github/workflows/winget.yml"
-    assert jobs["winget"]["secrets"] == "inherit"
+    assert jobs["winget"]["secrets"] == {
+        "WINGET_TOKEN": "${{ secrets.WINGET_TOKEN }}",
+    }

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -1,0 +1,57 @@
+"""Release-workflow contracts for the Windows executable and winget chain."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).parent.parent
+_WORKFLOWS = _ROOT / ".github" / "workflows"
+
+
+def _workflow(name: str) -> tuple[str, dict]:
+    text = (_WORKFLOWS / name).read_text(encoding="utf-8")
+    return text, yaml.safe_load(text)
+
+
+def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
+    text, workflow = _workflow("windows-exe.yml")
+    job = workflow["jobs"]["build"]
+    runs = "\n".join(str(step.get("run", "")) for step in job["steps"] if isinstance(step, dict))
+
+    assert "workflow_call:" in text
+    assert "workflow_dispatch:" in text
+    assert job["runs-on"] == "windows-latest"
+    assert "uv run pyinstaller packaging/pyinstaller/lgtmaybe.spec" in runs
+    for command in ("--help", "config path", "help review"):
+        assert command in runs
+    assert "gh release upload" in runs
+    assert "windows-x86_64.exe" in runs
+    assert ".Length" in runs
+
+
+def test_winget_workflow_updates_the_portable_package() -> None:
+    text, workflow = _workflow("winget.yml")
+    job = workflow["jobs"]["publish"]
+    runs = "\n".join(str(step.get("run", "")) for step in job["steps"] if isinstance(step, dict))
+
+    assert "workflow_call:" in text
+    assert "workflow_dispatch:" in text
+    assert job["runs-on"] == "windows-latest"
+    assert "MattJColes.lgtmaybe" in runs
+    assert "wingetcreate update" in runs
+    assert "WINGET_TOKEN" in text
+    assert "windows-x86_64.exe" in runs
+
+
+def test_release_please_sequences_windows_exe_before_winget() -> None:
+    _text, workflow = _workflow("release-please.yml")
+    jobs = workflow["jobs"]
+
+    assert jobs["windows-exe"]["needs"] == "release-please"
+    assert jobs["windows-exe"]["uses"] == "./.github/workflows/windows-exe.yml"
+    assert jobs["windows-exe"]["secrets"] == "inherit"
+    assert jobs["winget"]["needs"] == ["release-please", "windows-exe"]
+    assert jobs["winget"]["uses"] == "./.github/workflows/winget.yml"
+    assert jobs["winget"]["secrets"] == "inherit"

--- a/uv.lock
+++ b/uv.lock
@@ -148,6 +148,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1167,6 +1176,9 @@ dev = [
 docs = [
     { name = "mkdocs-material" },
 ]
+packaging = [
+    { name = "pyinstaller" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1196,6 +1208,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 docs = [{ name = "mkdocs-material", specifier = ">=9.5" }]
+packaging = [{ name = "pyinstaller", specifier = ">=6.11" }]
 
 [[package]]
 name = "librt"
@@ -1300,6 +1313,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
     { url = "https://files.pythonhosted.org/packages/0d/7f/b48d88cb32055b4ba7e51cd67e4ea13a589d4a568d33c3d0dc6994d13b83/litellm-1.93.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b", size = 20165502, upload-time = "2026-07-19T03:01:18.425Z" },
     { url = "https://files.pythonhosted.org/packages/45/6c/65a7f916326daa151131f1fce5e254d4834127a95d53a18f1c4d238dd5c3/litellm-1.93.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada", size = 20159007, upload-time = "2026-07-19T03:01:21.704Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -1744,6 +1769,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2029,6 +2063,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2090,6 +2164,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2581,6 +2664,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/23/eff37582f900cf742b5fc7709dfd0e63cc2bc0faefe6ec200f150666fa7a/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-macosx_10_14_x86_64.whl", hash = "sha256:4b22b5f4db17204648baf8bc58fcd74c09eb5f41bd407422193253b4de9af18e", size = 28050871, upload-time = "2024-07-10T10:05:52.086Z" },
     { url = "https://files.pythonhosted.org/packages/d6/88/35615a4e1142755cb3d2c86d63160f63ab770c111c82de9318bba27fb888/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-macosx_11_0_arm64.whl", hash = "sha256:fe5cf0ac8afdb786cbd4e6c97c418ca7adc8f4c42584a69dc7c10e15db5f7d9b", size = 33805877, upload-time = "2024-07-10T10:05:56.42Z" },
     { url = "https://files.pythonhosted.org/packages/fd/84/3b6afc829f54b331f47d55c565096ef74a98d96d794612d2e5330062d373/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-musllinux_1_0_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41797931371d05c41a6e09861b3d631136b4fe644d80802b2fd48af650e5fa5a", size = 32479030, upload-time = "2024-07-10T10:06:00.777Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Stack

Depends on #229. This PR targets `codex/windows` so the review diff contains only the executable and distribution work; retarget it to `main` after #229 merges.

## What changed

- add a one-file PyInstaller build for a Python 3.13 Windows x86_64 executable
- bundle lgtmaybe/litellm data, tiktoken registry imports, and `ast-grep.exe`
- add a reusable and manually dispatchable executable workflow with idempotency, smoke tests, size reporting, and release upload
- add a reusable WingetCreate workflow that waits for the release asset and updates `MattJColes.lgtmaybe`
- sequence executable publication before Winget submission in release-please
- document Winget installation, excluded keyless-cloud SDKs, and the one-time first-manifest setup
- add workflow contracts plus a Windows distribution living spec and YAML anchors

## Why

Windows users currently need to install through pip, and releases do not produce a native portable artifact. This adds a smoke-tested executable and a repeatable Winget update path without duplicating the CLI implementation.

## Impact

After the first Winget manifest is manually submitted and moderated, each release will publish `lgtmaybe-<version>-windows-x86_64.exe` and submit the next `MattJColes.lgtmaybe` update automatically. The executable covers API-key and local providers; keyless Bedrock, Vertex, and Azure remain on the documented pip path.

## Validation

- `1209 passed, 3 deselected`
- `ruff check .`
- `ruff format --check .`
- `mypy`
- 23 focused packaging, workflow, and living-spec tests
- all nine OpenSpec specs and the spec-anchor drift check
- local executable smoke tests: `--help`, `config path`, and `help review`
- archive inspection confirmed `ast-grep.exe`
- measured executable size: 58,329,145 bytes (55.6 MiB)

Local creation of a fresh packaging environment was blocked by Windows Defender quarantining the upstream `ast-grep-cli` `sg.exe`; the executable was successfully built and smoke-tested from the existing trusted environment. The hosted `windows-latest` workflow is the clean-environment release gate.

## One-time release setup

Before automated updates can succeed, create the first portable `MattJColes.lgtmaybe` manifest manually and add the documented `WINGET_TOKEN` repository secret.
