### PR TITLE
feat(preset): four distinct lenses on every provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,15 +258,14 @@ pattern, event bus, plugin framework.
    - **Per-lens fan-out (preset-shaped):** the prompt is composed per lens
      (`engine/prompt.py`) — each lens gets a **worked example** (with a real
      hunk header, teaching the line-number arithmetic). `ReviewConfig.preset`
-     picks the lens set: **`fast` (default)** covers security, correctness and
-     stated intent, performance, complexity, ponytail, and deprecation in
-     **four calls** when the provider can overlap work (dedicated security +
-     two correctness calls, flow and state — stated intent folds into
-     correctness with per-finding `category` attribution — plus merged
-     code-health, `prompt.FAST_GROUPS`), or **three** with one worker
-     (correctness combined); **`full`** restores tests and
-     documentation and runs one call per category. An explicit `categories`
-     list overrides the grouping. Every (batch, lens) call runs through **one global
+     picks the lens set: **`fast` (default)** covers all nine categories in
+     **four calls, one per concern** — dedicated security, dedicated
+     correctness (stated intent folds in, with per-finding `category`
+     attribution), merged code-health, and merged artefacts (tests +
+     documentation); the two merged lenses are `prompt.FAST_GROUPS`. The same
+     four run on **every** provider: worker count decides only whether they
+     overlap, never how many there are. **`full`** runs one call per category.
+     An explicit `categories` list overrides the grouping. Every (batch, lens) call runs through **one global
      `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 8
      cloud, 1 ollama/openai-compatible), then the findings are **merged and
      de-duped** (`engine._dedupe`, keyed on path/line/side) before reflection.

--- a/README.md
+++ b/README.md
@@ -60,21 +60,18 @@ forged delimiter break-out attempts), and redacts a broad set of secret formats
 credentials in connection strings) before anything leaves your environment. See
 [Data and Privacy](docs/explanation/data-and-privacy.md).
 
-**Fast by default.** Reviews run the **`fast` preset** by default: security,
-correctness (including stated intent), and code health
-(performance/complexity/ponytail/deprecation) run in **four parallel model
-calls** when more than one worker is available: correctness is split into
-focused flow and state/lifecycle checks so one oversized task cannot set the
-critical path. Single-worker configurations keep the combined **three-call**
-shape.
-Tests and documentation are reserved for `--preset full` (or `preset: full` in
-`.lgtmaybe.yml`), which restores the one-call-per-lens deep audit for release
-branches. This keeps the everyday path focused on code defects while avoiding a
-low-yield call that can dominate wall time.
+**Fast by default.** Reviews run the **`fast` preset** by default: all nine
+categories in **four model calls**, one per concern — security, correctness
+(including stated intent), code health
+(performance/complexity/ponytail/deprecation), and artefacts
+(tests/documentation). The same four run on every provider; worker count
+changes only how they are scheduled, so a cloud review overlaps them while a
+single-slot local one runs them in turn. `--preset full` (or `preset: full` in
+`.lgtmaybe.yml`) restores the one-call-per-lens deep audit for release branches.
 On top of that, all calls across all batches share **one concurrency pool**
 (`max_concurrency`, default 8 on cloud providers) and share a **cached
-preamble-plus-diff prefix** on anthropic/bedrock, so the diff is processed once
-per batch, not once per lens. Add `--profile` to any run to see exactly where
+preamble-plus-diff prefix** on the routes that support it, so the diff is
+processed once per batch, not once per lens. Add `--profile` to any run to see exactly where
 the time and tokens went.
 
 **How the scope is bounded.** Every run is capped so a large PR can't blow up

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -50,18 +50,18 @@ call per review lens — before the findings funnel back into a single stream:
 flowchart TD
     fetch["fetch<br/>diff via API — never a checkout"] --> compress["compress<br/>skip generated files · pad context · batch to budget"]
     compress --> security["security lens"]
-    compress --> correctnessflow["correctness flow + intent lens"]
-    compress --> correctnessstate["correctness state/lifecycle lens"]
+    compress --> correctness["correctness lens<br/>+ stated intent"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
+    compress --> artefacts["artefacts lens<br/>tests · documentation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
-    correctnessflow --> anchor
-    correctnessstate --> anchor
+    correctness --> anchor
     codehealth --> anchor
+    artefacts --> anchor
     anchor --> dedupe["merge / dedupe"] --> evidence["evidence gate<br/>defects need a failure scenario"] --> reflect["reflect<br/>validate scenarios · drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The four lens calls shown are the parallel-capable `fast` grouping. A
-single-worker configuration combines the two correctness calls; the `full`
+(The four lens calls shown are the `fast` grouping, and they are the same four
+on every provider — worker count decides only whether they overlap. The `full`
 preset fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
@@ -80,13 +80,12 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    line maps to nothing and is dropped rather than mis-posted.
 
 3. **prompt + parse** — this stage **fans out one model call per review
-   lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   seven code-focused categories in **four calls** when parallelism is
-   available: security, correctness flow (with stated intent when present),
-   correctness state/lifecycle, and merged code health (performance/
-   complexity/ponytail/deprecation). With one worker the two correctness tasks
-   stay combined, keeping the three-call serial path. `full` restores tests and
-   documentation and runs one call per category. Every
+   lens**. The `preset` decides the lens set. `fast` (the default) covers all
+   nine categories in **four calls**, one per concern: security, correctness
+   (with stated intent when present), merged code health (performance/
+   complexity/ponytail/deprecation), and artefacts (tests/documentation). The
+   same four run on every provider — worker count changes only how they are
+   scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -31,9 +31,8 @@ are followed by a self-reflection call. Each call contains some subset of:
   each commit message (on the CLI: the commit names from your local `git log`).
   This feeds the **intent lens** ("does the PR do what it says?"). It is
   redacted exactly like the diff, wrapped as untrusted data, and sent **only on
-  the single lens call that carries the intent** (the correctness-flow or
-  combined correctness call under the default `fast` preset, or the dedicated
-  intent lens under `full`) — drop `intent` from `categories` in
+  the single lens call that carries the intent** (the correctness call under
+  the default `fast` preset, or the dedicated intent lens under `full`) — drop `intent` from `categories` in
   `.lgtmaybe.yml` and it is never sent at all.
 - A **system prompt** — the fixed instructions that tell the model to return
   structured JSON findings.

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -277,7 +277,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens. |
+| `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -309,11 +309,11 @@ Each finding has:
 
 The nine review categories are security, correctness, deprecation, tests,
 documentation, performance, complexity, intent, and ponytail. The default
-`fast` preset covers seven of them in four concurrent calls when parallelism is
-available: security, correctness flow/intent, correctness state/lifecycle, and
-merged code health (performance/complexity/ponytail/deprecation). With one
-worker, correctness stays combined and the preset uses three calls.
-`preset: full` restores tests and documentation and runs each category as its
+`fast` preset covers all nine in four calls, one per concern: security,
+correctness (with stated intent folded in), merged code health
+(performance/complexity/ponytail/deprecation), and artefacts
+(tests/documentation). The same four run on every provider — worker count
+changes only how they are scheduled. `preset: full` runs each category as its
 own focused call with a worked example of its own finding type. Their findings
 are merged and de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -145,12 +145,19 @@ Default: `100000`.
 
 ### preset
 
-How many model calls the review spends. `fast` (the default) covers security,
-correctness and stated intent, performance, complexity, ponytail, and
-deprecation in **four calls when parallelism is available**: correctness splits
-into flow/intent and state/lifecycle tasks. With one worker it stays combined
-for three calls. `full` restores tests and documentation and runs one focused
-call per lens for release branches and deep audits.
+How many model calls the review spends. `fast` (the default) covers all nine
+categories in **four calls**, one per concern:
+
+| Call | Covers |
+|---|---|
+| security | security |
+| correctness | correctness, and stated intent when the PR states one |
+| code health | performance, complexity, ponytail, deprecation |
+| artefacts | tests, documentation |
+
+The same four run on every provider — worker count changes only how they are
+scheduled, not how many there are. `full` runs one focused call per lens for
+release branches and deep audits.
 
 ```yaml
 preset: full

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -202,22 +202,21 @@ model: qwen3.6:35b
 timeout: 1800
 ```
 
-The review fans out **three calls** under the default `fast` preset (nine under
+The review fans out **four calls** under the default `fast` preset (nine under
 `--preset full`). lgtmaybe runs those **serially for
 ollama**: a single ollama instance serves one request at a time, so firing them
 concurrently would only make each wait and time out. The trade-off is
 wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — three serial calls instead of nine is the
+is exactly why `fast` is the default — four serial calls instead of nine is the
 single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
 `OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match. With more than one worker, lgtmaybe splits correctness into focused flow
-and state/lifecycle calls, making four parallel fast-preset tasks instead of
-three combined serial tasks. By default lgtmaybe issues ollama calls one at a
-time. Add `--profile` to any run to see the per-call breakdown.
+match — the same four calls then overlap instead of queueing, which is close to
+a 4× wall-clock win. By default lgtmaybe issues ollama calls one at a time. Add
+`--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -207,7 +207,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
+| `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -546,7 +546,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `resolve_fixed` | `true` | Auto-resolve a review conversation once its finding is fixed (set `false` to resolve manually) |
 | `recursive` | `true` | Walk a file whose diff exceeds `max_input_tokens` hunk-by-hunk (RLM-style) instead of sending it whole; set `false` to disable |
 | `structured_output` | `true` | Constrain output to the findings JSON schema via `response_format` (JSON mode); set `false` for an `openai-compatible` gateway that rejects it |
-| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens |
+| `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
@@ -1738,22 +1738,21 @@ model: qwen3.6:35b
 timeout: 1800
 ```
 
-The review fans out **three calls** under the default `fast` preset (nine under
+The review fans out **four calls** under the default `fast` preset (nine under
 `--preset full`). lgtmaybe runs those **serially for
 ollama**: a single ollama instance serves one request at a time, so firing them
 concurrently would only make each wait and time out. The trade-off is
 wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — three serial calls instead of nine is the
+is exactly why `fast` is the default — four serial calls instead of nine is the
 single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
 `OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match. With more than one worker, lgtmaybe splits correctness into focused flow
-and state/lifecycle calls, making four parallel fast-preset tasks instead of
-three combined serial tasks. By default lgtmaybe issues ollama calls one at a
-time. Add `--profile` to any run to see the per-call breakdown.
+match — the same four calls then overlap instead of queueing, which is close to
+a 4× wall-clock win. By default lgtmaybe issues ollama calls one at a time. Add
+`--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 
@@ -2145,12 +2144,19 @@ Default: `100000`.
 
 ### preset
 
-How many model calls the review spends. `fast` (the default) covers security,
-correctness and stated intent, performance, complexity, ponytail, and
-deprecation in **four calls when parallelism is available**: correctness splits
-into flow/intent and state/lifecycle tasks. With one worker it stays combined
-for three calls. `full` restores tests and documentation and runs one focused
-call per lens for release branches and deep audits.
+How many model calls the review spends. `fast` (the default) covers all nine
+categories in **four calls**, one per concern:
+
+| Call | Covers |
+|---|---|
+| security | security |
+| correctness | correctness, and stated intent when the PR states one |
+| code health | performance, complexity, ponytail, deprecation |
+| artefacts | tests, documentation |
+
+The same four run on every provider — worker count changes only how they are
+scheduled, not how many there are. `full` runs one focused call per lens for
+release branches and deep audits.
 
 ```yaml
 preset: full
@@ -3580,7 +3586,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in categories in FOUR calls,\none per concern: security, correctness (with stated intent folded in), code\nhealth, and artefacts (tests + documentation). The same four run on every\nprovider \u2014 worker count changes the schedule, not the call count.\n``full`` runs each of the nine categories as its own call for release\nbranches and deep audits. An explicit ``categories`` list always wins over\nthe preset.",
       "enum": [
         "fast",
         "full"
@@ -4515,7 +4521,7 @@ configurable in `.lgtmaybe.yml` (see
 
 | Knob | Default | Effect |
 |---|---|---|
-| `preset` | `fast` | `fast` uses four calls when parallelism is available, three with one worker; `full` restores tests/documentation and runs one call per lens. |
+| `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
@@ -4547,11 +4553,11 @@ Each finding has:
 
 The nine review categories are security, correctness, deprecation, tests,
 documentation, performance, complexity, intent, and ponytail. The default
-`fast` preset covers seven of them in four concurrent calls when parallelism is
-available: security, correctness flow/intent, correctness state/lifecycle, and
-merged code health (performance/complexity/ponytail/deprecation). With one
-worker, correctness stays combined and the preset uses three calls.
-`preset: full` restores tests and documentation and runs each category as its
+`fast` preset covers all nine in four calls, one per concern: security,
+correctness (with stated intent folded in), merged code health
+(performance/complexity/ponytail/deprecation), and artefacts
+(tests/documentation). The same four run on every provider — worker count
+changes only how they are scheduled. `preset: full` runs each category as its
 own focused call with a worked example of its own finding type. Their findings
 are merged and de-duplicated. A
 self-reflection pass then runs over the merged set and drops low-confidence
@@ -4710,18 +4716,18 @@ call per review lens — before the findings funnel back into a single stream:
 flowchart TD
     fetch["fetch<br/>diff via API — never a checkout"] --> compress["compress<br/>skip generated files · pad context · batch to budget"]
     compress --> security["security lens"]
-    compress --> correctnessflow["correctness flow + intent lens"]
-    compress --> correctnessstate["correctness state/lifecycle lens"]
+    compress --> correctness["correctness lens<br/>+ stated intent"]
     compress --> codehealth["code-health lens<br/>performance · complexity · ponytail · deprecation"]
+    compress --> artefacts["artefacts lens<br/>tests · documentation"]
     security --> anchor["re-anchor<br/>snap lines to the real diff"]
-    correctnessflow --> anchor
-    correctnessstate --> anchor
+    correctness --> anchor
     codehealth --> anchor
+    artefacts --> anchor
     anchor --> dedupe["merge / dedupe"] --> evidence["evidence gate<br/>defects need a failure scenario"] --> reflect["reflect<br/>validate scenarios · drop low-confidence"] --> filter["filter<br/>severity floor · finding rules"] --> post["post<br/>inline comments + summary"]
 ```
 
-(The four lens calls shown are the parallel-capable `fast` grouping. A
-single-worker configuration combines the two correctness calls; the `full`
+(The four lens calls shown are the `fast` grouping, and they are the same four
+on every provider — worker count decides only whether they overlap. The `full`
 preset fans out one call per category, and custom lenses join the same fan-out.)
 
 1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
@@ -4740,13 +4746,12 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    line maps to nothing and is dropped rather than mis-posted.
 
 3. **prompt + parse** — this stage **fans out one model call per review
-   lens**. The `preset` decides the lens set. `fast` (the default) covers the
-   seven code-focused categories in **four calls** when parallelism is
-   available: security, correctness flow (with stated intent when present),
-   correctness state/lifecycle, and merged code health (performance/
-   complexity/ponytail/deprecation). With one worker the two correctness tasks
-   stay combined, keeping the three-call serial path. `full` restores tests and
-   documentation and runs one call per category. Every
+   lens**. The `preset` decides the lens set. `fast` (the default) covers all
+   nine categories in **four calls**, one per concern: security, correctness
+   (with stated intent when present), merged code health (performance/
+   complexity/ponytail/deprecation), and artefacts (tests/documentation). The
+   same four run on every provider — worker count changes only how they are
+   scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
    provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
@@ -5043,9 +5048,8 @@ are followed by a self-reflection call. Each call contains some subset of:
   each commit message (on the CLI: the commit names from your local `git log`).
   This feeds the **intent lens** ("does the PR do what it says?"). It is
   redacted exactly like the diff, wrapped as untrusted data, and sent **only on
-  the single lens call that carries the intent** (the correctness-flow or
-  combined correctness call under the default `fast` preset, or the dedicated
-  intent lens under `full`) — drop `intent` from `categories` in
+  the single lens call that carries the intent** (the correctness call under
+  the default `fast` preset, or the dedicated intent lens under `full`) — drop `intent` from `categories` in
   `.lgtmaybe.yml` and it is never sent at all.
 - A **system prompt** — the fixed instructions that tell the model to return
   structured JSON findings.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -442,7 +442,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in categories in FOUR calls,\none per concern: security, correctness (with stated intent folded in), code\nhealth, and artefacts (tests + documentation). The same four run on every\nprovider \u2014 worker count changes the schedule, not the call count.\n``full`` runs each of the nine categories as its own call for release\nbranches and deep audits. An explicit ``categories`` list always wins over\nthe preset.",
       "enum": [
         "fast",
         "full"

--- a/evals/fixtures/artefact-gaps/diff.txt
+++ b/evals/fixtures/artefact-gaps/diff.txt
@@ -1,0 +1,32 @@
+diff --git a/billing/refunds.py b/billing/refunds.py
+index 3a1b2c4..7d9e0f1 100644
+--- a/billing/refunds.py
++++ b/billing/refunds.py
+@@ -1,10 +1,30 @@
+ """Refund helpers.
+ 
+-`refund_order` issues a full refund for the order and returns the refund id.
+-It raises `OrderNotFound` when the order does not exist.
++`refund_order` issues a full refund for the order and returns the refund id.
++It raises `OrderNotFound` when the order does not exist.
+ """
+ 
+ 
+ def refund_order(order_id, amount=None):
+-    order = _load(order_id)
+-    return _gateway.refund(order.id, order.total)
++    order = _load(order_id)
++    if amount is None:
++        return _gateway.refund(order.id, order.total)
++    if amount > order.total:
++        raise ValueError("refund exceeds order total")
++    return _gateway.refund(order.id, amount)
++
++
++def refund_window_days(plan):
++    """Return how many days a plan has to request a refund."""
++    if plan == "enterprise":
++        return 90
++    if plan == "pro":
++        return 30
++    return 14

--- a/evals/fixtures/artefact-gaps/expected.json
+++ b/evals/fixtures/artefact-gaps/expected.json
@@ -1,0 +1,44 @@
+{
+  "name": "artefact-gaps",
+  "changed_file": "billing/refunds.py",
+  "expected": [
+    {
+      "label": "new partial-refund branches in refund_order have no test",
+      "line": 12,
+      "keywords": [
+        "test",
+        "untested",
+        "coverage",
+        "no test",
+        "test case"
+      ],
+      "severity_at_least": "low"
+    },
+    {
+      "label": "module docstring still describes refund_order as full-refund-only and omits ValueError",
+      "line": 3,
+      "keywords": [
+        "docstring",
+        "documentation",
+        "stale",
+        "outdated",
+        "amount",
+        "valueerror",
+        "describe"
+      ],
+      "severity_at_least": "info"
+    },
+    {
+      "label": "refund_window_days is entirely untested",
+      "line": 17,
+      "keywords": [
+        "test",
+        "untested",
+        "coverage",
+        "no test",
+        "test case"
+      ],
+      "severity_at_least": "low"
+    }
+  ]
+}

--- a/openspec/specs/prompt-and-lenses/spec.md
+++ b/openspec/specs/prompt-and-lenses/spec.md
@@ -54,34 +54,32 @@ sourced from PR-author content.
 - **THEN** it runs as one more concurrent lens call, findings merged like any
   built-in
 
-### Requirement: Fast preset splits correctness only when it can overlap
+### Requirement: Fast preset is four distinct lenses on every provider
 
-The default `fast` preset SHALL run security and code-health tasks plus
-provider-aware correctness tasks. A parallel-capable configuration SHALL split
-correctness into focused flow and state/lifecycle calls, both attributed to the
-`correctness` category; a single-worker configuration SHALL keep one combined
-correctness call. Stated intent SHALL remain attached to one correctness task.
-Tests and documentation SHALL remain reserved for `full` or explicit category
-reviews.
+The default `fast` preset SHALL run every built-in category as FOUR lenses —
+security, correctness, code health, and artefacts — one per concern. The lens
+set SHALL NOT vary with the number of available workers: a single-worker
+configuration runs the same four calls serially. Stated intent SHALL fold into
+the correctness call rather than consume its own.
 <!-- anchor: prompt.groups -->
 
 #### Scenario: cloud default
 - **WHEN** `fast` uses a cloud provider with auto-concurrency
-- **THEN** its four calls are security, correctness-flow, correctness-state,
-  and code health
+- **THEN** its four calls are security, correctness, code health, and artefacts,
+  and they may overlap
 
 #### Scenario: local single-slot default
 - **WHEN** `fast` uses Ollama with auto-concurrency
-- **THEN** its three calls are security, combined correctness, and code health
+- **THEN** the same four calls run within the single-worker pool, serially
 
 #### Scenario: intent with no dedicated call
 - **WHEN** the fast preset runs and the PR states an intent
 - **THEN** intent findings come out of the correctness call, attributed to the
   intent category
 
-#### Scenario: everyday review
+#### Scenario: everyday review covers artefacts
 - **WHEN** the fast preset runs with no category override
-- **THEN** tests and documentation do not consume a model call
+- **THEN** tests and documentation are reviewed by the artefacts call
 
 ### Requirement: Defect prompts require a concrete failure scenario
 

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -24,21 +24,19 @@ failure surfaces to the caller.
 ### Requirement: Per-lens fan-out through one bounded executor
 
 Every `(batch, lens)` call SHALL run through one global bounded executor sized
-by `max_concurrency` (auto: eight cloud, one for Ollama/OpenAI-compatible).
-When the effective executor can run more than one call, the default fast preset
-SHALL submit separate correctness-flow and correctness-state tasks; when it is
-single-worker, it SHALL submit the existing combined correctness task.
+by `max_concurrency` (auto: eight cloud, one for Ollama/OpenAI-compatible). The
+executor size SHALL determine only how the preset's calls are scheduled, never
+how many there are.
 <!-- anchor: engine.fan-out -->
 
 #### Scenario: parallel-capable default review
 - **WHEN** a fast review uses cloud auto-concurrency
-- **THEN** security, correctness-flow, correctness-state, and code-health calls
-  share the existing bounded executor and may overlap
+- **THEN** the security, correctness, code-health, and artefacts calls share the
+  bounded executor and may overlap
 
 #### Scenario: single-worker default review
 - **WHEN** a fast review uses Ollama auto-concurrency or `max_concurrency: 1`
-- **THEN** security, combined correctness, and code-health run within the
-  single-worker pool without an additional serial request
+- **THEN** the same four calls run within the single-worker pool, serially
 
 #### Scenario: deep audit
 - **WHEN** a review uses the `full` preset

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -90,7 +90,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     default=None,
     type=click.Choice(["fast", "full"]),
     help="Review preset: fast (default) covers security, correctness/intent, "
-    "performance, complexity, ponytail, and deprecation in four calls when "
+    "performance, complexity, ponytail, deprecation, tests and documentation in "
     "parallelism is available, or three with one worker; full restores "
     "tests/documentation and runs one call per lens for deep audits",
 )

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -94,13 +94,13 @@ class ReviewCategory(StrEnum):
 class ReviewPreset(StrEnum):
     """How many model calls a review spends: the everyday path or the deep audit.
 
-    ``fast`` (the default) covers seven built-in lenses in four calls when the
-    provider can overlap work: security, correctness flow/intent, correctness
-    state/lifecycle, and code health. With one worker, correctness stays
-    combined for three calls.
-    ``full`` restores tests and documentation and runs each of the nine lenses
-    as its own call for release branches and deep audits. An explicit
-    ``categories`` list always wins over the preset.
+    ``fast`` (the default) covers all nine built-in categories in FOUR calls,
+    one per concern: security, correctness (with stated intent folded in), code
+    health, and artefacts (tests + documentation). The same four run on every
+    provider — worker count changes the schedule, not the call count.
+    ``full`` runs each of the nine categories as its own call for release
+    branches and deep audits. An explicit ``categories`` list always wins over
+    the preset.
     """
 
     fast = "fast"

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1,7 +1,7 @@
 """LLMReviewEngine: the full review pipeline.
 
 Pipeline: redact → compress/batch → (per batch) fan out one call per review
-         category (concurrent for cloud, serial for ollama) → parse → merge/dedupe
+         lens (concurrent for cloud, serial for ollama) → parse → merge/dedupe
          → require defect evidence → self-reflect/filter → filter by min_severity
          → return findings + summary.
 """
@@ -43,11 +43,7 @@ from .profiling import profiler
 from .prompt import (
     FAST_GROUPS,
     build_correctness_block,
-    build_correctness_flow_block,
-    build_correctness_flow_prompt,
     build_correctness_prompt,
-    build_correctness_state_block,
-    build_correctness_state_prompt,
     build_custom_lens_block,
     build_group_block,
     build_group_prompt,
@@ -144,22 +140,18 @@ class _Lens:
     finding_category: str | None = None
 
 
-def _parallel_fast_enabled(cfg: ReviewConfig) -> bool:
-    """Whether the fast preset can overlap its two correctness tasks."""
-    if cfg.max_concurrency is not None:
-        return cfg.max_concurrency > 1
-    return cfg.provider not in _SINGLE_STREAM_PROVIDERS
-
-
 def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
     """All lenses to run: built-ins (grouped per the preset), then user lenses.
 
-    The fast preset runs seven built-ins in four calls when the provider can
-    overlap work, or three combined calls with one worker. This grouping applies
-    only when ``categories`` is the untouched default: a user who explicitly
-    listed lenses asked for exactly those, so the preset never regroups them.
-    The full preset runs every category; an explicit list runs exactly its
-    selected categories. Both skip intent when nothing states an intent.
+    The fast preset runs all nine built-ins as FOUR distinct lenses — security,
+    correctness, code health, artefacts — one per concern, the same set on every
+    provider. The lens set is a property of the preset, not of how many workers
+    happen to be available: a single-worker provider runs the same four calls,
+    serially. This grouping applies only when ``categories`` is the untouched
+    default: a user who explicitly listed lenses asked for exactly those, so the
+    preset never regroups them. The full preset runs every category; an explicit
+    list runs exactly its selected categories. Both skip intent when nothing
+    states an intent.
     """
     fast = cfg.preset is ReviewPreset.fast and list(cfg.categories) == list(ReviewCategory)
     if fast:
@@ -175,34 +167,15 @@ def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
             if has_intent
             else frozenset({ReviewCategory.correctness.value})
         )
-        if _parallel_fast_enabled(cfg):
-            lenses += [
-                _Lens(
-                    id="correctness-flow",
-                    system_prompt=build_correctness_flow_prompt(has_intent, cfg.language),
-                    user_block=build_correctness_flow_block(has_intent),
-                    carries_intent=has_intent,
-                    allowed_categories=correctness_categories,
-                    finding_category=ReviewCategory.correctness.value,
-                ),
-                _Lens(
-                    id="correctness-state",
-                    system_prompt=build_correctness_state_prompt(cfg.language),
-                    user_block=build_correctness_state_block(),
-                    allowed_categories=frozenset({ReviewCategory.correctness.value}),
-                    finding_category=ReviewCategory.correctness.value,
-                ),
-            ]
-        else:
-            lenses.append(
-                _Lens(
-                    id=ReviewCategory.correctness.value,
-                    system_prompt=build_correctness_prompt(has_intent, cfg.language),
-                    user_block=build_correctness_block(has_intent),
-                    carries_intent=has_intent,
-                    allowed_categories=correctness_categories if has_intent else None,
-                )
+        lenses.append(
+            _Lens(
+                id=ReviewCategory.correctness.value,
+                system_prompt=build_correctness_prompt(has_intent, cfg.language),
+                user_block=build_correctness_block(has_intent),
+                carries_intent=has_intent,
+                allowed_categories=correctness_categories if has_intent else None,
             )
+        )
         lenses += [
             _Lens(
                 id=group.id,

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -166,28 +166,6 @@ _CORRECTNESS_EXAMPLE = _example_block(
     },
 )
 
-_CORRECTNESS_STATE_EXAMPLE = _example_block(
-    "--- a/cache.py\n"
-    "+++ b/cache.py\n"
-    "@@ -8,1 +8,3 @@\n"
-    " def get_or_create(key):\n"
-    "+    if key not in cache:\n"
-    "+        cache[key] = create_value(key)\n",
-    {
-        "path": "cache.py",
-        "line": 9,
-        "side": "RIGHT",
-        "severity": "high",
-        "title": "Check-then-act race can create the value twice",
-        "body": "Concurrent callers can both observe a missing key and run create_value. "
-        "Protect the read-modify-write sequence or use an atomic cache operation.",
-        "failure_scenario": "When two callers miss the same key concurrently, both run "
-        "create_value and duplicate its side effects.",
-        "suggestion": None,
-        "anchor": "    if key not in cache:",
-    },
-)
-
 _DEPRECATION_EXAMPLE = _example_block(
     "--- a/clock.py\n"
     "+++ b/clock.py\n"
@@ -373,20 +351,6 @@ _CORRECTNESS_STATE_CHECKS = """\
   seconds/milliseconds epoch confusion, DST-unsafe date arithmetic.
 - **Aliasing & mutation** — mutable default arguments, storing a mutable value
   the caller still owns, mutating a collection while iterating over it."""
-
-_CORRECTNESS_FLOW_SECTION = f"""\
-## Correctness & control/data flow
-
-{_CORRECTNESS_INTRO}
-
-{_CORRECTNESS_FLOW_CHECKS}"""
-
-_CORRECTNESS_STATE_SECTION = f"""\
-## Correctness & state/lifecycle
-
-{_CORRECTNESS_INTRO}
-
-{_CORRECTNESS_STATE_CHECKS}"""
 
 _CORRECTNESS_SECTION = f"""\
 ## Correctness & logic (the substance of the change)
@@ -709,12 +673,19 @@ class LensGroup:
 
 
 # The fast preset's grouping (a judgement call the profile can't settle, so
-# here is the reasoning): security and correctness are the two lenses whose
-# recall is worth a dedicated, focused call — they find the merge-blocking
-# bugs. Code health keeps the lower-cost concerns that inspect the changed code
-# itself. Tests and documentation are reserved for full/explicit reviews: the
-# default artefacts call was the slowest call in production while yielding no
-# findings, so it did not earn a place in the everyday path.
+# here is the reasoning): one call per CONCERN, four concerns. Security and
+# correctness each earn a dedicated, focused call — they find the
+# merge-blocking bugs. Code health carries the concerns that inspect the
+# changed code itself, artefacts the ones that ask what the change failed to
+# bring with it.
+#
+# Artefacts was cut from the everyday path once, as the slowest call for no
+# findings. Two things changed: it now overlaps the other three instead of
+# extending them, and reads a cached shared prefix on the breakpoint routes —
+# so "slowest" costs far less than it did. And "no findings" was measured on
+# fixtures that plant no missing-test or stale-doc issue, which is a corpus
+# gap, not evidence the lens is silent. Restored with a fixture that actually
+# tests it; if it earns its place it stays, and now that is measurable.
 CODE_HEALTH_GROUP = LensGroup(
     id="code-health",
     members=(
@@ -726,7 +697,13 @@ CODE_HEALTH_GROUP = LensGroup(
     section=_CODE_HEALTH_SECTION,
     example=_PERFORMANCE_EXAMPLE,
 )
-FAST_GROUPS: tuple[LensGroup, ...] = (CODE_HEALTH_GROUP,)
+ARTEFACTS_GROUP = LensGroup(
+    id="artefacts",
+    members=(ReviewCategory.tests, ReviewCategory.documentation),
+    section=_ARTEFACTS_SECTION,
+    example=_TESTS_EXAMPLE,
+)
+FAST_GROUPS: tuple[LensGroup, ...] = (CODE_HEALTH_GROUP, ARTEFACTS_GROUP)
 
 
 def build_group_prompt(group: LensGroup, language: str | None = None) -> str:
@@ -759,41 +736,6 @@ def build_correctness_prompt(include_intent: bool, language: str | None = None) 
 def build_correctness_block(include_intent: bool) -> str:
     """The fast preset's correctness call, user-block (split) shape."""
     return f"{_LENS_LEAD_IN}\n\n{_correctness_section(include_intent)}\n\n{_CORRECTNESS_EXAMPLE}"
-
-
-@lru_cache(maxsize=2)
-def _correctness_flow_section(include_intent: bool) -> str:
-    """The parallel fast preset's flow section, optionally carrying intent."""
-    if not include_intent:
-        return _CORRECTNESS_FLOW_SECTION
-    return f"{_CORRECTNESS_INTENT_PREFIX}\n{_CORRECTNESS_FLOW_SECTION}\n\n{_INTENT_SECTION}"
-
-
-def build_correctness_flow_prompt(include_intent: bool, language: str | None = None) -> str:
-    """The parallel fast preset's correctness-flow system prompt."""
-    section = _correctness_flow_section(include_intent)
-    header = _localised_header(language)
-    return f"{header}\n{_CORRECTNESS_EXAMPLE}\n\n{section}\n\n{_SHARED_RULES}\n"
-
-
-def build_correctness_flow_block(include_intent: bool) -> str:
-    """The parallel fast preset's correctness-flow split block."""
-    return (
-        f"{_LENS_LEAD_IN}\n\n{_correctness_flow_section(include_intent)}\n\n{_CORRECTNESS_EXAMPLE}"
-    )
-
-
-def build_correctness_state_prompt(language: str | None = None) -> str:
-    """The parallel fast preset's correctness-state system prompt."""
-    return (
-        f"{_localised_header(language)}\n{_CORRECTNESS_STATE_EXAMPLE}\n\n"
-        f"{_CORRECTNESS_STATE_SECTION}\n\n{_SHARED_RULES}\n"
-    )
-
-
-def build_correctness_state_block() -> str:
-    """The parallel fast preset's correctness-state split block."""
-    return f"{_LENS_LEAD_IN}\n\n{_CORRECTNESS_STATE_SECTION}\n\n{_CORRECTNESS_STATE_EXAMPLE}"
 
 
 _CATEGORY_SECTIONS: dict[ReviewCategory, str] = {

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -530,8 +530,8 @@ def test_reflect_true_runs_the_reflection_pass() -> None:
     engine.review(_CTX, cfg)
 
     assert len(_reflection_calls(provider)) == 1  # exactly one reflection pass
-    # The default fast preset covers seven lenses in three grouped calls.
-    assert len(_review_calls(provider)) == 3
+    # The default fast preset covers nine categories in four distinct calls.
+    assert len(_review_calls(provider)) == 4
 
 
 # ---------------------------------------------------------------------------
@@ -1146,8 +1146,8 @@ def test_review_logs_an_upfront_work_summary(engine_logs) -> None:
 
     starting = [r for r in engine_logs if "review starting" in r.getMessage()]
     assert starting, "expected an up-front 'review starting' log"
-    # The default fast preset queues three grouped lens calls.
-    assert getattr(starting[0], "lenses", None) == 3
+    # The default fast preset queues four distinct lens calls.
+    assert getattr(starting[0], "lenses", None) == 4
 
 
 def test_review_logs_a_heartbeat_as_each_lens_runs(engine_logs) -> None:
@@ -1217,9 +1217,9 @@ def test_custom_lens_runs_as_an_extra_review_call() -> None:
     findings, _ = engine.review(_CTX, cfg)
 
     review_calls = _review_calls(provider)
-    # The default fast preset runs three grouped built-in calls; the custom
+    # The default fast preset runs four distinct built-in calls; the custom
     # lens always adds its own focused call on top.
-    assert len(review_calls) == 3 + 1
+    assert len(review_calls) == 4 + 1
     assert any("Simplify or delete" in _all_text(c) for c in review_calls)
     assert findings  # the custom lens's finding survived the pipeline
 

--- a/tests/engine/test_preset.py
+++ b/tests/engine/test_preset.py
@@ -42,64 +42,44 @@ class TestFastLensGrouping:
     def test_default_preset_is_fast(self) -> None:
         assert _cfg().preset is ReviewPreset.fast
 
-    def test_single_worker_fast_builds_three_lenses(self) -> None:
-        lenses = _build_lenses(_cfg(), has_intent=False)
-        assert [lens.id for lens in lenses] == [
-            "security",
-            "correctness",
-            "code-health",
-        ]
+    _FOUR = ["security", "correctness", "code-health", "artefacts"]
 
-    def test_parallel_fast_splits_correctness_into_two_lenses(self) -> None:
-        lenses = _build_lenses(
-            _cfg(provider=Provider.openai, max_concurrency=None), has_intent=False
-        )
-        assert [lens.id for lens in lenses] == [
-            "security",
-            "correctness-flow",
-            "correctness-state",
-            "code-health",
-        ]
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {},  # ollama: single-worker auto-concurrency
+            {"provider": Provider.openai, "max_concurrency": None},  # cloud auto
+            {"provider": Provider.openai, "max_concurrency": 1},  # forced serial
+            {"max_concurrency": 2},  # local provider, forced parallel
+        ],
+        ids=["ollama-auto", "cloud-auto", "cloud-serial", "local-parallel"],
+    )
+    def test_fast_builds_the_same_four_lenses_on_every_configuration(
+        self, overrides: dict[str, object]
+    ) -> None:
+        """The lens set is a property of the preset, not of how many workers
+        happen to be available: one concern per call, four calls, everywhere."""
+        lenses = _build_lenses(_cfg(**overrides), has_intent=False)
+        assert [lens.id for lens in lenses] == self._FOUR
 
-    def test_explicit_single_worker_keeps_combined_correctness(self) -> None:
-        lenses = _build_lenses(_cfg(provider=Provider.openai, max_concurrency=1), has_intent=False)
-        assert [lens.id for lens in lenses] == [
-            "security",
-            "correctness",
-            "code-health",
-        ]
-
-    def test_explicit_parallel_local_provider_splits_correctness(self) -> None:
-        lenses = _build_lenses(_cfg(max_concurrency=2), has_intent=False)
-        assert [lens.id for lens in lenses] == [
-            "security",
-            "correctness-flow",
-            "correctness-state",
-            "code-health",
-        ]
-
-    def test_fast_reserves_artefact_categories_for_deep_reviews(self) -> None:
+    def test_fast_covers_every_built_in_category(self) -> None:
+        """Four distinct lenses, but still all nine categories — nothing that
+        used to be reviewed silently stops being reviewed."""
         lenses = _build_lenses(_cfg(), has_intent=True)
         covered: set[str] = set()
         for lens in lenses:
             covered.add(lens.id)
             covered |= set(lens.allowed_categories or ())
-        assert covered >= {
-            "security",
-            "correctness",
-            "intent",
-            "performance",
-            "complexity",
-            "ponytail",
-            "deprecation",
-        }
-        assert covered.isdisjoint({"tests", "documentation"})
+        assert covered >= {c.value for c in ReviewCategory}
 
     def test_merged_prompts_name_their_member_categories(self) -> None:
         lenses = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=False)}
         code_health = lenses["code-health"].user_block
         for name in ("performance", "complexity", "ponytail", "deprecation"):
             assert f'"{name}"' in code_health
+        artefacts = lenses["artefacts"].user_block
+        for name in ("tests", "documentation"):
+            assert f'"{name}"' in artefacts
 
     def test_intent_folds_into_combined_correctness_when_stated(self) -> None:
         lenses = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=True)}
@@ -111,15 +91,6 @@ class TestFastLensGrouping:
         plain = {lens.id: lens for lens in _build_lenses(_cfg(), has_intent=False)}
         assert not plain["correctness"].carries_intent
         assert "stated intent" not in plain["correctness"].user_block
-
-    def test_parallel_intent_reaches_only_correctness_flow(self) -> None:
-        lenses = {
-            lens.id: lens for lens in _build_lenses(_cfg(provider=Provider.openai), has_intent=True)
-        }
-        assert lenses["correctness-flow"].carries_intent
-        assert "stated intent" in lenses["correctness-flow"].user_block
-        assert not lenses["correctness-state"].carries_intent
-        assert "stated intent" not in lenses["correctness-state"].user_block
 
     def test_full_preset_builds_one_lens_per_category(self) -> None:
         lenses = _build_lenses(_cfg(preset="full"), has_intent=True)
@@ -135,43 +106,13 @@ class TestFastLensGrouping:
         lenses = _build_lenses(cfg, has_intent=False)
         assert [lens.id for lens in lenses] == ["security", "performance"]
 
-    def test_fast_review_makes_three_calls(self) -> None:
-        provider = FakeProvider()
-        LLMReviewEngine(provider).review(_CTX, _cfg())
-        assert len(provider.calls) == 3
-
-    def test_parallel_fast_review_makes_four_calls(self) -> None:
-        provider = FakeProvider()
-        LLMReviewEngine(provider).review(_CTX, _cfg(provider=Provider.openai))
-        assert len(provider.calls) == 4
-
-
-class TestSplitCorrectnessAttribution:
-    def test_split_findings_are_correctness_and_deduplicated(self) -> None:
-        finding = ReviewFinding(
-            path="a.py",
-            line=1,
-            severity=Severity.high,
-            title="shared bug",
-            body="x",
-            failure_scenario="When the changed line runs, the shared operation fails.",
-        )
-        finding_text = json.dumps([finding.model_dump(mode="json")])
-
-        class _BothCorrectnessTasks(FakeProvider):
-            def complete(self, messages, model, **opts):  # type: ignore[override]
-                self.calls.append({"messages": messages, "model": model, "opts": opts})
-                prompt = "\n".join(str(m.get("content", "")) for m in messages)
-                if "Correctness &" in prompt:
-                    return ProviderResult(text=finding_text, input_tokens=1, output_tokens=1)
-                return ProviderResult(text='{"findings": []}', input_tokens=1, output_tokens=1)
-
-        findings, _ = LLMReviewEngine(_BothCorrectnessTasks()).review(
-            _CTX, _cfg(provider=Provider.openai, min_severity="info")
-        )
-
-        assert len(findings) == 1
-        assert findings[0].category == "correctness"
+    @pytest.mark.parametrize("provider", [Provider.ollama, Provider.openai])
+    def test_fast_review_makes_four_calls_on_any_provider(self, provider: Provider) -> None:
+        """Worker count changes how the four calls are scheduled, never how many
+        there are — a single-slot provider runs the same four, serially."""
+        fake = FakeProvider()
+        LLMReviewEngine(fake).review(_CTX, _cfg(provider=provider))
+        assert len(fake.calls) == 4
 
 
 class TestMergedCategoryStamping:

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -252,7 +252,7 @@ def test_end_to_end_symbol_deferral_drops_forbidden_finding_with_real_ast_grep()
 
 def test_fixtures_cover_performance_and_complexity_lenses() -> None:
     """Both fixtures plant a performance and a complexity issue so the e2e exercises
-    all seven code lenses, not just security + correctness. (The intent lens needs a
+    the code-health lens, not just security + correctness. (The intent lens needs a
     stated intent the fixtures don't carry, so the engine skips it there.) Guards
     against a future edit silently dropping these lower-severity lenses from the
     live recall check."""
@@ -263,6 +263,17 @@ def test_fixtures_cover_performance_and_complexity_lenses() -> None:
         assert "complexity" in keywords and "cyclomatic" in keywords, (
             f"{name}: no complexity finding"
         )
+
+
+def test_a_fixture_plants_test_and_documentation_gaps() -> None:
+    """The artefacts lens is in the default preset, so the corpus must be able to
+    score it. It was cut from the default once for "yielding no findings" — a claim
+    measured against fixtures that planted no missing test and no stale doc, so it
+    could only ever score zero. This fixture is what makes that claim falsifiable."""
+    _diff, manifest = _fixture("artefact-gaps")
+    keywords = " ".join(k.lower() for e in manifest.expected for k in e.keywords)
+    assert "untested" in keywords or "coverage" in keywords, "no test-gap finding"
+    assert "docstring" in keywords or "stale" in keywords, "no documentation finding"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -189,7 +189,9 @@ class TestEngineBehaviourMatrix:
         assert _resolve_workers(cfg, task_count=99) == expected
 
     @pytest.mark.parametrize("provider", list(Provider))
-    def test_fast_preset_call_count_is_provider_aware(self, provider: Provider) -> None:
+    def test_fast_preset_makes_four_calls_on_every_provider(self, provider: Provider) -> None:
+        """The fast lens set is four distinct concerns regardless of provider —
+        auto-concurrency changes the schedule, never the call count."""
         from lgtmaybe.core.models import PRContext, ReviewConfig
         from lgtmaybe.engine import LLMReviewEngine
         from tests.fakes import FakeProvider
@@ -205,8 +207,7 @@ class TestEngineBehaviourMatrix:
         cfg = ReviewConfig(provider=provider, model="m", reflect=False)
         fake = FakeProvider()
         LLMReviewEngine(fake).review(ctx, cfg)
-        expected = 3 if provider in self.SINGLE_STREAM else 4
-        assert len(fake.calls) == expected
+        assert len(fake.calls) == 4
 
     @pytest.mark.parametrize("provider", list(Provider))
     def test_review_deadline_field_defaults_on_every_provider(self, provider: Provider) -> None:

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -299,7 +299,7 @@
       "type": "object"
     },
     "ReviewPreset": {
-      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers seven built-in lenses in four calls when the\nprovider can overlap work: security, correctness flow/intent, correctness\nstate/lifecycle, and code health. With one worker, correctness stays\ncombined for three calls.\n``full`` restores tests and documentation and runs each of the nine lenses\nas its own call for release branches and deep audits. An explicit\n``categories`` list always wins over the preset.",
+      "description": "How many model calls a review spends: the everyday path or the deep audit.\n\n``fast`` (the default) covers all nine built-in categories in FOUR calls,\none per concern: security, correctness (with stated intent folded in), code\nhealth, and artefacts (tests + documentation). The same four run on every\nprovider \u2014 worker count changes the schedule, not the call count.\n``full`` runs each of the nine categories as its own call for release\nbranches and deep audits. An explicit ``categories`` list always wins over\nthe preset.",
       "enum": [
         "fast",
         "full"


### PR DESCRIPTION
## Why

The `fast` preset already made 4 calls — but two of them were the *same* `correctness` lens sliced into `correctness-flow` / `correctness-state` halves purely to fill a second worker, and `tests` / `documentation` got no call at all. So the default spent four calls on three concerns and skipped a whole class of finding. The lens set also changed shape depending on the provider: cloud got 4, single-slot got 3.

## What the default is now

One call per concern, the **same four on every provider**:

| Call | Covers |
|---|---|
| `security` | security |
| `correctness` | correctness, and stated intent when the PR states one |
| `code-health` | performance, complexity, ponytail, deprecation |
| `artefacts` | tests, documentation |

Worker count decides only whether they overlap, never how many there are. Deleted: `_parallel_fast_enabled`, the four `build_correctness_{flow,state}_*` builders, the two split-only sections, and `_CORRECTNESS_STATE_EXAMPLE`.

`_ARTEFACTS_SECTION` was **already in the tree, unreferenced** since the removal — this re-wires it rather than writing new prompt text.

## The revert this makes, and why it holds

Restoring artefacts undoes a deliberate, documented decision (`prompt.py`):

> the default artefacts call was the slowest call in production while yielding no findings, so it did not earn a place in the everyday path

Two things have changed since, and the reasoning is now recorded next to the group rather than left implicit:

- **"Slowest" costs much less.** It overlaps the other three instead of extending them, and reads a cached shared prefix on the routes #266 widened.
- **"No findings" was never measurable.** It was scored against fixtures that plant no missing test and no stale doc — a corpus gap, not evidence the lens is silent. A lens with nothing to find can only score zero.

So this PR also adds the **`artefact-gaps` eval fixture**: a diff that adds partial-refund branches with no test, adds an entirely untested function, and leaves the module docstring describing the old full-refund-only behaviour. `tests/evals/test_fixtures.py` now asserts the corpus can score the artefacts lens at all. If the lens still doesn't earn its place, the harness will now say so instead of the question being unanswerable.

## Trade-off

Single-worker providers (ollama, openai-compatible) go **3 → 4 serial calls**, roughly +33% wall clock locally. Uniformity is the point of the change, so that cost is taken rather than keeping a provider-dependent lens set; `docs/how-to/run-locally-with-ollama.md` is updated to say so, and notes that raising `OLLAMA_NUM_PARALLEL` + `--max-concurrency` lets the same four overlap.

## Tests

TDD, red first. `tests/engine/test_preset.py` now asserts the four-lens set across four configurations (ollama-auto, cloud-auto, cloud-serial, local-parallel) via one parametrized test, plus that fast still covers *every* built-in category — nothing silently stops being reviewed. `tests/providers/test_provider_matrix.py`'s `expected = 3 if provider in SINGLE_STREAM else 4` becomes a flat 4 across every provider.

Full suite: 1460 passed. `ruff check`, `ruff format --check`, `mypy src`, `pytest tests/specs`, and `openspec validate --specs` (10/10) all clean. Both affected spec requirements — "Fast preset splits correctness only when it can overlap" and "Per-lens fan-out through one bounded executor" — are rewritten for the new shape rather than left stale, along with the architecture diagram, README, CLAUDE.md and the config/action docs.

## Not in this PR

The parallelism sweep from the same request is separate. Worth recording what the survey found: the lens fan-out, multi-batch overlap, and head-revision file fetches are **already** pooled and concurrent. What is genuinely serial is static-analysis tools (default-off), reflection's deferral fetches, and the posting loops. Reflection itself is the structural tail — it cannot start until every lens returns, then runs 1 + up to `MAX_HOPS` strictly sequential calls, which is what now bounds default wall clock.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuzC47hXdohXyP6xzTH4V)_