### PR TITLE
test(retry): widen the wall-clock margin so Windows can't lose the race

### DIFF
--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -378,7 +378,13 @@ class TestFailFastOnPermanentErrors:
         def slow_transient(*args: Any, **kwargs: Any) -> Any:
             nonlocal calls
             calls += 1
-            time.sleep(0.06)
+            # Must outlast the 0.05s wall bound by more than the platform's timer
+            # granularity, or `future.result(timeout=...)` can over-wait, see the
+            # call already finished, and surface this RuntimeError instead of the
+            # TimeoutError under test — 0.06s lost that race on Windows (~15.6ms
+            # granularity). The wall timeout abandons the worker thread rather
+            # than joining it, so a long sleep costs no test time.
+            time.sleep(1.0)
             raise RuntimeError("transient")
 
         with patch("litellm.completion", side_effect=slow_transient):


### PR DESCRIPTION
## Why

`tests/providers/test_retry.py::test_attempts_share_a_wall_clock_budget_derived_from_the_timeout` flaked on #258's `test (windows-latest)` leg and passed on re-run. The diff there touched no Python source, so it wasn't caused by that change — the test itself is timing-fragile.

The mock slept `0.06s` against a `0.05s` per-request wall timeout: a **10ms margin**, under Windows' ~15.6ms default timer granularity. So `future.result(timeout=0.05)` can over-wait past the sleep, find the future already complete, and surface the mock's `RuntimeError("transient")` instead of the `TimeoutError` the test asserts. The failing log shows exactly that path.

## What changed

One line: sleep `1.0s` instead of `0.06s`, so the margin dwarfs any platform's clock granularity, plus a comment recording why the number matters (so it doesn't get "tidied" back down).

**This costs no test time.** `_completion_with_wall_timeout` runs the call on a bare `daemon=True` thread and *abandons* it when `future.result(timeout=...)` raises — there's no executor shutdown to join it, so the sleep never elapses in-test. Full suite: 57s, versus 64s before the change (noise, not a regression).

The production wall-timeout logic is correct and is untouched — only the test's margin was fragile.

Both assertions keep their meaning:

- `pytest.raises(TimeoutError, match="exceeded 0.05")` — now deterministically the wall bound, which is the behaviour under test.
- `assert calls < _MAX_ATTEMPTS` (4) — the budget is `0.05 × _CALL_BUDGET_MULTIPLIER` (2.5) = `0.125s`, and one attempt (~0.05s) plus the first `wait_exponential_jitter` backoff (initial 0.1s) still exceeds it, so `stop_after_delay` fires before the attempt cap.

It's the only sleep-margin test in the suite (`grep -rn 'sleep(0\.' tests/` → this one hit), so there's nothing else of this shape to fix.

## Testing

- Target test run 5× in a row — passed every time (it was intermittent before, so repetition is the check that matters locally)
- `uv run pytest -q` — 1419 passed, 3 deselected, 57.39s
- `uv run ruff check . && uv run ruff format --check .` — clean
- The real confirmation is this PR's `test (windows-latest)` leg, since Windows is the platform that flaked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4zvYY85Ci2goMGyYWzQdn)_