### PR TITLE
feat(cache): widen prompt caching to vertex, zai, and openrouter routes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ inputs:
     required: false
     default: ""
   prompt_cache:
-    description: "Cache the static system prompt across the per-lens calls on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
+    description: "Shape every per-lens call as a shared cacheable prefix, and mark an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
     required: false
     default: ""
   incremental:

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ inputs:
     required: false
     default: ""
   prompt_cache:
-    description: "Shape every per-lens call as a shared cacheable prefix, and mark an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
+    description: "Shape every per-lens call as a shared cacheable prefix, and mark an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
     required: false
     default: ""
   incremental:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -94,8 +94,9 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
    the lens-specific instruction as the final user block. On routes that
-   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, Claude
-   on vertex, zai GLM, and openrouter's claude/gemini/glm/minimax families)
+   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, vertex
+   Claude and Gemini, zai GLM, and openrouter's claude/gemini/glm/minimax
+   families)
    the prefix is marked with `cache_control`; on backends that cache
    automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
    its own. Either way every call after a batch's first reads that

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -93,10 +93,16 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
 
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
-   the lens-specific instruction as the final user block. On anthropic and
-   bedrock, every call after a batch's first reads that preamble-plus-diff
-   prefix from cache (on big diffs a warm-up primer runs the first lens
-   alone). Each lens's focused structured prompt requests JSON output with
+   the lens-specific instruction as the final user block. On routes that
+   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, Claude
+   on vertex, zai GLM, and openrouter's claude/gemini/glm/minimax families)
+   the prefix is marked with `cache_control`; on backends that cache
+   automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
+   its own. Either way every call after a batch's first reads that
+   preamble-plus-diff prefix from cache, and on big diffs a warm-up primer
+   runs the first lens alone so a concurrent wave doesn't all miss it.
+
+   Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,
    `body`, `failure_scenario`, `suggestion`, `anchor`) and carries
    prompt-injection defense instructions. Each response is parsed and validated against

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -266,7 +266,7 @@ Two mechanisms, picked per route:
 
 | Route | How it caches |
 |---|---|
-| **anthropic**, **bedrock** Claude/Nova, **Claude on vertex**, **zai** GLM, **openrouter** (claude / gemini / glm / minimax models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
+| **anthropic**, **bedrock** Claude/Nova, **vertex** (Claude and Gemini), **zai** GLM, **openrouter** (claude / gemini / glm / minimax / z-ai models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
 | **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
 | **ollama**, `openai-compatible` | the request is sent unchanged |
 
@@ -281,6 +281,21 @@ batch is dispatched alone and the rest release when it returns, so a fully
 concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
 pay the cache-write surcharge). This applies on every provider — it is about the
 shape of the first wave, not about the marker.
+
+Every call also carries a `prompt_cache_key` derived from the prefix itself:
+identical across the lenses of one batch, different for another PR. OpenRouter
+uses it to pin the whole fan-out to a single provider endpoint from the first
+call (without a key it only starts doing that *after* it notices a cache hit,
+which a concurrent wave reaches too late), and OpenAI takes the same field as a
+cache-routing hint. It is a digest, not prompt content.
+
+**Minimums are per model**, and a prefix below one is silently not cached — no
+error, just no discount. Roughly: 1,024 tokens for Claude Sonnet 4.x / Opus
+4–4.1 and Gemini 2.5 Flash, 2,048 for Claude Haiku 3.5, 4,096 for Claude Opus
+4.5+ / Haiku 4.5 and Gemini 2.5 Pro. lgtmaybe marks from 1,024 up so it never
+misses a chance on the lower-minimum models; on a higher-minimum model a small
+diff simply won't cache. Check with `--profile`, which reports cache read and
+write tokens.
 
 Leaving it on costs nothing. Turn it off only to rule caching out while
 debugging provider behaviour. CLI: `--no-prompt-cache`.

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -256,23 +256,37 @@ Default: `true`. See
 
 ### prompt_cache
 
-Cache the static system prompt across the per-lens review calls and the
-reflection call. lgtmaybe fans out one model call per lens, and every one of
-those calls shares the same large, static system prompt — on providers with an
-explicit cache breakpoint (**anthropic**, and **bedrock** Claude/Nova models)
-lgtmaybe marks that prompt with `cache_control` so every call after the first
-reads it from the provider's prompt cache at the cached-input discount instead
-of re-paying full input price. The diff and other per-PR content always stay
-outside the cached region.
+Reuse the expensive shared prefix — system preamble plus the wrapped diff —
+across the per-lens review calls and the reflection call, instead of re-paying
+full input price for it on every one. lgtmaybe fans out several model calls per
+review and they all begin with that same prefix, so it shapes every call
+identically and lets the backend serve it from cache.
 
-Support is feature-detected per model, and on every other provider (ollama,
-`openai-compatible`, and providers that cache automatically server-side like
-OpenAI) the request is sent unchanged — so leaving it on costs nothing. Turn it
-off only to rule caching out while debugging provider behaviour. CLI:
-`--no-prompt-cache`.
+Two mechanisms, picked per route:
+
+| Route | How it caches |
+|---|---|
+| **anthropic**, **bedrock** Claude/Nova, **Claude on vertex**, **zai** GLM, **openrouter** (claude / gemini / glm / minimax models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
+| **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
+| **ollama**, `openai-compatible` | the request is sent unchanged |
+
+Support is feature-detected per model, so a route in the first row whose model
+litellm doesn't know about simply falls back to the second behaviour — a missed
+discount, never an error. The diff-independent parts of the prompt are what get
+reused; per-PR content still enters the prefix, which is why it is only ever
+shared *within* one review.
+
+On a large diff lgtmaybe also runs a **warm-up primer**: the first lens of a
+batch is dispatched alone and the rest release when it returns, so a fully
+concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
+pay the cache-write surcharge). This applies on every provider — it is about the
+shape of the first wave, not about the marker.
+
+Leaving it on costs nothing. Turn it off only to rule caching out while
+debugging provider behaviour. CLI: `--no-prompt-cache`.
 
 ```yaml
-prompt_cache: false   # send every call uncached, even on anthropic/bedrock
+prompt_cache: false   # send every call uncached, and never warm the batch
 ```
 
 Default: `true`.

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -213,7 +213,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
+| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -213,7 +213,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |
+| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -552,7 +552,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
+| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
@@ -2266,7 +2266,7 @@ Two mechanisms, picked per route:
 
 | Route | How it caches |
 |---|---|
-| **anthropic**, **bedrock** Claude/Nova, **Claude on vertex**, **zai** GLM, **openrouter** (claude / gemini / glm / minimax models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
+| **anthropic**, **bedrock** Claude/Nova, **vertex** (Claude and Gemini), **zai** GLM, **openrouter** (claude / gemini / glm / minimax / z-ai models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
 | **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
 | **ollama**, `openai-compatible` | the request is sent unchanged |
 
@@ -2281,6 +2281,21 @@ batch is dispatched alone and the rest release when it returns, so a fully
 concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
 pay the cache-write surcharge). This applies on every provider — it is about the
 shape of the first wave, not about the marker.
+
+Every call also carries a `prompt_cache_key` derived from the prefix itself:
+identical across the lenses of one batch, different for another PR. OpenRouter
+uses it to pin the whole fan-out to a single provider endpoint from the first
+call (without a key it only starts doing that *after* it notices a cache hit,
+which a concurrent wave reaches too late), and OpenAI takes the same field as a
+cache-routing hint. It is a digest, not prompt content.
+
+**Minimums are per model**, and a prefix below one is silently not cached — no
+error, just no discount. Roughly: 1,024 tokens for Claude Sonnet 4.x / Opus
+4–4.1 and Gemini 2.5 Flash, 2,048 for Claude Haiku 3.5, 4,096 for Claude Opus
+4.5+ / Haiku 4.5 and Gemini 2.5 Pro. lgtmaybe marks from 1,024 up so it never
+misses a chance on the lower-minimum models; on a higher-minimum model a small
+diff simply won't cache. Check with `--profile`, which reports cache read and
+write tokens.
 
 Leaving it on costs nothing. Turn it off only to rule caching out while
 debugging provider behaviour. CLI: `--no-prompt-cache`.
@@ -4739,8 +4754,9 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
    the lens-specific instruction as the final user block. On routes that
-   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, Claude
-   on vertex, zai GLM, and openrouter's claude/gemini/glm/minimax families)
+   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, vertex
+   Claude and Gemini, zai GLM, and openrouter's claude/gemini/glm/minimax
+   families)
    the prefix is marked with `cache_control`; on backends that cache
    automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
    its own. Either way every call after a batch's first reads that

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -552,7 +552,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix on providers with an explicit cache breakpoint (anthropic, bedrock Claude/Nova); safe no-op elsewhere |
+| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
@@ -2256,23 +2256,37 @@ Default: `true`. See
 
 ### prompt_cache
 
-Cache the static system prompt across the per-lens review calls and the
-reflection call. lgtmaybe fans out one model call per lens, and every one of
-those calls shares the same large, static system prompt — on providers with an
-explicit cache breakpoint (**anthropic**, and **bedrock** Claude/Nova models)
-lgtmaybe marks that prompt with `cache_control` so every call after the first
-reads it from the provider's prompt cache at the cached-input discount instead
-of re-paying full input price. The diff and other per-PR content always stay
-outside the cached region.
+Reuse the expensive shared prefix — system preamble plus the wrapped diff —
+across the per-lens review calls and the reflection call, instead of re-paying
+full input price for it on every one. lgtmaybe fans out several model calls per
+review and they all begin with that same prefix, so it shapes every call
+identically and lets the backend serve it from cache.
 
-Support is feature-detected per model, and on every other provider (ollama,
-`openai-compatible`, and providers that cache automatically server-side like
-OpenAI) the request is sent unchanged — so leaving it on costs nothing. Turn it
-off only to rule caching out while debugging provider behaviour. CLI:
-`--no-prompt-cache`.
+Two mechanisms, picked per route:
+
+| Route | How it caches |
+|---|---|
+| **anthropic**, **bedrock** Claude/Nova, **Claude on vertex**, **zai** GLM, **openrouter** (claude / gemini / glm / minimax models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
+| **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
+| **ollama**, `openai-compatible` | the request is sent unchanged |
+
+Support is feature-detected per model, so a route in the first row whose model
+litellm doesn't know about simply falls back to the second behaviour — a missed
+discount, never an error. The diff-independent parts of the prompt are what get
+reused; per-PR content still enters the prefix, which is why it is only ever
+shared *within* one review.
+
+On a large diff lgtmaybe also runs a **warm-up primer**: the first lens of a
+batch is dispatched alone and the rest release when it returns, so a fully
+concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
+pay the cache-write surcharge). This applies on every provider — it is about the
+shape of the first wave, not about the marker.
+
+Leaving it on costs nothing. Turn it off only to rule caching out while
+debugging provider behaviour. CLI: `--no-prompt-cache`.
 
 ```yaml
-prompt_cache: false   # send every call uncached, even on anthropic/bedrock
+prompt_cache: false   # send every call uncached, and never warm the batch
 ```
 
 Default: `true`.
@@ -4724,10 +4738,16 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
 
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
-   the lens-specific instruction as the final user block. On anthropic and
-   bedrock, every call after a batch's first reads that preamble-plus-diff
-   prefix from cache (on big diffs a warm-up primer runs the first lens
-   alone). Each lens's focused structured prompt requests JSON output with
+   the lens-specific instruction as the final user block. On routes that
+   take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, Claude
+   on vertex, zai GLM, and openrouter's claude/gemini/glm/minimax families)
+   the prefix is marked with `cache_control`; on backends that cache
+   automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
+   its own. Either way every call after a batch's first reads that
+   preamble-plus-diff prefix from cache, and on big diffs a warm-up primer
+   runs the first lens alone so a concurrent wave doesn't all miss it.
+
+   Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,
    `body`, `failure_scenario`, `suggestion`, `anchor`) and carries
    prompt-injection defense instructions. Each response is parsed and validated against

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -291,9 +291,10 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
 @click.option(
     "--prompt-cache/--no-prompt-cache",
     default=None,
-    help="Cache the static system prompt across the per-lens calls on providers "
-    "that support it (anthropic, bedrock Claude/Nova) — cached reads are billed "
-    "at a steep discount. Safe no-op elsewhere (--no-prompt-cache disables)",
+    help="Shape every call as a shared cacheable prefix, and mark an explicit "
+    "cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, "
+    "Claude on vertex, zai GLM, openrouter) — cached reads are billed at a steep "
+    "discount. Safe no-op elsewhere (--no-prompt-cache disables)",
 )
 @click.option(
     "--static-analysis/--no-static-analysis",

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -293,7 +293,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     default=None,
     help="Shape every call as a shared cacheable prefix, and mark an explicit "
     "cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, "
-    "Claude on vertex, zai GLM, openrouter) — cached reads are billed at a steep "
+    "vertex, zai GLM, openrouter) — cached reads are billed at a steep "
     "discount. Safe no-op elsewhere (--no-prompt-cache disables)",
 )
 @click.option(

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -687,13 +687,15 @@ class ReviewConfig(_Strict):
     # prose/reasoning instead of findings. Disable for a model/provider that
     # doesn't support it (the lenient parser is the fallback).
     structured_output: bool = True
-    # Cache the static system prompt across the per-lens fan-out and reflection
-    # call. On providers with an explicit cache breakpoint (anthropic, bedrock
-    # Claude/Nova) the adapter marks the system prompt with cache_control —
-    # every call after the first reads the shared prefix at the provider's
-    # cached-input discount. Feature-detected per model and a safe no-op
-    # everywhere else (ollama, openai-compatible, and providers that cache
-    # automatically server-side), so leaving it on costs nothing.
+    # Reuse the shared prefix (system preamble + wrapped diff) across the
+    # per-lens fan-out and the reflection call instead of re-paying full input
+    # price for it on every call. On routes taking an explicit breakpoint
+    # (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter's
+    # claude/gemini/glm/minimax) the adapter marks it with cache_control;
+    # backends that cache a repeated prefix automatically (openai, azure,
+    # deepseek) need only the identical shape, which this also gives them. Also
+    # enables the per-batch warm-up primer. Feature-detected per model and a
+    # safe no-op on ollama/openai-compatible, so leaving it on costs nothing.
     prompt_cache: bool = True
 
     @model_validator(mode="after")

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -690,8 +690,9 @@ class ReviewConfig(_Strict):
     # Reuse the shared prefix (system preamble + wrapped diff) across the
     # per-lens fan-out and the reflection call instead of re-paying full input
     # price for it on every call. On routes taking an explicit breakpoint
-    # (anthropic, bedrock Claude/Nova, Claude on vertex, zai GLM, openrouter's
-    # claude/gemini/glm/minimax) the adapter marks it with cache_control;
+    # (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM,
+    # openrouter's claude/gemini/glm/minimax) the adapter marks it with
+    # cache_control;
     # backends that cache a repeated prefix automatically (openai, azure,
     # deepseek) need only the identical shape, which this also gives them. Also
     # enables the per-batch warm-up primer. Feature-detected per model and a

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -87,16 +87,6 @@ _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     }
 )
 
-# Providers whose litellm route takes an explicit cache_control breakpoint —
-# the ones where a batch's first call WRITES the shared preamble-plus-diff
-# prefix to the cache and the rest read it. Mirrors the adapter's
-# _CACHE_CONTROL_PREFIXES (providers/litellm_provider.py); keep the two in
-# sync. Provider-level only: whether the specific *model* caches is the
-# adapter's call, so warming here is an approximation — for a non-caching
-# model on these routes the primer costs one serialised call and buys nothing,
-# which the token floor below keeps cheap.
-_CACHE_BREAKPOINT_PROVIDERS = frozenset({Provider.anthropic, Provider.bedrock})
-
 # Don't warm the cache for a small diff. On wall-clock the primer is roughly
 # neutral — either the primer pays the one uncached pass and the rest read, or
 # a concurrent first wave all pays it in parallel — so the primer's real win
@@ -107,6 +97,13 @@ _CACHE_BREAKPOINT_PROVIDERS = frozenset({Provider.anthropic, Provider.bedrock})
 # Below ~2k tokens of wrapped diff the waste is too small to buy anything —
 # keep full concurrency. (Simulated A/B on a 5k-token prefix, 9 lenses:
 # warm-up ≈ +4s wall, −39k cache-write tokens.)
+#
+# Deliberately NOT gated on a provider list. The primer is about the shape of
+# the first wave, not about the cache_control marker: a backend that caches
+# automatically (OpenAI, Azure, DeepSeek — including via openrouter) pays the
+# same N-way miss when N identical prefixes arrive at once, and profits from
+# the same fix. A provider allowlist here would only be a second copy of the
+# adapter's route list, drifting from it every time a backend adds caching.
 _WARMUP_MIN_TOKENS = 2048
 
 
@@ -416,15 +413,15 @@ class LLMReviewEngine(ReviewEngine):
             batch_hints = [h for h in sa_hints if h.path in batch_paths]
             hint_block = wrap_hints(redact(format_hints(batch_hints))) if batch_hints else None
             # Warm the prompt cache for this batch: a fully concurrent first
-            # wave defeats it (every call misses and pays the cache write), so
-            # on breakpoint routes one lens is dispatched alone and the rest of
-            # the batch releases on its completion — reading the shared
-            # preamble-plus-diff prefix instead of re-writing it. Gated on diff
-            # size (see _WARMUP_MIN_TOKENS) so a small diff keeps full
-            # concurrency.
+            # wave defeats it (every call misses, and on explicit-breakpoint
+            # routes each also pays the cache write), so one lens is dispatched
+            # alone and the rest of the batch releases on its completion —
+            # reading the shared preamble-plus-diff prefix instead of
+            # re-writing it. Gated on diff size (see _WARMUP_MIN_TOKENS) so a
+            # small diff keeps full concurrency, and on a fan-out wide enough
+            # for there to be a wave at all.
             warm = (
                 cfg.prompt_cache
-                and cfg.provider in _CACHE_BREAKPOINT_PROVIDERS
                 and workers > 1
                 and len(lenses) > 1
                 and count_tokens(wrapped) >= _WARMUP_MIN_TOKENS

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -54,13 +54,36 @@ _MAX_ATTEMPTS = 4
 # that is better failed and surfaced than ground on.
 _CALL_BUDGET_MULTIPLIER = 2.5
 
-# Prompt caching (of the static system prompt) is applied only on routes where
-# an EXPLICIT cache breakpoint is the mechanism: Anthropic direct (cache_control)
-# and Bedrock (litellm translates cache_control to a Converse cachePoint for
-# Claude and Nova). Other providers either cache automatically server-side with
-# no marker (OpenAI, Azure) or don't cache at all (ollama, most
-# openai-compatible servers) — for all of them the request is sent unchanged.
-_CACHE_CONTROL_PREFIXES = ("anthropic/", "bedrock/")
+# Prompt caching (of the shared prefix) is applied on routes where an EXPLICIT
+# cache breakpoint is the mechanism:
+#
+# - ``anthropic/`` — cache_control, natively;
+# - ``bedrock/`` — litellm translates cache_control to a Converse cachePoint
+#   for Claude and Nova;
+# - ``vertex_ai/claude`` — the Anthropic partner-model route reads cache_control
+#   off the messages and sets the prompt-caching beta from it. Only the Claude
+#   models: Gemini on Vertex caches through the separate cachedContent API, not
+#   an inline breakpoint;
+# - ``zai/`` — ZAIChatConfig overrides litellm's strip step to always preserve
+#   cache_control, so GLM / Zhipu gets the breakpoint;
+# - ``openrouter/`` — marked for the WHOLE route on purpose. litellm's
+#   OpenrouterConfig keeps cache_control for the families that accept it
+#   (claude, gemini, minimax, glm, z-ai) and removes it for every other model
+#   before the request goes out, so a per-model allowlist here would only
+#   duplicate — and drift from — that list. Marking a deepseek or qwen model is
+#   a no-op upstream, not an error.
+#
+# Other providers either cache automatically server-side with no marker (OpenAI,
+# Azure, DeepSeek direct) or don't cache at all — for them the request is sent
+# unchanged. They still benefit from the split prefix shape, which keeps the
+# cached region byte-identical across the lens fan-out.
+_CACHE_CONTROL_PREFIXES = (
+    "anthropic/",
+    "bedrock/",
+    "vertex_ai/claude",
+    "zai/",
+    "openrouter/",
+)
 
 # Anthropic's documented minimum cacheable block. A smaller prefix is silently
 # not cached (some models require even more), so below this the marker is pure
@@ -418,10 +441,15 @@ def _supports_cache_control(model: str) -> bool:
     """Whether *model*'s route takes an explicit cache_control breakpoint.
 
     Feature detection, not configuration: the route must be one where litellm
-    forwards ``cache_control`` (Anthropic direct; Bedrock, where it becomes a
-    Converse ``cachePoint``), and litellm's model-capability map must say the
-    model itself caches. Any lookup failure (an unknown or freshly released
-    model) means "don't mark" — caching is an optimisation, never worth an error.
+    forwards ``cache_control`` (see :data:`_CACHE_CONTROL_PREFIXES`), and
+    litellm's model-capability map must say the model itself caches. Any lookup
+    failure (an unknown or freshly released model) means "don't mark" — caching
+    is an optimisation, never worth an error.
+
+    That capability map has gaps (it answers False for, say, a dated
+    ``vertex_ai/claude-3-5-sonnet@…`` id that does cache). A gap costs a missed
+    discount, never a broken call, so the conservative answer stays the right
+    one — and the split prefix shape still helps a model we decline to mark.
     """
     if not model.startswith(_CACHE_CONTROL_PREFIXES):
         return False

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -6,6 +6,7 @@ optional fallback model.
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from concurrent.futures import Future
@@ -60,10 +61,10 @@ _CALL_BUDGET_MULTIPLIER = 2.5
 # - ``anthropic/`` — cache_control, natively;
 # - ``bedrock/`` — litellm translates cache_control to a Converse cachePoint
 #   for Claude and Nova;
-# - ``vertex_ai/claude`` — the Anthropic partner-model route reads cache_control
-#   off the messages and sets the prompt-caching beta from it. Only the Claude
-#   models: Gemini on Vertex caches through the separate cachedContent API, not
-#   an inline breakpoint;
+# - ``vertex_ai/`` — both families, per litellm's documented support: the
+#   Anthropic partner-model route reads cache_control off the messages and sets
+#   the prompt-caching beta from it, and for Gemini litellm translates the same
+#   marker into Google's cachedContents API;
 # - ``zai/`` — ZAIChatConfig overrides litellm's strip step to always preserve
 #   cache_control, so GLM / Zhipu gets the breakpoint;
 # - ``openrouter/`` — marked for the WHOLE route on purpose. litellm's
@@ -80,14 +81,20 @@ _CALL_BUDGET_MULTIPLIER = 2.5
 _CACHE_CONTROL_PREFIXES = (
     "anthropic/",
     "bedrock/",
-    "vertex_ai/claude",
+    "vertex_ai/",
     "zai/",
     "openrouter/",
 )
 
-# Anthropic's documented minimum cacheable block. A smaller prefix is silently
-# not cached (some models require even more), so below this the marker is pure
-# request-shape churn — skip it and send the message unchanged.
+# The LOWEST documented minimum cacheable block across the marked routes, not
+# the highest. A prefix under a model's own minimum is silently not cached (no
+# error), and the minimum is per-model: 1,024 for Claude Sonnet 4.x/Opus 4-4.1
+# and Gemini 2.5 Flash; 2,048 for Claude Haiku 3.5; 4,096 for Claude Opus
+# 4.5+/Haiku 4.5 and Gemini 2.5 Pro. Gating on the lowest means we mark
+# whenever caching *could* engage — raising this to the highest would stop
+# marking in the 1k-4k range and lose real caching on the 1,024-token models.
+# Below the floor, though, no model can cache, so the marker is pure
+# request-shape churn: skip it and send the message unchanged.
 _MIN_CACHEABLE_TOKENS = 1024
 
 # Errors that retrying cannot fix: bad credentials, a malformed/unsupported
@@ -209,6 +216,14 @@ class LiteLLMProvider(ProviderClient):
         # failure isn't ground through two stacked backoff layers — the doubling
         # that helped a quota error run ~13 min before it surfaced.
         merged.setdefault("num_retries", 0)
+        # Sticky-routing / cache-routing hint, keyed on the shared prefix.
+        # OpenRouter pins a conversation to one provider endpoint to keep its
+        # cache warm, but with no key it only starts doing so AFTER it observes
+        # a cache hit — too late for a fan-out that dispatches its lenses at
+        # once. OpenAI uses the same field as a hint for prefix-sharing
+        # requests, so one param serves both; drop_params strips it elsewhere.
+        if self.prompt_cache:
+            merged.setdefault("prompt_cache_key", _prefix_cache_key(messages))
         # A factory-built provider carries the resolved litellm model string
         # (e.g. "ollama/qwen3:27b"); prefer it over the caller's raw cfg.model.
         effective_model = self.model or model
@@ -364,6 +379,21 @@ class LiteLLMProvider(ProviderClient):
         )
 
 
+def _prefix_cache_key(messages: list[Message]) -> str:
+    """A stable routing key identifying this call's *cacheable prefix*.
+
+    Everything except the final message, which is the per-lens block that sits
+    outside the cached region. So every lens of a batch produces the same key
+    (they share a prefix and should share a cache), while another PR — or the
+    reflection pass, which has its own preamble — produces a different one.
+
+    A digest, not the content: it travels to the provider as a routing hint,
+    and it is bounded well inside OpenRouter's 256-character ceiling.
+    """
+    prefix = "".join(f"{m.get('role')}:{m.get('content')!r}\n" for m in messages[:-1])
+    return "lgtmaybe-" + hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:32]
+
+
 def _cache_block(text: str) -> dict[str, Any]:
     """A text content block carrying an ephemeral cache breakpoint."""
     return {"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}
@@ -463,14 +493,31 @@ def _cache_usage(usage: Any) -> tuple[int, int]:
     """Extract (cache_read, cache_creation) token counts from a usage object.
 
     Anthropic/Bedrock report ``cache_read_input_tokens`` /
-    ``cache_creation_input_tokens``; OpenAI-style responses report reads under
-    ``prompt_tokens_details.cached_tokens``. All optional — absent means 0.
+    ``cache_creation_input_tokens`` at the top level. Everything else arrives
+    through litellm's normalised ``prompt_tokens_details`` wrapper —
+    OpenAI-style ``cached_tokens`` (which is also where DeepSeek's
+    ``prompt_cache_hit_tokens`` and an OpenRouter response land), plus a write
+    count under one of two names: litellm's own ``cache_creation_tokens`` or
+    OpenRouter's ``cache_write_tokens``, which litellm passes straight through
+    (its wrapper accepts extra fields, and it does not translate the name).
+
+    Every name is checked, because a count that exists but isn't read back
+    reports 0 — and in ``--profile`` a zero is indistinguishable from caching
+    never having engaged at all. All optional; genuinely absent means 0.
     """
-    cache_read = getattr(usage, "cache_read_input_tokens", None)
-    if not cache_read:
-        details = getattr(usage, "prompt_tokens_details", None)
-        cache_read = getattr(details, "cached_tokens", None) if details is not None else None
-    cache_creation = getattr(usage, "cache_creation_input_tokens", None)
+    details = getattr(usage, "prompt_tokens_details", None)
+
+    def _detail(*names: str) -> Any:
+        for name in names:
+            value = getattr(details, name, None) if details is not None else None
+            if value:
+                return value
+        return None
+
+    cache_read = getattr(usage, "cache_read_input_tokens", None) or _detail("cached_tokens")
+    cache_creation = getattr(usage, "cache_creation_input_tokens", None) or _detail(
+        "cache_creation_tokens", "cache_write_tokens"
+    )
     return int(cache_read or 0), int(cache_creation or 0)
 
 

--- a/tests/engine/test_prompt_split.py
+++ b/tests/engine/test_prompt_split.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from lgtmaybe.core.models import (
     CustomLens,
     PRContext,
@@ -193,10 +195,31 @@ class TestCacheWarmup:
         ]
         assert len(starts_before_first_end) >= 2
 
-    def test_no_warmup_on_providers_without_a_cache_breakpoint(self) -> None:
+    @pytest.mark.parametrize(
+        "provider_kind",
+        [Provider.openai, Provider.azure, Provider.openrouter, Provider.zai, Provider.vertex],
+    )
+    def test_primer_warms_automatic_caching_providers_too(self, provider_kind: Provider) -> None:
+        """The primer is not about the cache_control marker — it is about not
+        letting a concurrent first wave all miss the shared prefix. Providers
+        that cache automatically server-side (OpenAI, Azure, DeepSeek via
+        openrouter) pay that same N-way miss, so they get warmed as well."""
         provider = _EventOrderProvider()
         cfg = _cfg(
-            provider=Provider.openai,
+            provider=provider_kind,
+            categories=[ReviewCategory.security, ReviewCategory.performance, ReviewCategory.tests],
+        )
+        LLMReviewEngine(provider).review(_big_ctx(), cfg)
+        assert provider.events[0] == "start-0"
+        assert provider.events[1] == "end-0"
+
+    def test_no_warmup_when_prompt_cache_is_off(self) -> None:
+        """`prompt_cache: false` restores the legacy shape byte-for-byte, and
+        that includes dispatching the batch fully concurrently."""
+        provider = _EventOrderProvider()
+        cfg = _cfg(
+            provider=Provider.anthropic,
+            prompt_cache=False,
             categories=[ReviewCategory.security, ReviewCategory.performance, ReviewCategory.tests],
         )
         LLMReviewEngine(provider).review(_big_ctx(), cfg)

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -9,8 +9,9 @@ so those calls read the prefix from cache instead of re-paying for it.
 Everything here monkeypatches ``litellm.completion`` at the boundary — no
 network. The contract under test:
 
-- the marker is attached ONLY on cache-capable provider routes (``anthropic/``,
-  ``bedrock/``) whose model litellm's capability map says supports caching;
+- the marker is attached ONLY on routes that take an explicit breakpoint
+  (``anthropic/``, ``bedrock/``, ``vertex_ai/claude*``, ``zai/``, ``openrouter/``)
+  whose model litellm's capability map says supports caching;
 - only the (static) system message is marked — the user message (diff, intent)
   stays outside the cached prefix;
 - below the documented 1,024-token minimum cacheable block the request is sent
@@ -41,6 +42,19 @@ _CACHEABLE_MODELS = [
     "anthropic/claude-sonnet-4-20250514",
     "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
     "bedrock/us.amazon.nova-pro-v1:0",
+    # Claude on Vertex: litellm's anthropic partner-model route reads
+    # cache_control off the messages and sets the prompt-caching beta from it.
+    "vertex_ai/claude-sonnet-4-5",
+    # GLM / Zhipu: ZAIChatConfig overrides the strip step to always preserve
+    # cache_control, so the breakpoint reaches the API.
+    "zai/glm-4.6",
+    # OpenRouter passes cache_control through for the model families that take
+    # it (claude, gemini, minimax, glm, z-ai) and STRIPS it for the rest, so we
+    # mark broadly and let litellm decide per model — see the deepseek case in
+    # TestOpenRouterBreakpoints.
+    "openrouter/anthropic/claude-sonnet-4.5",
+    "openrouter/z-ai/glm-4.6",
+    "openrouter/minimax/minimax-m2",
 ]
 
 _UNCACHEABLE_MODELS = [
@@ -48,10 +62,17 @@ _UNCACHEABLE_MODELS = [
     "openai/gpt-4o",  # OpenAI caches automatically server-side — no marker
     "openai/local-model",  # openai-compatible route
     "azure/gpt-4o",
-    "openrouter/anthropic/claude-3.5-sonnet",
+    # Gemini on Vertex caches via the separate cachedContent API, not an inline
+    # breakpoint — only the Claude partner models take one.
     "vertex_ai/gemini-1.5-pro",
-    "zai/glm-4.6",
 ]
+
+
+def _block(text: str, *, cached: bool = False) -> dict[str, Any]:
+    block: dict[str, Any] = {"type": "text", "text": text}
+    if cached:
+        block["cache_control"] = {"type": "ephemeral"}
+    return block
 
 
 def _fake_response(content: str = "ok", **usage_extra: Any) -> Any:
@@ -200,6 +221,63 @@ class TestSplitShapeCacheMarking:
         sent = _sent_split(_CACHEABLE_MODELS[0], prompt_cache=False)
         assert sent[1] == {"role": "user", "content": f"{_DIFF_PREFIX}\n\n{_LENS_BLOCK}"}
         assert sent[0]["content"] == _BIG_SYSTEM
+
+
+class TestOpenRouterBreakpoints:
+    """OpenRouter is marked broadly on purpose — litellm gates it per model.
+
+    ``OpenrouterConfig`` preserves ``cache_control`` for the model families that
+    accept it (claude, gemini, minimax, glm, z-ai) and removes it for every
+    other model before the request goes out. So the adapter does not need its
+    own per-model allowlist for this route: marking a deepseek or qwen model is
+    a no-op, not an error, and those backends cache the shared prefix
+    automatically anyway.
+
+    These assertions run litellm's real transform (no network) so a litellm
+    upgrade that changes the supported-family list fails here rather than
+    silently costing money on every review.
+    """
+
+    @staticmethod
+    def _breakpoints_reaching_the_api(model: str) -> int:
+        import copy
+        import json
+
+        from litellm.llms.openrouter.chat.transformation import OpenrouterConfig
+
+        messages = [
+            {"role": "system", "content": [_block("PREAMBLE", cached=True)]},
+            {"role": "user", "content": [_block("DIFF", cached=True), _block("LENS")]},
+        ]
+        out = OpenrouterConfig().transform_request(
+            model=model,
+            messages=copy.deepcopy(messages),
+            optional_params={},
+            litellm_params={"custom_llm_provider": "openrouter"},
+            headers={},
+        )
+        return json.dumps(out["messages"]).count("cache_control")
+
+    @pytest.mark.parametrize(
+        "model",
+        ["anthropic/claude-sonnet-4.5", "z-ai/glm-4.6", "minimax/minimax-m2"],
+    )
+    def test_breakpoints_survive_for_supported_families(self, model: str) -> None:
+        assert self._breakpoints_reaching_the_api(model) == 2
+
+    @pytest.mark.parametrize("model", ["deepseek/deepseek-chat", "qwen/qwen3-max"])
+    def test_breakpoints_are_stripped_for_the_rest_not_rejected(self, model: str) -> None:
+        """The reason we can mark the whole openrouter route: an unsupported
+        model loses the marker upstream instead of erroring on it."""
+        assert self._breakpoints_reaching_the_api(model) == 0
+
+    def test_adapter_marks_a_stripped_model_anyway(self) -> None:
+        """deepseek via openrouter still gets our breakpoint — harmless (litellm
+        removes it) and it keeps the split prefix identical across lenses, which
+        is what deepseek's automatic caching keys on."""
+        sent = _sent_split("openrouter/deepseek/deepseek-chat", prompt_cache=True)
+        assert len(sent) == 2
+        assert sent[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
 
 
 class TestCacheUsageMapping:

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -1,24 +1,27 @@
-"""Prompt caching of the static system prompt (P1).
+"""Prompt caching of the shared prefix.
 
-The static system prompt (shared header + lens section + worked example) is
-re-sent on every concurrent lens call and again on reflection. On providers
-that support explicit cache breakpoints (Anthropic direct, Bedrock Claude/Nova)
-the adapter marks the system message with ``cache_control: {"type": "ephemeral"}``
-so those calls read the prefix from cache instead of re-paying for it.
+The system preamble and wrapped diff are re-sent on every concurrent lens call
+and again on reflection. On routes that take an explicit cache breakpoint the
+adapter marks that prefix with ``cache_control: {"type": "ephemeral"}`` so those
+calls read it from cache instead of re-paying for it; on routes that cache
+automatically the identical prefix shape does the same job unmarked.
 
 Everything here monkeypatches ``litellm.completion`` at the boundary — no
 network. The contract under test:
 
-- the marker is attached ONLY on routes that take an explicit breakpoint
-  (``anthropic/``, ``bedrock/``, ``vertex_ai/claude*``, ``zai/``, ``openrouter/``)
-  whose model litellm's capability map says supports caching;
-- only the (static) system message is marked — the user message (diff, intent)
-  stays outside the cached prefix;
-- below the documented 1,024-token minimum cacheable block the request is sent
-  unchanged (a smaller block would silently not cache);
-- with ``prompt_cache`` off, or on any other provider (ollama, openai-compatible,
-  …), the request is byte-for-byte what it was before this feature existed;
-- cache_read / cache_creation token counts are mapped into ``ProviderResult``.
+- the marker is attached ONLY on routes litellm forwards it on (``anthropic/``,
+  ``bedrock/``, ``vertex_ai/``, ``zai/``, ``openrouter/``) whose model litellm's
+  capability map says supports caching;
+- only the shared prefix is marked — the per-lens block stays outside it;
+- below the lowest documented minimum cacheable block (1,024 tokens) the request
+  is sent unchanged, since no model can cache a prefix that small;
+- with ``prompt_cache`` off, or on a route with neither mechanism (ollama,
+  openai-compatible), the request is byte-for-byte what it was before this
+  feature existed;
+- a sticky ``prompt_cache_key`` derived from the prefix pins the fan-out to one
+  provider endpoint;
+- cache read / write token counts are mapped into ``ProviderResult`` under every
+  field name the providers use for them.
 """
 
 from __future__ import annotations
@@ -42,9 +45,11 @@ _CACHEABLE_MODELS = [
     "anthropic/claude-sonnet-4-20250514",
     "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
     "bedrock/us.amazon.nova-pro-v1:0",
-    # Claude on Vertex: litellm's anthropic partner-model route reads
-    # cache_control off the messages and sets the prompt-caching beta from it.
+    # Vertex: litellm documents cache_control for BOTH the Claude partner
+    # models (prompt-caching beta) and Gemini (translated to Google's
+    # cachedContents API).
     "vertex_ai/claude-sonnet-4-5",
+    "vertex_ai/gemini-2.5-pro",
     # GLM / Zhipu: ZAIChatConfig overrides the strip step to always preserve
     # cache_control, so the breakpoint reaches the API.
     "zai/glm-4.6",
@@ -62,9 +67,6 @@ _UNCACHEABLE_MODELS = [
     "openai/gpt-4o",  # OpenAI caches automatically server-side — no marker
     "openai/local-model",  # openai-compatible route
     "azure/gpt-4o",
-    # Gemini on Vertex caches via the separate cachedContent API, not an inline
-    # breakpoint — only the Claude partner models take one.
-    "vertex_ai/gemini-1.5-pro",
 ]
 
 
@@ -304,6 +306,34 @@ class TestCacheUsageMapping:
         assert result.cache_read_tokens == 800
         assert result.cache_creation_tokens == 0
 
+    def test_cache_creation_falls_back_to_prompt_tokens_details_too(self) -> None:
+        """litellm normalises cache creation into the same wrapper it uses for
+        reads. Reads had a fallback and creation didn't, so any route reporting
+        only through the wrapper showed 0 cache writes — indistinguishable in
+        --profile from caching not being applied at all."""
+        response = _fake_response(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=800, cache_creation_tokens=64),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            result = provider.complete(_messages(), "openrouter/anthropic/claude-sonnet-4.5")
+        assert result.cache_read_tokens == 800
+        assert result.cache_creation_tokens == 64
+
+    def test_cache_writes_map_from_openrouters_field_name(self) -> None:
+        """OpenRouter reports writes as prompt_tokens_details.cache_write_tokens,
+        not litellm's cache_creation_tokens — and litellm passes the raw field
+        through. Missing it reported 0 writes on every openrouter review, which
+        reads as 'caching never engaged'."""
+        response = _fake_response(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=10318, cache_write_tokens=512),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            result = provider.complete(_messages(), "openrouter/anthropic/claude-sonnet-4.5")
+        assert result.cache_read_tokens == 10318
+        assert result.cache_creation_tokens == 512
+
     def test_cache_token_counts_default_to_zero(self) -> None:
         with patch("litellm.completion", return_value=_fake_response()):
             provider = LiteLLMProvider()
@@ -366,3 +396,62 @@ def test_capability_lookup_memoized_per_model() -> None:
         for _ in range(3):
             provider.complete(_messages(), model)
     assert lookup.call_count == 1
+
+
+class TestStickyCacheKey:
+    """OpenRouter pins a conversation to one provider endpoint to keep its cache
+    warm, but without a key it only starts doing so *after* it observes a cache
+    hit — too late for a concurrent lens fan-out. It accepts `prompt_cache_key`
+    as that key, and OpenAI uses the same field as a cache-routing hint, so one
+    param serves both. Derived from the cacheable prefix itself: identical
+    across every lens of a batch, different for another PR or the reflection
+    pass, and no plumbing through the engine.
+    """
+
+    @staticmethod
+    def _sent_kwargs(model: str, *, prompt_cache: bool = True) -> dict[str, Any]:
+        with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
+            provider = LiteLLMProvider(model=model, prompt_cache=prompt_cache)
+            provider.complete(_split_messages(), model)
+        return dict(mock_completion.call_args.kwargs)
+
+    def test_key_is_sent_and_is_stable_for_the_same_prefix(self) -> None:
+        model = "openrouter/anthropic/claude-sonnet-4.5"
+        first = self._sent_kwargs(model)["prompt_cache_key"]
+        second = self._sent_kwargs(model)["prompt_cache_key"]
+        assert first and first == second
+        assert len(first) <= 256  # OpenRouter's documented ceiling
+
+    def test_a_different_prefix_gets_a_different_key(self) -> None:
+        model = "openrouter/anthropic/claude-sonnet-4.5"
+        with patch("litellm.completion", return_value=_fake_response()) as mock:
+            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider.complete(_split_messages(), model)
+            provider.complete(_split_messages(prefix=_DIFF_PREFIX + "\n+another"), model)
+        keys = [c.kwargs["prompt_cache_key"] for c in mock.call_args_list]
+        assert keys[0] != keys[1]
+
+    def test_lens_block_does_not_change_the_key(self) -> None:
+        """Every lens of a batch must share the key — the lens block is the one
+        part of the message that differs, and it sits outside the cached prefix."""
+        model = "openrouter/anthropic/claude-sonnet-4.5"
+        messages = _split_messages()
+        other = [*messages[:-1], {"role": "user", "content": "A totally different lens block."}]
+        with patch("litellm.completion", return_value=_fake_response()) as mock:
+            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider.complete(messages, model)
+            provider.complete(other, model)
+        keys = [c.kwargs["prompt_cache_key"] for c in mock.call_args_list]
+        assert keys[0] == keys[1]
+
+    def test_no_key_when_prompt_cache_is_off(self) -> None:
+        assert "prompt_cache_key" not in self._sent_kwargs(
+            "openrouter/anthropic/claude-sonnet-4.5", prompt_cache=False
+        )
+
+    def test_caller_supplied_key_wins(self) -> None:
+        model = "openrouter/anthropic/claude-sonnet-4.5"
+        with patch("litellm.completion", return_value=_fake_response()) as mock:
+            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider.complete(_split_messages(), model, prompt_cache_key="mine")
+        assert mock.call_args.kwargs["prompt_cache_key"] == "mine"


### PR DESCRIPTION
## Why

Explicit `cache_control` breakpoints were only emitted on `anthropic/` and `bedrock/`. Every other route re-processed the shared preamble-plus-diff prefix uncached on *every lens of the fan-out* — so a 4-call `fast` review paid full input price four times for the same diff, and a 9-call `full` review nine times.

## Explicit breakpoints — widened to what litellm actually forwards

| Route | Mechanism |
|---|---|
| `anthropic/` | native `cache_control` (already) |
| `bedrock/` | translated to a Converse `cachePoint` (already) |
| `vertex_ai/` | **new** — Claude partner route sets the prompt-caching beta from the marker; Gemini has it translated into Google's cachedContents API |
| `zai/` | **new** — `ZAIChatConfig` overrides litellm's strip step to always preserve the marker, so GLM / Zhipu gets a breakpoint |
| `openrouter/` | **new** — marked for the whole route deliberately |

Marking the whole `openrouter/` route is the deliberate call: `OpenrouterConfig` keeps `cache_control` for the families that accept it (claude, gemini, minimax, glm, z-ai) and **removes** it for everything else before the request leaves. A per-model allowlist here would only duplicate that list and then drift from it. Marking a deepseek or qwen model is a no-op upstream, not an error.

## DeepSeek and the warm-up primer

DeepSeek needs no marker — litellm strips it and DeepSeek caches a repeated prefix automatically. What it actually wants is the **warm-up primer**, which was gated to `{anthropic, bedrock}`, so a concurrent first wave on any automatic-caching backend all missed.

The gate is now just `prompt_cache` + a wide-enough fan-out + the diff-size floor. The primer is about the shape of the first wave, not about the marker: N identical prefixes arriving at once miss on OpenAI, Azure and DeepSeek exactly as they do on Anthropic. Deleting the provider set also removes the engine-side copy of the adapter's route list — whose own comment asked future readers to keep the two in sync by hand.

## Corrections after reading the upstream docs

The first commit here was written against litellm's installed source; the second corrects it against litellm's and OpenRouter's published prompt-caching docs:

- **Vertex is both families.** The first pass scoped it to `vertex_ai/claude` on the assumption Gemini took no inline marker. litellm documents `vertex_ai/` for Claude *and* Gemini, so Gemini-on-Vertex was left uncached.
- **OpenRouter names cache writes `cache_write_tokens`**, not litellm's `cache_creation_tokens`, and litellm passes the raw field through untranslated. We read neither from the wrapper, so every openrouter review reported **0 cache writes** — in `--profile` that is indistinguishable from caching never engaging. Both names are read now, and reads gained the same wrapper fallback the top-level Anthropic field already had.
- **Sticky routing needs a key to start early.** OpenRouter pins a conversation to one provider endpoint to keep its cache warm, but with no key it only begins *after* it observes a cache hit — too late for a fan-out that dispatches its lenses at once. It accepts `prompt_cache_key` as that key, and OpenAI takes the same field as a cache-routing hint, so one param serves both. Every call now carries one derived from the cacheable prefix: identical across a batch's lenses, different for another PR or the reflection pass. A digest, not prompt content; `drop_params` strips it where unsupported.

Also recorded the real per-model minimum cacheable sizes (1,024 / 2,048 / 4,096 depending on model) beside the 1,024 floor, with why the floor tracks the **lowest** minimum rather than the highest — raising it would stop marking in the 1k–4k range and lose real caching on the 1,024-token models.

## Tests

TDD throughout — each batch of assertions was watched fail before the code moved.

The `TestOpenRouterBreakpoints` suite runs litellm's **real** openrouter transform (no network) to pin which families keep the breakpoint and which have it stripped, so a litellm upgrade that changes that list fails here instead of silently costing money on every review. `TestStickyCacheKey` pins that the key is stable across a batch's lenses, changes with the prefix, is absent when `prompt_cache` is off, and yields to a caller-supplied value.

Full suite: 1461 passed. `ruff check`, `ruff format --check`, `mypy src`, and `pytest tests/specs` clean. Both spec sections describe this qualitatively ("routes with cache breakpoints", "supported routes"), so neither went stale.

## Note

I could not open the upstream docs from this session — `openrouter.ai` and `docs.litellm.ai` are both denied by the egress policy (403 at the proxy). The corrections above came from the doc text supplied in-session, cross-checked against the installed litellm source and by executing its real transform and usage-mapping code locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuzC47hXdohXyP6xzTH4V)_