### PR TITLE
fix: make identity broker Lambda importable

### DIFF
--- a/infra/identity/stack.py
+++ b/infra/identity/stack.py
@@ -208,7 +208,6 @@ class IdentityBrokerStack(Stack):
         common: dict[str, object] = {
             "runtime": lambda_.Runtime.PYTHON_3_14,
             "architecture": lambda_.Architecture.X86_64,
-            "handler": "handler.handler",
             "timeout": Duration.seconds(15),
             "memory_size": 256,
             "reserved_concurrent_executions": 5,
@@ -230,6 +229,7 @@ class IdentityBrokerStack(Stack):
                 "Broker",
                 entry=str(SERVICE_ROOT),
                 index="handler.py",
+                handler="handler",
                 bundling=BundlingOptions(
                     asset_excludes=["__pycache__", "*.pyc", ".pytest_cache", ".venv"]
                 ),
@@ -239,5 +239,6 @@ class IdentityBrokerStack(Stack):
             self,
             "Broker",
             code=lambda_.Code.from_asset(str(SERVICE_ROOT)),
+            handler="handler.handler",
             **common,
         )

--- a/services/github_app_identity/handler.py
+++ b/services/github_app_identity/handler.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from aws_lambda_powertools import Logger
-from services.github_app_identity.broker import (
-    BrokerError,
-    HttpGitHubAppClient,
-    IdentityBroker,
-    PyJwtOidcVerifier,
-)
+
+if TYPE_CHECKING or __package__:
+    from .broker import BrokerError, HttpGitHubAppClient, IdentityBroker, PyJwtOidcVerifier
+else:
+    from broker import BrokerError, HttpGitHubAppClient, IdentityBroker, PyJwtOidcVerifier
 
 logger = Logger(service="github-app-identity")
 _broker: IdentityBroker | None = None

--- a/tests/identity/test_handler.py
+++ b/tests/identity/test_handler.py
@@ -1,10 +1,30 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
 
 from services.github_app_identity import handler
 from services.github_app_identity.broker import BrokerError, InstallationToken
+
+
+def test_handler_imports_from_the_flat_lambda_bundle() -> None:
+    service_root = Path(__file__).parents[2] / "services" / "github_app_identity"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            f"import sys; sys.path.insert(0, {str(service_root)!r}); import handler",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 class SuccessfulBroker:

--- a/tests/identity/test_stack.py
+++ b/tests/identity/test_stack.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", EncodingWarning)
+    import infra.identity.stack as identity_stack
     from aws_cdk import App
+    from aws_cdk import aws_lambda as lambda_
     from aws_cdk.assertions import Match, Template
     from infra.identity.stack import IdentityBrokerStack
 
@@ -47,6 +50,46 @@ def test_stack_provisions_a_bounded_python_lambda_and_retained_secret() -> None:
             "DeletionPolicy": "Retain",
             "UpdateReplacePolicy": "Retain",
         },
+    )
+
+
+def test_bundled_stack_names_the_exported_handler_once(monkeypatch) -> None:
+    python_function_arguments: dict[str, object] = {}
+
+    def fake_python_function(
+        scope,
+        construct_id: str,
+        *,
+        entry: str,
+        index: str,
+        bundling,
+        handler: str,
+        **kwargs,
+    ):
+        python_function_arguments.update({"entry": entry, "index": index, "handler": handler})
+        return lambda_.Function(
+            scope,
+            construct_id,
+            code=lambda_.Code.from_asset(entry),
+            handler=f"{Path(index).stem}.{handler}",
+            **kwargs,
+        )
+
+    monkeypatch.setattr(identity_stack, "PythonFunction", fake_python_function)
+
+    stack = IdentityBrokerStack(
+        App(),
+        "BundledIdentityBroker",
+        app_id="3987976",
+        alarm_email="matt@coles.codes",
+    )
+    template = Template.from_stack(stack)
+
+    assert python_function_arguments["index"] == "handler.py"
+    assert python_function_arguments["handler"] == "handler"
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"Handler": "handler.handler"},
     )
 
 


### PR DESCRIPTION
## Summary

- import the broker correctly from CDK's flattened Lambda bundle while preserving package imports in tests and local development
- pass the exported function name once to PythonFunction, preventing a fresh synth from producing handler.handler.handler
- cover both Lambda cold-start import and synthesized handler naming with regression tests

## Production verification

- synthesized the real Python 3.14 Lambda asset
- booted the synthesized asset in AWS's Python 3.14 Lambda image
- reviewed cdk diff: one in-place Lambda code asset update, no replacements or removals
- deployed LgtmaybeGithubAppIdentity
- invoked the deployed function and received the expected sanitized 401 with no Lambda FunctionError

## Validation

- pytest -q: 1415 passed, 3 deselected
- ruff check .
- ruff format --check .
- mypy
- uv lock --check
- openspec validate add-lgtmaybe-app-identity --strict
- openspec validate --specs