### PR TITLE
docs: expand WinGet installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instea
 - **CLI (PyPI)** — `pip install lgtmaybe`
 - **CLI (Homebrew)** — `brew tap MattJColes/lgtmaybe && brew trust MattJColes/lgtmaybe && brew install lgtmaybe`
   ([details](docs/how-to/install-the-cli.md) — the `brew trust` step is required for third-party taps)
-- **CLI (winget)** — `winget install MattJColes.lgtmaybe`
+- **CLI (WinGet, Windows x64)** — `winget install --id MattJColes.lgtmaybe --exact`
+  ([details](docs/how-to/install-the-cli.md#install-on-windows-winget))
 - **GitHub Action** — `uses: MattJColes/lgtmaybe@v1`
 
 ## Contributing

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -28,12 +28,33 @@ That prints the command list with usage examples; `lgtmaybe help <command>`
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 
-## Install on Windows (winget)
+## Install on Windows (WinGet)
 
-Install the portable Windows executable from winget:
+The WinGet package is a portable executable for Windows x86_64 (64-bit).
+Install it by its exact package identifier:
 
 ```powershell
-winget install MattJColes.lgtmaybe
+winget install --id MattJColes.lgtmaybe --exact
+```
+
+Verify the command alias:
+
+```powershell
+lgtmaybe --help
+```
+
+Upgrade or uninstall it later with the same package identifier:
+
+```powershell
+winget upgrade --id MattJColes.lgtmaybe --exact
+winget uninstall --id MattJColes.lgtmaybe --exact
+```
+
+If WinGet cannot find a newly published version, refresh its package sources
+and retry:
+
+```powershell
+winget source update
 ```
 
 The executable bundles ast-grep for cross-file symbol resolution, but it does

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -238,12 +238,33 @@ That prints the command list with usage examples; `lgtmaybe help <command>`
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 
-## Install on Windows (winget)
+## Install on Windows (WinGet)
 
-Install the portable Windows executable from winget:
+The WinGet package is a portable executable for Windows x86_64 (64-bit).
+Install it by its exact package identifier:
 
 ```powershell
-winget install MattJColes.lgtmaybe
+winget install --id MattJColes.lgtmaybe --exact
+```
+
+Verify the command alias:
+
+```powershell
+lgtmaybe --help
+```
+
+Upgrade or uninstall it later with the same package identifier:
+
+```powershell
+winget upgrade --id MattJColes.lgtmaybe --exact
+winget uninstall --id MattJColes.lgtmaybe --exact
+```
+
+If WinGet cannot find a newly published version, refresh its package sources
+and retry:
+
+```powershell
+winget source update
 ```
 
 The executable bundles ast-grep for cross-file symbol resolution, but it does

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -58,6 +58,23 @@ def test_winget_workflow_updates_the_portable_package() -> None:
     assert "windows-x86_64.exe" in runs
 
 
+def test_winget_docs_cover_installation_lifecycle() -> None:
+    readme = (_ROOT / "README.md").read_text(encoding="utf-8")
+    guide = (_ROOT / "docs" / "how-to" / "install-the-cli.md").read_text(encoding="utf-8")
+    install = "winget install --id MattJColes.lgtmaybe --exact"
+
+    assert install in readme
+    assert install in guide
+    for text in (
+        "Windows x86_64 (64-bit)",
+        "lgtmaybe --help",
+        "winget upgrade --id MattJColes.lgtmaybe --exact",
+        "winget uninstall --id MattJColes.lgtmaybe --exact",
+        "winget source update",
+    ):
+        assert text in guide
+
+
 def test_release_please_sequences_windows_exe_before_winget() -> None:
     _text, workflow = _workflow("release-please.yml")
     jobs = workflow["jobs"]


### PR DESCRIPTION
## Summary

- document the Windows x86_64 limitation and use WinGet's exact package identifier
- add verification, upgrade, uninstall, and package-source refresh commands
- link the README entry to the full guide and regenerate the LLM documentation corpus
- add a focused contract test so the installation lifecycle stays documented

## Why

The existing docs showed only the shortest install command. Users could not tell which Windows architecture is supported, how to verify the portable alias, how to update or remove it, or what to try when WinGet has not refreshed a newly published version.

## Validation

- `pytest -q`: 1333 passed, 3 deselected
- `ruff check .`
- `ruff format --check .`
- `mypy src`
- `mkdocs build --strict`
- spec drift: no drift
- OpenSpec validation: 9 passed
