### PR TITLE
feat: gate defect findings on failure scenarios

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -40,7 +40,7 @@ consensus across all tracks.
 The engine executes a pipeline of composable stages in sequence:
 
 ```
-fetch → compress → prompt → parse → re-anchor → merge/dedupe → reflect → filter → post
+fetch → compress → prompt → parse → re-anchor → merge/dedupe → evidence gate → reflect → filter → post
 ```
 
 The prompt/parse stage is where the pipeline fans out — one concurrent model
@@ -57,7 +57,7 @@ flowchart TD
     correctnessflow --> anchor
     correctnessstate --> anchor
     codehealth --> anchor
-    anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
+    anchor --> dedupe["merge / dedupe"] --> evidence["evidence gate<br/>defects need a failure scenario"] --> reflect["reflect<br/>validate scenarios · drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
 (The four lens calls shown are the parallel-capable `fast` grouping. A
@@ -98,8 +98,8 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    prefix from cache (on big diffs a warm-up primer runs the first lens
    alone). Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,
-   `body`, `suggestion`, `anchor`) and carries prompt-injection defense
-   instructions. Each response is parsed and validated against
+   `body`, `failure_scenario`, `suggestion`, `anchor`) and carries
+   prompt-injection defense instructions. Each response is parsed and validated against
    `ReviewFinding` using Pydantic; parse errors are logged and surfaced in
    the summary rather than silently discarded.
 
@@ -112,10 +112,17 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
 5. **merge/dedupe** — findings from every lens are merged and de-duplicated
    (`_dedupe`, keyed on path/line/side).
 
-6. **reflect** — a self-reflection pass (`engine/reflect.py`) asks the provider
+6. **evidence gate** — security, correctness, deprecation, and performance
+   findings must carry a concrete `failure_scenario`: the trigger, changed
+   behaviour, and observable impact. The engine applies this rule regardless
+   of model-selected severity, so lowering a finding to `low` cannot bypass it.
+   Gap and maintainability findings remain eligible without a runtime failure.
+
+7. **reflect** — a self-reflection pass (`engine/reflect.py`) asks the provider
    to audit its own findings and drops the ones it marks low-confidence
    (keep-all safe default when the verdict can't be parsed; skippable with
-   `--no-reflect`). When the auditor would drop a finding *only* because it
+   `--no-reflect`). It also tries to disprove each claimed failure scenario
+   against the diff and grounded file text. When the auditor would drop a finding *only* because it
    can't see code outside the diff, it **defers** by naming what it needs — a
    file path or a **symbol**. A path is fetched read-only
    (`get_file_contents`). A symbol is located by **ast-grep**
@@ -132,9 +139,9 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    it degrades to the path-only fetch (`--no-symbol-resolution` disables it
    entirely). It is bounded by the same hop/file caps as the path fetch.
 
-7. **filter** — findings below `min_severity` are dropped.
+8. **filter** — findings below `min_severity` are dropped.
 
-8. **post** — findings are batched into a single GitHub review request.
+9. **post** — findings are batched into a single GitHub review request.
    The summary comment is updated idempotently using a hidden marker, so
    re-running lgtmaybe on the same PR does not create duplicate comments. Each
    inline comment is stamped with a hidden per-finding fingerprint; on a re-run,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -196,7 +196,8 @@ lgtmaybe ran its pipeline over your local diff:
 2. **compress** — stripped generated files, binaries, and lockfiles
 3. **prompt** — built a structured prompt asking for JSON output
 4. **parse** — validated the model's JSON against the `ReviewFinding` schema
-5. **render** — printed the findings (the Action posts them to the PR instead)
+5. **gate** — dropped defect findings without a concrete `failure_scenario`
+6. **render** — printed the findings (the Action posts them to the PR instead)
 
 ## Next steps
 
@@ -2995,6 +2996,7 @@ The structured output the model must return for each inline comment. All fields 
 | `broad` | boolean | No | `False` | Broad |
 | `category` | string / null | No | `null` | Category |
 | `confidence` | integer / null | No | `null` | Confidence |
+| `failure_scenario` | string / null | No | `null` | Failure Scenario |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
 | `severity` | `critical` / `high` / `info` / `low` / `medium` | Yes | — |  |
@@ -3279,6 +3281,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
           ],
           "default": null,
           "title": "Confidence"
+        },
+        "failure_scenario": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Failure Scenario"
         },
         "line": {
           "minimum": 1,
@@ -3795,6 +3809,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       ],
       "default": null,
       "title": "Confidence"
+    },
+    "failure_scenario": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Failure Scenario"
     },
     "line": {
       "minimum": 1,
@@ -4437,7 +4463,7 @@ consensus across all tracks.
 The engine executes a pipeline of composable stages in sequence:
 
 ```
-fetch → compress → prompt → parse → re-anchor → merge/dedupe → reflect → filter → post
+fetch → compress → prompt → parse → re-anchor → merge/dedupe → evidence gate → reflect → filter → post
 ```
 
 The prompt/parse stage is where the pipeline fans out — one concurrent model
@@ -4454,7 +4480,7 @@ flowchart TD
     correctnessflow --> anchor
     correctnessstate --> anchor
     codehealth --> anchor
-    anchor --> dedupe["merge / dedupe"] --> reflect["reflect<br/>self-audit, drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
+    anchor --> dedupe["merge / dedupe"] --> evidence["evidence gate<br/>defects need a failure scenario"] --> reflect["reflect<br/>validate scenarios · drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
 (The four lens calls shown are the parallel-capable `fast` grouping. A
@@ -4495,8 +4521,8 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    prefix from cache (on big diffs a warm-up primer runs the first lens
    alone). Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,
-   `body`, `suggestion`, `anchor`) and carries prompt-injection defense
-   instructions. Each response is parsed and validated against
+   `body`, `failure_scenario`, `suggestion`, `anchor`) and carries
+   prompt-injection defense instructions. Each response is parsed and validated against
    `ReviewFinding` using Pydantic; parse errors are logged and surfaced in
    the summary rather than silently discarded.
 
@@ -4509,10 +4535,17 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
 5. **merge/dedupe** — findings from every lens are merged and de-duplicated
    (`_dedupe`, keyed on path/line/side).
 
-6. **reflect** — a self-reflection pass (`engine/reflect.py`) asks the provider
+6. **evidence gate** — security, correctness, deprecation, and performance
+   findings must carry a concrete `failure_scenario`: the trigger, changed
+   behaviour, and observable impact. The engine applies this rule regardless
+   of model-selected severity, so lowering a finding to `low` cannot bypass it.
+   Gap and maintainability findings remain eligible without a runtime failure.
+
+7. **reflect** — a self-reflection pass (`engine/reflect.py`) asks the provider
    to audit its own findings and drops the ones it marks low-confidence
    (keep-all safe default when the verdict can't be parsed; skippable with
-   `--no-reflect`). When the auditor would drop a finding *only* because it
+   `--no-reflect`). It also tries to disprove each claimed failure scenario
+   against the diff and grounded file text. When the auditor would drop a finding *only* because it
    can't see code outside the diff, it **defers** by naming what it needs — a
    file path or a **symbol**. A path is fetched read-only
    (`get_file_contents`). A symbol is located by **ast-grep**
@@ -4529,9 +4562,9 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    it degrades to the path-only fetch (`--no-symbol-resolution` disables it
    entirely). It is bounded by the same hop/file caps as the path fetch.
 
-7. **filter** — findings below `min_severity` are dropped.
+8. **filter** — findings below `min_severity` are dropped.
 
-8. **post** — findings are batched into a single GitHub review request.
+9. **post** — findings are batched into a single GitHub review request.
    The summary comment is updated idempotently using a hidden marker, so
    re-running lgtmaybe on the same PR does not create duplicate comments. Each
    inline comment is stamped with a hidden per-finding fingerprint; on a re-run,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -95,6 +95,7 @@ The structured output the model must return for each inline comment. All fields 
 | `broad` | boolean | No | `False` | Broad |
 | `category` | string / null | No | `null` | Category |
 | `confidence` | integer / null | No | `null` | Confidence |
+| `failure_scenario` | string / null | No | `null` | Failure Scenario |
 | `line` | integer | Yes | — | Line |
 | `path` | string | Yes | — | Path |
 | `severity` | `critical` / `high` / `info` / `low` / `medium` | Yes | — |  |
@@ -379,6 +380,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
           ],
           "default": null,
           "title": "Confidence"
+        },
+        "failure_scenario": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Failure Scenario"
         },
         "line": {
           "minimum": 1,
@@ -895,6 +908,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       ],
       "default": null,
       "title": "Confidence"
+    },
+    "failure_scenario": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Failure Scenario"
     },
     "line": {
       "minimum": 1,

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -103,7 +103,8 @@ lgtmaybe ran its pipeline over your local diff:
 2. **compress** — stripped generated files, binaries, and lockfiles
 3. **prompt** — built a structured prompt asking for JSON output
 4. **parse** — validated the model's JSON against the `ReviewFinding` schema
-5. **render** — printed the findings (the Action posts them to the PR instead)
+5. **gate** — dropped defect findings without a concrete `failure_scenario`
+6. **render** — printed the findings (the Action posts them to the PR instead)
 
 ## Next steps
 

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/.openspec.yaml
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/design.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`ReviewFinding` currently carries a prose explanation and a changed-line anchor. The engine deterministically verifies the anchor, then the reflection pass tries to disprove the finding with the diff and available file context. Severity is still supplied by the review model, so it cannot safely decide whether a finding must provide causal evidence.
+
+The built-in categories already separate defect claims from gap and maintainability observations. This allows the engine to apply an evidence gate without adding another classifier, provider call, dependency, or user setting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Require concrete causal evidence for built-in categories that claim broken behaviour.
+- Apply the requirement independently of model-selected severity.
+- Reuse the existing reflection pass to reject invented or unsupported scenarios.
+- Keep non-defect findings useful without forcing a fabricated runtime failure.
+- Enable the behaviour for every review by default.
+
+**Non-Goals:**
+
+- Re-score finding severity.
+- Prove failure scenarios with static execution or run PR code.
+- Gate custom lenses whose semantics are unknown to the engine.
+- Add a configuration toggle, another model call, or an A/B benchmark.
+- Change the existing `--no-reflect` override or reflection's keep-all error fallback.
+
+## Decisions
+
+1. Name the field `failure_scenario`, not `failure_path`. `ReviewFinding.path` already means a repository file, so using `path` for causal evidence is needlessly ambiguous.
+
+2. Add `failure_scenario: str | None = None` to `ReviewFinding`. The default preserves existing programmatic construction and custom-lens examples. The review prompt asks every built-in call to emit the field: defect findings provide a concise trigger, changed behaviour, and observable impact; other findings emit `null`.
+
+3. Gate by the engine-stamped category, never severity. Security, correctness, deprecation, and performance findings require a non-blank scenario. Tests, documentation, complexity, intent, ponytail, and custom-lens findings do not. A missing or whitespace-only required scenario is dropped before reflection, so it consumes no audit tokens.
+
+4. Reuse the reflection verdict's existing `keep` decision for semantic validation. The auditor receives `failure_scenario` with the finding and is instructed to drop a defect finding when the scenario is speculative, contradicts the diff or grounded file text, or relies on an unsupported causal step. No new verdict field or provider call is needed.
+
+5. Keep existing reflection escape hatches intact. `--no-reflect` still skips semantic validation, while the deterministic presence gate remains active. If reflection itself fails, its existing keep-all fallback still applies to findings that passed the presence gate.
+
+6. Keep `failure_scenario` as structured evidence rather than duplicating it in rendered prose. JSON output exposes the field automatically; GitHub, human, and agent renderers continue to use the concise title/body contract.
+
+## Risks / Trade-offs
+
+- [A model omits a scenario for a real defect] → The finding is dropped. This is the deliberate precision-over-recall trade-off requested for the default behaviour; focused acceptance tests pin it.
+- [A model invents a plausible scenario] → The existing grounded reflection pass actively tries to disprove it and drops unsupported claims.
+- [A weaker provider struggles with the extra field] → The field is nullable, examples show both forms, and the Pydantic default keeps parsing backwards-compatible for non-defect output.
+- [A custom lens reports defects without a scenario] → Custom lenses remain exempt because the engine cannot infer their semantics without another public configuration surface.
+- [The field adds output tokens] → Scenarios are constrained to one concise causal chain and reuse the existing call and audit.
+
+## Migration Plan
+
+Regenerate the model schema/reference artifacts and update all built-in prompt examples. The behaviour becomes active on upgrade with no config migration. Reverting the change restores the previous filter because no persisted data or external dependency is introduced.
+
+## Open Questions
+
+None.

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/proposal.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+A finding can be valid JSON, anchored to a changed line, and still be a plausible assertion with no concrete way for the change to fail. Requiring evidence based on model-selected severity leaves an escape hatch because the model can lower the severity.
+
+## What Changes
+
+- Add a nullable `failure_scenario` field to the structured finding contract.
+- Require a concrete trigger, changed behaviour, and observable impact for defect findings from the security, correctness, deprecation, and performance categories, regardless of severity.
+- Leave gap and maintainability findings from tests, documentation, complexity, intent, and ponytail categories eligible with `failure_scenario: null`.
+- Make the reflection pass verify each claimed failure scenario against the changed diff and available file context; missing or unsupported scenarios are dropped before posting.
+- Enable the gate by default with no configuration toggle and no A/B benchmark.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `core-contracts`: Extend the strict `ReviewFinding` wire format with the nullable failure scenario.
+- `prompt-and-lenses`: Teach built-in and custom review calls how to return concrete failure scenarios without inventing them for gap findings.
+- `finding-quality`: Gate defect findings on a non-empty, reflection-supported failure scenario independently of model-selected severity.
+
+## Impact
+
+The change affects the Pydantic finding schema and snapshots, review prompts and worked examples, finding parsing, reflection verdict handling, engine filtering, serialized CLI output, and focused engine/provider tests. It adds no dependency or user-facing configuration.

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/core-contracts/spec.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/core-contracts/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Findings are structured output only
+
+`ReviewFinding` SHALL be the only shape a finding takes: severity, file, line,
+side, title, body, optional suggestion, nullable `failure_scenario`, verbatim
+`anchor` line, `anchored` flag, 0-10 `confidence`, and the originating lens
+`category`. Models are strict (`extra="forbid"`), so drifted or injected fields
+are rejected — prose is never parsed.
+<!-- anchor: core.finding -->
+
+#### Scenario: model returns an unexpected field
+- **WHEN** the LLM's JSON carries a field the contract doesn't declare
+- **THEN** validation rejects it rather than silently accepting it
+
+#### Scenario: legacy code constructs a finding
+- **WHEN** a caller omits `failure_scenario`
+- **THEN** the field defaults to `null` so compatibility is preserved until the
+  engine applies category-specific eligibility

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/finding-quality/spec.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/finding-quality/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Defect findings earn eligibility with causal evidence
+
+The engine SHALL require a non-blank `failure_scenario` for security,
+correctness, deprecation, and performance findings before reflection and SHALL
+apply the rule regardless of model-selected severity. Tests, documentation,
+complexity, intent, ponytail, and custom-lens findings SHALL remain eligible
+without one.
+<!-- anchor: quality.failure-scenario -->
+
+#### Scenario: model lowers severity to avoid evidence
+- **WHEN** a correctness finding is marked `low` with no failure scenario
+- **THEN** the engine drops it before reflection and posting
+
+#### Scenario: gap finding has no runtime failure
+- **WHEN** a tests finding has `failure_scenario: null`
+- **THEN** it remains eligible for reflection and posting
+
+### Requirement: Reflection validates claimed failure scenarios
+
+When reflection is enabled, the auditor SHALL drop a defect finding whose
+failure scenario is speculative, contradicted by the diff or grounded file
+text, or depends on an unsupported causal step. The existing `--no-reflect`
+override and keep-all audit-error fallback SHALL remain unchanged.
+<!-- anchor: quality.failure-validation -->
+
+#### Scenario: scenario contradicts grounded code
+- **WHEN** the auditor can disprove a claimed failure using the diff or fetched
+  file context
+- **THEN** its verdict drops the finding
+
+#### Scenario: reflection is explicitly disabled
+- **WHEN** `--no-reflect` is used
+- **THEN** the presence gate still applies but semantic validation is skipped

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/prompt-and-lenses/spec.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/specs/prompt-and-lenses/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Defect prompts require a concrete failure scenario
+
+Every built-in review prompt SHALL request a nullable `failure_scenario`.
+Security, correctness, deprecation, and performance findings SHALL describe a
+concrete trigger, the changed behaviour, and its observable impact regardless
+of severity; tests, documentation, complexity, intent, and ponytail findings
+SHALL return `null` rather than invent a causal story.
+<!-- anchor: prompt.failure-scenario -->
+
+#### Scenario: correctness lens finds a low-severity defect
+- **WHEN** the correctness lens reports a defect as `low`
+- **THEN** it still returns a concrete `failure_scenario`
+
+#### Scenario: tests lens reports missing coverage
+- **WHEN** the tests lens reports a real coverage gap
+- **THEN** it returns `failure_scenario: null`

--- a/openspec/changes/gate-defect-findings-with-failure-scenarios/tasks.md
+++ b/openspec/changes/gate-defect-findings-with-failure-scenarios/tasks.md
@@ -1,0 +1,18 @@
+## 1. Acceptance Tests
+
+- [x] 1.1 Add failing contract and prompt tests for nullable `failure_scenario`, concrete defect examples, and `null` gap examples.
+- [x] 1.2 Add failing engine tests proving low-severity defect findings without a scenario are dropped while gap and custom-lens findings remain eligible.
+- [x] 1.3 Add failing reflection tests proving claimed scenarios reach the auditor and unsupported scenarios are rejected through its existing verdict.
+
+## 2. Default-On Gate
+
+- [x] 2.1 Extend `ReviewFinding` with backwards-compatible nullable `failure_scenario` and refresh schema snapshots.
+- [x] 2.2 Update the shared output contract, built-in lens instructions, and worked examples to produce concise scenarios only for defect categories.
+- [x] 2.3 Add the category-based non-blank scenario gate before reflection, independent of severity, with focused logging for dropped findings.
+- [x] 2.4 Tighten the reflection prompt to disprove each claimed scenario against the diff and grounded file context.
+
+## 3. Documentation and Verification
+
+- [x] 3.1 Regenerate the model/config reference and update maintained structured-output documentation.
+- [x] 3.2 Run the focused model, prompt, engine, reflection, CLI render, and provider contract tests.
+- [x] 3.3 Run the full test, lint, type, OpenSpec, anchor, drift, and documentation gates.

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -183,6 +183,11 @@ class ReviewFinding(_Strict):
     severity: Severity
     title: str
     body: str
+    # Concrete causal evidence for defect findings: the trigger, changed
+    # behaviour, and observable impact. The engine requires a non-blank value
+    # for built-in defect categories after it stamps `category`; gap and custom
+    # findings may leave it None.
+    failure_scenario: str | None = None
     suggestion: str | None = None
     # The verbatim text of the changed line this finding is about (no +/- marker).
     # The model can't count diff lines reliably, so the engine re-anchors `line`

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -2,7 +2,8 @@
 
 Pipeline: redact → compress/batch → (per batch) fan out one call per review
          category (concurrent for cloud, serial for ollama) → parse → merge/dedupe
-         → self-reflect/filter → filter by min_severity → return findings + summary.
+         → require defect evidence → self-reflect/filter → filter by min_severity
+         → return findings + summary.
 """
 
 from __future__ import annotations
@@ -77,6 +78,14 @@ _log = get_logger(__name__)
 #   default to 1 and let --max-concurrency raise it for batching servers.
 _CLOUD_MAX_WORKERS = 8
 _SINGLE_STREAM_PROVIDERS = frozenset({Provider.ollama, Provider.openai_compatible})
+_FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
+    {
+        ReviewCategory.security.value,
+        ReviewCategory.correctness.value,
+        ReviewCategory.deprecation.value,
+        ReviewCategory.performance.value,
+    }
+)
 
 # Providers whose litellm route takes an explicit cache_control breakpoint —
 # the ones where a batch's first call WRITES the shared preamble-plus-diff
@@ -488,6 +497,12 @@ class LLMReviewEngine(ReviewEngine):
         if suppressed:
             _log.info("suppressed findings", extra={"count": suppressed})
 
+        # 7c. Evidence gate: built-in defect findings must name a concrete way
+        #     the changed code fails. Category is engine-stamped, so lowering the
+        #     model-selected severity cannot bypass this check.
+        with profiler.stage("failure_scenario"):
+            all_findings = _filter_missing_failure_scenarios(all_findings)
+
         # 8. Self-reflection: filter out low-confidence findings. Reflect against
         #    only the reviewed diff — redacted, and free of skipped/over-cap files.
         #    Skippable (--no-reflect) for weaker models that drop valid findings here.
@@ -839,6 +854,28 @@ def _passes_severity_floor(finding: ReviewFinding, cfg: ReviewConfig) -> bool:
     return finding.severity >= cfg.min_severity and (
         finding.anchored or finding.severity >= cfg.unanchored_min_severity
     )
+
+
+def _filter_missing_failure_scenarios(
+    findings: list[ReviewFinding],
+) -> list[ReviewFinding]:
+    """Drop built-in defect findings that provide no concrete causal evidence."""
+    kept: list[ReviewFinding] = []
+    for finding in findings:
+        scenario = finding.failure_scenario
+        if finding.category in _FAILURE_SCENARIO_CATEGORIES and not (scenario and scenario.strip()):
+            _log.info(
+                "finding missing failure scenario — dropping",
+                extra={
+                    "path": finding.path,
+                    "line": finding.line,
+                    "title": finding.title,
+                    "category": finding.category,
+                },
+            )
+            continue
+        kept.append(finding)
+    return kept
 
 
 def _snap_findings(findings: list[ReviewFinding], diff: str) -> list[ReviewFinding]:

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -36,14 +36,21 @@ Use exactly one of these severity levels per finding:
 Return ONLY a JSON object with a single key `findings` whose value is an array of \
 finding objects — no prose, no reasoning, nothing before or after. Fields per element:
 path (string), line (integer), side ("LEFT" or "RIGHT", default "RIGHT"), severity (one of \
-the levels above), title (string ≤ 80 chars), body (string), suggestion (string or null), \
-anchor (string — the verbatim flagged line, see below).
+the levels above), title (string ≤ 80 chars), body (string), failure_scenario (string or \
+null), suggestion (string or null), anchor (string — the verbatim flagged line, see below).
 
 Report each distinct issue as its own finding.
 
-### How to fill `body` and `suggestion`
+### How to fill `body`, `failure_scenario`, and `suggestion`
 
 `body` holds your explanation — what is wrong and why it matters, in prose.
+
+`failure_scenario` is the concrete way a defect causes harm: name the trigger, the changed \
+behaviour, and the observable impact in one concise causal chain. It is REQUIRED for every \
+security, correctness, deprecation, and performance finding regardless of severity. Do not \
+invent one for a gap or maintainability observation: set it to null for tests, documentation, \
+complexity, intent, and ponytail findings. A custom lens may set it when its finding makes a \
+concrete defect claim, but custom findings are not gated on it.
 
 `suggestion` is rendered as a one-click committable change, so it must be the \
 **literal replacement code** for the flagged line(s): the exact source that should \
@@ -132,6 +139,8 @@ _SECURITY_EXAMPLE = _example_block(
         "title": "Unsafe deserialization via pickle.loads",
         "body": "pickle.loads executes arbitrary code when the input is attacker-controlled. "
         "Use a safe format such as json.loads instead.",
+        "failure_scenario": "When an attacker controls the file contents, pickle.loads "
+        "executes their serialized payload in the reviewer process.",
         "suggestion": '    return json.loads(open(path, "rb").read())',
         "anchor": '    return pickle.loads(open(path, "rb").read())',
     },
@@ -150,6 +159,8 @@ _CORRECTNESS_EXAMPLE = _example_block(
         "severity": "high",
         "title": "Off-by-one: items[len(items)] is out of range",
         "body": "Indexing with len(items) raises IndexError; the last index is len(items) - 1.",
+        "failure_scenario": "When last_item receives any list, indexing at len(items) raises "
+        "IndexError instead of returning an item.",
         "suggestion": "    return items[-1]",
         "anchor": "    return items[len(items)]",
     },
@@ -170,6 +181,8 @@ _CORRECTNESS_STATE_EXAMPLE = _example_block(
         "title": "Check-then-act race can create the value twice",
         "body": "Concurrent callers can both observe a missing key and run create_value. "
         "Protect the read-modify-write sequence or use an atomic cache operation.",
+        "failure_scenario": "When two callers miss the same key concurrently, both run "
+        "create_value and duplicate its side effects.",
         "suggestion": None,
         "anchor": "    if key not in cache:",
     },
@@ -188,6 +201,8 @@ _DEPRECATION_EXAMPLE = _example_block(
         "severity": "medium",
         "title": "datetime.utcnow() is deprecated",
         "body": "datetime.utcnow() is deprecated since Python 3.12 and returns a naive datetime.",
+        "failure_scenario": "When this value is compared with a timezone-aware datetime, "
+        "Python raises TypeError instead of completing the comparison.",
         "suggestion": "now = datetime.datetime.now(datetime.timezone.utc)",
         "anchor": "now = datetime.datetime.utcnow()",
     },
@@ -207,6 +222,7 @@ _TESTS_EXAMPLE = _example_block(
         "severity": "low",
         "title": "New VIP branch has no accompanying test",
         "body": "The new VIP discount path is untested; a regression here would ship silently.",
+        "failure_scenario": None,
         "suggestion": 'def test_vip_discount():\n    assert discount(100.0, "VIP") == 50.0',
         "anchor": '    if code == "VIP":',
     },
@@ -226,6 +242,7 @@ _DOCUMENTATION_EXAMPLE = _example_block(
         "severity": "info",
         "title": "Public function fetch_user lacks a docstring",
         "body": "fetch_user is a public API surface; a short docstring states the contract.",
+        "failure_scenario": None,
         "suggestion": 'def fetch_user(user_id):\n    """Fetch one user record by id."""',
         "anchor": "def fetch_user(user_id):",
     },
@@ -244,6 +261,8 @@ _PERFORMANCE_EXAMPLE = _example_block(
         "severity": "medium",
         "title": "N+1 query: one database call per user id",
         "body": "Each iteration issues its own query; the cost scales linearly with input size.",
+        "failure_scenario": "When user_ids is large, the function issues one database "
+        "round-trip per id, increasing latency and exhausting the connection pool.",
         "suggestion": "    return [u.email for u in db.get_users(user_ids)]",
         "anchor": "    return [db.get_user(uid).email for uid in user_ids]",
     },
@@ -264,6 +283,7 @@ _COMPLEXITY_EXAMPLE = _example_block(
         "severity": "medium",
         "title": "Deeply nested conditionals — invert to guard clauses",
         "body": "Three nesting levels for one happy path; guard clauses read flat.",
+        "failure_scenario": None,
         "suggestion": "    if not (req and req.user and req.user.active):\n        return None",
         "anchor": "    if req:",
     },
@@ -288,6 +308,7 @@ _PONYTAIL_EXAMPLE = _example_block(
             "This five-line loop is exactly what the standard library already does. "
             "The best code is the code you never wrote — delete it for the one-liner."
         ),
+        "failure_scenario": None,
         "suggestion": "    return text.upper()",
         "anchor": "    result = ''",
     },
@@ -309,6 +330,7 @@ _INTENT_EXAMPLE = _example_block(
             "The stated intent is a README typo fix, but this hunk turns off certificate "
             "verification in the HTTP client — unrelated to the intent and security-sensitive."
         ),
+        "failure_scenario": None,
         "suggestion": None,
         "anchor": "session.verify = False",
     },

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -65,6 +65,14 @@ finding's "broad" is ignored, so emit false there.
 Keep a finding only if you are confident it is a real issue in the actual changed code.
 Drop it if it is speculative, out of scope, or referring to unchanged lines.
 
+For every security, correctness, deprecation, or performance finding, validate its failure \
+scenario from the `failure_scenario` field by tracing the stated trigger through the changed \
+behaviour to its observable impact. Drop the finding when the scenario contradicts the diff \
+or grounded file text, relies on an unsupported causal step, or merely sounds plausible \
+without code support. The reviewing engine has already removed defect findings with an \
+empty scenario; your job is to disprove the non-empty scenario when the evidence does not \
+support it. Gap and maintainability findings may correctly carry `failure_scenario: null`.
+
 Also drop a finding that merely DESCRIBES the change without naming a concrete problem \
 ("X was removed", "Y now takes a new parameter", "this method is now async") — narration \
 that restates the diff is not a finding, only a changelog. Be especially strict with \

--- a/tests/cli/test_integration_e2e.py
+++ b/tests/cli/test_integration_e2e.py
@@ -57,6 +57,9 @@ _FINDING = ReviewFinding(
     severity=Severity.medium,
     title="Import order",
     body="sys should be sorted before os",
+    failure_scenario=(
+        "When the module is linted, the changed import order fails the configured check."
+    ),
 )
 
 

--- a/tests/engine/test_caps.py
+++ b/tests/engine/test_caps.py
@@ -65,7 +65,14 @@ class _Provider(FakeProvider):
         return ProviderResult(text=self._payload, input_tokens=10, output_tokens=20)
 
 
-_A_FINDING = ReviewFinding(path="a.py", line=1, severity=Severity.high, title="bug", body="broken")
+_A_FINDING = ReviewFinding(
+    path="a.py",
+    line=1,
+    severity=Severity.high,
+    title="bug",
+    body="broken",
+    failure_scenario="When the changed line runs, the operation fails instead of completing.",
+)
 
 
 def test_clean_review_says_lgtm() -> None:

--- a/tests/engine/test_deadline.py
+++ b/tests/engine/test_deadline.py
@@ -26,7 +26,8 @@ _CTX = PRContext(
 )
 
 _FINDING_JSON = (
-    '[{"path": "a.py", "line": 1, "severity": "high", "title": "bug", "body": "broken"}]'
+    '[{"path": "a.py", "line": 1, "severity": "high", "title": "bug", "body": "broken",'
+    ' "failure_scenario": "When the changed line runs, the operation fails."}]'
 )
 
 

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 
 from lgtmaybe.core.models import (
+    CustomLens,
     PRContext,
     Provider,
     ProviderResult,
@@ -72,6 +73,7 @@ _HIGH = ReviewFinding(
     severity=Severity.high,
     title="real bug",
     body="definitely broken",
+    failure_scenario="When the changed path runs, it produces the reported failure.",
 )
 _INFO = ReviewFinding(
     path="a.py",
@@ -82,7 +84,12 @@ _INFO = ReviewFinding(
 )
 
 
-def _provider_for(findings: list[ReviewFinding], reflection_keeps_all: bool = True) -> FakeProvider:
+def _provider_for(
+    findings: list[ReviewFinding],
+    reflection_keeps_all: bool = True,
+    *,
+    with_failure_scenarios: bool = True,
+) -> FakeProvider:
     """A FakeProvider that returns ``findings`` for every review call and a verdict
     for the reflection call.
 
@@ -90,7 +97,19 @@ def _provider_for(findings: list[ReviewFinding], reflection_keeps_all: bool = Tr
     which dedupe collapses) and to thread ordering — review vs reflection is told
     apart by the system prompt, not a call counter.
     """
-    findings_text = json.dumps([f.model_dump(mode="json") for f in findings])
+    prepared = [
+        finding.model_copy(
+            update={
+                "failure_scenario": (
+                    "When this changed path runs, it produces the reported observable failure."
+                )
+            }
+        )
+        if with_failure_scenarios and finding.failure_scenario is None
+        else finding
+        for finding in findings
+    ]
+    findings_text = json.dumps([f.model_dump(mode="json") for f in prepared])
     verdicts = {i: True for i in range(len(findings))} if reflection_keeps_all else {}
     reflection_text = json.dumps(verdicts)
 
@@ -213,6 +232,114 @@ def test_all_findings_returned_when_min_severity_info() -> None:
     findings, _ = engine.review(_CTX, cfg)
 
     assert len(findings) == 2
+
+
+# ---------------------------------------------------------------------------
+# defect evidence gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ReviewCategory.security,
+        ReviewCategory.correctness,
+        ReviewCategory.deprecation,
+        ReviewCategory.performance,
+    ],
+)
+@pytest.mark.parametrize("failure_scenario", [None, "   "])
+def test_low_severity_defect_without_failure_scenario_is_dropped_before_reflection(
+    category: ReviewCategory,
+    failure_scenario: str | None,
+) -> None:
+    finding = ReviewFinding(
+        path="a.py",
+        line=2,
+        severity=Severity.low,
+        title="unchecked lookup",
+        body="The lookup result can be None.",
+        failure_scenario=failure_scenario,
+    )
+    provider = _provider_for([finding], reflection_keeps_all=True, with_failure_scenarios=False)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        categories=[category],
+        min_severity=Severity.info,
+    )
+
+    findings, _ = LLMReviewEngine(provider).review(_CTX, cfg)
+
+    assert findings == []
+    assert _reflection_calls(provider) == []
+
+
+def test_missing_defect_scenario_is_dropped_when_reflection_is_disabled() -> None:
+    finding = ReviewFinding(
+        path="a.py",
+        line=2,
+        severity=Severity.low,
+        title="unchecked lookup",
+        body="The lookup result can be None.",
+    )
+    provider = _provider_for([finding], with_failure_scenarios=False)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        categories=[ReviewCategory.correctness],
+        min_severity=Severity.info,
+        reflect=False,
+    )
+
+    findings, _ = LLMReviewEngine(provider).review(_CTX, cfg)
+
+    assert findings == []
+
+
+def test_gap_finding_without_failure_scenario_remains_eligible() -> None:
+    finding = ReviewFinding(
+        path="a.py",
+        line=2,
+        severity=Severity.low,
+        title="missing boundary test",
+        body="The new branch has no test.",
+    )
+    provider = _provider_for([finding], with_failure_scenarios=False)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        categories=[ReviewCategory.tests],
+        min_severity=Severity.info,
+        reflect=False,
+    )
+
+    findings, _ = LLMReviewEngine(provider).review(_CTX, cfg)
+
+    assert [item.title for item in findings] == ["missing boundary test"]
+
+
+def test_custom_lens_finding_without_failure_scenario_remains_eligible() -> None:
+    finding = ReviewFinding(
+        path="a.py",
+        line=2,
+        severity=Severity.low,
+        title="house rule",
+        body="This name violates the repository convention.",
+    )
+    provider = _provider_for([finding], with_failure_scenarios=False)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        categories=[],
+        extra_lenses=[CustomLens(id="house-style", instructions="Enforce naming rules.")],
+        min_severity=Severity.info,
+        reflect=False,
+    )
+
+    findings, _ = LLMReviewEngine(provider).review(_CTX, cfg)
+
+    assert [item.title for item in findings] == ["house rule"]
 
 
 # ---------------------------------------------------------------------------
@@ -574,7 +701,12 @@ class _PerCategoryProvider(FakeProvider):
         for marker, (title, line) in _CATEGORY_BY_MARKER.items():
             if marker in prompt:
                 finding = ReviewFinding(
-                    path="a.py", line=line, severity=Severity.low, title=title, body="x"
+                    path="a.py",
+                    line=line,
+                    severity=Severity.low,
+                    title=title,
+                    body="x",
+                    failure_scenario="When this path runs, it produces the reported failure.",
                 )
                 return ProviderResult(
                     text=json.dumps([finding.model_dump(mode="json")]),
@@ -900,7 +1032,12 @@ def test_partial_failure_keeps_findings_with_a_notice_and_no_lgtm() -> None:
             prompt = "\n".join(str(m.get("content", "")) for m in messages).lower()
             if "owasp" in prompt:
                 f = ReviewFinding(
-                    path="a.py", line=1, severity=Severity.high, title="bug", body="x"
+                    path="a.py",
+                    line=1,
+                    severity=Severity.high,
+                    title="bug",
+                    body="x",
+                    failure_scenario="When this path runs, it produces the reported failure.",
                 )
                 return ProviderResult(
                     text=json.dumps([f.model_dump(mode="json")]), input_tokens=10, output_tokens=5

--- a/tests/engine/test_preset.py
+++ b/tests/engine/test_preset.py
@@ -154,6 +154,7 @@ class TestSplitCorrectnessAttribution:
             severity=Severity.high,
             title="shared bug",
             body="x",
+            failure_scenario="When the changed line runs, the shared operation fails.",
         )
         finding_text = json.dumps([finding.model_dump(mode="json")])
 
@@ -181,6 +182,7 @@ class TestMergedCategoryStamping:
             severity=Severity.medium,
             title="finding",
             body="x",
+            failure_scenario="When the changed line runs, the operation fails.",
             category=category,
         )
         return json.dumps([f.model_dump(mode="json")])

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -49,8 +49,55 @@ def test_prompt_contains_all_severity_levels() -> None:
 def test_prompt_contains_json_contract() -> None:
     prompt = _union_prompt()
     # Must describe the JSON output fields
-    for field in ("severity", "path", "line", "title", "body", "suggestion"):
+    for field in (
+        "severity",
+        "path",
+        "line",
+        "title",
+        "body",
+        "failure_scenario",
+        "suggestion",
+    ):
         assert field in prompt, f"JSON field '{field}' missing from system prompt"
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ReviewCategory.security,
+        ReviewCategory.correctness,
+        ReviewCategory.deprecation,
+        ReviewCategory.performance,
+    ],
+)
+def test_defect_examples_include_a_failure_scenario(category: ReviewCategory) -> None:
+    prompt = build_system_prompt(category)
+
+    assert '"failure_scenario": "' in prompt
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        ReviewCategory.tests,
+        ReviewCategory.documentation,
+        ReviewCategory.complexity,
+        ReviewCategory.intent,
+        ReviewCategory.ponytail,
+    ],
+)
+def test_gap_examples_use_a_null_failure_scenario(category: ReviewCategory) -> None:
+    prompt = build_system_prompt(category)
+
+    assert '"failure_scenario": null' in prompt
+
+
+def test_prompt_requires_failure_scenarios_independently_of_severity() -> None:
+    prompt = _union_prompt().lower()
+
+    assert "trigger" in prompt
+    assert "observable impact" in prompt
+    assert "regardless of severity" in prompt
 
 
 def test_contract_requires_suggestion_to_be_replacement_code() -> None:

--- a/tests/engine/test_prompt_split.py
+++ b/tests/engine/test_prompt_split.py
@@ -237,6 +237,7 @@ class TestReflectionSplitShape:
             "severity": "high",
             "title": "bug",
             "body": "broken",
+            "failure_scenario": "When the changed line runs, the operation fails.",
         }
 
         class _Reviewer(FakeProvider):

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -185,6 +185,35 @@ def test_reflect_prompt_drops_narration_only_findings() -> None:
     assert "narrat" in system or "describe" in system
 
 
+def test_failure_scenario_reaches_the_auditor_and_can_be_rejected() -> None:
+    scenario = "When the lookup misses, the changed dereference raises AttributeError."
+    finding = ReviewFinding(
+        path="a.py",
+        line=1,
+        severity=Severity.low,
+        title="unchecked lookup",
+        body="The lookup result can be None.",
+        failure_scenario=scenario,
+    )
+    provider = _fake_with_verdict({0: False})
+
+    survivors = reflect_findings([finding], _CTX, _CFG, provider)
+
+    assert survivors == []
+    assert scenario in _user_text(provider.calls[0])
+
+
+def test_reflect_prompt_requires_failure_scenario_validation() -> None:
+    provider = _fake_with_verdict({0: True})
+
+    reflect_findings([_HIGH], _CTX, _CFG, provider)
+
+    system = provider.calls[0]["messages"][0]["content"].lower()
+    assert "failure scenario" in system
+    assert "unsupported causal" in system
+    assert "drop" in system
+
+
 def test_unparseable_verdict_keeps_all() -> None:
     provider = _fake_with_text("I'm not really sure about these.")
 

--- a/tests/fakes/provider.py
+++ b/tests/fakes/provider.py
@@ -15,6 +15,7 @@ _DEFAULT_FINDINGS = [
         severity=Severity.low,
         title="canned finding",
         body="from FakeProvider",
+        failure_scenario="When the changed path runs, it produces the reported failure.",
     )
 ]
 

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -238,6 +238,18 @@
           "default": null,
           "title": "Confidence"
         },
+        "failure_scenario": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Failure Scenario"
+        },
         "line": {
           "minimum": 1,
           "title": "Line",

--- a/tests/snapshots/ReviewFinding.json
+++ b/tests/snapshots/ReviewFinding.json
@@ -68,6 +68,18 @@
       "default": null,
       "title": "Confidence"
     },
+    "failure_scenario": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Failure Scenario"
+    },
     "line": {
       "minimum": 1,
       "title": "Line",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,6 +91,28 @@ def test_review_finding_severity_is_case_insensitive() -> None:
         assert finding.severity is expected
 
 
+def test_review_finding_failure_scenario_defaults_to_none() -> None:
+    finding = ReviewFinding(path="x.py", line=1, severity=Severity.high, title="bug", body="broken")
+
+    assert finding.failure_scenario is None
+
+
+def test_review_finding_failure_scenario_round_trips() -> None:
+    scenario = "When the lookup misses, the new dereference raises AttributeError."
+    finding = ReviewFinding(
+        path="x.py",
+        line=1,
+        severity=Severity.low,
+        title="unchecked lookup",
+        body="The lookup result can be None.",
+        failure_scenario=scenario,
+    )
+
+    restored = ReviewFinding.model_validate_json(finding.model_dump_json())
+
+    assert restored.failure_scenario == scenario
+
+
 def test_review_config_accepts_api_base() -> None:
     cfg = ReviewConfig(provider=Provider.ollama, model="llama3", api_base="http://localhost:11434")
     assert cfg.api_base == "http://localhost:11434"


### PR DESCRIPTION
## What changed

- add a nullable `failure_scenario` field to the structured `ReviewFinding` contract
- require non-blank scenarios for security, correctness, deprecation, and performance findings regardless of model-selected severity
- keep tests, documentation, complexity, intent, ponytail, and custom-lens findings eligible without a scenario
- drop missing scenarios before reflection, then ask reflection to disprove unsupported causal claims against the diff and grounded context
- enable the gate by default with no configuration toggle or A/B path
- update prompts, worked examples, schema snapshots, generated docs, architecture docs, and the approved OpenSpec change

## Why

Valid JSON and a changed-line anchor do not stop a model from posting a plausible but causally unsupported defect claim. Requiring a concrete trigger → changed behaviour → observable impact makes defect findings earn the right to be posted, while category-based gating prevents severity sandbagging from bypassing the rule.

## Impact

Defect findings without concrete causal evidence are silently filtered before posting or reflection. Gap and maintainability findings keep their existing behavior. `failure_scenario` is exposed in structured JSON output but is not duplicated in GitHub, human, or agent rendering.

## Validation

- `pytest -q` — 1,358 passed, 3 deselected
- focused model/prompt/engine/reflection/CLI tests — 295 passed
- Ruff lint and format checks
- strict mypy
- `uv lock --check`
- OpenSpec validation
- strict MkDocs build
- living-spec anchor tests (included in the full suite)
- CLI smoke test
