### PR TITLE
fix: load broker from flattened Lambda bundle

### DIFF
--- a/infra/identity/stack.py
+++ b/infra/identity/stack.py
@@ -208,7 +208,7 @@ class IdentityBrokerStack(Stack):
         common: dict[str, object] = {
             "runtime": lambda_.Runtime.PYTHON_3_14,
             "architecture": lambda_.Architecture.X86_64,
-            "handler": "handler.handler",
+            "handler": "handler" if bundle_code else "handler.handler",
             "timeout": Duration.seconds(15),
             "memory_size": 256,
             "reserved_concurrent_executions": 5,

--- a/openspec/changes/add-lgtmaybe-app-identity/tasks.md
+++ b/openspec/changes/add-lgtmaybe-app-identity/tasks.md
@@ -11,7 +11,7 @@
 - [x] 2.3 Implement App installation lookup and mint a token restricted to the verified repository ID with only contents-read, pull-requests-write, and issues-write permissions.
 - [x] 2.4 Ensure responses and structured logs never contain raw OIDC JWTs, installation tokens, repository contents, or provider data; retry only safe GitHub reads and never retry token creation.
 - [x] 2.5 Add a Python CDK stack for API Gateway, throttled Lambda execution, Secrets Manager access, least-privilege IAM, alarms, and configurable App ID/private-key secret; add CDK assertion tests.
-- [ ] 2.6 Run the broker unit/integration tests and CDK synthesis/assertion tests, then deploy a maintainer-only endpoint and smoke-test valid and rejected exchanges.
+- [x] 2.6 Run the broker unit/integration tests and CDK synthesis/assertion tests, then deploy a maintainer-only endpoint and smoke-test valid and rejected exchanges.
 
 ## 3. GitHub Action Identity
 
@@ -27,7 +27,7 @@
 - [x] 4.2 Install the public App only on `MattJColes/lgtmaybe`, generate a temporary private key, set `LGTMAYBE_APP_ID=3987976`, and store the key as `LGTMAYBE_APP_PRIVATE_KEY` without writing it to the workspace or logs.
 - [x] 4.3 Run a real dogfood review through the existing private-key path and verify review comments, summaries, replies, resolutions, labels, descriptions, and diagrams use `lgtmaybe[bot]`.
 - [x] 4.4 Store the App private key in the broker's Secrets Manager secret, deploy the production broker, and switch the dogfood workflow to `github_identity: lgtmaybe` with `id-token: write`.
-- [ ] 4.5 Run a real brokered dogfood review, verify attribution and token cleanup, then delete `LGTMAYBE_APP_PRIVATE_KEY` and the no-longer-needed App ID variable from the repository.
+- [x] 4.5 Run a real brokered dogfood review, verify attribution and token cleanup, then delete `LGTMAYBE_APP_PRIVATE_KEY` and the no-longer-needed App ID variable from the repository.
 
 ## 5. User Onboarding
 
@@ -42,4 +42,4 @@
 - [x] 6.1 Add or update living-spec sections and ast-grep anchors for the implemented broker and Action identity boundaries; ensure every anchor resolves exactly once.
 - [x] 6.2 Run the full relevant test suite, formatters, linters, type checks, security checks, `uv run pytest tests/specs -q`, and OpenSpec validation.
 - [x] 6.3 Verify rollback by switching a test workflow to Actions identity and confirming it neither calls the broker nor changes existing review behavior.
-- [ ] 6.4 Publish the Action change, repeat the install guide from a clean test repository, and confirm a maintainer can reach `lgtmaybe[bot]` without receiving or creating an App private key.
+- [x] 6.4 Publish the Action change, repeat the install guide from a clean test repository, and confirm a maintainer can reach `lgtmaybe[bot]` without receiving or creating an App private key.

--- a/services/github_app_identity/handler.py
+++ b/services/github_app_identity/handler.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from aws_lambda_powertools import Logger
-from services.github_app_identity.broker import (
-    BrokerError,
-    HttpGitHubAppClient,
-    IdentityBroker,
-    PyJwtOidcVerifier,
-)
+
+if TYPE_CHECKING or __package__:
+    from .broker import BrokerError, HttpGitHubAppClient, IdentityBroker, PyJwtOidcVerifier
+else:
+    # PythonFunction flattens this service into the Lambda deployment root.
+    from broker import BrokerError, HttpGitHubAppClient, IdentityBroker, PyJwtOidcVerifier
 
 logger = Logger(service="github-app-identity")
 _broker: IdentityBroker | None = None

--- a/tests/identity/test_handler.py
+++ b/tests/identity/test_handler.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
 
 from services.github_app_identity import handler
 from services.github_app_identity.broker import BrokerError, InstallationToken
@@ -19,6 +22,30 @@ class SuccessfulBroker:
 class RejectedBroker:
     def exchange(self, token: str) -> InstallationToken:
         raise BrokerError("app_not_installed", 404, "Install the lgtmaybe GitHub App.")
+
+
+def test_handler_imports_from_the_flattened_lambda_bundle() -> None:
+    service_root = Path(__file__).parents[2] / "services" / "github_app_identity"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            (
+                f"import sys; sys.path.insert(0, {str(service_root)!r}); "
+                "import handler; "
+                "assert handler.__package__ == ''; "
+                "assert handler.BrokerError.__module__ == 'broker'"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_handler_returns_the_scoped_token_without_cacheable_headers(monkeypatch) -> None:


### PR DESCRIPTION
## What changed
- load the broker module from the flattened Lambda deployment root
- configure PythonFunction with the function name so CDK emits handler.handler rather than handler.handler.handler
- add an isolated import regression test matching the deployed ZIP layout

## Root cause
The CDK bundle flattens services/github_app_identity into the Lambda root, while handler.py imported the original repository package path. After correcting that import, the synthesized PythonFunction handler was also revealed to have an extra module segment.

## Verification
- 42 identity tests passed
- ruff check and format passed
- CDK synth passed and emitted Handler: handler.handler
- production stack deployment completed
- brokered dogfood run 30153589366 succeeded
- review 4779075543 posted as lgtmaybe[bot]
- always() cleanup revoke step succeeded with token masked