### PR TITLE
fix: pass GitHub identity timeout by keyword

### DIFF
--- a/scripts/github-app-identity.py
+++ b/scripts/github-app-identity.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
@@ -22,7 +22,12 @@ class IdentitySetupError(RuntimeError):
     """A user-actionable GitHub identity configuration error."""
 
 
-Opener = Callable[[Request, float], Any]
+class Opener(Protocol):
+    def __call__(self, request: Request, *, timeout: float) -> Any: ...
+
+
+def _open_url(request: Request, *, timeout: float) -> Any:
+    return urlopen(request, timeout=timeout)
 
 
 def validate(env: Mapping[str, str]) -> None:
@@ -49,7 +54,7 @@ def validate(env: Mapping[str, str]) -> None:
 def exchange(
     env: Mapping[str, str],
     *,
-    opener: Opener = urlopen,
+    opener: Opener = _open_url,
     stdout: IO[str] = sys.stdout,
 ) -> None:
     oidc_url = env.get("ACTIONS_ID_TOKEN_REQUEST_URL")
@@ -69,7 +74,7 @@ def exchange(
             _with_audience(oidc_url),
             headers={"Authorization": f"Bearer {oidc_request_token}"},
         )
-        with opener(oidc_request, TIMEOUT_SECONDS) as response:
+        with opener(oidc_request, timeout=TIMEOUT_SECONDS) as response:
             oidc_token = _json(response).get("value")
         if not isinstance(oidc_token, str) or not oidc_token:
             raise IdentitySetupError("GitHub did not return a workflow identity token.")
@@ -83,7 +88,7 @@ def exchange(
                 "Accept": "application/json",
             },
         )
-        with opener(broker_request, TIMEOUT_SECONDS) as response:
+        with opener(broker_request, timeout=TIMEOUT_SECONDS) as response:
             app_token = _json(response).get("token")
         if not isinstance(app_token, str) or not app_token:
             raise IdentitySetupError("The identity broker did not return an App token.")
@@ -104,7 +109,7 @@ def exchange(
 def revoke(
     env: Mapping[str, str],
     *,
-    opener: Opener = urlopen,
+    opener: Opener = _open_url,
     stdout: IO[str] = sys.stdout,
 ) -> None:
     token = env.get("LGTMAYBE_TOKEN")
@@ -121,7 +126,7 @@ def revoke(
         },
     )
     try:
-        with opener(request, TIMEOUT_SECONDS):
+        with opener(request, timeout=TIMEOUT_SECONDS):
             pass
     except (HTTPError, URLError, OSError):
         stdout.write(

--- a/tests/identity/test_action_script.py
+++ b/tests/identity/test_action_script.py
@@ -72,7 +72,7 @@ def test_exchange_requests_oidc_and_masks_the_brokered_token(tmp_path: Path) -> 
     module = _module()
     requests: list[Request] = []
 
-    def open_request(request: Request, timeout: float):
+    def open_request(request: Request, *, timeout: float):
         requests.append(request)
         assert timeout == 10.0
         if len(requests) == 1:
@@ -131,7 +131,7 @@ def test_exchange_preserves_the_broker_setup_message() -> None:
     )
     calls = 0
 
-    def open_request(request: Request, timeout: float):
+    def open_request(request: Request, *, timeout: float):
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -156,7 +156,7 @@ def test_revoke_is_best_effort_and_never_prints_the_token() -> None:
     request_seen: list[Request] = []
     stdout = io.StringIO()
 
-    def open_request(request: Request, timeout: float):
+    def open_request(request: Request, *, timeout: float):
         request_seen.append(request)
         return Response({}, status=204)
 


### PR DESCRIPTION
## What changed

- Route all GitHub identity HTTP calls through a typed opener that requires `timeout` by keyword.
- Pass the timeout explicitly for the OIDC request, broker exchange, and installation-token revocation.
- Make the focused test openers keyword-only so positional regressions fail immediately.

## Root cause

`urllib.request.urlopen` takes `data` as its second positional argument. The Action passed `TIMEOUT_SECONDS` positionally, so Python treated the float as the request body and failed before contacting GitHub OIDC:

`TypeError: message_body should be a bytes-like object or an iterable, got <class 'float'>`

This caused the [lgtmaybe review job on PR #242](https://github.com/MattJColes/lgtmaybe/actions/runs/30151060858/job/89661411130) to fail.

## Impact

`github_identity: lgtmaybe` can complete its OIDC and broker exchange again. The default Actions identity and review runtime are unchanged.

## Validation

- `pytest tests/identity tests/test_action_yml.py -q` — 52 passed
- `ruff check` and `ruff format --check` — passed
- `mypy --strict scripts/github-app-identity.py` — passed
- `pytest tests/specs -q -k 'not test_every_rule_resolves_to_exactly_one_place'` — 16 passed, 1 deselected for the known Windows command-line-length limitation
- `openspec validate --specs --strict` — 10 passed

## CI note

The `lgtmaybe / review (pull_request_target)` job on this PR is expected to repeat the original failure before merge. For fork safety, that workflow checks out and executes the base branch (`main` at `a36b7e6` in run 30151316748), not this PR's head. Its log therefore shows the old positional call at line 72. The branch-based CI jobs exercise this fix; the dogfood review can only verify it after the corrected script reaches `main`.
