### PR TITLE
fix(providers): make the wall-clock timeout clock-authoritative

### DIFF
--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -69,8 +69,14 @@ on `ProviderResult`.
 #### Scenario: provider SDK ignores its timeout
 - **WHEN** the underlying completion call remains blocked past the configured
   timeout
-- **THEN** the adapter raises a timeout error and the existing bounded retry
-  policy decides whether to retry
+- **THEN** the adapter raises a timeout error reporting the measured wait, and the
+  existing bounded retry policy decides whether to retry
+
+#### Scenario: the call completes just past the deadline
+- **WHEN** the completion finishes within the platform timer's granularity after
+  the deadline (coarse-timer platforms overshoot by ~15ms)
+- **THEN** its outcome is honoured rather than discarded, so a paid response is not
+  wasted and a permanent error is not masked as a retryable timeout
 
 #### Scenario: primary model keeps failing
 - **WHEN** retries on the primary model are exhausted and a fallback is set

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -7,6 +7,7 @@ optional fallback model.
 from __future__ import annotations
 
 import threading
+import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
@@ -344,7 +345,19 @@ def _cache_block(text: str) -> dict[str, Any]:
 def _completion_with_wall_timeout(
     model: str, messages: list[Message], kwargs: dict[str, Any]
 ) -> Any:
-    """Call LiteLLM with a real wall-clock bound even if its transport hangs."""
+    """Call LiteLLM with a real wall-clock bound even if its transport hangs.
+
+    The deadline is owned by the monotonic clock, not delegated to a single
+    ``Future.result(timeout=...)`` wait: on a coarse-timer platform (Windows'
+    default granularity is ~15.6ms) that wait can resolve either side of the
+    deadline, which made "did this time out?" a question about thread scheduling
+    rather than about elapsed time. Re-checking the clock keeps the bound honest and
+    puts the measured wait in the error.
+
+    A call that *did* complete, even a hair past the deadline, is still honoured —
+    discarding it would waste a response the provider already billed for and, worse,
+    resurface a permanent error (see ``_is_permanent``) as a retryable TimeoutError.
+    """
     timeout = float(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
     future: Future[Any] = Future()
 
@@ -354,11 +367,22 @@ def _completion_with_wall_timeout(
         except BaseException as exc:
             future.set_exception(exc)
 
+    start = time.monotonic()
+    deadline = start + timeout
     threading.Thread(target=complete, name="lgtmaybe-provider", daemon=True).start()
-    try:
-        return future.result(timeout=timeout)
-    except FutureTimeoutError as exc:
-        raise TimeoutError(f"provider request exceeded {timeout:g}s") from exc
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            return future.result(timeout=remaining)
+        except FutureTimeoutError:
+            continue  # the wait resolved early — trust the clock, not the wakeup
+    if future.done():
+        return future.result()
+    raise TimeoutError(
+        f"provider request exceeded {timeout:g}s (waited {time.monotonic() - start:.3f}s)"
+    )
 
 
 def _trailing_user_run(messages: list[Message]) -> tuple[int, list[Message]]:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -12,6 +12,7 @@ import httpx
 import litellm
 import pytest
 
+from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
 
 
@@ -45,6 +46,80 @@ class TestRetry:
             release.set()
 
         assert time.perf_counter() - started < 0.5
+
+    def test_timeout_error_reports_the_measured_wait(self) -> None:
+        """The bound is decided by the monotonic clock, so the error says how long
+        we actually waited — an overshoot on a coarse-timer platform (Windows'
+        ~15.6ms granularity) is then visible instead of silent."""
+        release = threading.Event()
+
+        def hangs(*args: Any, **kwargs: Any) -> Any:
+            release.wait(timeout=5)
+            return _fake_response()
+
+        try:
+            with (
+                patch("litellm.completion", side_effect=hangs),
+                patch("lgtmaybe.providers.litellm_provider._MAX_ATTEMPTS", 1),
+            ):
+                provider = LiteLLMProvider(timeout=0.05)
+                with pytest.raises(TimeoutError, match=r"exceeded 0.05s \(waited \d+\.\d+s\)"):
+                    provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+        finally:
+            release.set()
+
+    def test_call_completing_inside_the_timer_slop_is_not_discarded(self) -> None:
+        """A call that finished just past the deadline is honoured, not thrown away.
+
+        Discarding it would waste a response the provider already billed for, and
+        (worse) surface a *permanent* error as a retryable TimeoutError. Driven with
+        a fake clock and an inline worker so it pins the behaviour deterministically
+        rather than racing a real deadline.
+        """
+        # start=0.0, then every check is past the 0.05s deadline.
+        clock = iter([0.0] + [100.0] * 20)
+
+        class _InlineThread:
+            """Runs the worker inline, so the future is complete before the wait."""
+
+            def __init__(self, target: Any, **_: Any) -> None:
+                self._target = target
+
+            def start(self) -> None:
+                self._target()
+
+        with (
+            patch("litellm.completion", return_value=_fake_response("late but complete")),
+            patch.object(provider_module, "time", SimpleNamespace(monotonic=lambda: next(clock))),
+            patch.object(provider_module.threading, "Thread", _InlineThread),
+        ):
+            response = provider_module._completion_with_wall_timeout(
+                "openai/gpt-4o", [{"role": "user", "content": "hi"}], {"timeout": 0.05}
+            )
+
+        assert response.choices[0].message.content == "late but complete"
+
+    def test_permanent_error_is_not_converted_into_a_retryable_timeout(self) -> None:
+        """A permanent failure must surface as itself. TimeoutError is retryable
+        (it is not in _PERMANENT_ERROR_TYPES), so masking one as a timeout would
+        turn fail-fast into a retry storm."""
+        calls = 0
+
+        def bad_auth(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.AuthenticationError(
+                message="AuthenticationError: invalid api key",
+                model="gpt-4o",
+                llm_provider="openai",
+            )
+
+        with patch("litellm.completion", side_effect=bad_auth):
+            provider = LiteLLMProvider(timeout=0.05)
+            with pytest.raises(litellm.AuthenticationError):
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert calls == 1
 
     def test_first_call_raises_then_retry_succeeds(self) -> None:
         """Provider retries on transient failure and returns the good result."""


### PR DESCRIPTION
## Why

`_completion_with_wall_timeout` documents "a real wall-clock bound even if its transport hangs", but it delegated the entire decision to a single call:

```python
return future.result(timeout=timeout)
```

So whether a late call timed out depended on how that one `Condition.wait` happened to resolve, not on elapsed time — and when it overshot, nothing recorded that it had. Windows' ~15.6ms default timer granularity is where this surfaces: it's exactly what let a 0.06s call beat a 0.05s bound in #259. That PR fixed the right thing for that symptom (the test's margin); this fixes the underlying property.

## What changed

The deadline is now owned by the monotonic clock: compute it once from `time.monotonic()`, re-check the clock when a wait resolves early rather than trusting the wakeup, and report the measured wait in the error so an overshoot is visible instead of silent.

```
TimeoutError: provider request exceeded 0.05s (waited 0.052s)
```

## The deliberate carve-out

**A call that did complete — even a hair past the deadline — is still honoured, not discarded.** Being strict there would be actively worse:

1. It throws away a response the provider already billed for.
2. `TimeoutError` is **retryable** — it isn't in `_PERMANENT_ERROR_TYPES`. So converting a late-arriving *permanent* error (bad auth, malformed request) into a `TimeoutError` would turn fail-fast into a retry storm, which is precisely what `_is_permanent` exists to prevent.

This is a behaviour boundary rather than a pure bug fix, so it's pinned by a test *and* recorded as a spec scenario on `provider.complete`, so a later tidy-up can't quietly reverse it.

## Testing

Three tests added to `TestRetry` (`tests/providers/test_retry.py`):

- **`test_timeout_error_reports_the_measured_wait`** — the red case; the old message had no elapsed.
- **`test_call_completing_inside_the_timer_slop_is_not_discarded`** — the carve-out. Driven with a fake clock and an inline worker so it's deterministic; the whole point of #259 was that racing a real deadline is how you get a flaky test, so this one doesn't.
- **`test_permanent_error_is_not_converted_into_a_retryable_timeout`** — regression guard for reason 2 above.

The three existing `"exceeded 0.05"` matchers still pass — the message prefix is unchanged.

- `uv run pytest -q` — 1422 passed, 3 deselected
- `tests/providers/test_retry.py` run 5× consecutively — 26 passed each time
- `uv run pytest tests/specs -q` — 17 passed; `openspec validate --specs` — 10 passed, 0 failed
- `uv run ruff check . && uv run ruff format --check .` — clean; `uv run mypy src` — clean
- Windows is the platform that exposes the original weakness, so this PR's `test (windows-latest)` leg is the real confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4zvYY85Ci2goMGyYWzQdn)_