### PR TITLE
docs(preset): fix the mangled --preset help and sweep the stale call counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the time and tokens went.
 **How the scope is bounded.** Every run is capped so a large PR can't blow up
 latency:
 
-- `preset` (default `fast`) — four focused/grouped calls when concurrency is available, three with one worker; `full` restores tests and documentation and runs one call per lens.
+- `preset` (default `fast`) — four calls, one per concern (security, correctness, code health, artefacts), the same on every provider; `full` runs one call per lens.
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
 - `max_concurrency` (default 8 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ""
   preset:
-    description: "Review preset. fast (the default) covers security, correctness/intent, performance, complexity, ponytail, and deprecation in four model calls when parallelism is available, or three with one worker. full restores tests/documentation and runs one call per lens for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
+    description: "Review preset. fast (the default) covers all nine categories in four model calls, one per concern: security, correctness (stated intent folds in), code health (performance/complexity/ponytail/deprecation), and artefacts (tests/documentation). The same four run on every provider — worker count changes only how they are scheduled. full runs one call per lens for release branches and deep audits. An explicit categories list in .lgtmaybe.yml overrides the preset."
     required: false
     default: ""
   fallback_model:

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -10,9 +10,9 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends four grouped model calls under the default `fast` preset when
-the provider can overlap work, or three combined calls with one worker. `full`
-sends one per category. The review calls fan out through one bounded pool and
+lgtmaybe sends four grouped model calls under the default `fast` preset — the
+same four on every provider, overlapping when there is more than one worker.
+`full` sends one per category. The review calls fan out through one bounded pool and
 are followed by a self-reflection call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5027,9 +5027,9 @@ credentials are handled. No data flows occur beyond what is described here.
 
 ## What is sent to the LLM provider
 
-lgtmaybe sends four grouped model calls under the default `fast` preset when
-the provider can overlap work, or three combined calls with one worker. `full`
-sends one per category. The review calls fan out through one bounded pool and
+lgtmaybe sends four grouped model calls under the default `fast` preset — the
+same four on every provider, overlapping when there is more than one worker.
+`full` sends one per category. The review calls fan out through one bounded pool and
 are followed by a self-reflection call. Each call contains some subset of:
 
 - The **compressed PR diff** — the unified diff of changed files, after

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -89,10 +89,10 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "--preset",
     default=None,
     type=click.Choice(["fast", "full"]),
-    help="Review preset: fast (default) covers security, correctness/intent, "
-    "performance, complexity, ponytail, deprecation, tests and documentation in "
-    "parallelism is available, or three with one worker; full restores "
-    "tests/documentation and runs one call per lens for deep audits",
+    help="Review preset: fast (default) covers all nine categories in four "
+    "calls, one per concern — security, correctness (stated intent folds in), "
+    "code health, artefacts (tests/documentation) — the same four on every "
+    "provider; full runs one call per lens for deep audits",
 )
 @click.option(
     "--full",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -648,10 +648,10 @@ class ReviewConfig(_Strict):
     # replies and resolves the conversation. GitHub posting only — ignored by the
     # local CLI review, which has no conversations to resolve.
     resolve_fixed: bool = True
-    # Call-count preset (see ReviewPreset): `fast` (default) covers seven
-    # built-in lenses in four calls when the provider can overlap work (three
-    # with one worker); `full` restores tests/documentation and runs one call
-    # per lens. An explicit `categories` list overrides it.
+    # Call-count preset (see ReviewPreset): `fast` (default) covers all nine
+    # built-in categories in four calls, one per concern — security,
+    # correctness, code health, artefacts — the same four on every provider;
+    # `full` runs one call per lens. An explicit `categories` list overrides it.
     preset: ReviewPreset = ReviewPreset.fast
     # Review lenses to run. Each is asked in its own concurrent LLM call and the
     # findings are merged + deduped. Defaults to all of them (grouped per the

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -557,10 +557,10 @@ keep this lens to "should this exist at all?" — leave readability nits to othe
 
 # ---------------------------------------------------------------------------
 # Fast-preset merged lenses. Written as integrated checklists (not a paste-up
-# of the per-lens sections): the bounded pool runs four calls when parallelism
-# is available, or three combined calls with one worker. Each merged prompt
-# condenses its members to their high-signal items and demands the per-finding
-# `category` field so downstream rules/labels keep working.
+# of the per-lens sections): the preset runs four calls, one per concern, on
+# every provider. Each merged prompt condenses its members to their high-signal
+# items and demands the per-finding `category` field so downstream rules/labels
+# keep working.
 # ---------------------------------------------------------------------------
 
 _CODE_HEALTH_SECTION = """\


### PR DESCRIPTION
## Why

Follow-up to #268, from a finding lgtmaybe's own review left on that PR.

The bulk edit in #268 replaced only part of the `--preset` help string, splicing it mid-sentence:

```
"Review preset: fast (default) covers security, correctness/intent, "
"performance, complexity, ponytail, deprecation, tests and documentation in "
"parallelism is available, or three with one worker; full restores "
"tests/documentation and runs one call per lens for deep audits"
```

So `lgtmaybe review --help` printed *"…tests and documentation in parallelism is available, or three with one worker"* — a broken sentence describing behaviour that no longer exists. The bot flagged it as stale; it was also ungrammatical.

## What changed

The help string is rewritten, and the copies the same edit missed are swept — each still describing the old worker-dependent shape:

- `src/lgtmaybe/cli/commands.py` — the `--preset` help
- `action.yml` — the `preset` input description
- `src/lgtmaybe/core/models.py` — the `ReviewConfig.preset` field comment
- `src/lgtmaybe/engine/prompt.py` — the fast-preset merged-lens header comment
- `README.md` — the preset bullet
- `docs/explanation/data-and-privacy.md` — the "what is sent to the LLM provider" paragraph

`docs/llms-full.txt` regenerated. **`docs/reference/config.md` is unchanged and correct as-is** — the generator renders field *descriptions* from the JSON schema, and the two edits here are a `#` comment on `ReviewConfig.preset` and the `--preset` Click help, neither of which reaches the schema. The `ReviewPreset` docstring that config.md does render was already updated in #268; running `docs/generate_reference.py` produces no diff, which `tests/docs/test_reference_fresh.py` confirms.

Text only — no behaviour change. Verified by running `lgtmaybe review --help` and reading the rendered output.

Full suite: 1460 passed. `ruff check`, `ruff format --check` and `mypy src` clean.