### PR TITLE
fix: upgrade GitHub App token action to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
     - name: Mint a GitHub App token (branded bot identity)
       id: app-token
       if: ${{ inputs.app_id != '' }}
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         # Empty owner/repositories scope the token to the current repository;
         # set them to review PRs across a monorepo/org. The token is short-lived

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -90,7 +90,7 @@ def test_marketplace_setup_does_not_require_a_separate_github_app() -> None:
 
 def test_mint_step_is_pinned_and_gated_on_app_id() -> None:
     step = _mint_step()
-    assert step["uses"] == "actions/create-github-app-token@v2", (
+    assert step["uses"] == "actions/create-github-app-token@v3", (
         "pin the mint action to a major tag, matching the other bundled actions"
     )
     assert "app_id" in str(step.get("if", "")), (


### PR DESCRIPTION
## What changed

- Upgrade `actions/create-github-app-token` from `v2` to `v3` in the composite action.
- Update the existing structural regression test to require the Node 24-compatible major.

## Why

GitHub now forces Node.js 20 actions to run on Node.js 24 and emits a deprecation warning. The bundled GitHub App token step still referenced `v2`, whose action metadata targets Node.js 20. `v3` declares `using: node24`.

## Impact

Consumers using the optional GitHub App identity path no longer receive the Node.js 20 deprecation warning from this bundled step. The step inputs and token forwarding remain unchanged.

## Validation

- `pytest tests/test_action_yml.py -q` — 7 passed
- `pytest tests/specs -q -k 'not every_rule_resolves_to_exactly_one_place'` — 16 passed, 1 deselected
- `ruff check tests/test_action_yml.py`
- `git diff --check`
- Verified upstream `actions/create-github-app-token@v3` declares `using: node24`
- Verified no `actions/create-github-app-token@v2` references remain

The deselected spec test cannot start `ast-grep` on Windows because the generated inline-rule command exceeds the Windows command-line length limit (`The command line is too long`); it is unrelated to this two-line version bump.
