### PR TITLE
ci: test only minimum supported Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        include:
-          - os: windows-latest
-            python-version: "3.11"
-          - os: windows-latest
-            python-version: "3.13"
+        os: [ubuntu-latest, windows-latest]
     env:
       PYTHONWARNDEFAULTENCODING: "1"
     steps:
@@ -31,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: "3.11"
           enable-cache: true
 
       - name: Sync (with dev deps)
@@ -53,10 +47,9 @@ jobs:
         run: uv run pytest -q
 
   # Single, matrix-independent status for branch protection to require. The `test`
-  # job above runs once per Python version, so it reports as `test (3.11)` …
-  # `test (3.14)` — names that change whenever the matrix does. This gate reports a
-  # stable `check` context that is green only when every `test` leg passed, so the
-  # required check never dangles as "Expected" when the matrix is edited.
+  # job above reports one status per OS. This gate reports a stable `check` context
+  # that is green only when every `test` leg passed, so the required check never
+  # dangles as "Expected" when the matrix is edited.
   check:
     needs: [test]
     if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ hatch for anything else that speaks the OpenAI `/v1` wire format (DeepSeek's API
 llama.cpp, LM Studio, vLLM) — you bring the `--api-base`, the key is optional —
 so the provider list is never a cage.
 
-The main CI matrix runs Ubuntu on Python 3.11–3.14 and Windows on Python 3.11
-and 3.13. Windows runs with locale-default encoding behavior and disables
+The main CI matrix runs Ubuntu and Windows on the minimum supported Python
+version, 3.11. Windows runs with locale-default encoding behavior and disables
 autocrlf before checkout.
 
 ## Non-negotiables

--- a/openspec/changes/reduce-ci-python-matrix/design.md
+++ b/openspec/changes/reduce-ci-python-matrix/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The main `test` job currently expands to four Ubuntu Python versions and two
+Windows Python versions. Every leg installs the same dependencies and runs the
+same lock, lint, format, type, and pytest commands. Python 3.11 is the declared
+package minimum and therefore the compatibility boundary most likely to expose
+use of unsupported newer syntax or APIs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce the routine full-suite matrix from six jobs to two.
+- Keep Ubuntu and Windows behavior covered.
+- Exercise the minimum supported Python version.
+- Preserve the stable `check` job used by branch protection.
+
+**Non-Goals:**
+
+- Change the supported Python range.
+- Add a scheduled compatibility matrix or new workflow.
+- Change release, executable, or dependency-audit jobs.
+
+## Decisions
+
+- Keep an operating-system matrix with `ubuntu-latest` and `windows-latest`,
+  but set the test job's Python version directly to `3.11`. This expresses the
+  two intended jobs without a redundant one-value Python matrix.
+- Run the complete existing gate on both jobs. Splitting lint and tests into
+  separate workflows would add configuration and would not reduce the number of
+  platform test runs requested here.
+- Add a workflow contract test that asserts the two operating systems and the
+  fixed minimum Python version before changing the workflow.
+- Retain the stable `check` aggregation job unchanged apart from its stale
+  explanatory comment.
+
+## Risks / Trade-offs
+
+- Newer-Python-only incompatibilities will no longer be caught by the routine
+  test workflow. This is an accepted trade-off for lower Actions usage; the
+  declared minimum remains the strongest syntax and standard-library boundary.
+- Windows remains more expensive than Ubuntu, but removing it would lose direct
+  path, encoding, and line-ending coverage for a supported distribution.

--- a/openspec/changes/reduce-ci-python-matrix/proposal.md
+++ b/openspec/changes/reduce-ci-python-matrix/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The main CI workflow repeats the full gate six times across Python versions and
+operating systems, consuming GitHub Actions minutes without proportionate
+confidence. Running the gate on the minimum supported Python version preserves
+the strictest compatibility boundary while cutting four duplicate jobs.
+
+## What Changes
+
+- Run the full CI gate on Python 3.11 only.
+- Retain one Ubuntu job and one Windows job so platform-specific behavior stays
+  covered.
+- Stop running the routine pull-request gate on Python 3.12, 3.13, and 3.14.
+- Keep the stable, matrix-independent `check` job used by branch protection.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `windows-distribution`: Require the main CI gate on the minimum supported
+  Python version for both Ubuntu and Windows instead of every supported Python
+  version on Ubuntu and two Python versions on Windows.
+
+## Impact
+
+The change affects `.github/workflows/ci.yml`, its workflow contract test, the
+anchored `windows-distribution` living spec, and the CI matrix description in
+`CLAUDE.md`. It does not change the package's supported Python range,
+dependencies, runtime behavior, or release workflows.

--- a/openspec/changes/reduce-ci-python-matrix/specs/windows-distribution/spec.md
+++ b/openspec/changes/reduce-ci-python-matrix/specs/windows-distribution/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Supported Windows versions run the full CI gate
+<!-- anchor: windows.ci -->
+
+The main CI workflow SHALL run the same test, lint, format, and type-check gate
+on Ubuntu and Windows using only the minimum supported Python version. The
+Windows job MUST exercise locale-default encoding behavior rather than forcing
+Python UTF-8 mode.
+
+#### Scenario: a change breaks only under Windows path semantics
+- **WHEN** the pull request test matrix runs
+- **THEN** the Windows job fails before the shared required check can pass
+
+#### Scenario: the routine CI gate expands its test matrix
+- **WHEN** the main CI workflow builds its test jobs
+- **THEN** it creates exactly one Ubuntu job and one Windows job on the minimum
+  supported Python version

--- a/openspec/changes/reduce-ci-python-matrix/tasks.md
+++ b/openspec/changes/reduce-ci-python-matrix/tasks.md
@@ -1,0 +1,15 @@
+## 1. Reduce the routine CI matrix
+
+- [x] 1.1 Add a workflow contract test that expects exactly Ubuntu and Windows
+  test jobs using Python 3.11, then run it to confirm the current matrix fails.
+- [x] 1.2 Replace the Python-version matrix with the two-platform matrix and a
+  fixed Python 3.11 setup, preserving every existing gate step and the stable
+  `check` job.
+- [x] 1.3 Run the workflow contract test and confirm it passes.
+
+## 2. Keep durable guidance in sync
+
+- [x] 2.1 Update the anchored `windows-distribution` requirement and the CI
+  matrix description in `CLAUDE.md`.
+- [x] 2.2 Run the targeted workflow tests, `uv run pytest tests/specs -q`, and
+  OpenSpec validation.

--- a/openspec/specs/windows-distribution/spec.md
+++ b/openspec/specs/windows-distribution/spec.md
@@ -10,14 +10,19 @@ publishes, and distributes the portable CLI executable.
 ### Requirement: Supported Windows versions run the full CI gate
 
 The main CI workflow SHALL run the same test, lint, format, and type-check gate
-on Windows with Python 3.11 and 3.13 while retaining Ubuntu coverage for every
-supported Python version. The Windows jobs MUST exercise locale-default
-encoding behavior rather than forcing Python UTF-8 mode.
+on Ubuntu and Windows using only the minimum supported Python version. The
+Windows job MUST exercise locale-default encoding behavior rather than forcing
+Python UTF-8 mode.
 <!-- anchor: windows.ci -->
 
 #### Scenario: a change breaks only under Windows path semantics
 - **WHEN** the pull request test matrix runs
 - **THEN** a Windows job fails before the shared required check can pass
+
+#### Scenario: the routine CI gate expands its test matrix
+- **WHEN** the main CI workflow builds its test jobs
+- **THEN** it creates exactly one Ubuntu job and one Windows job on the minimum
+  supported Python version
 
 ### Requirement: Releases include a smoke-tested portable executable
 

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -15,6 +15,17 @@ def _workflow(name: str) -> tuple[str, dict]:
     return text, yaml.safe_load(text)
 
 
+def test_main_ci_runs_only_minimum_python_on_linux_and_windows() -> None:
+    _text, workflow = _workflow("ci.yml")
+    job = workflow["jobs"]["test"]
+    setup_uv = next(step for step in job["steps"] if step.get("uses") == "astral-sh/setup-uv@v7")
+
+    assert job["strategy"]["matrix"] == {
+        "os": ["ubuntu-latest", "windows-latest"],
+    }
+    assert setup_uv["with"]["python-version"] == "3.11"
+
+
 def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
     text, workflow = _workflow("windows-exe.yml")
     job = workflow["jobs"]["build"]


### PR DESCRIPTION
## Summary

- reduce the routine full CI matrix from six jobs to two
- run the complete gate on Ubuntu and Windows using Python 3.11
- retain the stable branch-protection `check` job
- add a workflow contract test and update the anchored OpenSpec requirement

## Why

The existing workflow repeats the same lock, lint, format, type, and pytest gate
across four Ubuntu Python versions and two Windows versions. Python 3.11 is the
declared minimum and the strictest syntax and standard-library compatibility
boundary, so the additional version legs consume GitHub Actions minutes without
proportionate confidence.

## Impact

Each push or pull request runs four fewer full-suite jobs. Ubuntu and Windows
coverage remain, and the package's supported Python range does not change.

## Validation

- `pytest tests/test_windows_distribution.py -q` — 4 passed
- `ruff check tests/test_windows_distribution.py`
- `ruff format --check tests/test_windows_distribution.py`
- `openspec validate reduce-ci-python-matrix`
- `openspec validate --specs` — 9 passed
- living-spec anchor exact-match assertion passed against the underlying
  ast-grep executable; the local Windows npm `.CMD` wrapper cannot forward
  multiline inline rules, while Linux CI invokes the executable directly
- `git diff --check`
