### PR TITLE
chore(homebrew): rename the tap to MattJColes/tap

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,6 +1,7 @@
 name: homebrew
 
-# Publishes lgtmaybe to the Homebrew tap (MattJColes/homebrew-lgtmaybe).
+# Publishes lgtmaybe to the Homebrew tap (MattJColes/homebrew-tap, i.e. the tap
+# MattJColes/tap — so the formula is MattJColes/tap/lgtmaybe).
 #
 # The formula installs lgtmaybe + its dependency tree from PyPI **wheels** into an
 # isolated virtualenv (see scripts/update-homebrew-formula.sh). Building every
@@ -14,7 +15,7 @@ name: homebrew
 # workflow_dispatch (manual; `force` re-publishes the same version), a daily
 # schedule safety net, and release: published (for a human-cut release).
 #
-# One-time setup (see docs/how-to/releasing.md): create MattJColes/homebrew-lgtmaybe
+# One-time setup (see docs/how-to/releasing.md): create MattJColes/homebrew-tap
 # and add repo secret HOMEBREW_TAP_TOKEN (a PAT with contents:write on the tap).
 on:
   workflow_call:
@@ -69,7 +70,7 @@ jobs:
       - name: Checkout the tap
         uses: actions/checkout@v7
         with:
-          repository: MattJColes/homebrew-lgtmaybe
+          repository: MattJColes/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 
@@ -104,12 +105,13 @@ jobs:
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
         run: |
-          tap_link="$(brew --repository)/Library/Taps/local/homebrew-lgtmaybe"
+          # The directory name sets the tap slug: homebrew-tap -> local/tap.
+          tap_link="$(brew --repository)/Library/Taps/local/homebrew-tap"
           mkdir -p "$(dirname "$tap_link")"
           ln -sfn "$GITHUB_WORKSPACE/tap" "$tap_link"
           # Exactly what a user runs. With `preserve_rpath` the install must now
           # exit cleanly AND link `lgtmaybe` onto the prefix bin.
-          brew install --formula "local/lgtmaybe/lgtmaybe"
+          brew install --formula "local/tap/lgtmaybe"
           "$(brew --prefix)/bin/lgtmaybe" --help | grep -qi usage
           echo "smoke test passed: lgtmaybe installs cleanly and runs"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,13 @@ OIDC/WIF for cloud providers), and gets a review. One core, four distribution
 variants:
 
 - **PyPI CLI** — `pip install lgtmaybe`
-- **Homebrew CLI** — `brew install MattJColes/lgtmaybe/lgtmaybe` (after
-  `brew tap MattJColes/lgtmaybe` + `brew trust MattJColes/lgtmaybe` — current
+- **Homebrew CLI** — `brew install MattJColes/tap/lgtmaybe` (after
+  `brew tap MattJColes/tap` + `brew trust MattJColes/tap` — current
   Homebrew requires trusting third-party taps), from the
-  `MattJColes/homebrew-lgtmaybe` tap. The formula (`scripts/update-homebrew-formula.sh`)
+  `MattJColes/homebrew-tap` repo (Homebrew strips `homebrew-`, so the tap is
+  `MattJColes/tap`; the repo is deliberately *not* named `homebrew-lgtmaybe`,
+  which would make the formula `MattJColes/lgtmaybe/lgtmaybe`).
+  The formula (`scripts/update-homebrew-formula.sh`)
   creates a venv and `pip install`s lgtmaybe + deps from **PyPI wheels** — *not*
   per-dependency source `resource` stanzas: litellm's tree includes Rust sdists
   (tokenizers, hf-xet) that can't build in Homebrew's sandbox, and the wheel path
@@ -379,7 +382,7 @@ pattern, event bus, plugin framework.
      `v1`. `.github/workflows/commitlint.yml` (`commitlint.config.cjs`) gates PR
      titles/commits to conventional-commit format so the automation can version.
    - **Homebrew tap** — `.github/workflows/homebrew.yml` fires on the published
-     release and regenerates the formula in the `MattJColes/homebrew-lgtmaybe`
+     release and regenerates the formula in the `MattJColes/homebrew-tap`
      tap via `scripts/update-homebrew-formula.sh` (resolves the PyPI sdist
      url/sha, then `brew update-python-resources` fills the full dependency tree;
      pushes with the `HOMEBREW_TAP_TOKEN` PAT). Regenerated wholesale each release

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ author identity. See
 ## Distribution
 
 - **CLI (PyPI)** — `pip install lgtmaybe`
-- **CLI (Homebrew)** — `brew tap MattJColes/lgtmaybe && brew trust MattJColes/lgtmaybe && brew install lgtmaybe`
+- **CLI (Homebrew)** — `brew tap MattJColes/tap && brew trust MattJColes/tap && brew install lgtmaybe`
   ([details](docs/how-to/install-the-cli.md) — the `brew trust` step is required for third-party taps)
 - **CLI (WinGet, Windows x64)** — `winget install --id MattJColes.lgtmaybe --exact`
   ([details](docs/how-to/install-the-cli.md#install-on-windows-winget))

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -65,11 +65,11 @@ The regular `pip install lgtmaybe` path also works on Windows.
 ## Install on macOS (Homebrew)
 
 On macOS (and Linuxbrew) you can install from the project's
-[Homebrew tap](https://github.com/MattJColes/homebrew-lgtmaybe) instead of `pip`:
+[Homebrew tap](https://github.com/MattJColes/homebrew-tap) instead of `pip`:
 
 ```bash
-brew tap MattJColes/lgtmaybe
-brew trust MattJColes/lgtmaybe
+brew tap MattJColes/tap
+brew trust MattJColes/tap
 brew install lgtmaybe
 ```
 
@@ -78,13 +78,18 @@ third-party tap until you explicitly **trust** it (`Error: Refusing to load
 formula … from untrusted tap`). This is a one-time, per-machine decision that
 applies to every tap outside Homebrew's core — the tap author can't waive it for
 you, by design. To trust only this one formula instead of the whole tap, use
-`brew trust --formula MattJColes/lgtmaybe/lgtmaybe`.
+`brew trust --formula MattJColes/tap/lgtmaybe`.
 
-Tapping and installing in one line (`brew install MattJColes/lgtmaybe/lgtmaybe`)
+Tapping and installing in one line (`brew install MattJColes/tap/lgtmaybe`)
 works too, but still needs the `brew trust …` step first — otherwise the install
 stops at the untrusted-tap error.
 
 Upgrade later with `brew upgrade lgtmaybe`.
+
+If you tapped the earlier `MattJColes/lgtmaybe` name, switch over once with
+`brew untap MattJColes/lgtmaybe && brew tap MattJColes/tap` (then `brew trust
+MattJColes/tap`). Upgrades keep working on the old tap either way — GitHub
+redirects the renamed repo — so this is tidying, not a break.
 
 Homebrew installs lgtmaybe into its own isolated virtualenv, so it never touches
 your system or project Python. The formula creates the venv and installs

--- a/docs/how-to/releasing.md
+++ b/docs/how-to/releasing.md
@@ -15,8 +15,9 @@ tag (`v{major}`, currently `v1`) via the reusable `.github/workflows/release.yml
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
-formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
-`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version.
+formula** in the tap repo (`MattJColes/homebrew-tap`, i.e. the tap
+`MattJColes/tap`) so `brew install MattJColes/tap/lgtmaybe` tracks the latest
+version.
 `scripts/update-homebrew-formula.sh` writes a small formula that creates a venv
 and `pip install`s lgtmaybe + its dependencies from **PyPI wheels**, with no
 per-dependency `resource` stanzas. litellm's tree includes Rust sdists
@@ -72,12 +73,16 @@ The only human-only pieces:
 - First release only: from the GitHub release page, tick **"Publish this Action
   to the GitHub Marketplace"**, accept the terms, and pick the categories
   `code-review` and `continuous-integration`.
-- **Homebrew tap:** create the repo **`MattJColes/homebrew-lgtmaybe`** with a
+- **Homebrew tap:** create the repo **`MattJColes/homebrew-tap`** with a
   `Formula/` directory (it can start empty — the workflow writes the formula).
-  Add a repo secret **`HOMEBREW_TAP_TOKEN`** to *this* repo: a fine-grained PAT
-  with `contents: write` on the tap repo (the default `GITHUB_TOKEN` cannot push
-  to another repository). To seed or verify the formula by hand on a Mac, run
-  `scripts/update-homebrew-formula.sh <version> path/to/homebrew-lgtmaybe/Formula/lgtmaybe.rb`.
+  Homebrew strips the `homebrew-` prefix, so that repo is the tap
+  `MattJColes/tap` and the formula inside it is `MattJColes/tap/lgtmaybe` — name
+  the repo `homebrew-tap`, not `homebrew-lgtmaybe`, or the formula reads as
+  `MattJColes/lgtmaybe/lgtmaybe`. Add a repo secret **`HOMEBREW_TAP_TOKEN`** to
+  *this* repo: a fine-grained PAT with `contents: write` on the tap repo (the
+  default `GITHUB_TOKEN` cannot push to another repository). To seed or verify
+  the formula by hand on a Mac, run
+  `scripts/update-homebrew-formula.sh <version> path/to/homebrew-tap/Formula/lgtmaybe.rb`.
 - **winget:** fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
   Create a classic GitHub PAT with the `public_repo` scope and add it to this
   repo as **`WINGET_TOKEN`**. For the first release, build/upload the Windows

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -117,8 +117,8 @@ pip install lgtmaybe
 On macOS you can install from the Homebrew tap instead:
 
 ```bash
-brew tap MattJColes/lgtmaybe
-brew trust MattJColes/lgtmaybe   # current Homebrew requires trusting third-party taps
+brew tap MattJColes/tap
+brew trust MattJColes/tap   # current Homebrew requires trusting third-party taps
 brew install lgtmaybe
 ```
 
@@ -276,11 +276,11 @@ The regular `pip install lgtmaybe` path also works on Windows.
 ## Install on macOS (Homebrew)
 
 On macOS (and Linuxbrew) you can install from the project's
-[Homebrew tap](https://github.com/MattJColes/homebrew-lgtmaybe) instead of `pip`:
+[Homebrew tap](https://github.com/MattJColes/homebrew-tap) instead of `pip`:
 
 ```bash
-brew tap MattJColes/lgtmaybe
-brew trust MattJColes/lgtmaybe
+brew tap MattJColes/tap
+brew trust MattJColes/tap
 brew install lgtmaybe
 ```
 
@@ -289,13 +289,18 @@ third-party tap until you explicitly **trust** it (`Error: Refusing to load
 formula … from untrusted tap`). This is a one-time, per-machine decision that
 applies to every tap outside Homebrew's core — the tap author can't waive it for
 you, by design. To trust only this one formula instead of the whole tap, use
-`brew trust --formula MattJColes/lgtmaybe/lgtmaybe`.
+`brew trust --formula MattJColes/tap/lgtmaybe`.
 
-Tapping and installing in one line (`brew install MattJColes/lgtmaybe/lgtmaybe`)
+Tapping and installing in one line (`brew install MattJColes/tap/lgtmaybe`)
 works too, but still needs the `brew trust …` step first — otherwise the install
 stops at the untrusted-tap error.
 
 Upgrade later with `brew upgrade lgtmaybe`.
+
+If you tapped the earlier `MattJColes/lgtmaybe` name, switch over once with
+`brew untap MattJColes/lgtmaybe && brew tap MattJColes/tap` (then `brew trust
+MattJColes/tap`). Upgrades keep working on the old tap either way — GitHub
+redirects the renamed repo — so this is tidying, not a break.
 
 Homebrew installs lgtmaybe into its own isolated virtualenv, so it never touches
 your system or project Python. The formula creates the venv and installs
@@ -2954,8 +2959,9 @@ tag (`v{major}`, currently `v1`) via the reusable `.github/workflows/release.yml
 (built-in `GITHUB_TOKEN`). No publish tokens live in secrets.
 
 A third workflow, `.github/workflows/homebrew.yml`, regenerates the **Homebrew
-formula** in the tap repo (`MattJColes/homebrew-lgtmaybe`) so
-`brew install MattJColes/lgtmaybe/lgtmaybe` tracks the latest version.
+formula** in the tap repo (`MattJColes/homebrew-tap`, i.e. the tap
+`MattJColes/tap`) so `brew install MattJColes/tap/lgtmaybe` tracks the latest
+version.
 `scripts/update-homebrew-formula.sh` writes a small formula that creates a venv
 and `pip install`s lgtmaybe + its dependencies from **PyPI wheels**, with no
 per-dependency `resource` stanzas. litellm's tree includes Rust sdists
@@ -3011,12 +3017,16 @@ The only human-only pieces:
 - First release only: from the GitHub release page, tick **"Publish this Action
   to the GitHub Marketplace"**, accept the terms, and pick the categories
   `code-review` and `continuous-integration`.
-- **Homebrew tap:** create the repo **`MattJColes/homebrew-lgtmaybe`** with a
+- **Homebrew tap:** create the repo **`MattJColes/homebrew-tap`** with a
   `Formula/` directory (it can start empty — the workflow writes the formula).
-  Add a repo secret **`HOMEBREW_TAP_TOKEN`** to *this* repo: a fine-grained PAT
-  with `contents: write` on the tap repo (the default `GITHUB_TOKEN` cannot push
-  to another repository). To seed or verify the formula by hand on a Mac, run
-  `scripts/update-homebrew-formula.sh <version> path/to/homebrew-lgtmaybe/Formula/lgtmaybe.rb`.
+  Homebrew strips the `homebrew-` prefix, so that repo is the tap
+  `MattJColes/tap` and the formula inside it is `MattJColes/tap/lgtmaybe` — name
+  the repo `homebrew-tap`, not `homebrew-lgtmaybe`, or the formula reads as
+  `MattJColes/lgtmaybe/lgtmaybe`. Add a repo secret **`HOMEBREW_TAP_TOKEN`** to
+  *this* repo: a fine-grained PAT with `contents: write` on the tap repo (the
+  default `GITHUB_TOKEN` cannot push to another repository). To seed or verify
+  the formula by hand on a Mac, run
+  `scripts/update-homebrew-formula.sh <version> path/to/homebrew-tap/Formula/lgtmaybe.rb`.
 - **winget:** fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
   Create a classic GitHub PAT with the `public_repo` scope and add it to this
   repo as **`WINGET_TOKEN`**. For the first release, build/upload the Windows

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -24,8 +24,8 @@ pip install lgtmaybe
 On macOS you can install from the Homebrew tap instead:
 
 ```bash
-brew tap MattJColes/lgtmaybe
-brew trust MattJColes/lgtmaybe   # current Homebrew requires trusting third-party taps
+brew tap MattJColes/tap
+brew trust MattJColes/tap   # current Homebrew requires trusting third-party taps
 brew install lgtmaybe
 ```
 

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   scripts/update-homebrew-formula.sh <version> <output-formula-path>
 # e.g.
-#   scripts/update-homebrew-formula.sh 0.7.2 ../homebrew-lgtmaybe/Formula/lgtmaybe.rb
+#   scripts/update-homebrew-formula.sh 0.7.2 ../homebrew-tap/Formula/lgtmaybe.rb
 set -euo pipefail
 
 VERSION="${1:?usage: update-homebrew-formula.sh <version> <output-formula-path>}"

--- a/tests/test_homebrew_distribution.py
+++ b/tests/test_homebrew_distribution.py
@@ -1,0 +1,75 @@
+"""Release-workflow and docs contracts for the Homebrew tap.
+
+The tap slug comes from the tap repo's name: `MattJColes/homebrew-tap` resolves to
+the tap `MattJColes/tap`, so the fully-qualified formula is
+`MattJColes/tap/lgtmaybe`. These tests pin that name in the publish workflow and
+the install docs, because a mismatch between the two only shows up at release time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).parent.parent
+_WORKFLOWS = _ROOT / ".github" / "workflows"
+
+TAP_REPO = "MattJColes/homebrew-tap"
+TAP = "MattJColes/tap"
+FORMULA = f"{TAP}/lgtmaybe"
+
+
+def _workflow(name: str) -> tuple[str, dict]:
+    text = (_WORKFLOWS / name).read_text(encoding="utf-8")
+    return text, yaml.safe_load(text)
+
+
+def test_homebrew_workflow_targets_the_tap_repo() -> None:
+    text, workflow = _workflow("homebrew.yml")
+    steps = {step["name"]: step for step in workflow["jobs"]["formula"]["steps"]}
+    checkout = steps["Checkout the tap"]
+
+    assert checkout["with"]["repository"] == TAP_REPO
+    assert checkout["with"]["token"] == "${{ secrets.HOMEBREW_TAP_TOKEN }}"
+    # A tap rename changes only the slug — the formula file keeps its name.
+    assert "tap/Formula/lgtmaybe.rb" in text
+    assert "homebrew-lgtmaybe" not in text
+
+
+def test_homebrew_smoke_test_installs_the_generated_formula() -> None:
+    _text, workflow = _workflow("homebrew.yml")
+    steps = {step["name"]: step for step in workflow["jobs"]["formula"]["steps"]}
+    run = steps["Smoke-test that the formula installs and runs"]["run"]
+
+    # The local tap directory name and the install spec must agree: Homebrew derives
+    # `local/tap` from a `Library/Taps/local/homebrew-tap` directory.
+    assert "Library/Taps/local/homebrew-tap" in run
+    assert 'brew install --formula "local/tap/lgtmaybe"' in run
+
+
+def test_homebrew_docs_use_the_renamed_tap() -> None:
+    readme = (_ROOT / "README.md").read_text(encoding="utf-8")
+    guide = (_ROOT / "docs" / "how-to" / "install-the-cli.md").read_text(encoding="utf-8")
+    tutorial = (_ROOT / "docs" / "tutorial" / "getting-started.md").read_text(encoding="utf-8")
+
+    for text in (readme, guide, tutorial):
+        assert f"brew tap {TAP}" in text
+        assert f"brew trust {TAP}" in text
+        assert "MattJColes/lgtmaybe/lgtmaybe" not in text
+
+    assert f"brew install {FORMULA}" in guide
+    assert f"https://github.com/{TAP_REPO}" in guide
+    # Anyone already on the old tap needs the one-time switch.
+    assert "brew untap MattJColes/lgtmaybe" in guide
+
+
+def test_releasing_guide_names_the_tap_repo_to_create() -> None:
+    guide = (_ROOT / "docs" / "how-to" / "releasing.md").read_text(encoding="utf-8")
+
+    assert TAP_REPO in guide
+    assert "HOMEBREW_TAP_TOKEN" in guide
+    assert f"brew install {FORMULA}" in guide
+    # The guide may name the old slug to explain why the repo isn't called that,
+    # but it must never point at it.
+    assert "MattJColes/homebrew-lgtmaybe" not in guide


### PR DESCRIPTION
## Why

`brew upgrade` prints third-party formulae fully qualified as `owner/tap/formula`, and the tap slug is the tap repo's name minus the `homebrew-` prefix. With the tap repo called `homebrew-lgtmaybe`, the formula rendered as `mattjcoles/lgtmaybe/lgtmaybe`:

```
==> Upgrading mattjcoles/lgtmaybe/lgtmaybe
  0.12.2 -> 1.5.3
```

That's correct Homebrew behaviour, not a bug — a two-component `mattjcoles/lgtmaybe` names a *tap*, never an installable formula, so the short form can't be made to work. The name just reads as duplicated.

Renaming the tap repo to `homebrew-tap` gives `MattJColes/tap/lgtmaybe` — the `hashicorp/tap/terraform` / `charmbracelet/tap/gum` convention — which reads as deliberate, and leaves room for a second formula in the same tap later.

## What changed

- **`.github/workflows/homebrew.yml`** — clone/push target is now `MattJColes/homebrew-tap`. The install gate's local tap symlink becomes `Library/Taps/local/homebrew-tap` and the install spec `local/tap/lgtmaybe`; those two derive from each other, so they had to move together or the gate breaks.
- **`scripts/update-homebrew-formula.sh`** — usage-example path only. The generated formula body is untouched: a tap rename doesn't change `Formula/lgtmaybe.rb` or `class Lgtmaybe`.
- **Docs** — every `brew tap` / `brew trust` / `brew install` string in `README.md`, `docs/tutorial/getting-started.md`, and `docs/how-to/install-the-cli.md`. The install guide also gains a one-time switch note for anyone already on the old tap (`brew untap MattJColes/lgtmaybe && brew tap MattJColes/tap`) — upgrades keep working via GitHub's redirect either way, so this is tidying, not a break.
- **`docs/how-to/releasing.md` + `CLAUDE.md`** — the tap repo to create, and an explicit note on why it's `homebrew-tap` and not `homebrew-lgtmaybe`, so the duplication doesn't get reintroduced.
- **`docs/llms-full.txt`** — regenerated via `docs/generate_llms_txt.py` (`docs/llms.txt` carries no slug and is unchanged).
- **`tests/test_homebrew_distribution.py`** (new) — written first and watched fail. Pins the workflow's checkout target, the symlink/install-spec agreement, and the docs strings.

## Required manual step

Rename the GitHub repo **`MattJColes/homebrew-lgtmaybe` → `MattJColes/homebrew-tap`** (Settings → General → Repository name) **before merging**, or at minimum before the next release fires `homebrew.yml`. GitHub redirects old → new, so existing users' `brew upgrade lgtmaybe` keeps working — but `actions/checkout` with the new name fails until the rename is done.

Nothing needs committing in the tap repo: the slug comes from the repo name, and the next release run rewrites `Formula/lgtmaybe.rb` as usual. `HOMEBREW_TAP_TOKEN` is scoped to the repo and survives a rename.

## Testing

- `uv run pytest -q` — 1419 passed, 3 deselected
- `uv run pytest tests/specs -q` — 17 passed (no spec covers Homebrew packaging, so no spec edit needed)
- `uv run ruff check . && uv run ruff format --check .` — clean
- Residual-slug sweep: the only remaining `homebrew-lgtmaybe` mentions are the deliberate "don't name it that" explanations and the negative test assertions.
- Not run here: the macOS `homebrew.yml` job itself. After the repo rename, dispatch it with `force=true` and confirm it reaches "smoke test passed" and pushes to the renamed tap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4zvYY85Ci2goMGyYWzQdn)_