### PR TITLE
fix: skip Winget update before initial publication

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -53,7 +53,28 @@ jobs:
             }
           }
 
+      - name: Check whether the winget package exists
+        id: package
+        shell: pwsh
+        run: |
+          $manifestUrl = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe"
+          try {
+            Invoke-WebRequest -Uri $manifestUrl -Method Get -TimeoutSec 30 -Headers @{
+              Accept = "application/vnd.github+json"
+              "X-GitHub-Api-Version" = "2022-11-28"
+            } | Out-Null
+            "exists=true" >> $env:GITHUB_OUTPUT
+          } catch {
+            if ([int]$_.Exception.Response.StatusCode -eq 404) {
+              "exists=false" >> $env:GITHUB_OUTPUT
+              Write-Warning "MattJColes.lgtmaybe is not published in winget yet. Submit and moderate the first manifest manually; automatic updates will start with the next release."
+              exit 0
+            }
+            throw
+          }
+
       - name: Install wingetcreate
+        if: steps.package.outputs.exists == 'true'
         shell: pwsh
         run: |
           winget install --id Microsoft.WingetCreate --exact `
@@ -61,6 +82,7 @@ jobs:
             --disable-interactivity
 
       - name: Submit winget update
+        if: steps.package.outputs.exists == 'true'
         shell: pwsh
         env:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -84,8 +84,10 @@ The only human-only pieces:
   asset and run `wingetcreate new <asset-url>` manually with package id
   `MattJColes.lgtmaybe`, installer type `portable`, command alias `lgtmaybe`,
   and MIT licence metadata. Microsoft moderates a new package before it exists;
-  this can take days or weeks. Once that first manifest is accepted, the release
-  workflow uses `wingetcreate update` for every later version.
+  this can take days or weeks. Until that first manifest is accepted, the
+  automatic release job warns and skips the winget update rather than failing
+  the other release artifacts. Once accepted, the workflow uses
+  `wingetcreate update` for every later version.
 
 ## Each release
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3023,8 +3023,10 @@ The only human-only pieces:
   asset and run `wingetcreate new <asset-url>` manually with package id
   `MattJColes.lgtmaybe`, installer type `portable`, command alias `lgtmaybe`,
   and MIT licence metadata. Microsoft moderates a new package before it exists;
-  this can take days or weeks. Once that first manifest is accepted, the release
-  workflow uses `wingetcreate update` for every later version.
+  this can take days or weeks. Until that first manifest is accepted, the
+  automatic release job warns and skips the winget update rather than failing
+  the other release artifacts. Once accepted, the workflow uses
+  `wingetcreate update` for every later version.
 
 ## Each release
 

--- a/openspec/changes/add-windows-support-and-winget/specs/windows-distribution/spec.md
+++ b/openspec/changes/add-windows-support-and-winget/specs/windows-distribution/spec.md
@@ -40,3 +40,8 @@ The reusable workflow MUST also support a manually dispatched recovery run.
 - **WHEN** maintainers prepare the first winget release
 - **THEN** they create the portable manifest manually before automated update
   submissions begin
+
+#### Scenario: release automation runs before initial moderation completes
+- **WHEN** the package is not yet present in `microsoft/winget-pkgs`
+- **THEN** the winget workflow warns and skips the update without failing the
+  other release artifacts

--- a/openspec/changes/add-windows-support-and-winget/tasks.md
+++ b/openspec/changes/add-windows-support-and-winget/tasks.md
@@ -39,6 +39,7 @@
 - [x] 6.1 Add reusable and dispatchable `.github/workflows/winget.yml` automation that normalises the version, polls for the executable asset, and runs `wingetcreate update MattJColes.lgtmaybe` with `WINGET_TOKEN`.
 - [x] 6.2 Wire release-please to call the executable workflow after release creation and the winget workflow only after the executable succeeds, preserving the existing PyPI, Homebrew, and GHCR release jobs.
 - [x] 6.3 Add workflow-structure tests that assert the executable smoke gate, release sequencing, asset URL, portable package ID, and secret wiring.
+- [x] 6.4 Detect an unmoderated initial package, warn and skip only the missing-package case, and retain automatic updates once the package exists.
 
 ## 7. PR 2 - Documentation, specs, and verification
 

--- a/openspec/specs/windows-distribution/spec.md
+++ b/openspec/specs/windows-distribution/spec.md
@@ -52,3 +52,8 @@ The reusable workflow MUST also support a manually dispatched recovery run.
 - **WHEN** maintainers prepare the first winget release
 - **THEN** they create the portable manifest manually before automated update
   submissions begin
+
+#### Scenario: release automation runs before initial moderation completes
+- **WHEN** the package is not yet present in `microsoft/winget-pkgs`
+- **THEN** the winget workflow warns and skips the update without failing the
+  other release artifacts

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -47,6 +47,7 @@ def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
 def test_winget_workflow_updates_the_portable_package() -> None:
     text, workflow = _workflow("winget.yml")
     job = workflow["jobs"]["publish"]
+    steps = {step["name"]: step for step in job["steps"]}
     runs = "\n".join(str(step.get("run", "")) for step in job["steps"] if isinstance(step, dict))
 
     assert "workflow_call:" in text
@@ -56,6 +57,12 @@ def test_winget_workflow_updates_the_portable_package() -> None:
     assert "wingetcreate update" in runs
     assert "WINGET_TOKEN" in text
     assert "windows-x86_64.exe" in runs
+    package_check = steps["Check whether the winget package exists"]
+    assert package_check["id"] == "package"
+    assert "microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe" in package_check["run"]
+    assert "StatusCode -eq 404" in package_check["run"]
+    for name in ("Install wingetcreate", "Submit winget update"):
+        assert steps[name]["if"] == "steps.package.outputs.exists == 'true'"
 
 
 def test_winget_docs_cover_installation_lifecycle() -> None:


### PR DESCRIPTION
## What changed

- Probe the public `microsoft/winget-pkgs` manifest path before installing WingetCreate.
- Treat only a confirmed 404 as the expected first-publication state: warn and skip the update.
- Keep every other preflight error fatal, and retain `wingetcreate update` unchanged once the package exists.
- Document and specify the moderation-gap behavior, with generated docs refreshed.

## Root cause

The 1.5.1 release ran `wingetcreate update MattJColes.lgtmaybe` before the initial package had been submitted and accepted. WingetCreate queried `microsoft/winget-pkgs`, received “not found,” and failed the otherwise successful release run.

The project deliberately keeps first submission manual because it establishes portable installer metadata and enters Microsoft moderation. This patch preserves that design while preventing the known pre-moderation 404 from failing unrelated release artifacts.

## Impact

Until the initial manifest is accepted, releases finish with a clear Winget warning. After acceptance, the same workflow automatically submits normal version updates. Authentication, rate-limit, and network failures still fail loud.

## Validation

- Live manifest probe — confirmed current response is HTTP 404
- `pytest tests/test_windows_distribution.py tests/docs -q` — 15 passed
- Ruff — passed
- `pytest tests/specs -q -k 'not test_every_rule_resolves_to_exactly_one_place'` — 16 passed, 1 deselected for the known Windows command-line-length limitation
- `openspec validate --specs --strict` — 10 passed
- `git diff --check`
