### PR TITLE
feat(timeouts): raise every wall-clock budget so slow calls finish

### DIFF
--- a/.github/workflows/action-e2e.yml
+++ b/.github/workflows/action-e2e.yml
@@ -42,8 +42,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'lgtmaybe-e2e')
     runs-on: ubuntu-latest
     # Each leg builds an image + runs one real review; cap it so a hung provider
-    # call can't hold the runner for GitHub's 6-hour default.
-    timeout-minutes: 20
+    # call can't hold the runner for GitHub's 6-hour default. Above the review's
+    # own `max_review_seconds` ceiling so the soft deadline fires first.
+    timeout-minutes: 75
     name: ${{ matrix.provider }}
     strategy:
       fail-fast: false

--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -48,8 +48,10 @@ jobs:
     # A healthy full review runs in a handful of minutes; cap it so a wedged
     # model call can't sit on the runner for GitHub's 6-hour default. Fail-fast on
     # permanent provider errors (quota/auth) means this only ever trips on a real
-    # hang, not on an out-of-credit key.
-    timeout-minutes: 20
+    # hang, not on an out-of-credit key. Kept above the review's own
+    # `max_review_seconds` ceiling (60 min) so the soft deadline — which posts
+    # partial findings — always fires first; a killed job posts nothing at all.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7 # base repo only — for action.yml + .lgtmaybe.yml config
       - uses: ./

--- a/action.yml
+++ b/action.yml
@@ -43,11 +43,11 @@ inputs:
     required: false
     default: ""
   timeout:
-    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama, openai-compatible and openrouter 900, cloud 300)."
+    description: "Enforced wall-clock timeout in seconds for each model call. Leave empty for the provider default (ollama, openai-compatible and openrouter 1800, cloud 600)."
     required: false
     default: ""
   max_review_seconds:
-    description: "Soft wall-clock ceiling for the whole review, in seconds (default 1800). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with an incomplete-results notice. Set 0 to disable."
+    description: "Soft wall-clock ceiling for the whole review, in seconds (default 3600). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with an incomplete-results notice. Set 0 to disable."
     required: false
     default: ""
   temperature:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -183,16 +183,18 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 300s for direct cloud providers, 900s for the ones that may front a
+  timeout: 600s for direct cloud providers, 1800s for the ones that may front a
   slow model — ollama and openai-compatible (local servers) and openrouter (a
   gateway to arbitrary models, including slow reasoning ones) — overridable via
   `timeout` / `--timeout`. All attempts for
   one call additionally share a wall-clock budget of **2.5× that timeout**, so
   a flaky model can't burn four full timeouts plus backoff per lens. The
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
-  run can't hold a runner for GitHub's six-hour default.
+  run can't hold a runner for GitHub's six-hour default — set above
+  `max_review_seconds`, so the soft deadline (which still posts partial
+  findings) always fires before the runner is killed.
 
-- **A whole-review deadline.** `max_review_seconds` (default 1800, `0` disables)
+- **A whole-review deadline.** `max_review_seconds` (default 3600, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -281,7 +281,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
-| `max_review_seconds` | 1800 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
+| `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
 | `min_severity` | `low` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`); `low` keeps everything except pure-`info` narration. |

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -226,16 +226,16 @@ Default: `true`.
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
-**provider-aware default**: **900 s for ollama, openai-compatible, and
+**provider-aware default**: **1800 s for ollama, openai-compatible, and
 openrouter** (local models are slow, and openrouter can route to slow reasoning
-models) and 300 s for direct cloud providers. Set it explicitly to raise it for a
+models) and 600 s for direct cloud providers. Set it explicitly to raise it for a
 large local model.
 
 ```yaml
-timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
+timeout: 3600   # an hour per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 300 s). See
+Default: auto (ollama/openai-compatible/openrouter 1800 s, cloud 600 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -183,23 +183,23 @@ branch locally before opening a PR. See
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
-long default per-request timeout (900 seconds)** automatically — you don't need
-to set anything for a normal run. (Direct cloud providers default to 300 s.)
+long default per-request timeout (1800 seconds)** automatically — you don't need
+to set anything for a normal run. (Direct cloud providers default to 600 s.)
 
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 1800.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 1800
+  --api-base http://localhost:11434 --timeout 3600
 ```
 
 ```yaml
 # or in .lgtmaybe.yml (also how the GitHub Action picks it up):
 provider: ollama
 model: qwen3.6:35b
-timeout: 900
+timeout: 1800
 ```
 
 The review fans out **three calls** under the default `fast` preset (nine under
@@ -247,14 +247,14 @@ ignore it):
 # A large multi-file diff on a local model — more time and more context
 # (32768 is already the default; go above it for very large diffs):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 900 --num-ctx 65536
+  --api-base http://localhost:11434 --timeout 1800 --num-ctx 65536
 ```
 
 ```yaml
 # or in .lgtmaybe.yml (also how the GitHub Action picks it up):
 provider: ollama
 model: qwen3.6:35b
-timeout: 900
+timeout: 1800
 num_ctx: 65536
 ```
 

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -66,7 +66,7 @@ The API key, when you do supply one, is read from the environment or `--api-key`
 and is **never persisted** to config.
 
 Because the endpoint might be a slow local model, `openai-compatible` defaults to
-the same generous **900s** per-call timeout as ollama. For a fast hosted endpoint
+the same generous **1800s** per-call timeout as ollama. For a fast hosted endpoint
 like DeepSeek you can dial it down with `--timeout` (or `timeout:` in config).
 
 ## DeepSeek (hosted, keyed)

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -200,7 +200,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 300s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -210,7 +210,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `1800` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -539,7 +539,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 900s, cloud 300s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -549,7 +549,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `1800` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |
@@ -1719,23 +1719,23 @@ branch locally before opening a PR. See
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
-long default per-request timeout (900 seconds)** automatically — you don't need
-to set anything for a normal run. (Direct cloud providers default to 300 s.)
+long default per-request timeout (1800 seconds)** automatically — you don't need
+to set anything for a normal run. (Direct cloud providers default to 600 s.)
 
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 900.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 1800.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 1800
+  --api-base http://localhost:11434 --timeout 3600
 ```
 
 ```yaml
 # or in .lgtmaybe.yml (also how the GitHub Action picks it up):
 provider: ollama
 model: qwen3.6:35b
-timeout: 900
+timeout: 1800
 ```
 
 The review fans out **three calls** under the default `fast` preset (nine under
@@ -1783,14 +1783,14 @@ ignore it):
 # A large multi-file diff on a local model — more time and more context
 # (32768 is already the default; go above it for very large diffs):
 lgtmaybe review --provider ollama --model qwen3.6:35b \
-  --api-base http://localhost:11434 --timeout 900 --num-ctx 65536
+  --api-base http://localhost:11434 --timeout 1800 --num-ctx 65536
 ```
 
 ```yaml
 # or in .lgtmaybe.yml (also how the GitHub Action picks it up):
 provider: ollama
 model: qwen3.6:35b
-timeout: 900
+timeout: 1800
 num_ctx: 65536
 ```
 
@@ -1882,7 +1882,7 @@ The API key, when you do supply one, is read from the environment or `--api-key`
 and is **never persisted** to config.
 
 Because the endpoint might be a slow local model, `openai-compatible` defaults to
-the same generous **900s** per-call timeout as ollama. For a fast hosted endpoint
+the same generous **1800s** per-call timeout as ollama. For a fast hosted endpoint
 like DeepSeek you can dial it down with `--timeout` (or `timeout:` in config).
 
 ## DeepSeek (hosted, keyed)
@@ -2226,16 +2226,16 @@ Default: `true`.
 ### timeout
 
 Per-request timeout in seconds for each model call. Left unset, lgtmaybe picks a
-**provider-aware default**: **900 s for ollama, openai-compatible, and
+**provider-aware default**: **1800 s for ollama, openai-compatible, and
 openrouter** (local models are slow, and openrouter can route to slow reasoning
-models) and 300 s for direct cloud providers. Set it explicitly to raise it for a
+models) and 600 s for direct cloud providers. Set it explicitly to raise it for a
 large local model.
 
 ```yaml
-timeout: 1800   # 30 minutes per call, e.g. for a big model on CPU
+timeout: 3600   # an hour per call, e.g. for a big model on CPU
 ```
 
-Default: auto (ollama/openai-compatible/openrouter 900 s, cloud 300 s). See
+Default: auto (ollama/openai-compatible/openrouter 1800 s, cloud 600 s). See
 [Run locally with ollama](run-locally-with-ollama.md#slow-models-and-timeouts).
 
 ### structured_output
@@ -3144,7 +3144,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
-| `max_review_seconds` | integer | No | `1800` | Max Review Seconds |
+| `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -3790,7 +3790,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 1800,
+      "default": 3600,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"
@@ -4490,7 +4490,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
-| `max_review_seconds` | 1800 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
+| `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
 | `min_severity` | `low` | Drops findings below the chosen floor (`info` → `low` → `medium` → `high` → `critical`); `low` keeps everything except pure-`info` narration. |
@@ -4814,16 +4814,18 @@ network recovers but a dead-end failure surfaces fast:
   — lgtmaybe owns the retry policy in one place.
 
 - **Per-request timeout and a shared retry budget.** Every model call carries a
-  timeout: 300s for direct cloud providers, 900s for the ones that may front a
+  timeout: 600s for direct cloud providers, 1800s for the ones that may front a
   slow model — ollama and openai-compatible (local servers) and openrouter (a
   gateway to arbitrary models, including slow reasoning ones) — overridable via
   `timeout` / `--timeout`. All attempts for
   one call additionally share a wall-clock budget of **2.5× that timeout**, so
   a flaky model can't burn four full timeouts plus backoff per lens. The
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
-  run can't hold a runner for GitHub's six-hour default.
+  run can't hold a runner for GitHub's six-hour default — set above
+  `max_review_seconds`, so the soft deadline (which still posts partial
+  findings) always fires before the runner is killed.
 
-- **A whole-review deadline.** `max_review_seconds` (default 1800, `0` disables)
+- **A whole-review deadline.** `max_review_seconds` (default 3600, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -35,7 +35,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
-| `max_review_seconds` | integer | No | `1800` | Max Review Seconds |
+| `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -681,7 +681,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 1800,
+      "default": 3600,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -238,7 +238,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "--max-review-seconds",
     default=None,
     type=click.IntRange(min=0),
-    help="Soft wall-clock ceiling for the whole review (default 1800). Past it, "
+    help="Soft wall-clock ceiling for the whole review (default 3600). Past it, "
     "no further model calls are dispatched — in-flight calls finish and the "
     "review returns partial results with an incomplete-results notice. 0 disables",
 )

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -670,10 +670,10 @@ class ReviewConfig(_Strict):
     # findings post, and the summary carries the existing "results may be
     # incomplete" notice naming the skipped calls. It can never turn a total
     # failure into a silent LGTM — a run where every call failed or was
-    # skipped still fails loud. Generous by default (30 minutes — 2× the
+    # skipped still fails loud. Generous by default (60 minutes — 2× the
     # generous per-call timeout, so one slow gateway/local call can't eat the
     # whole review budget); 0 disables the ceiling entirely.
-    max_review_seconds: int = Field(default=1800, ge=0)
+    max_review_seconds: int = Field(default=3600, ge=0)
     # Ceiling on concurrent review calls across the WHOLE fan-out (every
     # (batch, lens) task shares one pool). None means auto: 8 for hosted cloud
     # providers (their retry layer absorbs a capacity 429, and on bedrock cache

--- a/src/lgtmaybe/engine/astgrep.py
+++ b/src/lgtmaybe/engine/astgrep.py
@@ -45,8 +45,9 @@ RootProvider = Callable[[], "Path | None"]
 AstGrepRunner = Callable[[str, str, Path], str]
 
 # A structural scan of one repo is sub-second (validated at ~20ms over this repo);
-# the timeout only caps a pathological run, never a normal one.
-_SCAN_TIMEOUT = 20
+# the timeout only caps a pathological run, never a normal one — so it is set well
+# above what a large monorepo needs rather than near the measured cost.
+_SCAN_TIMEOUT = 60
 _MAX_CANDIDATES = 3
 # Only resolve identifier-shaped names. This both filters out path-shaped `needs`
 # (handled by the path fetcher) and keeps the symbol safe to drop into the rule's

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -38,8 +38,10 @@ from lgtmaybe.core.models import ReviewConfig, Severity, StaticAnalysisTool
 _log = get_logger(__name__)
 _WINDOWS = os.name == "nt"
 
-# Hard per-tool wall-clock cap: a hung linter must never hang the review.
-_TOOL_TIMEOUT = 60
+# Hard per-tool wall-clock cap: a hung linter must never hang the review. Large
+# enough that semgrep over a many-file change still finishes — a tool killed
+# mid-scan degrades to no hints at all, silently.
+_TOOL_TIMEOUT = 180
 
 # Ceiling on hints handed to the prompts, most severe first. Beyond this a
 # noisy lint run is compressed rather than allowed to crowd out the diff.

--- a/src/lgtmaybe/github/checkout.py
+++ b/src/lgtmaybe/github/checkout.py
@@ -29,7 +29,9 @@ _log = get_logger(__name__)
 
 # A shallow single-branch clone of one repo is quick; the timeout only caps a
 # pathological clone, and a slow one degrades to "no corpus" rather than hanging.
-_CLONE_TIMEOUT = 120
+# Sized for a big monorepo on a cold runner — losing symbol resolution to an
+# impatient clock costs the auditor real context.
+_CLONE_TIMEOUT = 300
 
 # Injected so tests don't shell out to real git. Mirrors subprocess.run's surface
 # for the args we pass.

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -35,7 +35,10 @@ from .diff import CommentableLines, build_commentable_lines, is_reviewable
 
 _log = get_logger(__name__)
 
-_TIMEOUT = httpx.Timeout(30.0)
+# GitHub's API is usually fast, but a cold runner behind a proxy — or a large
+# PR's file listing — is not. The timeout exists to cap a hung socket, not to
+# race a slow-but-healthy response into a failed review.
+_TIMEOUT = httpx.Timeout(60.0)
 _MARKER = "<!-- lgtmaybe -->"
 _GRAPHQL_URL = "https://api.github.com/graphql"
 

--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -14,7 +14,9 @@ from pathlib import Path
 
 from lgtmaybe.core.models import PRContext
 
-_TIMEOUT = 30
+# `git diff` over a large working tree (or a repo whose objects are cold) can
+# take a while; the timeout only caps a hung git, never a slow one.
+_TIMEOUT = 120
 
 
 def local_pr_context(

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -45,8 +45,13 @@ _PREFIXES: dict[Provider, str] = {
 # default; direct cloud providers get a shorter one that still leaves room
 # for a reasoning model to think. An explicit --timeout always wins, so a
 # fast endpoint can dial it down.
-_SLOW_TIMEOUT = 900
-_CLOUD_TIMEOUT = 300
+#
+# Both are sized for the failure that matters: a timed-out lens call posts
+# "results may be incomplete" with no findings, which a human reads as a clean
+# review. Waiting longer for an answer beats reporting a confident nothing, so
+# these are deliberately far above what a healthy call needs.
+_SLOW_TIMEOUT = 1800
+_CLOUD_TIMEOUT = 600
 
 # Providers whose endpoint may be a slow model (local server or open gateway).
 _SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider.openrouter})

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -39,15 +39,19 @@ from lgtmaybe.core.ports import Message, ProviderClient
 
 _log = get_logger(__name__)
 
-_DEFAULT_TIMEOUT = 60  # seconds
+# Last-resort per-request timeout (seconds), used only when a caller builds this
+# adapter outside the factory or passes no timeout at all. Kept at the factory's
+# shortest provider default (see providers.factory) rather than something tighter:
+# a fallback that silently undercuts the configured budget is how a reasoning
+# model's review turns into "1 of 8 review calls failed" with zero findings.
+_DEFAULT_TIMEOUT = 600  # seconds
 _MAX_ATTEMPTS = 4
 
 # All attempts for one completion share a total wall-clock budget of this many
 # times the per-request timeout, so a flaky model can't burn
-# attempts × timeout + backoff per call (four 60s timeouts plus waits is over
-# four minutes — per lens). 2.5× leaves room for one full-length failure, a
-# retry, and the backoff between them; a call that needs more than that is
-# better failed and surfaced than ground on.
+# attempts × timeout + backoff per call. 2.5× leaves room for one full-length
+# failure, a retry, and the backoff between them; a call that needs more than
+# that is better failed and surfaced than ground on.
 _CALL_BUDGET_MULTIPLIER = 2.5
 
 # Prompt caching (of the static system prompt) is applied only on routes where

--- a/tests/engine/test_deadline.py
+++ b/tests/engine/test_deadline.py
@@ -79,9 +79,9 @@ class TestReviewDeadline:
     def test_generous_default_never_trips_a_normal_run(self) -> None:
         provider = _SlowProvider(delay=0.0)
         cfg = _cfg()
-        # 2× the generous per-call timeout (900s), so one slow gateway/local
+        # 2× the generous per-call timeout (1800s), so one slow gateway/local
         # call can't eat the whole review budget on its own.
-        assert cfg.max_review_seconds == 1800
+        assert cfg.max_review_seconds == 3600
         _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
         assert len(provider.calls) == 3
         assert "deadline" not in summary

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -121,7 +121,7 @@ class TestBuildProvider:
             api_key="sk-x",
             api_base="https://api.deepseek.com/v1",
         )
-        assert provider.default_opts.get("timeout") == 900
+        assert provider.default_opts.get("timeout") == 1800
 
     def test_openai_compatible_timeout_is_overridable(self) -> None:
         provider = build_provider(
@@ -147,11 +147,11 @@ class TestBuildProvider:
 
     def test_ollama_gets_a_long_default_timeout_when_unset(self) -> None:
         provider = build_provider(Provider.ollama, "llama2")
-        assert provider.default_opts.get("timeout") == 900
+        assert provider.default_opts.get("timeout") == 1800
 
     def test_cloud_gets_a_short_default_timeout_when_unset(self) -> None:
         provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")
-        assert provider.default_opts.get("timeout") == 300
+        assert provider.default_opts.get("timeout") == 600
 
     def test_explicit_timeout_overrides_the_provider_default(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", timeout=45)
@@ -199,11 +199,28 @@ class TestDefaultTimeout:
 
     def test_openrouter_default_matches_ollama(self) -> None:
         # openrouter is a gateway to arbitrary models, including reasoning models
-        # that routinely think past the 60s cloud default — it gets the generous
-        # default too.
+        # that routinely think well past a cloud-sized budget — it gets the
+        # generous default too.
         from lgtmaybe.providers.factory import default_timeout_for
 
         assert default_timeout_for(Provider.openrouter) == default_timeout_for(Provider.ollama)
+
+    def test_every_provider_default_clears_ten_minutes(self) -> None:
+        """No provider may default to a budget a reasoning model can blow through:
+        a 60s-class default is what turned real reviews into 'call failed'
+        notices with zero findings."""
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert all(default_timeout_for(p) >= 600 for p in Provider)
+
+    def test_adapter_fallback_is_never_tighter_than_a_provider_default(self) -> None:
+        """The adapter's last-resort timeout applies whenever a caller builds a
+        provider outside the factory (or passes timeout=None through), so it must
+        not silently reimpose a budget shorter than the factory would have."""
+        from lgtmaybe.providers.factory import default_timeout_for
+        from lgtmaybe.providers.litellm_provider import _DEFAULT_TIMEOUT
+
+        assert _DEFAULT_TIMEOUT >= min(default_timeout_for(p) for p in Provider)
 
     def test_build_provider_threads_temperature_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", temperature=0.0)

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -212,7 +212,7 @@ class TestEngineBehaviourMatrix:
     def test_review_deadline_field_defaults_on_every_provider(self, provider: Provider) -> None:
         from lgtmaybe.core.models import ReviewConfig
 
-        assert ReviewConfig(provider=provider, model="m").max_review_seconds == 1800
+        assert ReviewConfig(provider=provider, model="m").max_review_seconds == 3600
 
 
 _CUSTOM_BASE = "https://api.deepseek.com/v1"

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -538,7 +538,7 @@
       "type": "integer"
     },
     "max_review_seconds": {
-      "default": 1800,
+      "default": 3600,
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"

--- a/tests/test_timeout_floors.py
+++ b/tests/test_timeout_floors.py
@@ -1,0 +1,54 @@
+"""Floors for every wall-clock budget lgtmaybe enforces.
+
+A timeout only earns its keep by capping a *pathological* run. Set one tight
+enough to trip a healthy-but-slow one and it stops being a safety net: the
+review posts "⚠️ N of M review calls failed … results may be incomplete" with
+zero findings, which reads to a human exactly like a clean bill of health.
+
+These are deliberately floors, not equalities — raising a budget is always
+safe here, lowering one below the floor is the regression worth catching.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.models import Provider, ReviewConfig
+from lgtmaybe.providers.factory import default_timeout_for
+
+
+class TestModelCallBudgets:
+    def test_whole_review_ceiling_holds_two_slow_calls(self) -> None:
+        """The soft whole-review deadline must stay at least 2× the most generous
+        per-call budget, so one slow gateway/local call can never eat the run."""
+        slowest = max(default_timeout_for(p) for p in Provider)
+        assert ReviewConfig(provider=Provider.openai, model="m").max_review_seconds >= 2 * slowest
+
+
+class TestSupportingBudgets:
+    """The non-model timeouts around the review: GitHub I/O, git, and the
+    sandboxed analysis subprocesses. A cold CI runner is slower than a laptop."""
+
+    def test_github_api_calls_get_a_minute(self) -> None:
+        from lgtmaybe.github.rest_gateway import _TIMEOUT
+
+        assert _TIMEOUT.connect is not None and _TIMEOUT.read is not None
+        assert min(_TIMEOUT.connect, _TIMEOUT.read) >= 60
+
+    def test_local_git_commands_get_two_minutes(self) -> None:
+        from lgtmaybe.local import _TIMEOUT
+
+        assert _TIMEOUT >= 120
+
+    def test_base_branch_clone_gets_five_minutes(self) -> None:
+        from lgtmaybe.github.checkout import _CLONE_TIMEOUT
+
+        assert _CLONE_TIMEOUT >= 300
+
+    def test_static_analysis_tools_get_three_minutes(self) -> None:
+        from lgtmaybe.engine.static_analysis import _TOOL_TIMEOUT
+
+        assert _TOOL_TIMEOUT >= 180
+
+    def test_astgrep_scan_gets_a_minute(self) -> None:
+        from lgtmaybe.engine.astgrep import _SCAN_TIMEOUT
+
+        assert _SCAN_TIMEOUT >= 60


### PR DESCRIPTION
## Why

A review that reports

> ⚠️ 1 of 8 review calls failed (TimeoutError: provider request exceeded 60s); results may be incomplete.
>
> 0 findings

is worse than one that takes longer. A human skims "0 findings" and reads it as a clean bill of health; the notice above it does not undo that. A timeout only earns its keep by capping a *pathological* run — set tight enough to trip a healthy-but-slow reasoning model and it stops being a safety net.

So every wall-clock budget in the codebase is now sized well above what a healthy run needs, rather than near it.

## What changed

**Model-call budgets** (`providers/factory.py`, `providers/litellm_provider.py`)

| | before | after |
|---|---|---|
| slow-capable providers (ollama, openai-compatible, openrouter) | 900s | 1800s |
| direct cloud providers | 300s | 600s |
| adapter last-resort default | **60s** | 600s |

That 60s fallback was the tightest budget in the tree and applied whenever a caller built `LiteLLMProvider` outside the factory or let a `None` timeout through — silently undercutting whatever the factory would have chosen. It now matches the shortest provider default, so the fallback can never be the binding constraint.

**Whole-review ceiling** (`core/models.py`) — `max_review_seconds` 1800 → 3600, preserving its documented "2× the most generous per-call timeout" invariant now that the generous default is 1800s.

**Supporting budgets** — GitHub API 30s → 60s, local `git` 30s → 120s, base-branch clone 120s → 300s, static-analysis tools 60s → 180s, ast-grep scan 20s → 60s. None of these caused the reported failure; they were all sized near their measured cost rather than above it, and a cold CI runner is slower than a laptop.

**Workflow job caps** — `lgtmaybe.yml` and `action-e2e.yml` go from `timeout-minutes: 20` to `75`. A 20-minute runner cap contradicts a 60-minute review ceiling: the job would be killed before the soft deadline could fire, and the soft deadline is the path that still posts partial findings. A killed job posts nothing.

## Tests

TDD, red first — the value assertions in `tests/providers/test_factory.py`, `tests/engine/test_deadline.py` and `tests/providers/test_provider_matrix.py` were updated and watched fail before the constants moved.

New `tests/test_timeout_floors.py` records these as **floors, not equalities**:

- every provider default clears ten minutes;
- the adapter's last-resort default is never tighter than the shortest provider default (the specific regression here);
- `max_review_seconds` holds at least two of the slowest per-call budgets;
- each supporting budget clears its floor.

Raising a budget stays safe; dropping one back under is the regression worth catching.

`tests/snapshots/ReviewConfig.json` and the generated `docs/reference/config.md` / `docs/llms-full.txt` are regenerated for the new `max_review_seconds` default; the prose docs, `action.yml` input descriptions and the `--max-review-seconds` help text are updated to the new numbers.

Full suite: 1431 passed. `ruff check`, `ruff format --check`, `mypy src`, and `pytest tests/specs` all clean. The provider-gateway spec describes the defaults qualitatively ("long" vs "short"), so no spec section went stale.

## Note on the reported failure

The 60s in that message can't come from a current-`main` openrouter run — `default_timeout_for(openrouter)` has resolved to 900s since the slow-provider defaults landed. It's either an explicit `timeout: 60` in that repo's config, or an action version predating that change. Worth checking, but the fix direction is the same either way, and the 60s fallback that *could* have produced it is now gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuzC47hXdohXyP6xzTH4V)_