### PR TITLE
fix: pass repository to release commands

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -44,7 +44,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $assets = gh release view "${{ steps.ver.outputs.tag }}" --json assets --jq '.assets[].name'
+          $assets = gh release view "${{ steps.ver.outputs.tag }}" `
+            --repo "$env:GITHUB_REPOSITORY" --json assets --jq '.assets[].name'
           if ($LASTEXITCODE -ne 0) {
             throw "release ${{ steps.ver.outputs.tag }} does not exist"
           }
@@ -105,7 +106,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ steps.ver.outputs.tag }}" `
-            "${{ steps.ver.outputs.asset }}" --clobber
+            "${{ steps.ver.outputs.asset }}" --clobber `
+            --repo "$env:GITHUB_REPOSITORY"
           if ($LASTEXITCODE -ne 0) {
             throw "gh release upload failed with exit code $LASTEXITCODE"
           }

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -27,6 +27,7 @@ def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
     for command in ("--help", "config path", "help review"):
         assert command in runs
     assert "gh release upload" in runs
+    assert runs.count('--repo "$env:GITHUB_REPOSITORY"') == 2
     assert "gh release upload failed with exit code $LASTEXITCODE" in runs
     assert "windows-x86_64.exe" in runs
     assert ".Length" in runs

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "lgtmaybe"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },


### PR DESCRIPTION
## What changed

- pass `GITHUB_REPOSITORY` explicitly to `gh release view` before checkout
- pass the same repository explicitly to `gh release upload`
- add a workflow contract regression assertion covering both commands

## Root cause

The v1.4.0 Windows executable job checks whether the release asset exists before
checking out the repository. Without `--repo`, GitHub CLI attempted to discover
the repository from the working directory and failed with
`fatal: not a git repository`.

## Impact

The Windows executable recovery workflow can now run before checkout and publish
the v1.4.0 asset, unblocking the first Winget manifest submission.

## Validation

- 1,340 tests passed, 3 deselected
- focused Windows distribution and spec tests: 20 passed
- Ruff check and format check
- mypy
- spec drift check
- all nine OpenSpec specs
