### PR TITLE
feat: add public lgtmaybe bot identity

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -2,10 +2,9 @@
 # Runs the in-repo action (./) so changes to action.yml are exercised too.
 # Add an OPENROUTER_API_KEY repo secret.
 #
-# Reviews post as lgtmaybe[bot] (name + avatar) via the GitHub App identity —
-# see docs/how-to/post-as-a-github-app.md. Set the LGTMAYBE_APP_ID repo
-# variable and LGTMAYBE_APP_PRIVATE_KEY secret; until they exist the action
-# falls back to the default workflow token (github-actions[bot]).
+# Reviews post as lgtmaybe[bot] (name + avatar) via the public GitHub App
+# identity. The workflow proves its repository identity with GitHub OIDC; no
+# App private key is stored in this repository.
 #
 # Reviews run automatically on PRs from trusted authors (owner / member /
 # collaborator), and on demand via slash commands (/review, /improve, /ask,
@@ -26,6 +25,7 @@ on:
 # out PR code.
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -58,5 +58,4 @@ jobs:
           model: deepseek/deepseek-v4-pro
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          app_id: ${{ vars.LGTMAYBE_APP_ID }}
-          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
+          github_identity: lgtmaybe

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+**/cdk.out/
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -245,10 +245,14 @@ Azure) are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` /
 [Use as a GitHub Action](docs/how-to/use-as-github-action.md). ollama is local
 only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instead.
 
-**Recommended:** post reviews under your own branded GitHub App identity (e.g.
-`lgtmaybe[bot]` with an avatar) instead of `github-actions[bot]` — add `app_id`
-/ `app_private_key` to any workflow after a one-time five-minute App setup. See
-[Post reviews as a GitHub App](docs/how-to/post-as-a-github-app.md).
+By default, reviews post as `github-actions[bot]`. To post as
+`lgtmaybe[bot]`, install the public
+[lgtmaybe App](https://github.com/apps/lgtmaybe/installations/new), grant the
+workflow `id-token: write`, and add `github_identity: lgtmaybe` beside the
+provider settings. You never receive or manage the App's private key. lgtmaybe
+is still the Action running in your workflow; the App changes only the GitHub
+author identity. See
+[Post as lgtmaybe[bot]](docs/how-to/post-as-a-github-app.md).
 
 > **🔧 Choose who can trigger reviews.** You decide who reviews run for —
 > everyone, trusted contributors, or just admins. The example workflows default

--- a/action.yml
+++ b/action.yml
@@ -158,8 +158,16 @@ inputs:
     description: "Token used to fetch the diff and post the review. Defaults to the workflow token."
     required: false
     default: ${{ github.token }}
+  github_identity:
+    description: "GitHub author for review comments: actions posts as github-actions[bot] (default); lgtmaybe posts as lgtmaybe[bot] after you install the public lgtmaybe App and grant id-token: write."
+    required: false
+    default: "actions"
+  identity_broker_url:
+    description: "Advanced: lgtmaybe identity broker endpoint. Most users should keep the default."
+    required: false
+    default: "https://m8h7wpmdyi.execute-api.ap-southeast-2.amazonaws.com/token"
   app_id:
-    description: "Advanced: ID of an existing GitHub App used with app_private_key. Most users should leave this empty and use the default workflow token."
+    description: "Advanced: ID of your own GitHub App used with app_private_key. Do not combine this with github_identity: lgtmaybe."
     required: false
     default: ""
   app_private_key:
@@ -178,6 +186,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate GitHub identity configuration
+      id: validate-identity
+      shell: bash
+      env:
+        GITHUB_IDENTITY: ${{ inputs.github_identity }}
+        APP_ID: ${{ inputs.app_id }}
+        APP_PRIVATE_KEY: ${{ inputs.app_private_key }}
+        FAIL_ON: ${{ inputs.fail_on }}
+      run: python3 "${{ github.action_path }}/scripts/github-app-identity.py" validate
+
+    - name: Exchange workflow identity for lgtmaybe App token
+      id: lgtmaybe-token
+      if: ${{ inputs.github_identity == 'lgtmaybe' }}
+      shell: bash
+      env:
+        IDENTITY_BROKER_URL: ${{ inputs.identity_broker_url }}
+      run: python3 "${{ github.action_path }}/scripts/github-app-identity.py" exchange
+
     - name: Configure AWS credentials (OIDC, keyless)
       if: ${{ inputs.aws_role_arn != '' }}
       uses: aws-actions/configure-aws-credentials@v6
@@ -217,7 +243,7 @@ runs:
 
     - name: Mint a GitHub App token (branded bot identity)
       id: app-token
-      if: ${{ inputs.app_id != '' }}
+      if: ${{ inputs.app_id != '' && inputs.github_identity != 'lgtmaybe' }}
       uses: actions/create-github-app-token@v3
       with:
         # Empty owner/repositories scope the token to the current repository;
@@ -231,10 +257,9 @@ runs:
     - name: Run lgtmaybe
       shell: bash
       env:
-        # Prefer the minted App token (branded bot + higher rate limits); a
-        # skipped mint step yields an empty output, so fall back to the default
-        # workflow token.
-        GITHUB_TOKEN: ${{ steps.app-token.outputs.token || inputs.github_token }}
+        # Prefer the selected branded App identity; a skipped mint/exchange
+        # yields an empty output, so the default remains github-actions[bot].
+        GITHUB_TOKEN: ${{ steps.lgtmaybe-token.outputs.token || steps.app-token.outputs.token || inputs.github_token }}
         INPUT_PROVIDER: ${{ inputs.provider }}
         INPUT_MODEL: ${{ inputs.model }}
         INPUT_PRESET: ${{ inputs.preset }}
@@ -298,3 +323,12 @@ runs:
           -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
           -w "${GITHUB_WORKSPACE}" \
           "${LGTMAYBE_IMAGE}" action
+
+    - name: Revoke temporary lgtmaybe App token
+      id: revoke-lgtmaybe-token
+      if: ${{ always() && steps.lgtmaybe-token.outputs.token != '' }}
+      continue-on-error: true
+      shell: bash
+      env:
+        LGTMAYBE_TOKEN: ${{ steps.lgtmaybe-token.outputs.token }}
+      run: python3 "${{ github.action_path }}/scripts/github-app-identity.py" revoke

--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -1,20 +1,116 @@
 ---
-description: lgtmaybe is a GitHub Marketplace Action and uses GitHub Actions' built-in token; no separate GitHub App setup is required.
+description: Post lgtmaybe reviews as lgtmaybe[bot] with the public App, or use a self-managed GitHub App.
 ---
 
-# No GitHub App setup required
+# Post as lgtmaybe[bot]
 
-lgtmaybe is published to GitHub Marketplace as a **GitHub Action**. Add the
-Action to your workflow and GitHub Actions supplies the short-lived,
-repository-scoped token it needs. Reviews post as `github-actions[bot]` by
-default.
+lgtmaybe is a GitHub Action. The Action runs the reviewer and keeps the
+provider, model, and provider authentication in the workflow's `with:` block.
+A GitHub App is optional: it changes the author of GitHub comments from
+`github-actions[bot]` to a branded bot.
 
-You do not need to create or install a separate GitHub App, manage a private
-key, or run a hosted lgtmaybe service. Choose the model provider and
-authentication method in the workflow instead.
+There are three identity choices:
 
-[Use lgtmaybe as a GitHub Action](./use-as-github-action.md)
+- Do nothing: the Action uses GitHub's workflow token and posts as
+  `github-actions[bot]`.
+- Install the public lgtmaybe App: the Action posts as `lgtmaybe[bot]`; you do
+  not receive or manage an App private key.
+- Use your own GitHub App: provide its App ID and private key as an advanced,
+  self-managed setup.
 
-If your organisation already operates a GitHub App, the advanced `github_token`
-input can use a token minted elsewhere. This is optional and is not part of the
-standard setup.
+## Install the public lgtmaybe App
+
+1. [Install the lgtmaybe App](https://github.com/apps/lgtmaybe/installations/new)
+   and select only the repositories where it should review pull requests.
+2. Add `id-token: write` to the workflow permissions.
+3. Set `github_identity: lgtmaybe` on the Action step.
+
+Here is a complete OpenAI workflow:
+
+```yaml
+name: lgtmaybe
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7 # base repository only
+      - uses: MattJColes/lgtmaybe@v1
+        with:
+          github_identity: lgtmaybe
+          provider: openai
+          model: gpt-5.5
+          api_key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The provider configuration is unchanged. `github_identity` selects who posts
+on GitHub; it does not select or host the model.
+
+The public App has only:
+
+- `contents: read`, to fetch repository and pull-request content
+- `pull requests: write`, to post reviews, comments, and labels
+- `issues: write`, to answer pull-request issue comments
+
+The Action exchanges GitHub's signed workflow identity for a short-lived App
+token restricted to the triggering repository and those exact permissions.
+The identity broker verifies the repository, event, and default-branch
+workflow. It never receives your diff, provider key, prompt, model response, or
+review findings.
+
+Selecting `github_identity: lgtmaybe` is explicit: if `id-token: write` is
+missing, the App is not installed on the repository, the workflow is not
+trusted, or the identity service is unavailable, the job fails with setup
+guidance. It does not fall back to `github-actions[bot]`.
+
+To remove access, uninstall the App from the repository or remove that
+repository from the installation. Remove `github_identity: lgtmaybe` and
+`id-token: write` from the workflow to return to `github-actions[bot]`. The
+Action also revokes its temporary App token after each run; GitHub expires it
+automatically if cleanup cannot run.
+
+The public App intentionally has no `Checks: write` permission, so
+`github_identity: lgtmaybe` cannot be combined with `fail_on`. Keep the
+default `github_identity: actions` and grant the workflow `checks: write`, or
+use a self-managed App with `Checks: write`, when lgtmaybe must create a merge
+gate.
+
+## Use your own GitHub App
+
+Use this path only when your organisation already operates a GitHub App and
+wants reviews attributed to it.
+
+Configure the App with repository permissions `contents: read`, `pull
+requests: write`, and `issues: write`. Add `checks: write` only when using
+`fail_on`. Then install it on the repositories it may review. Store its ID as
+the `LGTMAYBE_APP_ID` repository variable and its PEM private key as the
+`LGTMAYBE_APP_PRIVATE_KEY` Actions secret:
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@v7
+  - uses: MattJColes/lgtmaybe@v1
+    with:
+      provider: openai
+      model: gpt-5.5
+      api_key: ${{ secrets.OPENAI_API_KEY }}
+      app_id: ${{ vars.LGTMAYBE_APP_ID }}
+      app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
+```
+
+Do not combine `app_id` / `app_private_key` with
+`github_identity: lgtmaybe`. The Action validates this before minting a token.

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -57,6 +57,7 @@ The only human-only pieces:
 
 - [One-time setup](#one-time-setup)
 - [Each release](#each-release)
+- [Rotate the public App private key](#rotate-the-public-app-private-key)
 - [Before going public](#before-going-public)
 
 ## One-time setup
@@ -96,6 +97,55 @@ The only human-only pieces:
    `release-please` workflow via **workflow_dispatch** with the tag name.
 4. If Windows publication needs recovery, dispatch `windows-exe` for the tag,
    then dispatch `winget` after the release asset is visible.
+
+## Rotate the public App private key
+
+Rotate the public `lgtmaybe` GitHub App key quarterly, whenever maintainer access
+changes, and immediately after any suspected exposure. Keep the old key active
+until the replacement has passed a brokered smoke test so rotation does not
+interrupt reviews.
+
+1. In the GitHub App settings, generate a new private key. Do not delete the old
+   key yet.
+2. From the directory containing the downloaded PEM, replace the retained
+   Secrets Manager value without printing the key:
+
+    ```bash
+    aws secretsmanager put-secret-value \
+      --secret-id lgtmaybe/github-app/private-key \
+      --secret-string file://lgtmaybe.private-key.pem \
+      --region ap-southeast-2
+    ```
+
+3. Refresh the Lambda configuration so every execution environment drops its
+   cached copy of the old key:
+
+    ```bash
+    FUNCTION_NAME="$(
+      aws cloudformation describe-stack-resources \
+        --stack-name LgtmaybeGithubAppIdentity \
+        --region ap-southeast-2 \
+        --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId | [0]" \
+        --output text
+    )"
+    aws lambda update-function-configuration \
+      --function-name "$FUNCTION_NAME" \
+      --description "GitHub App key rotated $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --region ap-southeast-2
+    aws lambda wait function-updated-v2 \
+      --function-name "$FUNCTION_NAME" \
+      --region ap-southeast-2
+    ```
+
+4. Run a brokered dogfood review and confirm GitHub attributes it to
+   `lgtmaybe[bot]`.
+5. Delete the old key in the GitHub App settings, then delete the downloaded PEM
+   from the maintainer machine. Never paste the PEM into a command argument,
+   issue, workflow log, or repository file.
+
+If the smoke test fails, leave the old GitHub key active, put its PEM back into
+the same Secrets Manager secret, refresh the Lambda configuration again, and
+investigate before retrying.
 
 ## Before going public
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -9,11 +9,14 @@ that reviews pull requests automatically.
 
 Use lgtmaybe from the
 [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
-It is a **GitHub Action**, not a hosted GitHub App. Its provider, model, and
-authentication settings live in the workflow's `with:` block. GitHub Actions
-supplies the repository token, so there is no separate App to install. The
+It is a **GitHub Action**: the reviewer runs in your workflow, and its provider,
+model, and provider authentication settings live in the step's `with:` block.
+GitHub Actions supplies the repository token by default, so reviews post as
+`github-actions[bot]`. You can optionally install the public lgtmaybe App and
+set `github_identity: lgtmaybe` to post as `lgtmaybe[bot]`; the App changes only
+the GitHub author identity. The
 [minimal OpenAI workflow](#minimal-workflow-openai) below shows the complete
-shape.
+default shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
@@ -28,6 +31,7 @@ ollama runs the model on your own machine, so it is local-only — use the
 - [Security requirement: pull_request_target](#security-requirement-pull_request_target)
 - [Who can trigger a review](#who-can-trigger-a-review)
 - [Minimal workflow — openai](#minimal-workflow-openai)
+- [Choose the GitHub author](#choose-the-github-author)
 - [Other key-based providers](#other-key-based-providers)
 - [Keyless cloud workflows](#keyless-cloud-workflows)
 - [Action inputs](#action-inputs)
@@ -130,6 +134,21 @@ jobs:
           api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+## Choose the GitHub author
+
+The minimal workflow uses GitHub's built-in workflow token and posts as
+`github-actions[bot]`. This path needs no App installation and remains the
+default.
+
+To post as `lgtmaybe[bot]`, install the public lgtmaybe App on selected
+repositories, add `id-token: write` to the workflow, and set
+`github_identity: lgtmaybe`. The provider, model, and provider key stay exactly
+where they are. Follow [Post as lgtmaybe[bot]](./post-as-a-github-app.md) for
+the complete workflow, permission boundary, and uninstall instructions.
+
+If your organisation operates its own App, the same guide documents the
+advanced `app_id` / `app_private_key` inputs.
+
 ## Other key-based providers
 
 Swap the `provider`, `model`, and `api_key` inputs:
@@ -211,8 +230,10 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `azure_tenant_id` | — | Entra (Azure AD) tenant ID for keyless azure |
 | `config_path` | `.lgtmaybe.yml` | Path to the config file, relative to repo root |
 | `github_token` | `${{ github.token }}` | Token for reading the PR and posting the review |
-| `app_id` | — | Advanced: ID of an existing GitHub App used with `app_private_key`; most users should leave this empty |
-| `app_private_key` | — | Advanced: private key of the existing App named by `app_id`; most users should leave this empty |
+| `github_identity` | `actions` | GitHub author identity: `actions` posts as `github-actions[bot]`; `lgtmaybe` posts as `lgtmaybe[bot]` after the public App is installed and `id-token: write` is granted |
+| `identity_broker_url` | managed endpoint | Advanced override for the public App identity exchange |
+| `app_id` | — | Advanced: ID of your own GitHub App used with `app_private_key`; do not combine with `github_identity: lgtmaybe` |
+| `app_private_key` | — | Advanced: private key of your own App named by `app_id` |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
 | `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
@@ -249,6 +270,12 @@ A PR with a finding at or above the threshold then shows a failing `lgtmaybe`
 check and cannot merge until the finding is resolved (or `fail_on` is lowered).
 Leave `fail_on` unset to keep reviews advisory (the default) — no check run is
 created.
+
+Creating the Check Run requires `checks: write`. For the default Actions
+identity, add it to the workflow `permissions:` block. The public
+`lgtmaybe[bot]` App intentionally does not hold that permission, so
+`github_identity: lgtmaybe` cannot be combined with `fail_on`; use the Actions
+identity or a self-managed App granted `Checks: write`.
 
 ## Adding a config file
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -343,11 +343,14 @@ that reviews pull requests automatically.
 
 Use lgtmaybe from the
 [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
-It is a **GitHub Action**, not a hosted GitHub App. Its provider, model, and
-authentication settings live in the workflow's `with:` block. GitHub Actions
-supplies the repository token, so there is no separate App to install. The
+It is a **GitHub Action**: the reviewer runs in your workflow, and its provider,
+model, and provider authentication settings live in the step's `with:` block.
+GitHub Actions supplies the repository token by default, so reviews post as
+`github-actions[bot]`. You can optionally install the public lgtmaybe App and
+set `github_identity: lgtmaybe` to post as `lgtmaybe[bot]`; the App changes only
+the GitHub author identity. The
 [minimal OpenAI workflow](#minimal-workflow-openai) below shows the complete
-shape.
+default shape.
 
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
@@ -362,6 +365,7 @@ ollama runs the model on your own machine, so it is local-only — use the
 - [Security requirement: pull_request_target](#security-requirement-pull_request_target)
 - [Who can trigger a review](#who-can-trigger-a-review)
 - [Minimal workflow — openai](#minimal-workflow-openai)
+- [Choose the GitHub author](#choose-the-github-author)
 - [Other key-based providers](#other-key-based-providers)
 - [Keyless cloud workflows](#keyless-cloud-workflows)
 - [Action inputs](#action-inputs)
@@ -464,6 +468,21 @@ jobs:
           api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+## Choose the GitHub author
+
+The minimal workflow uses GitHub's built-in workflow token and posts as
+`github-actions[bot]`. This path needs no App installation and remains the
+default.
+
+To post as `lgtmaybe[bot]`, install the public lgtmaybe App on selected
+repositories, add `id-token: write` to the workflow, and set
+`github_identity: lgtmaybe`. The provider, model, and provider key stay exactly
+where they are. Follow [Post as lgtmaybe[bot]](./post-as-a-github-app.md) for
+the complete workflow, permission boundary, and uninstall instructions.
+
+If your organisation operates its own App, the same guide documents the
+advanced `app_id` / `app_private_key` inputs.
+
 ## Other key-based providers
 
 Swap the `provider`, `model`, and `api_key` inputs:
@@ -545,8 +564,10 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `azure_tenant_id` | — | Entra (Azure AD) tenant ID for keyless azure |
 | `config_path` | `.lgtmaybe.yml` | Path to the config file, relative to repo root |
 | `github_token` | `${{ github.token }}` | Token for reading the PR and posting the review |
-| `app_id` | — | Advanced: ID of an existing GitHub App used with `app_private_key`; most users should leave this empty |
-| `app_private_key` | — | Advanced: private key of the existing App named by `app_id`; most users should leave this empty |
+| `github_identity` | `actions` | GitHub author identity: `actions` posts as `github-actions[bot]`; `lgtmaybe` posts as `lgtmaybe[bot]` after the public App is installed and `id-token: write` is granted |
+| `identity_broker_url` | managed endpoint | Advanced override for the public App identity exchange |
+| `app_id` | — | Advanced: ID of your own GitHub App used with `app_private_key`; do not combine with `github_identity: lgtmaybe` |
+| `app_private_key` | — | Advanced: private key of your own App named by `app_id` |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
 | `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
@@ -584,6 +605,12 @@ check and cannot merge until the finding is resolved (or `fail_on` is lowered).
 Leave `fail_on` unset to keep reviews advisory (the default) — no check run is
 created.
 
+Creating the Check Run requires `checks: write`. For the default Actions
+identity, add it to the workflow `permissions:` block. The public
+`lgtmaybe[bot]` App intentionally does not hold that permission, so
+`github_identity: lgtmaybe` cannot be combined with `fail_on`; use the Actions
+identity or a self-managed App granted `Checks: write`.
+
 ## Adding a config file
 
 Place a `.lgtmaybe.yml` at the repo root to control severity thresholds, path
@@ -598,6 +625,123 @@ use a full version tag:
 ```yaml
 uses: MattJColes/lgtmaybe@v1.0.0
 ```
+
+---
+
+<!-- Source: https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/ -->
+
+# Post as lgtmaybe[bot]
+
+lgtmaybe is a GitHub Action. The Action runs the reviewer and keeps the
+provider, model, and provider authentication in the workflow's `with:` block.
+A GitHub App is optional: it changes the author of GitHub comments from
+`github-actions[bot]` to a branded bot.
+
+There are three identity choices:
+
+- Do nothing: the Action uses GitHub's workflow token and posts as
+  `github-actions[bot]`.
+- Install the public lgtmaybe App: the Action posts as `lgtmaybe[bot]`; you do
+  not receive or manage an App private key.
+- Use your own GitHub App: provide its App ID and private key as an advanced,
+  self-managed setup.
+
+## Install the public lgtmaybe App
+
+1. [Install the lgtmaybe App](https://github.com/apps/lgtmaybe/installations/new)
+   and select only the repositories where it should review pull requests.
+2. Add `id-token: write` to the workflow permissions.
+3. Set `github_identity: lgtmaybe` on the Action step.
+
+Here is a complete OpenAI workflow:
+
+```yaml
+name: lgtmaybe
+
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7 # base repository only
+      - uses: MattJColes/lgtmaybe@v1
+        with:
+          github_identity: lgtmaybe
+          provider: openai
+          model: gpt-5.5
+          api_key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The provider configuration is unchanged. `github_identity` selects who posts
+on GitHub; it does not select or host the model.
+
+The public App has only:
+
+- `contents: read`, to fetch repository and pull-request content
+- `pull requests: write`, to post reviews, comments, and labels
+- `issues: write`, to answer pull-request issue comments
+
+The Action exchanges GitHub's signed workflow identity for a short-lived App
+token restricted to the triggering repository and those exact permissions.
+The identity broker verifies the repository, event, and default-branch
+workflow. It never receives your diff, provider key, prompt, model response, or
+review findings.
+
+Selecting `github_identity: lgtmaybe` is explicit: if `id-token: write` is
+missing, the App is not installed on the repository, the workflow is not
+trusted, or the identity service is unavailable, the job fails with setup
+guidance. It does not fall back to `github-actions[bot]`.
+
+To remove access, uninstall the App from the repository or remove that
+repository from the installation. Remove `github_identity: lgtmaybe` and
+`id-token: write` from the workflow to return to `github-actions[bot]`. The
+Action also revokes its temporary App token after each run; GitHub expires it
+automatically if cleanup cannot run.
+
+The public App intentionally has no `Checks: write` permission, so
+`github_identity: lgtmaybe` cannot be combined with `fail_on`. Keep the
+default `github_identity: actions` and grant the workflow `checks: write`, or
+use a self-managed App with `Checks: write`, when lgtmaybe must create a merge
+gate.
+
+## Use your own GitHub App
+
+Use this path only when your organisation already operates a GitHub App and
+wants reviews attributed to it.
+
+Configure the App with repository permissions `contents: read`, `pull
+requests: write`, and `issues: write`. Add `checks: write` only when using
+`fail_on`. Then install it on the repositories it may review. Store its ID as
+the `LGTMAYBE_APP_ID` repository variable and its PEM private key as the
+`LGTMAYBE_APP_PRIVATE_KEY` Actions secret:
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@v7
+  - uses: MattJColes/lgtmaybe@v1
+    with:
+      provider: openai
+      model: gpt-5.5
+      api_key: ${{ secrets.OPENAI_API_KEY }}
+      app_id: ${{ vars.LGTMAYBE_APP_ID }}
+      app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}
+```
+
+Do not combine `app_id` / `app_private_key` with
+`github_identity: lgtmaybe`. The Action validates this before minting a token.
 
 ---
 
@@ -2852,6 +2996,7 @@ The only human-only pieces:
 
 - [One-time setup](#one-time-setup)
 - [Each release](#each-release)
+- [Rotate the public App private key](#rotate-the-public-app-private-key)
 - [Before going public](#before-going-public)
 
 ## One-time setup
@@ -2891,6 +3036,55 @@ The only human-only pieces:
    `release-please` workflow via **workflow_dispatch** with the tag name.
 4. If Windows publication needs recovery, dispatch `windows-exe` for the tag,
    then dispatch `winget` after the release asset is visible.
+
+## Rotate the public App private key
+
+Rotate the public `lgtmaybe` GitHub App key quarterly, whenever maintainer access
+changes, and immediately after any suspected exposure. Keep the old key active
+until the replacement has passed a brokered smoke test so rotation does not
+interrupt reviews.
+
+1. In the GitHub App settings, generate a new private key. Do not delete the old
+   key yet.
+2. From the directory containing the downloaded PEM, replace the retained
+   Secrets Manager value without printing the key:
+
+    ```bash
+    aws secretsmanager put-secret-value \
+      --secret-id lgtmaybe/github-app/private-key \
+      --secret-string file://lgtmaybe.private-key.pem \
+      --region ap-southeast-2
+    ```
+
+3. Refresh the Lambda configuration so every execution environment drops its
+   cached copy of the old key:
+
+    ```bash
+    FUNCTION_NAME="$(
+      aws cloudformation describe-stack-resources \
+        --stack-name LgtmaybeGithubAppIdentity \
+        --region ap-southeast-2 \
+        --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId | [0]" \
+        --output text
+    )"
+    aws lambda update-function-configuration \
+      --function-name "$FUNCTION_NAME" \
+      --description "GitHub App key rotated $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --region ap-southeast-2
+    aws lambda wait function-updated-v2 \
+      --function-name "$FUNCTION_NAME" \
+      --region ap-southeast-2
+    ```
+
+4. Run a brokered dogfood review and confirm GitHub attributes it to
+   `lgtmaybe[bot]`.
+5. Delete the old key in the GitHub App settings, then delete the downloaded PEM
+   from the maintainer machine. Never paste the PEM into a command argument,
+   issue, workflow log, or repository file.
+
+If the smoke test fails, leave the old GitHub key active, put its PEM back into
+the same Secrets Manager secret, refresh the Lambda configuration again, and
+investigate before retrying.
 
 ## Before going public
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,7 @@
 
 - [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS), Homebrew (macOS/Linuxbrew), or winget (Windows), and add cloud extras for keyless Bedrock/Vertex/Azure.
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
+- [Post as lgtmaybe[bot]](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews as lgtmaybe[bot] with the public App, or use a self-managed GitHub App.
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
 - [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
 - [Review with OpenRouter](https://lgtmaybe.coles.codes/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.

--- a/examples/workflows/review-self-managed-github-app.yml
+++ b/examples/workflows/review-self-managed-github-app.yml
@@ -1,12 +1,10 @@
 # Copy into your repo at .github/workflows/lgtmaybe.yml
 #
-# Public branded identity: install https://github.com/apps/lgtmaybe on this
-# repository, then use github_identity: lgtmaybe. You do not create or store a
-# GitHub App private key. The provider configuration is otherwise unchanged.
-#
-# Secret to add:
-#   OPENAI_API_KEY — your model provider key
-name: lgtmaybe (public app)
+# Advanced: use this only if your organisation already operates a GitHub App.
+# Store its ID in LGTMAYBE_APP_ID and PEM private key in
+# LGTMAYBE_APP_PRIVATE_KEY. The App should have contents: read,
+# pull requests: write, and issues: write on the selected repositories.
+name: lgtmaybe (self-managed app)
 
 on:
   pull_request_target:
@@ -17,11 +15,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-
-concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
 
 jobs:
   review:
@@ -37,7 +30,8 @@ jobs:
       - uses: actions/checkout@v7 # base repository only
       - uses: MattJColes/lgtmaybe@v1
         with:
-          github_identity: lgtmaybe
           provider: openai
           model: gpt-5.5
           api_key: ${{ secrets.OPENAI_API_KEY }}
+          app_id: ${{ vars.LGTMAYBE_APP_ID }}
+          app_private_key: ${{ secrets.LGTMAYBE_APP_PRIVATE_KEY }}

--- a/infra/identity/__init__.py
+++ b/infra/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure for the GitHub App identity broker."""

--- a/infra/identity/app.py
+++ b/infra/identity/app.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from aws_cdk import App, Aspects, Environment
+from cdk_nag import AwsSolutionsChecks
+
+
+def main() -> None:
+    sys.path.insert(0, str(Path(__file__).parents[2]))
+    from infra.identity.stack import IdentityBrokerStack
+
+    app = App()
+    stack = IdentityBrokerStack(
+        app,
+        "LgtmaybeGithubAppIdentity",
+        app_id=app.node.try_get_context("githubAppId") or "3987976",
+        alarm_email=app.node.try_get_context("alarmEmail") or "matt@coles.codes",
+        env=Environment(
+            account=os.environ.get("CDK_DEFAULT_ACCOUNT"),
+            region=os.environ.get("CDK_DEFAULT_REGION", "ap-southeast-2"),
+        ),
+    )
+    Aspects.of(stack).add(AwsSolutionsChecks(verbose=True))
+    app.synth()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/identity/cdk.json
+++ b/infra/identity/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "python app.py",
+  "context": {
+    "alarmEmail": "matt@coles.codes",
+    "githubAppId": "3987976"
+  }
+}

--- a/infra/identity/identity.guard
+++ b/infra/identity/identity.guard
@@ -1,0 +1,29 @@
+let broker_functions = Resources.*[
+    Type == 'AWS::Lambda::Function'
+]
+
+let identity_stages = Resources.*[
+    Type == 'AWS::ApiGatewayV2::Stage'
+]
+
+let app_secrets = Resources.*[
+    Type == 'AWS::SecretsManager::Secret'
+]
+
+rule broker_lambda_is_bounded when %broker_functions !empty {
+    %broker_functions.Properties.Runtime == 'python3.14'
+    %broker_functions.Properties.Timeout <= 15
+    %broker_functions.Properties.ReservedConcurrentExecutions <= 5
+}
+
+rule identity_api_is_throttled_and_logged when %identity_stages !empty {
+    %identity_stages.Properties.DefaultRouteSettings.DetailedMetricsEnabled == false
+    %identity_stages.Properties.DefaultRouteSettings.ThrottlingRateLimit <= 2
+    %identity_stages.Properties.DefaultRouteSettings.ThrottlingBurstLimit <= 5
+    %identity_stages.Properties.AccessLogSettings exists
+}
+
+rule app_private_key_is_retained when %app_secrets !empty {
+    %app_secrets.DeletionPolicy == 'Retain'
+    %app_secrets.UpdateReplacePolicy == 'Retain'
+}

--- a/infra/identity/stack.py
+++ b/infra/identity/stack.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from aws_cdk import (
+    CfnOutput,
+    Duration,
+    RemovalPolicy,
+    Stack,
+    Tags,
+)
+from aws_cdk import (
+    aws_apigatewayv2 as apigwv2,
+)
+from aws_cdk import (
+    aws_cloudwatch as cloudwatch,
+)
+from aws_cdk import (
+    aws_cloudwatch_actions as cloudwatch_actions,
+)
+from aws_cdk import (
+    aws_iam as iam,
+)
+from aws_cdk import (
+    aws_kms as kms,
+)
+from aws_cdk import (
+    aws_lambda as lambda_,
+)
+from aws_cdk import (
+    aws_logs as logs,
+)
+from aws_cdk import (
+    aws_secretsmanager as secretsmanager,
+)
+from aws_cdk import (
+    aws_sns as sns,
+)
+from aws_cdk import (
+    aws_sns_subscriptions as subscriptions,
+)
+from aws_cdk.aws_apigatewayv2_authorizers import HttpJwtAuthorizer
+from aws_cdk.aws_apigatewayv2_integrations import HttpLambdaIntegration
+from aws_cdk.aws_lambda_python_alpha import BundlingOptions, PythonFunction
+from cdk_nag import NagSuppressions
+from constructs import Construct
+from services.github_app_identity.broker import OIDC_AUDIENCE, OIDC_ISSUER
+
+SERVICE_ROOT = Path(__file__).parents[2] / "services" / "github_app_identity"
+
+
+class IdentityBrokerStack(Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        app_id: str,
+        alarm_email: str,
+        bundle_code: bool = True,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        private_key = secretsmanager.Secret(
+            self,
+            "AppPrivateKey",
+            secret_name="lgtmaybe/github-app/private-key",
+            description="Private key for the public lgtmaybe GitHub App",
+            removal_policy=RemovalPolicy.RETAIN,
+        )
+        NagSuppressions.add_resource_suppressions(
+            private_key,
+            [
+                {
+                    "id": "AwsSolutions-SMG4",
+                    "reason": (
+                        "GitHub App private keys are rotated in GitHub and cannot use "
+                        "Secrets Manager's database rotation contract."
+                    ),
+                }
+            ],
+        )
+        log_group = logs.LogGroup(
+            self,
+            "BrokerLogs",
+            retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+        broker = self._function(
+            app_id=app_id,
+            secret_arn=private_key.secret_arn,
+            log_group=log_group,
+            bundle_code=bundle_code,
+        )
+        private_key.grant_read(broker)
+
+        api = apigwv2.HttpApi(
+            self,
+            "IdentityApi",
+            api_name="lgtmaybe-github-app-identity",
+            description="Exchanges GitHub Actions OIDC for a scoped lgtmaybe App token",
+            create_default_stage=False,
+        )
+        authorizer = HttpJwtAuthorizer(
+            "GitHubOidc",
+            OIDC_ISSUER,
+            jwt_audience=[OIDC_AUDIENCE],
+            identity_source=["$request.header.Authorization"],
+        )
+        api.add_routes(
+            path="/token",
+            methods=[apigwv2.HttpMethod.POST],
+            integration=HttpLambdaIntegration("BrokerIntegration", broker),
+            authorizer=authorizer,
+        )
+        api_log_group = logs.LogGroup(
+            self,
+            "ApiAccessLogs",
+            retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+        stage = apigwv2.HttpStage(
+            self,
+            "DefaultStage",
+            http_api=api,
+            stage_name="$default",
+            auto_deploy=True,
+            detailed_metrics_enabled=False,
+            throttle=apigwv2.ThrottleSettings(rate_limit=2, burst_limit=5),
+        )
+        cfn_stage = stage.node.default_child
+        assert isinstance(cfn_stage, apigwv2.CfnStage)
+        cfn_stage.add_property_override(
+            "AccessLogSettings",
+            {
+                "DestinationArn": api_log_group.log_group_arn,
+                "Format": (
+                    '{"requestId":"$context.requestId","routeKey":"$context.routeKey",'
+                    '"status":"$context.status","responseLength":"$context.responseLength"}'
+                ),
+            },
+        )
+        NagSuppressions.add_resource_suppressions(
+            stage,
+            [
+                {
+                    "id": "AwsSolutions-APIG1",
+                    "reason": (
+                        "Access logging is applied directly to the underlying CfnStage "
+                        "because this CDK HttpStage L2 has no concrete access-log settings type."
+                    ),
+                }
+            ],
+        )
+
+        alarm_topic = sns.Topic(
+            self,
+            "AlarmTopic",
+            display_name="lgtmaybe GitHub App identity alarms",
+            enforce_ssl=True,
+            master_key=kms.Alias.from_alias_name(self, "AlarmTopicKey", "alias/aws/sns"),
+        )
+        alarm_topic.add_subscription(subscriptions.EmailSubscription(alarm_email))
+        broker_errors = cloudwatch.Alarm(
+            self,
+            "BrokerErrors",
+            metric=broker.metric_errors(period=Duration.minutes(5)),
+            threshold=1,
+            evaluation_periods=1,
+            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        )
+        api_server_errors = cloudwatch.Alarm(
+            self,
+            "ApiServerErrors",
+            metric=cloudwatch.Metric(
+                namespace="AWS/ApiGateway",
+                metric_name="5xx",
+                dimensions_map={"ApiId": api.api_id, "Stage": stage.stage_name},
+                statistic="Sum",
+                period=Duration.minutes(5),
+            ),
+            threshold=1,
+            evaluation_periods=1,
+            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        )
+        for alarm in (broker_errors, api_server_errors):
+            alarm.add_alarm_action(cloudwatch_actions.SnsAction(alarm_topic))
+
+        Tags.of(self).add("context", "github-app-identity")
+        CfnOutput(self, "BrokerUrl", value=f"{api.api_endpoint}/token")
+        CfnOutput(self, "PrivateKeySecretArn", value=private_key.secret_arn)
+
+    def _function(
+        self,
+        *,
+        app_id: str,
+        secret_arn: str,
+        log_group: logs.ILogGroup,
+        bundle_code: bool,
+    ) -> lambda_.Function:
+        role = iam.Role(
+            self,
+            "BrokerRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+        )
+        log_group.grant_write(role)
+        common: dict[str, object] = {
+            "runtime": lambda_.Runtime.PYTHON_3_14,
+            "architecture": lambda_.Architecture.X86_64,
+            "handler": "handler.handler",
+            "timeout": Duration.seconds(15),
+            "memory_size": 256,
+            "reserved_concurrent_executions": 5,
+            "environment": {
+                "GITHUB_APP_ID": app_id,
+                "APP_PRIVATE_KEY_SECRET_ARN": secret_arn,
+                "POWERTOOLS_SERVICE_NAME": "github-app-identity",
+                "POWERTOOLS_LOG_LEVEL": "INFO",
+            },
+            "log_group": log_group,
+            "logging_format": lambda_.LoggingFormat.JSON,
+            "application_log_level_v2": lambda_.ApplicationLogLevel.INFO,
+            "system_log_level_v2": lambda_.SystemLogLevel.WARN,
+            "role": role,
+        }
+        if bundle_code:
+            return PythonFunction(
+                self,
+                "Broker",
+                entry=str(SERVICE_ROOT),
+                index="handler.py",
+                bundling=BundlingOptions(
+                    asset_excludes=["__pycache__", "*.pyc", ".pytest_cache", ".venv"]
+                ),
+                **common,
+            )
+        return lambda_.Function(
+            self,
+            "Broker",
+            code=lambda_.Code.from_asset(str(SERVICE_ROOT)),
+            **common,
+        )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Install & run:
           - Install the CLI: how-to/install-the-cli.md
           - Use as a GitHub Action: how-to/use-as-github-action.md
+          - Post as lgtmaybe[bot]: how-to/post-as-a-github-app.md
       - Cloud providers (API key):
           - Review with OpenAI: how-to/review-with-openai.md
           - Review with Claude (Anthropic): how-to/review-with-anthropic.md

--- a/openspec/changes/add-lgtmaybe-app-identity/design.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/design.md
@@ -1,0 +1,129 @@
+## Context
+
+lgtmaybe is correctly implemented as a GitHub Action: the runner executes the
+review, repository secrets provide model credentials, and `GITHUB_TOKEN`
+provides repository access. The unavoidable consequence is that GitHub
+attributes every API write to `github-actions[bot]`.
+
+A public GitHub App named `lgtmaybe` already exists (App ID `3987976`) with no
+webhook subscriptions. The current working tree also contains an advanced
+`app_id`/`app_private_key` Action path and a dogfood workflow prepared to use
+it, but the App is not yet represented by repository variables or secrets.
+That path is suitable for the maintainer's own repository; distributing the
+App private key to users is not.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Attribute opted-in reviews and PR comments to `lgtmaybe[bot]`.
+- Keep review execution and all provider credentials inside GitHub Actions.
+- Give users a short installation flow with no App-development knowledge or
+  private-key handling.
+- Restrict every minted token to the requesting installed repository and the
+  minimum permissions lgtmaybe uses.
+- Make the identity boundary observable, revocable, and safe to dogfood.
+
+**Non-Goals:**
+
+- Turn lgtmaybe into a hosted review service.
+- Store provider keys, diffs, findings, repository contents, or user config.
+- Replace the zero-hosting `github-actions[bot]` path.
+- Add billing, persistent user accounts, or a GitHub App settings UI.
+- Trigger reviews from App webhooks; repository workflows remain the trigger.
+
+## Decisions
+
+1. **Keep a hybrid Action plus App architecture.** The Action remains the
+   product runtime; the App supplies only a branded GitHub identity. A fully
+   hosted App would make lgtmaybe responsible for customer model credentials
+   and compute, while an Action alone cannot change its API actor.
+
+2. **Exchange GitHub Actions OIDC for an installation token.** In branded mode
+   the Action requests a JWT with a fixed lgtmaybe audience and sends it to a
+   small HTTPS broker. The broker validates GitHub's issuer and JWKS signature,
+   audience, time claims, immutable `repository_id`/`repository_owner_id`,
+   repository name, default-branch workflow ref, and an allowlisted base-safe
+   event (`pull_request_target`, `issue_comment`, or
+   `pull_request_review_comment`). It then confirms that the App is installed
+   on that exact repository.
+
+3. **Mint the narrowest token GitHub permits.** The broker authenticates as the
+   lgtmaybe App, requests an installation token limited to the verified
+   repository ID, and narrows permissions to `contents: read`,
+   `pull_requests: write`, and `issues: write`. It never returns an
+   installation-wide token. The App registration drops its current
+   `contents: write` grant to `contents: read`. The public App deliberately
+   excludes `checks: write`; public branded mode rejects `fail_on` with setup
+   guidance instead of gaining permission to forge a required merge check.
+
+4. **Host the broker as a small Python AWS Lambda behind API Gateway.** The App
+   private key lives in AWS Secrets Manager and only the Lambda role can read
+   it. API Gateway supplies TLS and throttling; Lambda has explicit short
+   timeouts for GitHub JWKS and API calls. CDK Python provisions the isolated
+   stack. No database is required because GitHub is the installation source of
+   truth and both OIDC and installation tokens are short-lived.
+
+5. **Make identity selection explicit.** A `github_identity` Action input uses
+   `actions` by default and `lgtmaybe` for the broker path. Existing
+   `app_id`/`app_private_key` inputs remain an advanced self-managed option for
+   organisations that want their own App identity. Conflicting identity inputs
+   fail validation instead of choosing implicitly.
+
+6. **Never silently lose the requested identity.** `github_identity:
+   lgtmaybe` fails with an install link or a broker-specific diagnostic when
+   the App is missing or exchange fails. It does not fall back to
+   `github-actions[bot]`. The default `actions` mode never contacts the broker.
+
+7. **Keep tokens internal and short-lived.** The exchange response is masked,
+   passed only to the lgtmaybe container, never exposed as a public Action
+   output, and revoked in an `always()` cleanup step when possible. Natural
+   expiry remains the cancellation fallback. Neither raw OIDC JWTs nor
+   installation tokens are logged.
+
+8. **Teach the architecture through a two-path setup.** Marketplace, README,
+   and how-to content first explain that the Action does the work. Users then
+   choose either zero-install setup (`github-actions[bot]`) or install the
+   public App plus add `id-token: write` (`lgtmaybe[bot]`). Provider/model
+   configuration stays identical in both examples. Self-managed App creation
+   moves to an advanced section.
+
+9. **Dogfood before public rollout.** Install the existing App only on
+   `MattJColes/lgtmaybe`, temporarily store its ID/private key for the already
+   prepared direct path, and verify real review/reply/resolve/label behavior.
+   After broker deployment, switch the dogfood workflow to OIDC, verify the
+   actor again, and delete the repository-held private key.
+
+## Risks / Trade-offs
+
+- [The broker becomes an availability dependency for branded mode] -> Keep
+  Actions mode independent, retry only idempotent GitHub reads, and fail with a
+  clear status rather than retry token creation or post under the wrong actor.
+- [A broker compromise could mint App tokens] -> Store the key in Secrets
+  Manager, use a least-privilege Lambda role, validate immutable repository
+  claims, scope every token down, throttle requests, and support rapid key
+  rotation/revocation.
+- [An unsafe caller workflow could expose its token] -> Accept only base-safe
+  events/default-branch workflow refs, document `pull_request_target` plus
+  API-only diff access, mask the token, and revoke it after use.
+- [App permission changes can surprise existing installations] -> Reduce
+  permissions before public onboarding and show the exact grants in the guide.
+- [The existing working tree has overlapping unfinished App documentation] ->
+  implement against the resolved final files, preserve unrelated work, and use
+  the new acceptance tests to settle the intended copy.
+
+## Migration Plan
+
+1. Add failing broker, Action-input, workflow, and documentation acceptance
+   tests.
+2. Implement and deploy the broker to a non-public endpoint; configure the App
+   private key in Secrets Manager.
+3. Reduce the public App permissions, install it on `MattJColes/lgtmaybe`, and
+   exercise the existing direct private-key dogfood path.
+4. Switch the dogfood workflow to `github_identity: lgtmaybe` with
+   `id-token: write`; verify GitHub attributes real review operations to
+   `lgtmaybe[bot]`.
+5. Publish the install link and two-path setup, then remove the App private key
+   from the repository.
+6. Roll back by changing the dogfood workflow to `github_identity: actions`;
+   the Action-only product remains functional even if the broker is disabled.

--- a/openspec/changes/add-lgtmaybe-app-identity/proposal.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+lgtmaybe reviews currently post as `github-actions[bot]`, which hides the
+product identity and makes the public `lgtmaybe` GitHub App appear inert.
+Users need a clear, safe installation path that keeps model credentials in
+their workflow while attributing review activity to `lgtmaybe[bot]`.
+
+## What Changes
+
+- Keep the GitHub Action as the review runtime and workflow `with:` block as
+  the provider, model, and provider-authentication surface.
+- Make the public `lgtmaybe` GitHub App a thin identity and permissions layer:
+  users install it on selected repositories, then opt into branded posting in
+  their workflow.
+- Add a small hosted token broker that validates a GitHub Actions OIDC token,
+  confirms the matching App installation, and returns a short-lived,
+  repository-scoped installation token. The broker never receives diffs,
+  findings, or model credentials.
+- Update the Action to request and use the installation token when branded
+  posting is selected, while preserving `github-actions[bot]` as the
+  zero-hosting default.
+- Replace the current App-development guidance with a two-path onboarding
+  choice: basic Action setup or Action plus the installed lgtmaybe App.
+- Dogfood the branded path in `MattJColes/lgtmaybe`, first through the existing
+  private-key flow and then through the public broker flow.
+- Tighten the existing App registration to the minimum repository permissions
+  required by lgtmaybe.
+
+## Capabilities
+
+### New Capabilities
+
+- `github-app-identity`: Installation, OIDC exchange, token brokering,
+  least-privilege App permissions, failure behavior, and user onboarding for
+  posting as `lgtmaybe[bot]`.
+
+### Modified Capabilities
+
+- `github-posting`: Reviews and related PR activity can be attributed to the
+  installed lgtmaybe App instead of the built-in GitHub Actions App.
+- `cli-and-local`: The GitHub Action entrypoint gains an explicit identity mode
+  and obtains App credentials without exposing the App private key to users.
+
+## Impact
+
+The change affects `action.yml`, the dogfood and example workflows, GitHub
+authentication wiring, Marketplace/README/how-to documentation, and the public
+GitHub App registration. It introduces a small hosted security boundary for
+OIDC validation and installation-token minting plus its deployment and
+operational configuration. Review execution, provider routing, model
+credentials, local CLI behavior, and diff handling remain unchanged.

--- a/openspec/changes/add-lgtmaybe-app-identity/specs/cli-and-local/spec.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/specs/cli-and-local/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: The Action selects GitHub identity explicitly
+<!-- anchor: cli.github-identity -->
+
+The GitHub Action SHALL expose a typed identity choice whose default uses the
+built-in workflow token and whose lgtmaybe value performs the OIDC exchange
+before the existing Action entrypoint runs.
+
+#### Scenario: Identity input is omitted
+- **WHEN** a user runs the Action without a GitHub identity input
+- **THEN** the Action uses the supplied or default `github_token` exactly as before
+
+#### Scenario: lgtmaybe identity is selected
+- **WHEN** a user selects the lgtmaybe identity and grants `id-token: write`
+- **THEN** the Action obtains a brokered installation token without requiring App credentials in workflow secrets
+
+#### Scenario: Identity configuration conflicts
+- **WHEN** a workflow selects the public lgtmaybe identity and also supplies self-managed App credentials
+- **THEN** the Action fails before review execution with instructions to choose one identity path
+
+### Requirement: Branded setup remains provider-independent
+<!-- anchor: cli.github-identity-provider -->
+
+Selecting a GitHub posting identity SHALL NOT change provider, model, provider
+authentication, review configuration, or local CLI behavior.
+
+#### Scenario: User changes only identity mode
+- **WHEN** an existing Action workflow switches from Actions identity to lgtmaybe identity
+- **THEN** its provider and review inputs continue to reach the same runtime entrypoint unchanged

--- a/openspec/changes/add-lgtmaybe-app-identity/specs/github-app-identity/spec.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/specs/github-app-identity/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Installing the App opts a repository into branded identity
+<!-- anchor: github-app.install -->
+
+The public lgtmaybe GitHub App SHALL act only as an identity and
+least-privilege repository-access layer; review execution and provider
+credentials SHALL remain in the repository's GitHub Actions workflow.
+
+#### Scenario: User chooses branded posting
+- **WHEN** a repository administrator installs the lgtmaybe App on a repository and selects the lgtmaybe identity in its workflow
+- **THEN** review activity is eligible to post as `lgtmaybe[bot]` without an App private key in that repository
+
+#### Scenario: User keeps the zero-install path
+- **WHEN** a workflow keeps the default Actions identity
+- **THEN** lgtmaybe uses the built-in workflow token and does not contact the identity broker
+
+### Requirement: The broker trusts only the requesting installed repository
+<!-- anchor: github-app.exchange -->
+
+The token broker MUST verify the GitHub OIDC signature, issuer, audience,
+time, repository identity, default-branch workflow reference, and allowed
+event before checking that the lgtmaybe App is installed on that repository.
+
+#### Scenario: Valid workflow exchanges identity
+- **WHEN** an allowed base-safe workflow presents a valid OIDC token for a repository where the App is installed
+- **THEN** the broker returns a short-lived installation token limited to that exact repository
+
+#### Scenario: Untrusted identity is rejected
+- **WHEN** any required claim is invalid, the event is not allowed, or the App is not installed on the claimed repository
+- **THEN** the broker returns no GitHub credential and a non-secret diagnostic
+
+### Requirement: Installation tokens carry minimum permissions
+<!-- anchor: github-app.scope -->
+
+The App registration and every brokered token SHALL grant only repository
+contents read, pull requests write, issues write, and required metadata access.
+
+#### Scenario: Installation covers multiple repositories
+- **WHEN** the broker mints a token for one repository in a multi-repository installation
+- **THEN** the token is explicitly restricted to the verified repository ID and cannot access sibling repositories
+
+### Requirement: The broker is an identity-only data boundary
+<!-- anchor: github-app.boundary -->
+
+The broker MUST NOT receive or persist provider credentials, diffs, file
+contents, prompts, findings, or repository configuration, and MUST NOT log raw
+OIDC or installation tokens.
+
+#### Scenario: Action exchanges identity
+- **WHEN** the Action calls the broker
+- **THEN** it sends only the GitHub OIDC credential and protocol metadata needed to validate and complete the exchange
+
+### Requirement: Branded identity fails loud
+<!-- anchor: github-app.failure -->
+
+The Action SHALL NOT silently fall back to `github-actions[bot]` after a user
+explicitly selects the lgtmaybe identity.
+
+#### Scenario: Broker is unavailable
+- **WHEN** branded identity is selected and the bounded exchange cannot complete
+- **THEN** the Action fails with setup or service guidance before posting review output

--- a/openspec/changes/add-lgtmaybe-app-identity/specs/github-posting/spec.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/specs/github-posting/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: App-authenticated PR activity carries the lgtmaybe identity
+<!-- anchor: github.app-attribution -->
+
+The GitHub adapter SHALL use the selected credential uniformly for review
+comments, summary comments, slash-command replies, thread resolution, labels,
+descriptions, and diagrams so opted-in activity is attributable to the
+installed lgtmaybe App. Public branded mode SHALL reject `fail_on` because the
+least-privilege public App does not hold `checks: write`.
+
+#### Scenario: Branded review completes
+- **WHEN** the engine posts a review using a brokered lgtmaybe App installation token
+- **THEN** GitHub attributes every supported write in that run to `lgtmaybe[bot]`
+
+#### Scenario: Public branded review requests a merge gate
+- **WHEN** `github_identity` is `lgtmaybe` and `fail_on` is set
+- **THEN** the Action fails before token exchange with guidance to use Actions identity or a self-managed App
+
+#### Scenario: Default review completes
+- **WHEN** the engine posts a review using the built-in workflow token
+- **THEN** existing `github-actions[bot]` posting behavior remains unchanged

--- a/openspec/changes/add-lgtmaybe-app-identity/tasks.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/tasks.md
@@ -1,0 +1,45 @@
+## 1. Acceptance Tests
+
+- [x] 1.1 Add broker tests for valid exchange, invalid signature/issuer/audience/time claims, mutable-name mismatch, disallowed event, non-default workflow ref, missing installation, repository scoping, permission scoping, and secret-free logs; run them and confirm they fail.
+- [x] 1.2 Add Action metadata tests for the default Actions identity, explicit lgtmaybe identity, conflicting self-managed credentials, masked internal token handling, cleanup, and actionable failures; run them and confirm they fail.
+- [x] 1.3 Add documentation tests requiring the two setup paths, public App install link, `id-token: write`, unchanged provider inputs, permissions explanation, and no private key in the public branded example; run them and confirm they fail.
+
+## 2. Identity Broker
+
+- [x] 2.1 Add the isolated Python broker package with strict request/response models and explicit timeouts for every GitHub/JWKS call.
+- [x] 2.2 Implement GitHub OIDC verification for signature, issuer, fixed audience, time, immutable repository identity, repository name, default-branch workflow ref, and the allowlisted base-safe events.
+- [x] 2.3 Implement App installation lookup and mint a token restricted to the verified repository ID with only contents-read, pull-requests-write, and issues-write permissions.
+- [x] 2.4 Ensure responses and structured logs never contain raw OIDC JWTs, installation tokens, repository contents, or provider data; retry only safe GitHub reads and never retry token creation.
+- [x] 2.5 Add a Python CDK stack for API Gateway, throttled Lambda execution, Secrets Manager access, least-privilege IAM, alarms, and configurable App ID/private-key secret; add CDK assertion tests.
+- [ ] 2.6 Run the broker unit/integration tests and CDK synthesis/assertion tests, then deploy a maintainer-only endpoint and smoke-test valid and rejected exchanges.
+
+## 3. GitHub Action Identity
+
+- [x] 3.1 Add and validate the `github_identity` input (`actions` default, `lgtmaybe` broker mode) while retaining the existing App ID/private-key path as advanced self-managed authentication.
+- [x] 3.2 In lgtmaybe mode, request a GitHub OIDC token for the fixed audience, exchange it through the broker with explicit timeouts and no retry of token creation, mask the returned token, and pass it only to the existing container entrypoint.
+- [x] 3.3 Add an `always()` cleanup step that revokes the brokered installation token when the job reaches cleanup, without exposing it as an Action output.
+- [x] 3.4 Emit distinct actionable failures for missing `id-token: write`, missing App installation, invalid workflow provenance, broker unavailability, and conflicting identity inputs; never fall back after lgtmaybe mode is selected.
+- [x] 3.5 Run the focused Action, CLI entrypoint, workflow example, packaging, and security tests.
+
+## 4. App Registration and Dogfooding
+
+- [x] 4.1 Change the existing public App registration from contents-write to contents-read while retaining pull-requests-write, issues-write, metadata-read, and no webhook subscriptions.
+- [x] 4.2 Install the public App only on `MattJColes/lgtmaybe`, generate a temporary private key, set `LGTMAYBE_APP_ID=3987976`, and store the key as `LGTMAYBE_APP_PRIVATE_KEY` without writing it to the workspace or logs.
+- [x] 4.3 Run a real dogfood review through the existing private-key path and verify review comments, summaries, replies, resolutions, labels, descriptions, and diagrams use `lgtmaybe[bot]`.
+- [x] 4.4 Store the App private key in the broker's Secrets Manager secret, deploy the production broker, and switch the dogfood workflow to `github_identity: lgtmaybe` with `id-token: write`.
+- [ ] 4.5 Run a real brokered dogfood review, verify attribution and token cleanup, then delete `LGTMAYBE_APP_PRIVATE_KEY` and the no-longer-needed App ID variable from the repository.
+
+## 5. User Onboarding
+
+- [x] 5.1 Update `action.yml` Marketplace descriptions, README, and the primary GitHub Action guide to explain what the Action does, what the App does, and when users see `github-actions[bot]` versus `lgtmaybe[bot]`.
+- [x] 5.2 Rewrite the App how-to as a short public install flow: install on selected repositories, grant `id-token: write`, set `github_identity: lgtmaybe`, and keep provider/model/authentication inputs unchanged.
+- [x] 5.3 Update the App profile/homepage and add complete default, public branded, and advanced self-managed workflow examples with the exact permissions each path needs.
+- [x] 5.4 Document the identity broker's data boundary, availability behavior, token lifetime/scoping, App permissions, uninstall/revocation path, and troubleshooting messages.
+- [x] 5.5 Regenerate derived reference and `llms.txt` documentation, then run the documentation tests and strict MkDocs build.
+
+## 6. Specification and Release Verification
+
+- [x] 6.1 Add or update living-spec sections and ast-grep anchors for the implemented broker and Action identity boundaries; ensure every anchor resolves exactly once.
+- [x] 6.2 Run the full relevant test suite, formatters, linters, type checks, security checks, `uv run pytest tests/specs -q`, and OpenSpec validation.
+- [x] 6.3 Verify rollback by switching a test workflow to Actions identity and confirming it neither calls the broker nor changes existing review behavior.
+- [ ] 6.4 Publish the Action change, repeat the install guide from a clean test repository, and confirm a maintainer can reach `lgtmaybe[bot]` without receiving or creating an App private key.

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -44,6 +44,18 @@ cli.config:
       has: { field: name, regex: '^set_key$' }
     files: [src/lgtmaybe/config/**/*.py]
 
+cli.github-identity:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^validate$' }
+  files: [scripts/github-app-identity.py]
+
+cli.github-identity-provider:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^exchange$' }
+  files: [scripts/github-app-identity.py]
+
 cli.utf8-boundaries:
   rule:
     kind: function_definition

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -101,6 +101,31 @@ defaults; the default `.lgtmaybe.yml` probe stays lenient when absent.
 - **WHEN** `lgtmaybe config set` targets an API key
 - **THEN** it is refused; keys are read from env/flags at run time only
 
+### Requirement: The Action selects GitHub identity explicitly
+
+The GitHub Action SHALL default to the built-in workflow token and perform the
+public App OIDC exchange only when `github_identity: lgtmaybe` is selected,
+while retaining App ID/private-key inputs as an advanced self-managed path.
+<!-- anchor: cli.github-identity -->
+
+#### Scenario: Identity input is omitted
+- **WHEN** a user runs the Action without a GitHub identity input
+- **THEN** the supplied or default `github_token` is used exactly as before
+
+#### Scenario: Identity configuration conflicts
+- **WHEN** public lgtmaybe identity and self-managed App credentials are both set
+- **THEN** the Action fails before review execution and asks the user to choose one path
+
+### Requirement: Branded setup remains provider-independent
+
+Selecting a GitHub posting identity SHALL NOT change provider, model, provider
+authentication, review configuration, or local CLI behavior.
+<!-- anchor: cli.github-identity-provider -->
+
+#### Scenario: User changes only identity mode
+- **WHEN** an existing workflow switches from Actions identity to lgtmaybe identity
+- **THEN** all provider and review inputs reach the same runtime entrypoint unchanged
+
 ### Requirement: Text boundaries are deterministic across host locales
 
 The CLI, local git adapter, and configuration store SHALL read and write owned

--- a/openspec/specs/github-app-identity/anchors.yml
+++ b/openspec/specs/github-app-identity/anchors.yml
@@ -1,0 +1,37 @@
+github-app.install:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^main$' }
+  files: [scripts/github-app-identity.py]
+
+github-app.exchange:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^exchange$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^IdentityBroker$' }
+      stopBy: end
+  files: [services/github_app_identity/**/*.py]
+
+github-app.scope:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^create_token$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^HttpGitHubAppClient$' }
+      stopBy: end
+  files: [services/github_app_identity/**/*.py]
+
+github-app.boundary:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^handler$' }
+  files: [services/github_app_identity/**/*.py]
+
+github-app.failure:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_http_error_message$' }
+  files: [scripts/github-app-identity.py]

--- a/openspec/specs/github-app-identity/spec.md
+++ b/openspec/specs/github-app-identity/spec.md
@@ -1,0 +1,70 @@
+# github-app-identity Specification
+
+## Purpose
+
+The optional public GitHub App identity and its hosted token broker: repositories
+keep review execution and model credentials in GitHub Actions while GitHub
+writes can be attributed to `lgtmaybe[bot]`.
+
+## Requirements
+
+### Requirement: Installing the App opts into branded identity
+
+The public lgtmaybe GitHub App SHALL act only as an identity and
+least-privilege repository-access layer; review execution and provider
+credentials remain in the repository's workflow.
+<!-- anchor: github-app.install -->
+
+#### Scenario: User keeps the zero-install path
+- **WHEN** a workflow keeps the default Actions identity
+- **THEN** it uses the workflow token and does not contact the identity broker
+
+#### Scenario: User chooses branded posting
+- **WHEN** the App is installed and lgtmaybe identity is selected
+- **THEN** review activity can post as `lgtmaybe[bot]` without a repository App key
+
+### Requirement: The broker trusts only the installed repository
+
+The token broker MUST verify GitHub OIDC signature, issuer, audience, time,
+immutable repository identity, repository name, default-branch workflow
+reference, and an allowed event before accepting the installation.
+<!-- anchor: github-app.exchange -->
+
+#### Scenario: Valid workflow exchanges identity
+- **WHEN** an allowed workflow identifies an installed repository
+- **THEN** the broker returns a short-lived token limited to that repository
+
+#### Scenario: Untrusted identity is rejected
+- **WHEN** a required claim is invalid or the App is not installed
+- **THEN** the broker returns no credential and a non-secret diagnostic
+
+### Requirement: Installation tokens carry minimum permissions
+
+Every brokered token SHALL grant only contents read, pull requests write,
+issues write, and required metadata access on the verified repository.
+<!-- anchor: github-app.scope -->
+
+#### Scenario: Installation covers multiple repositories
+- **WHEN** one repository in that installation requests a token
+- **THEN** sibling repositories are excluded from the token
+
+### Requirement: The broker is an identity-only boundary
+
+The broker MUST NOT receive or persist provider credentials, diffs, file
+contents, prompts, findings, or repository configuration, and MUST NOT log raw
+OIDC or installation tokens.
+<!-- anchor: github-app.boundary -->
+
+#### Scenario: Action exchanges identity
+- **WHEN** the Action calls the broker
+- **THEN** it sends only its GitHub OIDC credential and protocol metadata
+
+### Requirement: Branded identity fails loud
+
+The Action SHALL NOT fall back to `github-actions[bot]` after a user explicitly
+selects lgtmaybe identity.
+<!-- anchor: github-app.failure -->
+
+#### Scenario: Broker is unavailable
+- **WHEN** the bounded exchange cannot complete
+- **THEN** the Action fails with setup or service guidance before posting

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -89,3 +89,13 @@ github.check-run:
       has: { field: name, regex: '^RestGitHubGateway$' }
       stopBy: end
   files: [src/lgtmaybe/github/**/*.py]
+
+github.app-attribution:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^__init__$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^RestGitHubGateway$' }
+      stopBy: end
+  files: [src/lgtmaybe/github/**/*.py]

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -144,3 +144,23 @@ approval state is never set. `fail_on` unset (default) creates no check run.
 #### Scenario: no finding meets the threshold
 - **WHEN** `fail_on` is set and no surviving finding reaches it
 - **THEN** the Check Run is created with conclusion `success`
+
+### Requirement: App-authenticated activity carries one identity
+
+The GitHub adapter SHALL use the selected credential uniformly for review and
+summary comments, slash-command replies, thread resolution, labels,
+descriptions, and diagrams. Public branded mode SHALL reject `fail_on` because
+the least-privilege public App does not hold `checks: write`.
+<!-- anchor: github.app-attribution -->
+
+#### Scenario: Branded review completes
+- **WHEN** a review uses a brokered lgtmaybe App installation token
+- **THEN** GitHub attributes every supported write in that run to `lgtmaybe[bot]`
+
+#### Scenario: Public branded review requests a merge gate
+- **WHEN** `github_identity` is `lgtmaybe` and `fail_on` is set
+- **THEN** the Action fails before token exchange with guidance to use Actions identity or a self-managed App
+
+#### Scenario: Default review completes
+- **WHEN** a review uses the built-in workflow token
+- **THEN** existing `github-actions[bot]` posting behavior remains unchanged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ static-analysis = [
     "bandit>=1.7",
     "semgrep>=1.60",
 ]
+# Hosted identity broker only; not installed by CLI or Action users.
+identity-broker = [
+    "aws-lambda-powertools>=3.23",
+    "httpx>=0.28.1",
+    "pyjwt[crypto]>=2.10",
+]
 
 [project.scripts]
 lgtmaybe = "lgtmaybe.cli:main"
@@ -57,6 +63,13 @@ Repository = "https://github.com/MattJColes/lgtmaybe"
 
 [dependency-groups]
 dev = [
+    "aws-cdk-lib>=2.261,<3",
+    "aws-cdk.aws-lambda-python-alpha>=2.261.0a0,<3",
+    "aws-lambda-powertools>=3.23",
+    "boto3>=1.34",
+    "cdk-nag>=2.36,<3",
+    "constructs>=10,<11",
+    "pyjwt[crypto]>=2.10",
     "pytest>=8",
     "ruff>=0.5",
     "mypy>=1.10",

--- a/scripts/check_spec_drift.py
+++ b/scripts/check_spec_drift.py
@@ -6,7 +6,8 @@ capability's anchors.yml sidecar. On a PR this script:
 
 1. scans the sidecar rules at HEAD and at the merge-base with the target branch
    (a temporary git worktree — the scan cwd matters: `files:` globs resolve
-   against it, so both scans run from a repo root targeting src/);
+   against it, so both scans run from a repo root targeting the anchored code
+   and workflow roots);
 2. flags DANGLING rules — matched at the base, match nothing now (a rename or
    removal nobody re-pointed; intersection alone goes blind here);
 3. flags DRIFT — a rule's match intersects the PR's changed lines while the diff
@@ -38,7 +39,7 @@ import yaml
 from lgtmaybe.core.diffparse import changed_line_index
 
 ANCHOR_RE = re.compile(r"^<!-- anchor: (?P<id>[a-z0-9.-]+) -->$")
-SCAN_TARGETS = ("src/", ".github/workflows/")
+SCAN_TARGETS = ("src/", "services/", "scripts/", ".github/workflows/")
 
 
 @dataclass(frozen=True)
@@ -137,17 +138,24 @@ def parse_scan_output(json_text: str) -> dict[str, list[Match]]:
 
 def run_scan(binary: str, inline_rules: str, cwd: Path) -> dict[str, list[Match]]:
     """Run ast-grep from *cwd* so each rule's files glob resolves consistently."""
-    result = subprocess.run(
-        [binary, "scan", "--inline-rules", inline_rules, "--json", *SCAN_TARGETS],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=True,
-        timeout=120,
-    )
-    return parse_scan_output(result.stdout)
+    matches: dict[str, list[Match]] = {}
+    with tempfile.TemporaryDirectory(prefix="lgtmaybe-anchor-rules-") as temp_dir:
+        for index, rule_text in enumerate(inline_rules.split("\n---\n")):
+            rule_path = Path(temp_dir) / f"{index}.yml"
+            rule_path.write_text(rule_text, encoding="utf-8", newline="\n")
+            result = subprocess.run(
+                [binary, "scan", "--rule", str(rule_path), "--json=compact", *SCAN_TARGETS],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=True,
+                timeout=120,
+            )
+            for rule_id, rule_matches in parse_scan_output(result.stdout).items():
+                matches.setdefault(rule_id, []).extend(rule_matches)
+    return matches
 
 
 def extract_sections(spec_md: str, spec_path: str) -> dict[str, SpecSection]:

--- a/scripts/github-app-identity.py
+++ b/scripts/github-app-identity.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Exchange a GitHub Actions OIDC token for a scoped lgtmaybe App token."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import IO, Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+OIDC_AUDIENCE = "https://lgtmaybe.coles.codes/github-app-identity"
+GITHUB_API_URL = "https://api.github.com"
+TIMEOUT_SECONDS = 10.0
+
+
+class IdentitySetupError(RuntimeError):
+    """A user-actionable GitHub identity configuration error."""
+
+
+Opener = Callable[[Request, float], Any]
+
+
+def validate(env: Mapping[str, str]) -> None:
+    identity = env.get("GITHUB_IDENTITY", "actions")
+    if identity not in {"actions", "lgtmaybe"}:
+        raise IdentitySetupError("github_identity must be either 'actions' or 'lgtmaybe'.")
+
+    app_id = env.get("APP_ID", "")
+    private_key = env.get("APP_PRIVATE_KEY", "")
+    if identity == "lgtmaybe" and (app_id or private_key):
+        raise IdentitySetupError(
+            "Choose either github_identity: lgtmaybe or app_id/app_private_key, not both."
+        )
+    if bool(app_id) != bool(private_key):
+        raise IdentitySetupError("app_id and app_private_key must be provided together.")
+    if identity == "lgtmaybe" and env.get("FAIL_ON"):
+        raise IdentitySetupError(
+            "github_identity: lgtmaybe cannot be combined with fail_on because the "
+            "public App intentionally has no Checks: write permission. Use "
+            "github_identity: actions or a self-managed App with Checks: write."
+        )
+
+
+def exchange(
+    env: Mapping[str, str],
+    *,
+    opener: Opener = urlopen,
+    stdout: IO[str] = sys.stdout,
+) -> None:
+    oidc_url = env.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+    oidc_request_token = env.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    if not oidc_url or not oidc_request_token:
+        raise IdentitySetupError(
+            "The lgtmaybe bot identity needs `permissions: id-token: write` in the workflow."
+        )
+
+    broker_url = env.get("IDENTITY_BROKER_URL")
+    output_path = env.get("GITHUB_OUTPUT")
+    if not broker_url or not output_path:
+        raise IdentitySetupError("The lgtmaybe identity exchange is not configured.")
+
+    try:
+        oidc_request = Request(
+            _with_audience(oidc_url),
+            headers={"Authorization": f"Bearer {oidc_request_token}"},
+        )
+        with opener(oidc_request, TIMEOUT_SECONDS) as response:
+            oidc_token = _json(response).get("value")
+        if not isinstance(oidc_token, str) or not oidc_token:
+            raise IdentitySetupError("GitHub did not return a workflow identity token.")
+
+        broker_request = Request(
+            broker_url,
+            data=b"",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {oidc_token}",
+                "Accept": "application/json",
+            },
+        )
+        with opener(broker_request, TIMEOUT_SECONDS) as response:
+            app_token = _json(response).get("token")
+        if not isinstance(app_token, str) or not app_token:
+            raise IdentitySetupError("The identity broker did not return an App token.")
+    except IdentitySetupError:
+        raise
+    except HTTPError as error:
+        raise IdentitySetupError(_http_error_message(error)) from error
+    except (URLError, OSError, ValueError, json.JSONDecodeError) as error:
+        raise IdentitySetupError(
+            "The lgtmaybe identity broker is unavailable. Retry the workflow shortly."
+        ) from error
+
+    stdout.write(f"::add-mask::{app_token}\n")
+    with Path(output_path).open("a", encoding="utf-8", newline="\n") as output:
+        output.write(f"token={app_token}\n")
+
+
+def revoke(
+    env: Mapping[str, str],
+    *,
+    opener: Opener = urlopen,
+    stdout: IO[str] = sys.stdout,
+) -> None:
+    token = env.get("LGTMAYBE_TOKEN")
+    if not token:
+        return
+
+    request = Request(
+        f"{GITHUB_API_URL}/installation/token",
+        method="DELETE",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with opener(request, TIMEOUT_SECONDS):
+            pass
+    except (HTTPError, URLError, OSError):
+        stdout.write(
+            "::warning::Could not revoke the temporary lgtmaybe App token; "
+            "GitHub will expire it automatically.\n"
+        )
+
+
+def _with_audience(url: str) -> str:
+    parts = urlsplit(url)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(("audience", OIDC_AUDIENCE))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+def _json(response: Any) -> dict[str, object]:
+    payload = json.loads(response.read())
+    if not isinstance(payload, dict):
+        raise ValueError("Expected a JSON object")
+    return payload
+
+
+def _http_error_message(error: HTTPError) -> str:
+    try:
+        payload = json.loads(error.read())
+        message = payload.get("message") if isinstance(payload, dict) else None
+        if isinstance(message, str) and message:
+            return message
+    except (OSError, ValueError, json.JSONDecodeError):
+        pass
+
+    if error.code == 401:
+        return "GitHub rejected the workflow identity. Check `permissions: id-token: write`."
+    return "The lgtmaybe identity broker rejected this workflow."
+
+
+def main(argv: list[str] | None = None, env: Mapping[str, str] = os.environ) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1 or args[0] not in {"validate", "exchange", "revoke"}:
+        print("usage: github-app-identity.py {validate|exchange|revoke}", file=sys.stderr)
+        return 2
+
+    try:
+        if args[0] == "validate":
+            validate(env)
+        elif args[0] == "exchange":
+            exchange(env)
+        else:
+            revoke(env)
+    except IdentitySetupError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/github_app_identity/__init__.py
+++ b/services/github_app_identity/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub App identity token broker."""

--- a/services/github_app_identity/broker.py
+++ b/services/github_app_identity/broker.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+import httpx
+import jwt
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+OIDC_AUDIENCE = "https://lgtmaybe.coles.codes/github-app-identity"
+OIDC_JWKS_URL = f"{OIDC_ISSUER}/.well-known/jwks"
+INSTALL_URL = "https://github.com/apps/lgtmaybe/installations/new"
+GITHUB_API = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+ALLOWED_EVENTS = frozenset({"pull_request_target", "issue_comment", "pull_request_review_comment"})
+TOKEN_PERMISSIONS = {
+    "contents": "read",
+    "pull_requests": "write",
+    "issues": "write",
+}
+HTTP_TIMEOUT = httpx.Timeout(5.0)
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerError(ValueError):
+    def __init__(self, code: str, status_code: int, message: str):
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+@dataclass(frozen=True, slots=True)
+class InstallationToken:
+    token: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubRepository:
+    id: int
+    full_name: str
+    owner_id: int
+    default_branch: str
+
+
+@dataclass(frozen=True, slots=True)
+class OidcClaims:
+    repository: str
+    repository_id: int
+    repository_owner_id: int
+    event_name: str
+    workflow_ref: str
+    jti: str
+
+    @classmethod
+    def parse(cls, raw: Mapping[str, object]) -> OidcClaims:
+        try:
+            repository = _required_string(raw, "repository")
+            return cls(
+                repository=repository,
+                repository_id=_required_integer(raw, "repository_id"),
+                repository_owner_id=_required_integer(raw, "repository_owner_id"),
+                event_name=_required_string(raw, "event_name"),
+                workflow_ref=_required_string(raw, "workflow_ref"),
+                jti=_required_string(raw, "jti"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerError(
+                "invalid_oidc",
+                401,
+                "GitHub OIDC token is missing required repository or workflow claims.",
+            ) from exc
+
+
+class OidcVerifier(Protocol):
+    def verify(self, token: str) -> Mapping[str, object]: ...
+
+
+class GitHubClient(Protocol):
+    def find_installation(self, full_name: str) -> int: ...
+
+    def create_token(
+        self,
+        installation_id: int,
+        repository_id: int,
+        permissions: dict[str, str],
+    ) -> InstallationToken: ...
+
+    def get_repository(self, full_name: str, token: str) -> GitHubRepository: ...
+
+    def revoke_token(self, token: str) -> None: ...
+
+
+class JwksClient(Protocol):
+    def get_signing_key_from_jwt(self, token: str) -> Any: ...
+
+
+class PyJwtOidcVerifier:
+    def __init__(self, jwks_client: JwksClient | None = None):
+        self._jwks_client = jwks_client or jwt.PyJWKClient(OIDC_JWKS_URL, timeout=5.0)
+
+    def verify(self, token: str) -> Mapping[str, object]:
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=OIDC_AUDIENCE,
+                issuer=OIDC_ISSUER,
+                options={
+                    "require": [
+                        "exp",
+                        "iat",
+                        "nbf",
+                        "jti",
+                        "repository",
+                        "repository_id",
+                        "repository_owner_id",
+                        "event_name",
+                        "workflow_ref",
+                    ]
+                },
+            )
+        except (jwt.PyJWKClientError, jwt.InvalidTokenError) as exc:
+            raise BrokerError(
+                "invalid_oidc",
+                401,
+                "GitHub OIDC token was rejected. Check `id-token: write` and workflow origin.",
+            ) from exc
+        if not isinstance(claims, dict):
+            raise BrokerError("invalid_oidc", 401, "GitHub OIDC token payload is invalid.")
+        return claims
+
+
+class IdentityBroker:
+    def __init__(self, verifier: OidcVerifier, github: GitHubClient):
+        self._verifier = verifier
+        self._github = github
+
+    def exchange(self, oidc_token: str) -> InstallationToken:
+        claims = OidcClaims.parse(self._verifier.verify(oidc_token))
+        self._validate_pre_mint(claims)
+
+        installation_id = self._github.find_installation(claims.repository)
+        token = self._github.create_token(
+            installation_id,
+            claims.repository_id,
+            TOKEN_PERMISSIONS.copy(),
+        )
+        try:
+            repository = self._github.get_repository(claims.repository, token.token)
+            self._validate_repository(claims, repository)
+        except Exception:
+            self._revoke_after_rejection(token.token)
+            raise
+
+        logger.info(
+            "GitHub App identity exchanged repository_id=%s event=%s",
+            repository.id,
+            claims.event_name,
+        )
+        return token
+
+    @staticmethod
+    def _validate_pre_mint(claims: OidcClaims) -> None:
+        workflow_prefix = f"{claims.repository}/.github/workflows/"
+        if claims.event_name not in ALLOWED_EVENTS or not claims.workflow_ref.startswith(
+            workflow_prefix
+        ):
+            raise BrokerError(
+                "untrusted_workflow",
+                403,
+                "Branded identity is limited to a default-branch lgtmaybe workflow "
+                "triggered by pull_request_target or a PR comment.",
+            )
+
+    @staticmethod
+    def _validate_repository(claims: OidcClaims, repository: GitHubRepository) -> None:
+        expected_ref = f"@refs/heads/{repository.default_branch}"
+        if (
+            repository.id != claims.repository_id
+            or repository.owner_id != claims.repository_owner_id
+            or repository.full_name.casefold() != claims.repository.casefold()
+        ):
+            raise BrokerError(
+                "repository_mismatch",
+                403,
+                "GitHub repository identity no longer matches the signed workflow identity.",
+            )
+        if not claims.workflow_ref.endswith(expected_ref):
+            raise BrokerError(
+                "untrusted_workflow",
+                403,
+                "The lgtmaybe identity exchange must run from the repository's default branch.",
+            )
+
+    def _revoke_after_rejection(self, token: str) -> None:
+        try:
+            self._github.revoke_token(token)
+        except Exception:
+            logger.warning("Failed to revoke a rejected installation token", exc_info=True)
+
+
+class _RetryableGitHubRead(RuntimeError):
+    pass
+
+
+class HttpGitHubAppClient:
+    def __init__(
+        self,
+        app_id: int,
+        private_key: str,
+        *,
+        client: httpx.Client | None = None,
+        now: Callable[[], datetime] | None = None,
+    ):
+        self._app_id = app_id
+        self._private_key = private_key
+        self._client = client or httpx.Client(timeout=HTTP_TIMEOUT)
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def find_installation(self, full_name: str) -> int:
+        response = self._get(
+            f"/repos/{full_name}/installation",
+            token=self._app_jwt(),
+        )
+        if response.status_code == 404:
+            raise BrokerError(
+                "app_not_installed",
+                404,
+                f"Install the lgtmaybe GitHub App on this repository: {INSTALL_URL}",
+            )
+        _raise_github_error(response, "Could not verify the lgtmaybe App installation.")
+        return _json_integer(response, "id")
+
+    def create_token(
+        self,
+        installation_id: int,
+        repository_id: int,
+        permissions: dict[str, str],
+    ) -> InstallationToken:
+        response = self._request(
+            "POST",
+            f"/app/installations/{installation_id}/access_tokens",
+            token=self._app_jwt(),
+            json={"repository_ids": [repository_id], "permissions": permissions},
+        )
+        _raise_github_error(response, "Could not create a scoped GitHub App token.")
+        payload = _json_object(response)
+        raw_token = payload.get("token")
+        raw_expiry = payload.get("expires_at")
+        if not isinstance(raw_token, str) or not isinstance(raw_expiry, str):
+            raise BrokerError("github_response", 502, "GitHub returned an invalid token response.")
+        return InstallationToken(
+            token=raw_token,
+            expires_at=datetime.fromisoformat(raw_expiry.replace("Z", "+00:00")),
+        )
+
+    def get_repository(self, full_name: str, token: str) -> GitHubRepository:
+        response = self._get(f"/repos/{full_name}", token=token)
+        _raise_github_error(response, "Could not verify repository identity.")
+        payload = _json_object(response)
+        owner = payload.get("owner")
+        if not isinstance(owner, dict):
+            raise BrokerError("github_response", 502, "GitHub returned invalid repository data.")
+        try:
+            return GitHubRepository(
+                id=int(payload["id"]),
+                full_name=str(payload["full_name"]),
+                owner_id=int(owner["id"]),
+                default_branch=str(payload["default_branch"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerError(
+                "github_response", 502, "GitHub returned invalid repository data."
+            ) from exc
+
+    def revoke_token(self, token: str) -> None:
+        response = self._request("DELETE", "/installation/token", token=token)
+        if response.status_code != 204:
+            _raise_github_error(response, "Could not revoke the GitHub App token.")
+
+    @retry(
+        retry=retry_if_exception_type((httpx.TransportError, _RetryableGitHubRead)),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential_jitter(initial=0.1, max=1.0),
+        reraise=True,
+    )
+    def _get(self, path: str, *, token: str) -> httpx.Response:
+        response = self._request("GET", path, token=token)
+        if response.status_code >= 500:
+            raise _RetryableGitHubRead(f"GitHub read returned {response.status_code}")
+        return response
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str,
+        json: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        return self._client.request(
+            method,
+            f"{GITHUB_API}{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            },
+            json=json,
+            timeout=HTTP_TIMEOUT,
+        )
+
+    def _app_jwt(self) -> str:
+        now = self._now()
+        return jwt.encode(
+            {
+                "iat": int((now - timedelta(seconds=60)).timestamp()),
+                "exp": int((now + timedelta(minutes=9)).timestamp()),
+                "iss": str(self._app_id),
+            },
+            self._private_key,
+            algorithm="RS256",
+        )
+
+
+def _required_string(raw: Mapping[str, object], key: str) -> str:
+    value = raw[key]
+    if not isinstance(value, str) or not value:
+        raise TypeError(key)
+    return value
+
+
+def _required_integer(raw: Mapping[str, object], key: str) -> int:
+    value = _required_string(raw, key)
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(key)
+    return parsed
+
+
+def _json_object(response: httpx.Response) -> dict[str, object]:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise BrokerError("github_response", 502, "GitHub returned invalid JSON.") from exc
+    if not isinstance(payload, dict):
+        raise BrokerError("github_response", 502, "GitHub returned invalid JSON.")
+    return payload
+
+
+def _json_integer(response: httpx.Response, key: str) -> int:
+    try:
+        return int(_json_object(response)[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise BrokerError("github_response", 502, "GitHub returned invalid identity data.") from exc
+
+
+def _raise_github_error(response: httpx.Response, message: str) -> None:
+    if response.is_success:
+        return
+    status_code = 503 if response.status_code >= 500 else 502
+    raise BrokerError("github_api", status_code, message)

--- a/services/github_app_identity/handler.py
+++ b/services/github_app_identity/handler.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import boto3
+from aws_lambda_powertools import Logger
+from services.github_app_identity.broker import (
+    BrokerError,
+    HttpGitHubAppClient,
+    IdentityBroker,
+    PyJwtOidcVerifier,
+)
+
+logger = Logger(service="github-app-identity")
+_broker: IdentityBroker | None = None
+
+
+def handler(event: dict[str, Any], context: object) -> dict[str, object]:
+    del context
+    try:
+        token = _bearer_token(event)
+        result = _get_broker().exchange(token)
+    except BrokerError as exc:
+        logger.warning("Identity exchange rejected", code=exc.code, status=exc.status_code)
+        return _response(exc.status_code, {"code": exc.code, "message": str(exc)})
+    except Exception:
+        logger.exception("Identity exchange failed")
+        return _response(
+            503,
+            {
+                "code": "broker_unavailable",
+                "message": "lgtmaybe identity service is unavailable; retry the workflow later.",
+            },
+        )
+
+    return _response(
+        200,
+        {
+            "token": result.token,
+            "expires_at": result.expires_at.isoformat().replace("+00:00", "Z"),
+        },
+    )
+
+
+def _bearer_token(event: dict[str, Any]) -> str:
+    headers = event.get("headers")
+    if not isinstance(headers, dict):
+        raise BrokerError("invalid_request", 401, "Authorization bearer token is required.")
+    authorization = next(
+        (
+            value
+            for key, value in headers.items()
+            if isinstance(key, str) and key.casefold() == "authorization"
+        ),
+        None,
+    )
+    if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+        raise BrokerError("invalid_request", 401, "Authorization bearer token is required.")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not token:
+        raise BrokerError("invalid_request", 401, "Authorization bearer token is required.")
+    return token
+
+
+def _get_broker() -> IdentityBroker:
+    global _broker
+    if _broker is None:
+        app_id = int(os.environ["GITHUB_APP_ID"])
+        secret_arn = os.environ["APP_PRIVATE_KEY_SECRET_ARN"]
+        secret = boto3.client("secretsmanager").get_secret_value(SecretId=secret_arn)
+        private_key = _private_key(secret)
+        _broker = IdentityBroker(
+            PyJwtOidcVerifier(),
+            HttpGitHubAppClient(app_id, private_key),
+        )
+    return _broker
+
+
+def _private_key(secret: dict[str, Any]) -> str:
+    raw = secret.get("SecretString")
+    if not isinstance(raw, str) or not raw:
+        raise RuntimeError("GitHub App private-key secret is empty")
+    if raw.lstrip().startswith("{"):
+        payload = json.loads(raw)
+        raw = payload.get("private_key")
+    if not isinstance(raw, str) or "PRIVATE KEY" not in raw:
+        raise RuntimeError("GitHub App private-key secret is invalid")
+    return raw
+
+
+def _response(status_code: int, body: dict[str, object]) -> dict[str, object]:
+    return {
+        "statusCode": status_code,
+        "headers": {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+            "x-content-type-options": "nosniff",
+        },
+        "body": json.dumps(body, separators=(",", ":")),
+    }

--- a/services/github_app_identity/pyproject.toml
+++ b/services/github_app_identity/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "lgtmaybe-github-app-identity"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "aws-lambda-powertools>=3.23",
+    "boto3>=1.34",
+    "httpx>=0.28.1",
+    "pyjwt[crypto]>=2.10",
+    "tenacity>=9.1.4",
+]
+
+[tool.uv]
+package = false

--- a/services/github_app_identity/uv.lock
+++ b/services/github_app_identity/uv.lock
@@ -1,0 +1,360 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "aws-lambda-powertools"
+version = "3.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/77/8c74a558facb8bebdc6f3f0096ff5735b779d57c7bbdb7948f3e6d873504/aws_lambda_powertools-3.31.1.tar.gz", hash = "sha256:b46e575c7e290c55fe81ae4a38d8b5c91238242a4644438f8b858ce535a4125c", size = 800496, upload-time = "2026-07-13T09:22:11.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/e1/67a119333cb3656b9b482a77bb4b25e0488ca969218b71479b4ecfc1a5e1/aws_lambda_powertools-3.31.1-py3-none-any.whl", hash = "sha256:cd03f824bc11b59df727744fa9a419a01772d85fd0b15a67eee07f5472b37c77", size = 957593, upload-time = "2026-07-13T09:22:09.354Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/05/23e1aa8c9e4b0399a61e7fd65c4f9cc0625121f24760e37471f776404abb/boto3-1.43.56.tar.gz", hash = "sha256:57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4", size = 112673, upload-time = "2026-07-24T19:31:48.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/57/3a960c9f581c00f2a591901b46e035ff79ab3956d16607f12306b3b8d483/boto3-1.43.56-py3-none-any.whl", hash = "sha256:feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b", size = 140026, upload-time = "2026-07-24T19:31:47.155Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/cc/7f84a5d3071fe878380e9f610ab36ca87b8cbbc4aa81ba2727f90e1f3ea3/botocore-1.43.56.tar.gz", hash = "sha256:6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57", size = 15733117, upload-time = "2026-07-24T19:31:38.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl", hash = "sha256:aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976", size = 15418773, upload-time = "2026-07-24T19:31:34.758Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "lgtmaybe-github-app-identity"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "aws-lambda-powertools" },
+    { name = "boto3" },
+    { name = "httpx" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "tenacity" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aws-lambda-powertools", specifier = ">=3.23" },
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
+    { name = "tenacity", specifier = ">=9.1.4" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/tests/docs/test_github_app_identity.py
+++ b/tests/docs/test_github_app_identity.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+README = ROOT / "README.md"
+ACTION_GUIDE = ROOT / "docs" / "how-to" / "use-as-github-action.md"
+APP_GUIDE = ROOT / "docs" / "how-to" / "post-as-a-github-app.md"
+RELEASING_GUIDE = ROOT / "docs" / "how-to" / "releasing.md"
+
+
+def _public_app_example() -> str:
+    guide = APP_GUIDE.read_text(encoding="utf-8")
+    return guide.split("## Install the public lgtmaybe App", 1)[1].split(
+        "## Use your own GitHub App", 1
+    )[0]
+
+
+def test_docs_present_action_only_and_lgtmaybe_bot_paths() -> None:
+    combined = "\n".join(
+        path.read_text(encoding="utf-8") for path in (README, ACTION_GUIDE, APP_GUIDE)
+    )
+
+    assert "github-actions[bot]" in combined
+    assert "lgtmaybe[bot]" in combined
+    assert "https://github.com/apps/lgtmaybe/installations/new" in combined
+
+
+def test_public_app_example_needs_oidc_but_no_private_key() -> None:
+    example = _public_app_example()
+
+    assert "id-token: write" in example
+    assert "github_identity: lgtmaybe" in example
+    assert "app_private_key" not in example
+    assert "LGTMAYBE_APP_PRIVATE_KEY" not in example
+
+
+def test_identity_choice_does_not_replace_provider_configuration() -> None:
+    example = _public_app_example()
+
+    for setting in ("provider:", "model:", "api_key:"):
+        assert setting in example
+
+
+def test_docs_explain_permissions_privacy_failure_and_uninstall() -> None:
+    guide = APP_GUIDE.read_text(encoding="utf-8").casefold()
+
+    for phrase in (
+        "contents: read",
+        "pull requests: write",
+        "issues: write",
+        "cannot be combined with `fail_on`",
+        "never receives your diff",
+        "does not fall back",
+        "uninstall",
+    ):
+        assert phrase in guide
+
+    assert not re.search(r"copy (?:our|the lgtmaybe) private key", guide)
+
+
+def test_maintainer_docs_explain_safe_private_key_rotation() -> None:
+    guide = RELEASING_GUIDE.read_text(encoding="utf-8").casefold()
+    rotation = guide.split("## rotate the public app private key", 1)[1]
+
+    assert rotation.index("generate a new private key") < rotation.index("delete the old key")
+    assert "lgtmaybe/github-app/private-key" in rotation
+    assert "update-function-configuration" in rotation
+    assert "smoke" in rotation

--- a/tests/identity/test_action_script.py
+++ b/tests/identity/test_action_script.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request
+
+import pytest
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "github-app-identity.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("github_app_identity_script", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Response:
+    def __init__(self, payload: dict[str, object], status: int = 200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
+def test_validation_accepts_default_actions_identity() -> None:
+    module = _module()
+
+    module.validate({"GITHUB_IDENTITY": "actions", "APP_ID": "", "APP_PRIVATE_KEY": ""})
+
+
+def test_validation_rejects_public_and_self_managed_identity_together() -> None:
+    module = _module()
+
+    with pytest.raises(module.IdentitySetupError, match="Choose either"):
+        module.validate(
+            {
+                "GITHUB_IDENTITY": "lgtmaybe",
+                "APP_ID": "123",
+                "APP_PRIVATE_KEY": "secret",
+            }
+        )
+
+
+def test_validation_rejects_public_identity_for_check_runs() -> None:
+    module = _module()
+
+    with pytest.raises(module.IdentitySetupError, match="Checks: write"):
+        module.validate(
+            {
+                "GITHUB_IDENTITY": "lgtmaybe",
+                "APP_ID": "",
+                "APP_PRIVATE_KEY": "",
+                "FAIL_ON": "high",
+            }
+        )
+
+
+def test_exchange_requests_oidc_and_masks_the_brokered_token(tmp_path: Path) -> None:
+    module = _module()
+    requests: list[Request] = []
+
+    def open_request(request: Request, timeout: float):
+        requests.append(request)
+        assert timeout == 10.0
+        if len(requests) == 1:
+            return Response({"value": "oidc-token"})
+        return Response({"token": "ghs_scoped", "expires_at": "2026-07-25T10:00:00Z"})
+
+    output = tmp_path / "github-output"
+    stdout = io.StringIO()
+    module.exchange(
+        {
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token?x=1",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+            "IDENTITY_BROKER_URL": "https://identity.example/token",
+            "GITHUB_OUTPUT": str(output),
+        },
+        opener=open_request,
+        stdout=stdout,
+    )
+
+    assert requests[0].full_url.endswith(
+        "&audience=https%3A%2F%2Flgtmaybe.coles.codes%2Fgithub-app-identity"
+    )
+    assert requests[0].headers["Authorization"] == "Bearer request-token"
+    assert requests[1].method == "POST"
+    assert requests[1].headers["Authorization"] == "Bearer oidc-token"
+    assert output.read_text(encoding="utf-8") == "token=ghs_scoped\n"
+    assert stdout.getvalue() == "::add-mask::ghs_scoped\n"
+
+
+def test_exchange_explains_missing_id_token_permission() -> None:
+    module = _module()
+
+    with pytest.raises(module.IdentitySetupError, match="id-token: write"):
+        module.exchange(
+            {"IDENTITY_BROKER_URL": "https://identity.example/token"},
+            opener=lambda request, timeout: Response({}),
+            stdout=io.StringIO(),
+        )
+
+
+def test_exchange_preserves_the_broker_setup_message() -> None:
+    module = _module()
+    error = HTTPError(
+        "https://identity.example/token",
+        404,
+        "Not Found",
+        {},
+        io.BytesIO(
+            json.dumps(
+                {
+                    "code": "app_not_installed",
+                    "message": "Install the lgtmaybe GitHub App.",
+                }
+            ).encode()
+        ),
+    )
+    calls = 0
+
+    def open_request(request: Request, timeout: float):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return Response({"value": "oidc-token"})
+        raise error
+
+    with pytest.raises(module.IdentitySetupError, match="Install the lgtmaybe GitHub App"):
+        module.exchange(
+            {
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token?x=1",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "IDENTITY_BROKER_URL": "https://identity.example/token",
+                "GITHUB_OUTPUT": "unused",
+            },
+            opener=open_request,
+            stdout=io.StringIO(),
+        )
+
+
+def test_revoke_is_best_effort_and_never_prints_the_token() -> None:
+    module = _module()
+    request_seen: list[Request] = []
+    stdout = io.StringIO()
+
+    def open_request(request: Request, timeout: float):
+        request_seen.append(request)
+        return Response({}, status=204)
+
+    module.revoke(
+        {"LGTMAYBE_TOKEN": "ghs_scoped"},
+        opener=open_request,
+        stdout=stdout,
+    )
+
+    assert request_seen[0].method == "DELETE"
+    assert request_seen[0].headers["Authorization"] == "Bearer ghs_scoped"
+    assert "ghs_scoped" not in stdout.getvalue()

--- a/tests/identity/test_broker.py
+++ b/tests/identity/test_broker.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from services.github_app_identity.broker import (
+    BrokerError,
+    GitHubRepository,
+    IdentityBroker,
+    InstallationToken,
+)
+
+REPOSITORY = GitHubRepository(
+    id=456,
+    full_name="octo-org/octo-repo",
+    owner_id=123,
+    default_branch="main",
+)
+
+
+def _claims(**overrides: object) -> dict[str, object]:
+    claims: dict[str, object] = {
+        "repository": REPOSITORY.full_name,
+        "repository_id": str(REPOSITORY.id),
+        "repository_owner_id": str(REPOSITORY.owner_id),
+        "event_name": "pull_request_target",
+        "workflow_ref": f"{REPOSITORY.full_name}/.github/workflows/lgtmaybe.yml@refs/heads/main",
+        "jti": "oidc-request-1",
+    }
+    claims.update(overrides)
+    return claims
+
+
+class FakeVerifier:
+    def __init__(self, claims: dict[str, object] | None = None, error: BrokerError | None = None):
+        self.claims = claims or _claims()
+        self.error = error
+
+    def verify(self, token: str) -> dict[str, object]:
+        assert token == "oidc-token"
+        if self.error:
+            raise self.error
+        return self.claims
+
+
+class FakeGitHub:
+    def __init__(
+        self,
+        repository: GitHubRepository = REPOSITORY,
+        installation_id: int | None = 789,
+    ):
+        self.repository = repository
+        self.installation_id = installation_id
+        self.created_for: tuple[int, int, dict[str, str]] | None = None
+        self.revoked: list[str] = []
+
+    def find_installation(self, full_name: str) -> int:
+        assert full_name
+        if self.installation_id is None:
+            raise BrokerError("app_not_installed", 404, "Install the lgtmaybe GitHub App.")
+        return self.installation_id
+
+    def create_token(
+        self,
+        installation_id: int,
+        repository_id: int,
+        permissions: dict[str, str],
+    ) -> InstallationToken:
+        self.created_for = (installation_id, repository_id, permissions)
+        return InstallationToken(
+            token="ghs_installation_token",
+            expires_at=datetime.now(UTC) + timedelta(minutes=55),
+        )
+
+    def get_repository(self, full_name: str, token: str) -> GitHubRepository:
+        assert full_name
+        assert token == "ghs_installation_token"
+        return self.repository
+
+    def revoke_token(self, token: str) -> None:
+        self.revoked.append(token)
+
+
+def _broker(
+    *,
+    claims: dict[str, object] | None = None,
+    verifier_error: BrokerError | None = None,
+    github: FakeGitHub | None = None,
+) -> tuple[IdentityBroker, FakeGitHub]:
+    client = github or FakeGitHub()
+    return IdentityBroker(FakeVerifier(claims, verifier_error), client), client
+
+
+def test_valid_exchange_is_scoped_to_the_verified_repository() -> None:
+    broker, github = _broker()
+
+    result = broker.exchange("oidc-token")
+
+    assert result.token == "ghs_installation_token"
+    assert github.created_for == (
+        789,
+        REPOSITORY.id,
+        {"contents": "read", "pull_requests": "write", "issues": "write"},
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["invalid_signature", "invalid_issuer", "invalid_audience", "expired", "not_yet_valid"],
+)
+def test_invalid_standard_oidc_claims_are_rejected(reason: str) -> None:
+    error = BrokerError("invalid_oidc", 401, f"OIDC token rejected: {reason}")
+    broker, github = _broker(verifier_error=error)
+
+    with pytest.raises(BrokerError, match="OIDC token rejected") as raised:
+        broker.exchange("oidc-token")
+
+    assert raised.value.code == "invalid_oidc"
+    assert github.created_for is None
+
+
+@pytest.mark.parametrize("event_name", ["pull_request", "push", "workflow_dispatch"])
+def test_non_base_safe_event_is_rejected(event_name: str) -> None:
+    broker, github = _broker(claims=_claims(event_name=event_name))
+
+    with pytest.raises(BrokerError) as raised:
+        broker.exchange("oidc-token")
+
+    assert raised.value.code == "untrusted_workflow"
+    assert github.created_for is None
+
+
+def test_non_default_branch_workflow_is_rejected_and_token_revoked() -> None:
+    broker, github = _broker(
+        claims=_claims(
+            workflow_ref=f"{REPOSITORY.full_name}/.github/workflows/lgtmaybe.yml@refs/heads/dev"
+        )
+    )
+
+    with pytest.raises(BrokerError) as raised:
+        broker.exchange("oidc-token")
+
+    assert raised.value.code == "untrusted_workflow"
+    assert github.revoked == ["ghs_installation_token"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("repository", "renamed-org/octo-repo"),
+        ("repository_id", "999"),
+        ("repository_owner_id", "999"),
+    ],
+)
+def test_mutable_repository_mismatch_is_rejected_and_token_revoked(field: str, value: str) -> None:
+    overrides: dict[str, object] = {field: value}
+    if field == "repository":
+        overrides["workflow_ref"] = f"{value}/.github/workflows/lgtmaybe.yml@refs/heads/main"
+    broker, github = _broker(claims=_claims(**overrides))
+
+    with pytest.raises(BrokerError) as raised:
+        broker.exchange("oidc-token")
+
+    assert raised.value.code == "repository_mismatch"
+    assert github.revoked == ["ghs_installation_token"]
+
+
+def test_missing_installation_returns_actionable_error() -> None:
+    broker, github = _broker(github=FakeGitHub(installation_id=None))
+
+    with pytest.raises(BrokerError, match="Install the lgtmaybe GitHub App") as raised:
+        broker.exchange("oidc-token")
+
+    assert raised.value.code == "app_not_installed"
+    assert github.created_for is None
+
+
+def test_logs_contain_identity_metadata_but_no_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    broker, _ = _broker()
+
+    with caplog.at_level(logging.INFO):
+        broker.exchange("oidc-token")
+
+    log_output = caplog.text
+    assert "456" in log_output
+    assert "oidc-token" not in log_output
+    assert "ghs_installation_token" not in log_output

--- a/tests/identity/test_github_client.py
+++ b/tests/identity/test_github_client.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from services.github_app_identity.broker import (
+    TOKEN_PERMISSIONS,
+    BrokerError,
+    HttpGitHubAppClient,
+)
+
+
+def _private_key() -> tuple[str, object]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return pem, key.public_key()
+
+
+def test_client_mints_a_repository_and_permission_scoped_token() -> None:
+    private_key, public_key = _private_key()
+    requests: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/installation"):
+            app_jwt = request.headers["Authorization"].removeprefix("Bearer ")
+            claims = jwt.decode(
+                app_jwt,
+                public_key,
+                algorithms=["RS256"],
+                options={"verify_exp": False, "verify_iat": False},
+            )
+            assert claims["iss"] == "3987976"
+            return httpx.Response(200, json={"id": 789})
+        if request.url.path.endswith("/access_tokens"):
+            assert json.loads(request.content) == {
+                "repository_ids": [456],
+                "permissions": TOKEN_PERMISSIONS,
+            }
+            return httpx.Response(
+                201,
+                json={"token": "ghs_scoped", "expires_at": "2026-07-25T10:00:00Z"},
+            )
+        if request.url.path == "/repos/octo-org/octo-repo":
+            assert request.headers["Authorization"] == "Bearer ghs_scoped"
+            return httpx.Response(
+                200,
+                json={
+                    "id": 456,
+                    "full_name": "octo-org/octo-repo",
+                    "owner": {"id": 123},
+                    "default_branch": "main",
+                },
+            )
+        raise AssertionError(request.url)
+
+    client = HttpGitHubAppClient(
+        3987976,
+        private_key,
+        client=httpx.Client(transport=httpx.MockTransport(respond)),
+        now=lambda: datetime(2026, 7, 25, tzinfo=UTC),
+    )
+
+    installation_id = client.find_installation("octo-org/octo-repo")
+    token = client.create_token(installation_id, 456, TOKEN_PERMISSIONS.copy())
+    repository = client.get_repository("octo-org/octo-repo", token.token)
+
+    assert repository.id == 456
+    assert len(requests) == 3
+    assert all(request.extensions["timeout"]["read"] == 5.0 for request in requests)
+
+
+def test_safe_github_reads_retry_transient_failures() -> None:
+    private_key, _ = _private_key()
+    attempts = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        status = 200 if attempts == 3 else 502
+        return httpx.Response(status, json={"id": 789})
+
+    client = HttpGitHubAppClient(
+        3987976,
+        private_key,
+        client=httpx.Client(transport=httpx.MockTransport(respond)),
+    )
+
+    assert client.find_installation("octo-org/octo-repo") == 789
+    assert attempts == 3
+
+
+def test_token_creation_is_not_retried() -> None:
+    private_key, _ = _private_key()
+    attempts = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(502, json={"message": "try later"})
+
+    client = HttpGitHubAppClient(
+        3987976,
+        private_key,
+        client=httpx.Client(transport=httpx.MockTransport(respond)),
+    )
+
+    with pytest.raises(BrokerError):
+        client.create_token(789, 456, TOKEN_PERMISSIONS.copy())
+
+    assert attempts == 1
+
+
+def test_missing_installation_points_to_the_public_app() -> None:
+    private_key, _ = _private_key()
+    client = HttpGitHubAppClient(
+        3987976,
+        private_key,
+        client=httpx.Client(
+            transport=httpx.MockTransport(lambda request: httpx.Response(404, json={}))
+        ),
+    )
+
+    with pytest.raises(BrokerError, match="github.com/apps/lgtmaybe/installations/new"):
+        client.find_installation("octo-org/octo-repo")

--- a/tests/identity/test_handler.py
+++ b/tests/identity/test_handler.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from services.github_app_identity import handler
+from services.github_app_identity.broker import BrokerError, InstallationToken
+
+
+class SuccessfulBroker:
+    def exchange(self, token: str) -> InstallationToken:
+        assert token == "oidc-token"
+        return InstallationToken(
+            token="ghs_installation_token",
+            expires_at=datetime(2026, 7, 25, 10, 0, tzinfo=UTC),
+        )
+
+
+class RejectedBroker:
+    def exchange(self, token: str) -> InstallationToken:
+        raise BrokerError("app_not_installed", 404, "Install the lgtmaybe GitHub App.")
+
+
+def test_handler_returns_the_scoped_token_without_cacheable_headers(monkeypatch) -> None:
+    monkeypatch.setattr(handler, "_broker", SuccessfulBroker())
+
+    response = handler.handler(
+        {"headers": {"authorization": "Bearer oidc-token"}},
+        context=None,
+    )
+
+    assert response["statusCode"] == 200
+    assert response["headers"]["cache-control"] == "no-store"
+    assert json.loads(response["body"]) == {
+        "token": "ghs_installation_token",
+        "expires_at": "2026-07-25T10:00:00Z",
+    }
+
+
+def test_handler_returns_an_actionable_sanitized_rejection(monkeypatch) -> None:
+    monkeypatch.setattr(handler, "_broker", RejectedBroker())
+
+    response = handler.handler(
+        {"headers": {"Authorization": "Bearer oidc-token"}},
+        context=None,
+    )
+
+    assert response["statusCode"] == 404
+    assert json.loads(response["body"]) == {
+        "code": "app_not_installed",
+        "message": "Install the lgtmaybe GitHub App.",
+    }
+    assert "oidc-token" not in response["body"]
+
+
+def test_handler_rejects_a_missing_bearer_token() -> None:
+    response = handler.handler({"headers": {}}, context=None)
+
+    assert response["statusCode"] == 401
+    assert json.loads(response["body"])["code"] == "invalid_request"

--- a/tests/identity/test_oidc.py
+++ b/tests/identity/test_oidc.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from services.github_app_identity.broker import (
+    OIDC_AUDIENCE,
+    OIDC_ISSUER,
+    BrokerError,
+    PyJwtOidcVerifier,
+)
+
+
+class StaticJwksClient:
+    def __init__(self, key: object):
+        self.key = key
+
+    def get_signing_key_from_jwt(self, token: str) -> object:
+        assert token
+        return type("SigningKey", (), {"key": self.key})()
+
+
+def _keys() -> tuple[object, object]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key, private_key.public_key()
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    now = datetime.now(UTC)
+    payload: dict[str, object] = {
+        "iss": OIDC_ISSUER,
+        "aud": OIDC_AUDIENCE,
+        "iat": now,
+        "nbf": now - timedelta(seconds=5),
+        "exp": now + timedelta(minutes=5),
+        "jti": "request-1",
+        "repository": "octo-org/octo-repo",
+        "repository_id": "456",
+        "repository_owner_id": "123",
+        "event_name": "pull_request_target",
+        "workflow_ref": "octo-org/octo-repo/.github/workflows/lgtmaybe.yml@refs/heads/main",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_verifier_accepts_a_valid_github_oidc_token() -> None:
+    private_key, public_key = _keys()
+    token = jwt.encode(_payload(), private_key, algorithm="RS256", headers={"kid": "test"})
+    verifier = PyJwtOidcVerifier(jwks_client=StaticJwksClient(public_key))
+
+    claims = verifier.verify(token)
+
+    assert claims["repository_id"] == "456"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"iss": "https://attacker.example"},
+        {"aud": "https://attacker.example"},
+        {"exp": datetime.now(UTC) - timedelta(seconds=1)},
+        {"nbf": datetime.now(UTC) + timedelta(minutes=5)},
+    ],
+)
+def test_verifier_rejects_invalid_standard_claims(overrides: dict[str, object]) -> None:
+    private_key, public_key = _keys()
+    token = jwt.encode(
+        _payload(**overrides), private_key, algorithm="RS256", headers={"kid": "test"}
+    )
+    verifier = PyJwtOidcVerifier(jwks_client=StaticJwksClient(public_key))
+
+    with pytest.raises(BrokerError) as raised:
+        verifier.verify(token)
+
+    assert raised.value.code == "invalid_oidc"
+
+
+def test_verifier_rejects_an_invalid_signature() -> None:
+    signer, _ = _keys()
+    _, trusted_public_key = _keys()
+    token = jwt.encode(_payload(), signer, algorithm="RS256", headers={"kid": "test"})
+    verifier = PyJwtOidcVerifier(jwks_client=StaticJwksClient(trusted_public_key))
+
+    with pytest.raises(BrokerError) as raised:
+        verifier.verify(token)
+
+    assert raised.value.code == "invalid_oidc"

--- a/tests/identity/test_stack.py
+++ b/tests/identity/test_stack.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", EncodingWarning)
+    from aws_cdk import App
+    from aws_cdk.assertions import Match, Template
+    from infra.identity.stack import IdentityBrokerStack
+
+from services.github_app_identity.broker import OIDC_AUDIENCE, OIDC_ISSUER
+
+
+def _template() -> Template:
+    stack = IdentityBrokerStack(
+        App(),
+        "IdentityBroker",
+        app_id="3987976",
+        alarm_email="matt@coles.codes",
+        bundle_code=False,
+    )
+    return Template.from_stack(stack)
+
+
+def test_stack_provisions_a_bounded_python_lambda_and_retained_secret() -> None:
+    template = _template()
+
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Runtime": "python3.14",
+            "Handler": "handler.handler",
+            "Architectures": ["x86_64"],
+            "ReservedConcurrentExecutions": 5,
+            "Timeout": 15,
+            "Environment": {
+                "Variables": {
+                    "GITHUB_APP_ID": "3987976",
+                    "APP_PRIVATE_KEY_SECRET_ARN": Match.any_value(),
+                }
+            },
+        },
+    )
+    template.has_resource(
+        "AWS::SecretsManager::Secret",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )
+
+
+def test_stack_restricts_the_secret_grant_to_get_secret_value() -> None:
+    policies = _template().find_resources("AWS::IAM::Policy")
+    statements = [
+        statement
+        for policy in policies.values()
+        for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+    ]
+    secret_grants = [
+        statement
+        for statement in statements
+        if "secretsmanager:GetSecretValue"
+        in (statement["Action"] if isinstance(statement["Action"], list) else [statement["Action"]])
+    ]
+
+    assert len(secret_grants) == 1
+    assert set(secret_grants[0]["Action"]) == {
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+    }
+    assert secret_grants[0]["Resource"] != "*"
+
+
+def test_stack_puts_github_oidc_authorization_and_throttling_in_front() -> None:
+    template = _template()
+
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Authorizer",
+        {
+            "AuthorizerType": "JWT",
+            "IdentitySource": ["$request.header.Authorization"],
+            "JwtConfiguration": {
+                "Audience": [OIDC_AUDIENCE],
+                "Issuer": OIDC_ISSUER,
+            },
+        },
+    )
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Route",
+        {
+            "AuthorizationType": "JWT",
+            "RouteKey": "POST /token",
+        },
+    )
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Stage",
+        {
+            "AutoDeploy": True,
+            "DefaultRouteSettings": {
+                "DetailedMetricsEnabled": False,
+                "ThrottlingBurstLimit": 5,
+                "ThrottlingRateLimit": 2,
+            },
+            "AccessLogSettings": {
+                "DestinationArn": Match.any_value(),
+                "Format": Match.any_value(),
+            },
+        },
+    )
+
+
+def test_stack_uses_a_resource_scoped_lambda_role() -> None:
+    roles = _template().find_resources("AWS::IAM::Role")
+
+    assert all("ManagedPolicyArns" not in role["Properties"] for role in roles.values())
+
+
+def test_stack_alarms_on_lambda_errors_and_api_throttles() -> None:
+    template = _template()
+    alarms = template.find_resources("AWS::CloudWatch::Alarm")
+
+    assert len(alarms) == 2
+    alarm_actions = [alarm["Properties"]["AlarmActions"] for alarm in alarms.values()]
+    assert all(len(actions) == 1 for actions in alarm_actions)
+    assert alarm_actions[0] == alarm_actions[1]
+
+
+def test_stack_sends_alarm_notifications_to_the_maintainer() -> None:
+    template = _template()
+
+    template.resource_count_is("AWS::SNS::Topic", 1)
+    template.has_resource_properties(
+        "AWS::SNS::Subscription",
+        {
+            "Endpoint": "matt@coles.codes",
+            "Protocol": "email",
+            "TopicArn": Match.any_value(),
+        },
+    )

--- a/tests/specs/test_anchors.py
+++ b/tests/specs/test_anchors.py
@@ -5,7 +5,8 @@ comment) bound to code by ast-grep rules in the capability's co-located
 ``anchors.yml`` sidecar. This suite enforces the convention deterministically:
 
 - spec.md anchor ids and anchors.yml rule ids are a bijection, per capability
-- every rule resolves to EXACTLY one place in src/ (0 = dangling, >1 = too loose)
+- every rule resolves to EXACTLY one place in an anchored code root
+  (0 = dangling, >1 = too loose)
 - every spec.md has the OpenSpec shape (Purpose / Requirements / Scenario, SHALL)
 - requirement sections stay under the 40-line soft cap (split, don't append)
 

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -1,13 +1,4 @@
-"""Structural guard for the composite ``action.yml``.
-
-The GitHub App branded-bot path lives entirely in ``action.yml``: it mints an
-installation token with ``actions/create-github-app-token`` (gated on the
-``app_id`` input, the same shape as the three keyless-cloud auth steps) and
-forwards it in the ``GITHUB_TOKEN`` the container already reads — preferring the
-minted token and falling back to the default workflow token when the mint step
-is skipped. There is no Python behaviour change, so this test pins that wiring so
-a refactor of the YAML can't silently drop the fallback or the gate.
-"""
+"""Structural guards for the composite ``action.yml``."""
 
 from __future__ import annotations
 
@@ -24,10 +15,10 @@ _README = Path(__file__).parent.parent / "README.md"
 _GITHUB_APP_GUIDE = Path(__file__).parent.parent / "docs" / "how-to" / "post-as-a-github-app.md"
 _MKDOCS = Path(__file__).parent.parent / "mkdocs.yml"
 
-# The container reads GITHUB_TOKEN; prefer the minted App token, else the default
-# workflow token. A skipped mint step yields an empty output, so ``||`` falls
-# through to the pass-through ``github_token`` input.
-_TOKEN_EXPR = "${{ steps.app-token.outputs.token || inputs.github_token }}"
+_TOKEN_EXPR = (
+    "${{ steps.lgtmaybe-token.outputs.token || "
+    "steps.app-token.outputs.token || inputs.github_token }}"
+)
 
 
 def _action() -> dict:
@@ -52,10 +43,24 @@ def _mint_step() -> dict:
     raise AssertionError("no actions/create-github-app-token step")
 
 
+def _step(step_id: str) -> dict:
+    for step in _steps():
+        if step.get("id") == step_id:
+            return step
+    raise AssertionError(f"no step with id {step_id!r}")
+
+
 def test_declares_github_app_inputs() -> None:
     inputs = _action()["inputs"]
     for name in ("app_id", "app_private_key", "app_owner", "app_repositories"):
         assert name in inputs, f"action.yml must declare the '{name}' input"
+
+
+def test_declares_explicit_github_identity_inputs() -> None:
+    inputs = _action()["inputs"]
+
+    assert inputs["github_identity"]["default"] == "actions"
+    assert inputs["identity_broker_url"]["default"].startswith("https://")
 
 
 def test_marketplace_setup_explains_workflow_configuration() -> None:
@@ -81,11 +86,12 @@ def test_marketplace_setup_explains_workflow_configuration() -> None:
         assert input_name in action_section
 
 
-def test_marketplace_setup_does_not_require_a_separate_github_app() -> None:
+def test_marketplace_setup_explains_optional_branded_identity() -> None:
     guide = _GITHUB_APP_GUIDE.read_text(encoding="utf-8")
-    assert "do not need to create or install a separate GitHub App" in guide
-    assert "[Use lgtmaybe as a GitHub Action](./use-as-github-action.md)" in guide
-    assert "Post reviews as a GitHub App" not in _MKDOCS.read_text(encoding="utf-8")
+    assert "https://github.com/apps/lgtmaybe/installations/new" in guide
+    assert "github_identity: lgtmaybe" in guide
+    assert "id-token: write" in guide
+    assert "Post as lgtmaybe[bot]" in _MKDOCS.read_text(encoding="utf-8")
 
 
 def test_mint_step_is_pinned_and_gated_on_app_id() -> None:
@@ -101,8 +107,34 @@ def test_mint_step_is_pinned_and_gated_on_app_id() -> None:
     assert with_.get("private-key") == "${{ inputs.app_private_key }}"
 
 
-def test_container_token_prefers_the_minted_app_token() -> None:
+def test_container_token_prefers_the_selected_app_token() -> None:
     assert _run_lgtmaybe_step()["env"]["GITHUB_TOKEN"] == _TOKEN_EXPR
+
+
+def test_public_identity_exchange_is_gated_and_masks_the_token() -> None:
+    step = _step("lgtmaybe-token")
+
+    assert "github_identity" in str(step.get("if", ""))
+    assert "github-app-identity.py" in step["run"]
+    assert "exchange" in step["run"]
+
+
+def test_public_identity_cleanup_is_always_run_without_public_output() -> None:
+    action = _action()
+    cleanup = _step("revoke-lgtmaybe-token")
+
+    assert "always()" in str(cleanup.get("if", ""))
+    assert "revoke" in cleanup["run"]
+    assert "outputs" not in action
+
+
+def test_identity_configuration_is_validated_before_minting() -> None:
+    validation = _step("validate-identity")
+
+    assert "GITHUB_IDENTITY" in validation["env"]
+    assert "APP_ID" in validation["env"]
+    assert "FAIL_ON" in validation["env"]
+    assert "validate" in validation["run"]
 
 
 def test_default_container_image_tracks_package_major() -> None:

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -53,3 +53,18 @@ def test_dogfood_concurrency_only_applies_to_eligible_review_job() -> None:
         "group": "lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}",
         "cancel-in-progress": True,
     }
+
+
+def test_dogfood_workflow_uses_the_public_app_identity() -> None:
+    workflow = yaml.safe_load(_DOGFOOD_WORKFLOW.read_text(encoding="utf-8"))
+    assert workflow["permissions"]["id-token"] == "write"
+    [action_step] = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("uses") == "./"
+    ]
+    inputs = action_step["with"]
+    assert inputs["github_identity"] == "lgtmaybe"
+    assert "app_id" not in inputs
+    assert "app_private_key" not in inputs

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,92 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-cdk-asset-awscli-v1"
+version = "2.2.282"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/30/90558d9e05c2b1a5a8d7d87332b4bed4a2e5d2eb04cc7064f6e9e0c8a2f2/aws_cdk_asset_awscli_v1-2.2.282.tar.gz", hash = "sha256:f86e61653927f77fb235b5ec148c955c610117430c869d182c8b20f7e07e2df2", size = 20740538, upload-time = "2026-05-25T21:33:20.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/86/dcb45969f1b34351cfd9afdb6b35bff38a3e929c8bc42b07036879f3a62e/aws_cdk_asset_awscli_v1-2.2.282-py3-none-any.whl", hash = "sha256:24139da0eb1be59f8cfda22c6343d51e8d50bb89b5052b049cfab92683de7790", size = 20738955, upload-time = "2026-05-25T21:33:17.673Z" },
+]
+
+[[package]]
+name = "aws-cdk-asset-node-proxy-agent-v6"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/e3/92e49ecaa002b4ac54371538991389c248577cbae7394ea9d1261ff41078/aws_cdk_asset_node_proxy_agent_v6-2.1.2.tar.gz", hash = "sha256:1340588dd351dcae37e07188f39075364f73ccde6ed9468c1184b06ada4af665", size = 1534674, upload-time = "2026-05-15T08:14:19.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/06/29837eb8ae4dc82ed2e593e4b24449394393b9a8a247b0ce2cee811e5cbb/aws_cdk_asset_node_proxy_agent_v6-2.1.2-py3-none-any.whl", hash = "sha256:1028bff16fdb87b8c82404e9b48f32ed383429dece84067f47379c4049da5da4", size = 1533233, upload-time = "2026-05-15T08:14:17.622Z" },
+]
+
+[[package]]
+name = "aws-cdk-aws-lambda-python-alpha"
+version = "2.262.1a0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-lib" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/fa/e02639ab8ec9a932290c6c4f3982407e6bad0a4114f5e6846a2cd0cf581e/aws_cdk_aws_lambda_python_alpha-2.262.1a0.tar.gz", hash = "sha256:a7c1bd8f0736d8f2fef8794e86e09a6e969403bb4352463e6f44bad88a39e52d", size = 100293, upload-time = "2026-07-24T14:43:15.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/25/327b0253fb1b37c8f840d87d6a9b8966176c4062c49c1802e40760b4f265/aws_cdk_aws_lambda_python_alpha-2.262.1a0-py3-none-any.whl", hash = "sha256:e200a6a1edf40feaf8a9f5ec90c0627988e0a0dff7dd5596e79dadfc914464c5", size = 99293, upload-time = "2026-07-24T14:42:29.617Z" },
+]
+
+[[package]]
+name = "aws-cdk-cloud-assembly-schema"
+version = "54.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/7f/8aa19ea1279f8d5917375a94cc70095dee4ca4751e73fe570e135a70330a/aws_cdk_cloud_assembly_schema-54.14.0.tar.gz", hash = "sha256:d1f3371b6141932042efc284300f7f00fd291e92ae198651d4ebe6bcc1cd3480", size = 282887, upload-time = "2026-07-23T19:21:44.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/e4/badc4a25352fc53ac87208079145a811789c8b98be2c9b7b610619c285e0/aws_cdk_cloud_assembly_schema-54.14.0-py3-none-any.whl", hash = "sha256:9445f5a6a8b28dd71e2f55448292db795042adf4c3ac48c5b5f735e208591f42", size = 281930, upload-time = "2026-07-23T19:21:42.732Z" },
+]
+
+[[package]]
+name = "aws-cdk-lib"
+version = "2.262.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-asset-awscli-v1" },
+    { name = "aws-cdk-asset-node-proxy-agent-v6" },
+    { name = "aws-cdk-cloud-assembly-schema" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/9c/84b65f2e579173bcd04177e4380e5f0fd68d071f7be153fc72ead05cde88/aws_cdk_lib-2.262.1.tar.gz", hash = "sha256:e9ae7ef2454bd4044f300d6c80df692ecee3fa4d5850013e473e198ebaf6303d", size = 54894297, upload-time = "2026-07-24T14:43:31.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ad/6592d901edc64bd51dda85d2f49d494071796a7874f37ffefac59fc31a88/aws_cdk_lib-2.262.1-py3-none-any.whl", hash = "sha256:5fe31beed6f22986c66e625e7683087168e780eebf7f001800574ac420af3c9c", size = 55566690, upload-time = "2026-07-24T14:42:52.656Z" },
+]
+
+[[package]]
+name = "aws-lambda-powertools"
+version = "3.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/77/8c74a558facb8bebdc6f3f0096ff5735b779d57c7bbdb7948f3e6d873504/aws_lambda_powertools-3.31.1.tar.gz", hash = "sha256:b46e575c7e290c55fe81ae4a38d8b5c91238242a4644438f8b858ce535a4125c", size = 800496, upload-time = "2026-07-13T09:22:11.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/e1/67a119333cb3656b9b482a77bb4b25e0488ca969218b71479b4ecfc1a5e1/aws_lambda_powertools-3.31.1-py3-none-any.whl", hash = "sha256:cd03f824bc11b59df727744fa9a419a01772d85fd0b15a67eee07f5472b37c77", size = 957593, upload-time = "2026-07-13T09:22:09.354Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -362,6 +448,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
+name = "cdk-nag"
+version = "2.38.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-lib" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/c1/2caccd33f659d95c0a48a13c838ae885aa3a4ee6ed768d40848cc7eb4202/cdk_nag-2.38.2.tar.gz", hash = "sha256:a4d419062ea4d64c2892942214b9184b124eb2bc36d087982007b3455e1ac443", size = 777714, upload-time = "2026-04-27T17:33:08.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/f5/ff45ffcf45d421a668c6a0a994d5e0491167d8ca432108a339e272e012e4/cdk_nag-2.38.2-py3-none-any.whl", hash = "sha256:d37f18ae9450f401bcc55d5d82138beee561486806579849cb9be25ff7565904", size = 771251, upload-time = "2026-04-27T17:33:05.04Z" },
 ]
 
 [[package]]
@@ -563,6 +678,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "constructs"
+version = "10.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsii" },
+    { name = "publication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/1e/f8616b97256cad2a2ec27a6bbb74ae478182ddd782ba10fd97924970a75d/constructs-10.7.1.tar.gz", hash = "sha256:7b33d60851fc8c6d4c4a111dc342088e467c344b22d9a562a5e0b6fbbbaf4b2a", size = 71079, upload-time = "2026-07-20T08:01:34.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/e7/f014792cb9e76d407e552aead634e048134c22e59a2f892b1cb7324afc71/constructs-10.7.1-py3-none-any.whl", hash = "sha256:f212c66b37249c45eca4638c6b33c68efddae50599d27062d71d0bf81c11431e", size = 69144, upload-time = "2026-07-20T08:01:32.43Z" },
 ]
 
 [[package]]
@@ -1109,6 +1237,23 @@ wheels = [
 ]
 
 [[package]]
+name = "jsii"
+version = "1.139.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "publication" },
+    { name = "python-dateutil" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/71/7c612c16291a6dc654bac00f56bef24c45f86e9a7c9668dc7d36f187e808/jsii-1.139.0.tar.gz", hash = "sha256:163c5d3ec00fd4ec89a33b9097f20a6f27626dd69d6875a8f7cc7577b8021ad0", size = 531387, upload-time = "2026-07-17T02:34:33.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3e/fce01768f79b2d5d0cf6258b55045f4b083ee86fd5de24c1af38168312ab/jsii-1.139.0-py3-none-any.whl", hash = "sha256:11468f767c6da698ed9888a04352850af33ccccfec7656475626caf36fca8bbb", size = 501693, upload-time = "2026-07-17T02:34:31.747Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1156,6 +1301,11 @@ azure = [
 bedrock = [
     { name = "boto3" },
 ]
+identity-broker = [
+    { name = "aws-lambda-powertools" },
+    { name = "httpx" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
 static-analysis = [
     { name = "bandit" },
     { name = "ruff" },
@@ -1167,7 +1317,14 @@ vertex = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aws-cdk-aws-lambda-python-alpha" },
+    { name = "aws-cdk-lib" },
+    { name = "aws-lambda-powertools" },
+    { name = "boto3" },
+    { name = "cdk-nag" },
+    { name = "constructs" },
     { name = "mypy" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest" },
     { name = "respx" },
     { name = "ruff" },
@@ -1183,25 +1340,35 @@ packaging = [
 [package.metadata]
 requires-dist = [
     { name = "ast-grep-cli", specifier = ">=0.44.0" },
+    { name = "aws-lambda-powertools", marker = "extra == 'identity-broker'", specifier = ">=3.23" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.19" },
     { name = "bandit", marker = "extra == 'static-analysis'", specifier = ">=1.7" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.4.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'identity-broker'", specifier = ">=0.28.1" },
     { name = "litellm", marker = "python_full_version < '3.14'", specifier = ">=1.87.1" },
     { name = "litellm", marker = "python_full_version >= '3.14'", specifier = ">=1.87.1,<1.94" },
     { name = "pydantic", specifier = ">=2.7" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'identity-broker'", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'static-analysis'", specifier = ">=0.5" },
     { name = "semgrep", marker = "extra == 'static-analysis'", specifier = ">=1.60" },
     { name = "tenacity", specifier = ">=9.1.4" },
 ]
-provides-extras = ["azure", "bedrock", "vertex", "static-analysis"]
+provides-extras = ["azure", "bedrock", "vertex", "static-analysis", "identity-broker"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aws-cdk-aws-lambda-python-alpha", specifier = ">=2.261.0a0,<3" },
+    { name = "aws-cdk-lib", specifier = ">=2.261,<3" },
+    { name = "aws-lambda-powertools", specifier = ">=3.23" },
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "cdk-nag", specifier = ">=2.36,<3" },
+    { name = "constructs", specifier = ">=10,<11" },
     { name = "mypy", specifier = ">=1.10" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10" },
     { name = "pytest", specifier = ">=8" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.5" },
@@ -1904,6 +2071,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "publication"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/8e/8c9fe7e32fdf9c386f83d59610cc819a25dadb874b5920f2d0ef7d35f46d/publication-0.0.3.tar.gz", hash = "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4", size = 5484, upload-time = "2019-01-15T07:52:23.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/d3/6308debad7afcdb3ea5f50b4b3d852f41eb566a311fbcb4da23755a28155/publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6", size = 7687, upload-time = "2019-01-15T07:52:22.151Z" },
 ]
 
 [[package]]
@@ -2820,6 +2996,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add `github_identity: lgtmaybe` to exchange GitHub Actions OIDC for a repository-scoped public App token
- deploy the least-privilege AWS broker with Contents read / PR write / Issues write, bounded concurrency and throttle, SNS-backed alarms, and retained private-key storage
- keep `github-actions[bot]` as the default and the existing private-key path as the self-managed option
- document public install, security/data boundaries, rollback, troubleshooting, and private-key rotation
- switch this repo's dogfood workflow to the brokered identity

## Security

The broker validates GitHub issuer/signature/audience/time claims, immutable repository and owner IDs, allowed base-safe events, and the default-branch workflow ref. Tokens are restricted to one verified repository and the App's narrow permissions, masked, and revoked after use. The broker never receives diffs, prompts, model/provider credentials, findings, or repository contents.

The public App intentionally has no `Checks: write`; `github_identity: lgtmaybe` rejects `fail_on` before exchange rather than granting a stolen App key the ability to forge a required merge check.

## Verification

- 1,384 tests passed; 3 intentionally deselected
- Ruff lint/format, strict mypy, and lockfile check passed
- strict MkDocs build passed
- all 10 living specs and the OpenSpec change validate
- CDK synth, CDK assertions, cdk-nag, CloudFormation Guard, and cfn-lint passed
- broker dependency audit found no known vulnerabilities
- live direct-App dogfood posted as `lgtmaybe[bot]` in both configured repositories