### PR TITLE
fix: prevent bot comments cancelling reviews

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -28,10 +28,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     # Only trusted authors (repo owner / org member / collaborator) trigger a
@@ -45,6 +41,9 @@ jobs:
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    concurrency:
+      group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     # A healthy full review runs in a handful of minutes; cap it so a wedged
     # model call can't sit on the runner for GitHub's 6-hour default. Fail-fast on

--- a/openspec/changes/prevent-comment-self-cancellation/.openspec.yaml
+++ b/openspec/changes/prevent-comment-self-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/prevent-comment-self-cancellation/design.md
+++ b/openspec/changes/prevent-comment-self-cancellation/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The dogfood workflow listens for PR events and comment commands. It currently
+declares concurrency at workflow scope, so every matching event acquires the
+per-PR group before the `review` job's author-association guard is evaluated.
+An App-authored diagram comment therefore starts a skipped run that cancels the
+active review.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent ineligible bot or untrusted comment events from canceling reviews.
+- Keep newest-run-wins behavior between eligible jobs for one PR.
+- Retain the existing triggers, eligibility guard, App identity, and automatic
+  diagram behavior.
+
+**Non-Goals:**
+
+- Suppressing GitHub App events.
+- Changing review commands, authentication, or diagram posting.
+- Adding a second workflow or scheduler.
+
+## Decisions
+
+Move the existing concurrency mapping unchanged beneath `jobs.review`. GitHub
+then evaluates the job guard before an eligible job can occupy the group.
+Eligible PR events and trusted commands still share the same per-PR key and
+retain `cancel-in-progress: true`.
+
+A conditional workflow-level `cancel-in-progress` was rejected because an
+ineligible run would still occupy the group and could serialize or replace
+eligible work. Disabling auto-diagrams was rejected because the diagram merely
+exposed the workflow-scoping bug.
+
+The regression test parses the workflow and pins concurrency to the guarded
+review job. GitHub's scheduler cannot be simulated locally, so the next
+post-merge dogfood run remains the runtime verification.
+
+## Risks / Trade-offs
+
+- [GitHub changes job-concurrency scheduling semantics] → Keep the regression
+  focused on the documented job-level structure and verify the dogfood run
+  after merge.
+- [A future unguarded job is added] → Its author must choose its own concurrency
+  behavior explicitly; it will not silently inherit review cancellation.
+
+## Migration Plan
+
+Merge the workflow change. Existing runs are unaffected; new runs use job-level
+concurrency immediately. Roll back by restoring the top-level mapping.
+
+## Open Questions
+
+None.

--- a/openspec/changes/prevent-comment-self-cancellation/proposal.md
+++ b/openspec/changes/prevent-comment-self-cancellation/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Comments posted with lgtmaybe's GitHub App token emit new `issue_comment`
+workflow runs. Those skipped bot runs currently enter the workflow-level
+concurrency group before the review job's eligibility guard runs, canceling the
+active review that posted the comment.
+
+## What Changes
+
+- Scope per-PR concurrency to the eligible review job.
+- Preserve newest-run-wins cancellation between eligible reviews and trusted
+  slash commands for the same PR.
+- Add a structural regression test for the workflow placement.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-posting`: Ineligible workflow events must not preempt an active,
+  eligible review for the same PR.
+
+## Impact
+
+The dogfood GitHub Actions workflow and its structural tests change. There are
+no public API, configuration, authentication, or dependency changes.

--- a/openspec/changes/prevent-comment-self-cancellation/specs/github-posting/spec.md
+++ b/openspec/changes/prevent-comment-self-cancellation/specs/github-posting/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Ineligible events cannot preempt active reviews
+<!-- anchor: github.workflow-concurrency -->
+
+The dogfood workflow SHALL apply per-PR concurrency only to an event that passes
+the review job's eligibility guard. Eligible jobs for the same PR MUST retain
+newest-run-wins cancellation.
+
+#### Scenario: lgtmaybe posts an automatic diagram
+
+- **WHEN** the GitHub App comment emits an `issue_comment` workflow run whose
+  author does not pass the review job guard
+- **THEN** that run does not enter the review concurrency group or cancel the
+  active review
+
+#### Scenario: a newer eligible review starts
+
+- **WHEN** a newer PR event or trusted command passes the review job guard for
+  the same PR
+- **THEN** the newer job cancels the older eligible review job

--- a/openspec/changes/prevent-comment-self-cancellation/tasks.md
+++ b/openspec/changes/prevent-comment-self-cancellation/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a structural test requiring concurrency to live on the guarded
+  review job
+- [x] 1.2 Run the focused test and confirm it fails against the current workflow
+
+## 2. Workflow Fix
+
+- [x] 2.1 Move the existing per-PR concurrency mapping from workflow scope to
+  `jobs.review`
+- [x] 2.2 Re-run the focused workflow tests and confirm they pass
+
+## 3. Validation
+
+- [x] 3.1 Validate the OpenSpec change and living-spec anchors
+- [x] 3.2 Run the relevant workflow tests and repository quality gates

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -41,3 +41,15 @@ def test_dogfood_workflow_prints_the_timing_profile() -> None:
         if step.get("uses") == "./"
     ]
     assert action_step.get("with", {}).get("profile") is True
+
+
+def test_dogfood_concurrency_only_applies_to_eligible_review_job() -> None:
+    workflow = yaml.safe_load(_DOGFOOD_WORKFLOW.read_text(encoding="utf-8"))
+    review_job = workflow["jobs"]["review"]
+
+    assert "concurrency" not in workflow
+    assert "if" in review_job
+    assert review_job["concurrency"] == {
+        "group": "lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}",
+        "cancel-in-progress": True,
+    }


### PR DESCRIPTION
## What changed

- move the per-PR concurrency group from workflow scope to the guarded `review` job
- preserve newest-run-wins cancellation between eligible review jobs
- add a structural regression test for the concurrency placement
- record the behavior in the `prevent-comment-self-cancellation` OpenSpec change

## Why

lgtmaybe posts diagrams and other comments with its GitHub App token. Those
comments emit new `issue_comment` workflow runs. With concurrency at workflow
scope, a bot-authored run entered the per-PR group and cancelled the active
review before its `review` job was skipped by the author-association guard.

Job-level concurrency means an ineligible bot or untrusted event is skipped
without acquiring the group. Eligible PR events and trusted slash commands
still cancel older eligible work for the same PR.

## Impact

Automatic diagrams remain enabled. Authentication, triggers, commands, and
public configuration are unchanged.

## Validation

- `pytest -q` — 1359 passed, 3 deselected
- `ruff check .`
- `ruff format --check .`
- `mypy`
- `uv lock --check`
- OpenSpec change and living specs validated
- anchor tests — 17 passed
