### PR TITLE
chore: record correctness dogfood profile

### DIFF
--- a/openspec/changes/parallelise-correctness-review/tasks.md
+++ b/openspec/changes/parallelise-correctness-review/tasks.md
@@ -20,5 +20,11 @@
 
 - [x] 3.1 Run focused preset, prompt, concurrency, and eval tests.
 - [x] 3.2 Run the full test, lint, type, OpenSpec, anchor, drift, and docs gates.
-- [ ] 3.3 Compare the dogfood profile's correctness critical path and total
+- [x] 3.3 Compare the dogfood profile's correctness critical path and total
   tokens before deciding whether the split should ship.
+  The recorded pre-split straggler took 513 seconds and emitted 32,768 output
+  tokens. Production dogfood run 30154965187 split the work into
+  `correctness-flow` (97.37 seconds) and `correctness-state` (0.81 seconds);
+  together they used 8,907 input and 3,885 output tokens. The diffs were not
+  identical, so this is directional rather than a controlled A/B result, but
+  it shows no regression and supports keeping the split enabled.


### PR DESCRIPTION
## Summary

- record the production dogfood profile for split correctness review
- compare the observed split critical path and tokens with the recorded pre-split straggler
- complete the final OpenSpec task while noting this was directional evidence, not an A/B test

## Why

The split already shipped by explicit decision. The remaining task was to inspect production profiling and decide whether to keep it enabled.

## Impact

No runtime change. The parallel correctness change reaches 9/9 tasks complete and is ready for archival after this evidence lands.

## Validation

- openspec validate parallelise-correctness-review --strict
- git diff --check
- dogfood run 30154965187: correctness-flow 97.37s and correctness-state 0.81s, with 12,792 combined input/output tokens
- recorded pre-split straggler: 513s and 32,768 output tokens