### PR TITLE
perf: overlap the three serial I/O stages, isolate resolve failures

### DIFF
--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -72,10 +72,11 @@ When a finding is gone and GitHub marks its thread outdated, the thread SHALL
 be replied to and resolved via GraphQL (the one op REST can't do), and the
 opening comment's fingerprint marker rewritten into a disjoint "resolved"
 family so a finding that reappears later posts again instead of staying
-suppressed by re-run dedupe. The thread SHALL be resolved BEFORE the reply is
-posted — the reply records a resolution and must never outlive one. Best-effort
-is PER THREAD: threads are independent and resolve concurrently, so one that
-fails never stops the others.
+suppressed by re-run dedupe. The three steps SHALL run in order of consequence:
+resolve (the gate), rewrite the marker (the only chance — a resolved thread is
+never revisited), then reply (cosmetic). Each is independently best-effort, and
+best-effort is PER THREAD: threads are independent and resolve concurrently, so
+one that fails never stops the others.
 <!-- anchor: github.resolve-fixed -->
 
 #### Scenario: GraphQL call errors
@@ -90,6 +91,11 @@ fails never stops the others.
 - **WHEN** `resolveReviewThread` is refused for the configured identity
 - **THEN** no reply is posted and no marker is rewritten, so the step is a no-op
   that cannot accumulate a reply on every subsequent run
+
+#### Scenario: the reply fails after a successful resolve
+- **WHEN** the thread resolves but its reply errors
+- **THEN** the fingerprint marker is still rewritten — a resolved thread is never
+  revisited, so leaving an active marker would suppress the finding forever
 
 ### Requirement: Downvoted findings are read from 👎 reactions
 

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -72,8 +72,10 @@ When a finding is gone and GitHub marks its thread outdated, the thread SHALL
 be replied to and resolved via GraphQL (the one op REST can't do), and the
 opening comment's fingerprint marker rewritten into a disjoint "resolved"
 family so a finding that reappears later posts again instead of staying
-suppressed by re-run dedupe. Best-effort is PER THREAD: threads are independent
-and resolve concurrently, so one that fails never stops the others.
+suppressed by re-run dedupe. The thread SHALL be resolved BEFORE the reply is
+posted — the reply records a resolution and must never outlive one. Best-effort
+is PER THREAD: threads are independent and resolve concurrently, so one that
+fails never stops the others.
 <!-- anchor: github.resolve-fixed -->
 
 #### Scenario: GraphQL call errors
@@ -83,6 +85,11 @@ and resolve concurrently, so one that fails never stops the others.
 #### Scenario: one thread of several fails
 - **WHEN** several threads are fixed and one errors mid-resolve
 - **THEN** the remaining threads are still replied to and resolved
+
+#### Scenario: the identity may not resolve threads
+- **WHEN** `resolveReviewThread` is refused for the configured identity
+- **THEN** no reply is posted and no marker is rewritten, so the step is a no-op
+  that cannot accumulate a reply on every subsequent run
 
 ### Requirement: Downvoted findings are read from 👎 reactions
 

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -72,12 +72,17 @@ When a finding is gone and GitHub marks its thread outdated, the thread SHALL
 be replied to and resolved via GraphQL (the one op REST can't do), and the
 opening comment's fingerprint marker rewritten into a disjoint "resolved"
 family so a finding that reappears later posts again instead of staying
-suppressed by re-run dedupe — best-effort, never failing the review.
+suppressed by re-run dedupe. Best-effort is PER THREAD: threads are independent
+and resolve concurrently, so one that fails never stops the others.
 <!-- anchor: github.resolve-fixed -->
 
 #### Scenario: GraphQL call errors
 - **WHEN** `resolveReviewThread` fails
 - **THEN** the review still completes and posts normally
+
+#### Scenario: one thread of several fails
+- **WHEN** several threads are fixed and one errors mid-resolve
+- **THEN** the remaining threads are still replied to and resolved
 
 ### Requirement: Downvoted findings are read from 👎 reactions
 

--- a/src/lgtmaybe/engine/retrieve.py
+++ b/src/lgtmaybe/engine/retrieve.py
@@ -105,26 +105,30 @@ def resolve_needs(
         used += cost
         return True
 
-    # Fetch in waves of at most `max_files`, so a long needs list never pulls
-    # (and pays for) far more files than the cap can ever accept.
-    pending = list(needs)
-    while pending and len(out) < max_files:
-        wave, pending = pending[:max_files], pending[max_files:]
-        prefetch(wave)
-        for need in wave:
-            if len(out) >= max_files:
-                break
-            if accept(need) or resolve_symbol is None:
-                continue
-            # Not a fetchable path — try resolving it as a symbol to its defining
-            # file(s), then fetch those through the same read-only boundary.
-            # ast-grep is a local scan, so this stays on the ordered walk; only
-            # its resulting fetches are batched.
-            candidates = resolve_symbol(need)
-            prefetch(candidates)
-            for candidate in candidates:
+    def take_in_waves(paths: list[str], *, resolve_symbols: bool) -> None:
+        """Fetch + accept *paths*, never fetching more than the cap can accept.
+
+        Overlapping the I/O must not cost more of it: a wave is only ever as
+        wide as the remaining headroom, so a long list (or a symbol with many
+        definitions) can't burst fetches for files that could never be
+        accepted. Successive waves keep going, so an unfetchable entry doesn't
+        end the search early — the same reach the blocking version had.
+        """
+        pending = list(paths)
+        while pending and len(out) < max_files:
+            width = max_files - len(out)
+            wave, pending = pending[:width], pending[width:]
+            prefetch(wave)
+            for path in wave:
                 if len(out) >= max_files:
                     break
-                accept(candidate)
+                if accept(path) or not resolve_symbols or resolve_symbol is None:
+                    continue
+                # Not a fetchable path — try resolving it as a symbol to its
+                # defining file(s), then fetch those through the same read-only
+                # boundary. ast-grep is a local scan, so it stays on the ordered
+                # walk; only its resulting fetches are batched.
+                take_in_waves(resolve_symbol(path), resolve_symbols=False)
 
+    take_in_waves(list(needs), resolve_symbols=True)
     return out

--- a/src/lgtmaybe/engine/retrieve.py
+++ b/src/lgtmaybe/engine/retrieve.py
@@ -114,6 +114,11 @@ def resolve_needs(
         accepted. Successive waves keep going, so an unfetchable entry doesn't
         end the search early — the same reach the blocking version had.
         """
+        # Copied, not aliased: the slicing below rebinds rather than mutates, so
+        # aliasing would work today — but it would make that an invariant a
+        # later `pending.pop(0)` could silently break, corrupting the caller's
+        # list. The lists here are bounded by the auditor's `needs`, so the copy
+        # is not worth reasoning about.
         pending = list(paths)
         while pending and len(out) < max_files:
             width = max_files - len(out)
@@ -130,5 +135,5 @@ def resolve_needs(
                 # walk; only its resulting fetches are batched.
                 take_in_waves(resolve_symbol(path), resolve_symbols=False)
 
-    take_in_waves(list(needs), resolve_symbols=True)
+    take_in_waves(needs, resolve_symbols=True)
     return out

--- a/src/lgtmaybe/engine/retrieve.py
+++ b/src/lgtmaybe/engine/retrieve.py
@@ -15,7 +15,8 @@ loop and its hop cap live in ``reflect.py``; the hard stops it relies on
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor
 
 from .astgrep import SymbolResolver
 from .compress import count_tokens
@@ -31,6 +32,12 @@ FileFetcher = Callable[[str], "str | None"]
 # hard stops that keep a deferral from looping or fetching the whole repo.
 MAX_HOPS = 2
 MAX_FETCH_FILES = 5
+
+# Concurrent read-only fetches per wave. The deferral fetch sits on the review's
+# serial tail — reflection cannot begin until every lens has returned — so these
+# round-trips are pure added wall clock, and they are independent of each other.
+# Bounded so a long `needs` list can't open a connection per entry.
+_FETCH_WORKERS = 8
 
 
 def resolve_needs(
@@ -61,35 +68,63 @@ def resolve_needs(
     out: dict[str, str] = {}
     used = 0
     seen: set[str] = set()
+    fetched: dict[str, str | None] = {}
 
-    def accept(path: str) -> None:
-        """Fetch + redact *path* into *out*, respecting the token + file caps."""
+    def prefetch(paths: Iterable[str]) -> None:
+        """Fetch *paths* concurrently into the raw cache, once each.
+
+        Only the I/O is overlapped. Acceptance below still walks `needs` in
+        order, so the token budget and file cap allocate exactly as they did
+        when each fetch blocked — the same `needs` list must always resolve to
+        the same files, whatever order the responses happen to land in.
+        """
+        todo = [p for p in dict.fromkeys(paths) if p not in seen and p not in already]
+        if not todo:
+            return
+        seen.update(todo)
+        with ThreadPoolExecutor(max_workers=min(_FETCH_WORKERS, len(todo))) as pool:
+            fetched.update(zip(todo, pool.map(fetch_file, todo), strict=True))
+
+    def accept(path: str) -> bool:
+        """Take an already-fetched *path* into *out*, respecting the caps.
+
+        False when it was not fetched, is already in, or would blow the budget —
+        the same three cases that used to leave `out` unchanged.
+        """
         nonlocal used
-        if path in already or path in seen or path in out:
-            return
-        seen.add(path)
-        raw = fetch_file(path)
+        if path in out:
+            return False
+        raw = fetched.get(path)
         if not raw:
-            return
+            return False
         text = redact(raw)
         cost = count_tokens(text)
         if used + cost > budget_tokens:
-            return  # would blow the per-hop budget — skip this file
+            return False  # would blow the per-hop budget — skip this file
         out[path] = text
         used += cost
+        return True
 
-    for need in needs:
-        if len(out) >= max_files:
-            break
-        before = len(out)
-        accept(need)
-        if len(out) > before or resolve_symbol is None:
-            continue
-        # Not a fetchable path — try resolving it as a symbol to its defining
-        # file(s), then fetch those through the same read-only boundary.
-        for candidate in resolve_symbol(need):
+    # Fetch in waves of at most `max_files`, so a long needs list never pulls
+    # (and pays for) far more files than the cap can ever accept.
+    pending = list(needs)
+    while pending and len(out) < max_files:
+        wave, pending = pending[:max_files], pending[max_files:]
+        prefetch(wave)
+        for need in wave:
             if len(out) >= max_files:
                 break
-            accept(candidate)
+            if accept(need) or resolve_symbol is None:
+                continue
+            # Not a fetchable path — try resolving it as a symbol to its defining
+            # file(s), then fetch those through the same read-only boundary.
+            # ast-grep is a local scan, so this stays on the ordered walk; only
+            # its resulting fetches are batched.
+            candidates = resolve_symbol(need)
+            prefetch(candidates)
+            for candidate in candidates:
+                if len(out) >= max_files:
+                    break
+                accept(candidate)
 
     return out

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -83,7 +83,9 @@ def run_static_analysis(file_contents: dict[str, str], cfg: ReviewConfig) -> lis
     worth failing a review over.
     """
     sa = cfg.static_analysis
-    if not sa.enabled or not file_contents:
+    # `not sa.tools` guards the executor below (max_workers must be > 0) and,
+    # more usefully, skips writing a corpus nothing would ever read.
+    if not sa.enabled or not sa.tools or not file_contents:
         return []
 
     findings: list[ToolFinding] = []

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -28,6 +28,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -91,8 +92,15 @@ def run_static_analysis(file_contents: dict[str, str], cfg: ReviewConfig) -> lis
         written = _write_corpus(root, file_contents)
         if not written:
             return []
-        for tool in sa.tools:
-            findings.extend(_run_tool(tool, root, cfg))
+        # Each tool is an independent subprocess reading the same corpus
+        # read-only, and each carries its own _TOOL_TIMEOUT — run serially their
+        # worst cases stack. `map` yields in submission order, so the hint list
+        # stays ordered by `sa.tools` whatever order the processes finish in:
+        # hints feed the prompt, and a prompt that reorders run to run would
+        # bust the shared-prefix cache for nothing.
+        with ThreadPoolExecutor(max_workers=len(sa.tools)) as pool:
+            for tool_findings in pool.map(lambda tool: _run_tool(tool, root, cfg), sa.tools):
+                findings.extend(tool_findings)
 
     # Per-tool floors win over the global floor, in either direction.
     floors = {tool.value: floor for tool, floor in sa.tool_min_severity.items()}

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -854,7 +854,18 @@ class RestGitHubGateway(GitHubGateway):
                 self._reply_and_resolve(thread_id)
                 self._mark_comment_resolved(comment_id, first_body)
             except Exception as exc:  # noqa: BLE001 — one thread never blocks the rest
-                _log.warning("auto-resolve of thread %s failed: %s", thread_id, exc)
+                if "FORBIDDEN" in str(exc) or "not accessible by integration" in str(exc):
+                    # Not transient: the identity simply cannot resolve threads,
+                    # so this recurs every run until someone changes the setup.
+                    # Say what to do about it rather than repeating a bare error.
+                    _log.warning(
+                        "auto-resolve is not permitted for this identity — threads stay open. "
+                        "Grant the token/App pull-request write access, or set "
+                        "resolve_fixed: false to stop attempting it. (%s)",
+                        exc,
+                    )
+                else:
+                    _log.warning("auto-resolve of thread %s failed: %s", thread_id, exc)
 
         # Each thread costs a reply + a resolve + a marker rewrite; a PR with
         # several fixed findings paid all of it serially. They touch different
@@ -923,14 +934,23 @@ class RestGitHubGateway(GitHubGateway):
         return fixed
 
     def _reply_and_resolve(self, thread_id: str) -> None:
-        """Post a short reply on a thread, then mark it resolved."""
-        self.reply_in_thread(thread_id, "✅ Looks resolved.")
+        """Mark a thread resolved, then post the short reply recording it.
+
+        Resolve FIRST. The reply is the record of a resolution, so it must never
+        outlive one: replying first meant a resolve the app isn't permitted to
+        make (GitHub answers FORBIDDEN, and GraphQL errors arrive as HTTP 200)
+        left "✅ Looks resolved." on a thread that stayed open — which then
+        re-qualified as fixed on every later run and collected another reply each
+        time. Resolving first makes the whole step no-op when it can't complete,
+        instead of unboundedly noisy.
+        """
         resolve = """
         mutation($threadId:ID!){
           resolveReviewThread(input:{threadId:$threadId}){ thread{ id isResolved } }
         }
         """
         self._graphql(resolve, {"threadId": thread_id})
+        self.reply_in_thread(thread_id, "✅ Looks resolved.")
 
     def _mark_comment_resolved(self, comment_id: int | None, body: str) -> None:
         """Rewrite a resolved comment's fingerprint marker into the "resolved" family.

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -80,6 +80,11 @@ def finding_fingerprint(path: str, title: str) -> str:
 # GETs, so fetching them serially is pure round-trip latency on a many-file PR.
 _CONTENT_FETCH_WORKERS = 8
 
+# Concurrency for resolve-on-fix. Deliberately lower than the read pool above:
+# these are writes (reply, resolve, marker rewrite) against one PR, and GitHub
+# is stricter about concurrent mutations than concurrent reads.
+_RESOLVE_WORKERS = 4
+
 # Zero-width space, inserted to break up a triple-backtick run so it can't be
 # parsed as a Markdown fence delimiter.
 _ZWSP = "​"
@@ -830,14 +835,32 @@ class RestGitHubGateway(GitHubGateway):
 
         Entirely best-effort: any failure is logged and swallowed so an
         auto-resolve hiccup can never fail an otherwise-successful review.
+        Best-effort **per thread** — the threads are independent, so one that
+        fails is logged and the rest still resolve rather than being abandoned
+        wherever the loop happened to stop.
         """
         try:
             current = {finding_fingerprint(f.path, f.title) for f in findings}
-            for thread_id, comment_id, first_body in self._fixed_threads(current):
-                self._reply_and_resolve(thread_id)
-                self._mark_comment_resolved(comment_id, first_body)
+            fixed = self._fixed_threads(current)
         except Exception as exc:  # noqa: BLE001 — best-effort; never fail the review
             _log.warning("auto-resolve of fixed conversations failed: %s", exc)
+            return
+        if not fixed:
+            return
+
+        def resolve_one(thread: tuple[str, int | None, str]) -> None:
+            thread_id, comment_id, first_body = thread
+            try:
+                self._reply_and_resolve(thread_id)
+                self._mark_comment_resolved(comment_id, first_body)
+            except Exception as exc:  # noqa: BLE001 — one thread never blocks the rest
+                _log.warning("auto-resolve of thread %s failed: %s", thread_id, exc)
+
+        # Each thread costs a reply + a resolve + a marker rewrite; a PR with
+        # several fixed findings paid all of it serially. They touch different
+        # threads, so they overlap on the shared (thread-safe) httpx client.
+        with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(fixed))) as pool:
+            list(pool.map(resolve_one, fixed))
 
     def _fixed_threads(self, current: set[str]) -> list[tuple[str, int | None, str]]:
         """Our unresolved, outdated conversations whose finding is gone.

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -849,10 +849,24 @@ class RestGitHubGateway(GitHubGateway):
             return
 
         def resolve_one(thread: tuple[str, int | None, str]) -> None:
+            """Resolve one thread, then record it — in that order, deliberately.
+
+            Three steps with three different consequences, so they are sequenced
+            by how much a failure costs:
+
+            1. **Resolve** — the gate. Until it succeeds nothing else should
+               happen: a reply on a thread that stays open re-qualifies as fixed
+               on every later run and collects another reply each time.
+            2. **Rewrite the marker** — correctness-critical, and this is the
+               only chance. A resolved thread is skipped by `_fixed_threads`
+               forever, so an active fingerprint left behind would let re-run
+               dedupe suppress the finding permanently if it came back.
+            3. **Reply** — cosmetic audit trail. Last, because a failure here
+               must not skip step 2.
+            """
             thread_id, comment_id, first_body = thread
             try:
-                self._reply_and_resolve(thread_id)
-                self._mark_comment_resolved(comment_id, first_body)
+                self._resolve_thread(thread_id)
             except Exception as exc:  # noqa: BLE001 — one thread never blocks the rest
                 if "FORBIDDEN" in str(exc) or "not accessible by integration" in str(exc):
                     # Not transient: the identity simply cannot resolve threads,
@@ -866,6 +880,15 @@ class RestGitHubGateway(GitHubGateway):
                     )
                 else:
                     _log.warning("auto-resolve of thread %s failed: %s", thread_id, exc)
+                return
+            try:
+                self._mark_comment_resolved(comment_id, first_body)
+            except Exception as exc:  # noqa: BLE001 — the thread is already resolved
+                _log.warning("resolved-marker rewrite on %s failed: %s", thread_id, exc)
+            try:
+                self.reply_in_thread(thread_id, "✅ Looks resolved.")
+            except Exception as exc:  # noqa: BLE001 — nothing depends on the reply
+                _log.warning("resolved-thread reply on %s failed: %s", thread_id, exc)
 
         # Each thread costs a reply + a resolve + a marker rewrite; a PR with
         # several fixed findings paid all of it serially. They touch different
@@ -933,16 +956,15 @@ class RestGitHubGateway(GitHubGateway):
             cursor = page.get("endCursor")
         return fixed
 
-    def _reply_and_resolve(self, thread_id: str) -> None:
-        """Mark a thread resolved, then post the short reply recording it.
+    def _resolve_thread(self, thread_id: str) -> None:
+        """Mark a review thread resolved. Raises if the identity may not.
 
-        Resolve FIRST. The reply is the record of a resolution, so it must never
-        outlive one: replying first meant a resolve the app isn't permitted to
-        make (GitHub answers FORBIDDEN, and GraphQL errors arrive as HTTP 200)
-        left "✅ Looks resolved." on a thread that stayed open — which then
-        re-qualified as fixed on every later run and collected another reply each
-        time. Resolving first makes the whole step no-op when it can't complete,
-        instead of unboundedly noisy.
+        The gate for the whole resolve-on-fix step (see `resolve_one`): nothing
+        else may happen until this succeeds. Replying first meant a resolve the
+        app isn't permitted to make (GitHub answers FORBIDDEN, and GraphQL errors
+        arrive as HTTP 200) left "✅ Looks resolved." on a thread that stayed
+        open — which then re-qualified as fixed on every later run and collected
+        another reply each time.
         """
         resolve = """
         mutation($threadId:ID!){
@@ -950,7 +972,6 @@ class RestGitHubGateway(GitHubGateway):
         }
         """
         self._graphql(resolve, {"threadId": thread_id})
-        self.reply_in_thread(thread_id, "✅ Looks resolved.")
 
     def _mark_comment_resolved(self, comment_id: int | None, body: str) -> None:
         """Rewrite a resolved comment's fingerprint marker into the "resolved" family.

--- a/tests/engine/test_retrieve.py
+++ b/tests/engine/test_retrieve.py
@@ -194,3 +194,75 @@ def test_resolve_needs_symbol_resolution_respects_caps() -> None:
 def test_module_bounds_are_small() -> None:
     assert MAX_HOPS == 2
     assert MAX_FETCH_FILES == 5
+
+
+class TestConcurrentFetching:
+    """The deferral fetch is on the critical path: reflection can't start until
+    every lens returns, so its round-trips are pure serial tail. They're
+    independent, so they overlap — but the budget/cap accounting stays strictly
+    ordered, or the same needs list could resolve differently run to run.
+    """
+
+    @staticmethod
+    def _ordering_fetcher(delay: float = 0.05):
+        """Records start/end order; each fetch sleeps so serial runs interleave."""
+        import threading
+
+        lock = threading.Lock()
+        events: list[str] = []
+
+        def fetch(path: str) -> str | None:
+            with lock:
+                events.append(f"start-{path}")
+            threading.Event().wait(delay)
+            with lock:
+                events.append(f"end-{path}")
+            return f"# {path}\nx = 1\n"
+
+        return fetch, events
+
+    def test_independent_fetches_overlap(self) -> None:
+        fetch, events = self._ordering_fetcher()
+        resolve_needs(
+            ["a.py", "b.py", "c.py"], fetch, already=set(), budget_tokens=10_000, max_files=5
+        )
+        # Serial would be start-a, end-a, start-b, ... — at least two starts must
+        # land before the first end.
+        first_end = next(i for i, e in enumerate(events) if e.startswith("end-"))
+        assert len([e for e in events[:first_end] if e.startswith("start-")]) >= 2
+
+    def test_budget_still_applied_in_needs_order(self) -> None:
+        """Concurrency must not reorder budget accounting: the first-named file
+        takes the budget, the second is skipped — the same either way."""
+        big = "\n".join(f"line {i} of a reasonably large file" for i in range(400)) + "\n"
+
+        def fetch(path: str) -> str | None:
+            return big
+
+        out = resolve_needs(
+            ["first.py", "second.py"],
+            fetch,
+            already=set(),
+            budget_tokens=count_tokens(big) + 10,
+            max_files=5,
+        )
+        assert list(out) == ["first.py"]
+
+    def test_cap_bounds_the_number_of_fetches(self) -> None:
+        """Overlapping must not fetch every candidate when the cap is far lower —
+        an unbounded prefetch would burn API calls on files it then discards."""
+        calls: list[str] = []
+
+        def fetch(path: str) -> str | None:
+            calls.append(path)
+            return "x = 1\n"
+
+        out = resolve_needs(
+            [f"f{i}.py" for i in range(40)],
+            fetch,
+            already=set(),
+            budget_tokens=10_000,
+            max_files=2,
+        )
+        assert len(out) == 2
+        assert len(calls) <= 10, f"fetched {len(calls)} files for a cap of 2"

--- a/tests/engine/test_retrieve.py
+++ b/tests/engine/test_retrieve.py
@@ -266,3 +266,54 @@ class TestConcurrentFetching:
         )
         assert len(out) == 2
         assert len(calls) <= 10, f"fetched {len(calls)} files for a cap of 2"
+
+
+def test_symbol_candidates_are_also_bounded_by_the_cap() -> None:
+    """The symbol branch must respect `max_files` too. `SymbolResolver` is an
+    injected callable — ast-grep caps itself at 3 candidates, but that is the
+    default's detail, not the contract — so prefetching every definition a
+    resolver returns would burn fetches the cap can never accept."""
+    calls: list[str] = []
+
+    def fetch(path: str) -> str | None:
+        calls.append(path)
+        return "x = 1\n" if path.endswith(".py") else None
+
+    def resolve_symbol(symbol: str) -> list[str]:
+        return [f"def{i}.py" for i in range(30)]
+
+    out = resolve_needs(
+        ["a_symbol"],
+        fetch,
+        already=set(),
+        budget_tokens=10_000,
+        max_files=2,
+        resolve_symbol=resolve_symbol,
+    )
+
+    assert len(out) == 2
+    # 1 direct attempt on the symbol name + at most a cap-sized wave of candidates.
+    assert len(calls) <= 5, f"fetched {len(calls)} candidates for a cap of 2"
+
+
+def test_symbol_candidates_keep_trying_past_an_unfetchable_one() -> None:
+    """Bounding the burst must not stop the search early: if the first candidate
+    can't be fetched, later ones are still tried, as they were when each fetch
+    blocked."""
+
+    def fetch(path: str) -> str | None:
+        return None if path in ("sym", "miss.py") else "x = 1\n"
+
+    def resolve_symbol(symbol: str) -> list[str]:
+        return ["miss.py", "real.py"]
+
+    out = resolve_needs(
+        ["sym"],
+        fetch,
+        already=set(),
+        budget_tokens=10_000,
+        max_files=1,
+        resolve_symbol=resolve_symbol,
+    )
+
+    assert list(out) == ["real.py"]

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -443,3 +443,16 @@ def test_concurrent_tools_keep_deterministic_finding_order(monkeypatch) -> None:
     findings = static_analysis.run_static_analysis({"a.py": "x = 1\n"}, cfg)
 
     assert [f.tool for f in findings] == ["ruff", "bandit"]
+
+
+def test_enabled_with_no_tools_returns_nothing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Enabling the feature but selecting no tools must degrade to no hints, not
+    raise — every other "nothing to do" path here returns [] quietly."""
+    run = _FakeRun()
+    _patch_tools(monkeypatch, run, present={"ruff", "bandit", "semgrep"})
+
+    cfg = _cfg(enabled=True, tools=[])
+    findings = static_analysis.run_static_analysis({"a.py": "x = 1\n"}, cfg)
+
+    assert findings == []
+    assert run.calls == []

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -374,3 +374,72 @@ def test_per_tool_floor_defaults_to_the_global_floor(monkeypatch) -> None:  # ty
     )
 
     assert [f.tool for f in findings] == ["bandit"]
+
+
+def test_tools_run_concurrently(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Each tool is an independent subprocess with its own 180s cap, so running
+    them one after another stacks their worst cases. Nothing is shared but the
+    read-only corpus, so they overlap."""
+    import threading
+
+    lock = threading.Lock()
+    events: list[str] = []
+
+    def slow_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        tool = Path(argv[0]).name
+        with lock:
+            events.append(f"start-{tool}")
+        threading.Event().wait(0.05)
+        with lock:
+            events.append(f"end-{tool}")
+        return subprocess.CompletedProcess(argv, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(static_analysis.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(subprocess, "run", slow_run)
+
+    cfg = _cfg(enabled=True, tools=list(StaticAnalysisTool))
+    static_analysis.run_static_analysis({"a.py": "x = 1\n"}, cfg)
+
+    first_end = next(i for i, e in enumerate(events) if e.startswith("end-"))
+    starts_before = [e for e in events[:first_end] if e.startswith("start-")]
+    assert len(starts_before) >= 2, f"tools ran serially: {events}"
+
+
+def test_concurrent_tools_keep_deterministic_finding_order(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Whichever subprocess finishes first, the hint list must be ordered by the
+    configured tool list — hints feed the prompt, and a prompt that reorders run
+    to run defeats the shared-prefix cache."""
+    payloads = {
+        "ruff": json.dumps(
+            [{"filename": "a.py", "location": {"row": 1}, "code": "F401", "message": "ruff msg"}]
+        ),
+        "bandit": json.dumps(
+            {
+                "results": [
+                    {
+                        "filename": "a.py",
+                        "line_number": 1,
+                        "test_id": "B101",
+                        "issue_text": "bandit msg",
+                        "issue_severity": "HIGH",
+                    }
+                ]
+            }
+        ),
+    }
+
+    import threading
+
+    def run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        tool = Path(argv[0]).name
+        # ruff is configured first but deliberately made the slower one.
+        threading.Event().wait(0.05 if tool == "ruff" else 0.0)
+        return subprocess.CompletedProcess(argv, 0, stdout=payloads.get(tool, "[]"), stderr="")
+
+    monkeypatch.setattr(static_analysis.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(subprocess, "run", run)
+
+    cfg = _cfg(enabled=True, tools=[StaticAnalysisTool.ruff, StaticAnalysisTool.bandit])
+    findings = static_analysis.run_static_analysis({"a.py": "x = 1\n"}, cfg)
+
+    assert [f.tool for f in findings] == ["ruff", "bandit"]

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1120,3 +1120,45 @@ def test_one_failing_thread_does_not_block_the_others() -> None:
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
 
     assert sorted(graphql.resolved) == ["THREAD0", "THREAD2"]
+
+
+@respx.mock
+def test_failed_resolve_posts_no_reply() -> None:
+    """The reply is the *record* of a resolution, so it must never outlive one.
+
+    Regression: the reply was posted before the resolve, so a `resolveReviewThread`
+    the app isn't permitted to make (GitHub answers FORBIDDEN, and GraphQL errors
+    come back as HTTP 200) left a "Looks resolved" on a thread that stayed open —
+    and the thread then re-qualified on every later run, adding another reply each
+    time. Unbounded, not merely duplicated.
+    """
+    _mark_existing_review()
+    gone_fp = finding_fingerprint("src/old.py", "Removed bug")
+    graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1")])
+
+    def forbid_resolve(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if "resolveReviewThread" in payload.get("query", ""):
+            return httpx.Response(
+                200,
+                json={
+                    "data": None,
+                    "errors": [
+                        {"type": "FORBIDDEN", "message": "Resource not accessible by integration"}
+                    ],
+                },
+            )
+        return graphql(request)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=forbid_resolve)
+    patched: list[httpx.Request] = []
+    respx.route(method="PATCH").mock(
+        side_effect=lambda request: (patched.append(request), httpx.Response(200, json={}))[1]
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert graphql.replies == [], "replied on a thread that was never resolved"
+    assert graphql.resolved == []
+    assert patched == [], "rewrote the fingerprint marker of an unresolved thread"

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -545,6 +545,9 @@ def test_resolve_fixed_resolves_outdated_disappeared_thread() -> None:
     gone_fp = finding_fingerprint("src/old.py", "Removed bug")
     graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1")])
     respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=graphql)
+    # The marker rewrite is part of resolving; mock it rather than relying on an
+    # exception guard to swallow an unmocked request.
+    respx.route(method="PATCH").mock(return_value=httpx.Response(200, json={}))
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
@@ -1162,3 +1165,39 @@ def test_failed_resolve_posts_no_reply() -> None:
     assert graphql.replies == [], "replied on a thread that was never resolved"
     assert graphql.resolved == []
     assert patched == [], "rewrote the fingerprint marker of an unresolved thread"
+
+
+@respx.mock
+def test_reply_failure_still_rewrites_the_fingerprint_marker() -> None:
+    """The marker rewrite is correctness-critical; the reply is cosmetic.
+
+    Once the thread is resolved it is skipped by `_fixed_threads` forever, so
+    this is the only chance to move its fingerprint into the "resolved" family.
+    A failing reply must not strand an active marker on a resolved thread — that
+    would let re-run dedupe suppress the finding permanently if it came back.
+    """
+    _mark_existing_review()
+    gone_fp = finding_fingerprint("src/old.py", "Removed bug")
+    graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1")])
+
+    def resolve_ok_reply_fails(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if "addPullRequestReviewThreadReply" in payload.get("query", ""):
+            return httpx.Response(200, json={"errors": [{"message": "reply exploded"}]})
+        return graphql(request)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=resolve_ok_reply_fails)
+    patched: list[str] = []
+
+    def capture_patch(request: httpx.Request) -> httpx.Response:
+        patched.append(json.loads(request.content)["body"])
+        return httpx.Response(200, json={})
+
+    respx.route(method="PATCH").mock(side_effect=capture_patch)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert graphql.resolved == ["THREAD1"]
+    assert patched, "resolved thread kept its active fingerprint marker"
+    assert "lgtmaybe-resolved-fingerprint:" in patched[0]

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1056,3 +1056,67 @@ def test_reviews_list_fetched_once_per_run() -> None:
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
 
     assert len(reviews_calls) == 1, "the unchanged reviews list must not be re-paginated"
+
+
+@respx.mock
+def test_resolve_fixed_threads_are_resolved_concurrently() -> None:
+    """Each fixed thread costs a reply + a resolve + a marker rewrite. A PR where
+    several findings were fixed at once paid all of that serially; the threads are
+    independent, so they overlap."""
+    import threading
+
+    _mark_existing_review()
+    fps = [finding_fingerprint(f"src/gone{i}.py", "Removed bug") for i in range(4)]
+    threads = [
+        _thread(fp, outdated=True, tid=f"THREAD{i}", comment_id=600 + i) for i, fp in enumerate(fps)
+    ]
+
+    lock = threading.Lock()
+    events: list[str] = []
+    graphql = _GraphQL(threads)
+
+    def slow_graphql(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if "mutation" in payload.get("query", ""):
+            with lock:
+                events.append("start")
+            threading.Event().wait(0.05)
+            with lock:
+                events.append("end")
+        return graphql(request)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=slow_graphql)
+    respx.route(method="PATCH").mock(return_value=httpx.Response(200, json={}))
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert sorted(graphql.resolved) == [f"THREAD{i}" for i in range(4)]
+    first_end = next(i for i, e in enumerate(events) if e == "end")
+    assert events[:first_end].count("start") >= 2, f"threads resolved serially: {events}"
+
+
+@respx.mock
+def test_one_failing_thread_does_not_block_the_others() -> None:
+    """Pooling must not let a single bad thread take the rest down with it — the
+    pass is best-effort per thread, not all-or-nothing."""
+    _mark_existing_review()
+    fps = [finding_fingerprint(f"src/gone{i}.py", "Removed bug") for i in range(3)]
+    threads = [
+        _thread(fp, outdated=True, tid=f"THREAD{i}", comment_id=700 + i) for i, fp in enumerate(fps)
+    ]
+    graphql = _GraphQL(threads)
+
+    def flaky(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if "THREAD1" in json.dumps(payload.get("variables", {})):
+            raise httpx.ConnectError("boom")
+        return graphql(request)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=flaky)
+    respx.route(method="PATCH").mock(return_value=httpx.Response(200, json={}))
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert sorted(graphql.resolved) == ["THREAD0", "THREAD2"]


### PR DESCRIPTION
## What the survey found

Before changing anything: the lens fan-out, multi-batch overlap, and the head-revision content fetches are **already pooled**. There was nothing to win there. Three stages were genuinely serial, and one of them turned out to hide a real defect.

## 1. Deferral fetches — `retrieve.resolve_needs`

Up to `MAX_FETCH_FILES` round-trips per hop, `MAX_HOPS` hops, every one of them on reflection's **serial tail** — reflection can't begin until every lens has returned, so these were pure added wall clock at the end of the review.

Now prefetched concurrently in waves of at most `max_files`. Two properties are preserved on purpose and pinned by new tests:

- **Budget order is unchanged.** Acceptance still walks `needs` in order, so the token budget and file cap allocate exactly as they did when each fetch blocked. The same `needs` list must resolve to the same files whatever order the responses land in — otherwise reflection becomes non-deterministic.
- **The wave cap bounds over-fetch.** A 40-entry `needs` list with `max_files=2` must not fetch 40 files to accept 2.

Only the fetches overlap. `resolve_symbol` is a fast local ast-grep scan, so it stays on the ordered walk and only its resulting fetches are batched — that keeps the symbol-fallback semantics byte-identical rather than approximating them.

## 2. Static-analysis tools

ruff → bandit → semgrep ran one after another, each with its own 180s cap, so their worst cases stacked. Pooled.

`map` yields in submission order, so hints stay ordered by `sa.tools` whatever order the processes finish in — hints feed the prompt, and a prompt that reorders run to run would bust the shared-prefix cache for nothing. There's a test for that specifically, with the first-configured tool made the slowest.

## 3. Resolve-on-fix — and a real bug

A reply + resolve + marker rewrite per fixed thread, all serial. Pooled at 4 workers, deliberately lower than the read pool: these are writes against a single PR, and GitHub is stricter about concurrent mutations.

More importantly, the loop sat inside **one** `try/except`, so a single failing thread abandoned every remaining thread — on a PR where five findings were fixed and the second errored, threads 3–5 silently never resolved. Best-effort is now per thread. `test_one_failing_thread_does_not_block_the_others` fails on `main` and passes here.

The `github.resolve-fixed` spec requirement said "best-effort" without stating the granularity, which is exactly what changed — updated, with a scenario for the partial-failure case.

## Deliberately not done

- **Speculative grounding prefetch** (which I'd floated earlier). It would fetch files during the fan-out that most reviews never need — deferrals are the exception, not the rule — so it buys latency on a minority path by spending API calls on *every* run. The wave-concurrent `resolve_needs` above captures the same win without speculating.
- **Pooling label reconciliation.** lgtmaybe owns three label families, so it's ~3 calls, and concurrent DELETEs against one issue's labels invite races for no measurable gain.
- **Anything touching reflection's structure.** It remains the critical path (1 + up to `MAX_HOPS` strictly sequential calls, each depending on the last verdict). Sharding or overlapping the audit trades the auditor's cross-finding view — which is how it spots duplicates and cross-file false positives — for latency. That deserves profiled numbers first, not a guess.

## Tests

TDD throughout; each concurrency assertion uses the event-ordering pattern already established in `test_prompt_split.py`'s warm-up-primer tests rather than timing thresholds. Alongside each, a determinism guard: budget-in-needs-order, hint ordering, and the fetch cap.

Full suite: 1467 passed. `ruff check`, `ruff format --check`, `mypy src`, `pytest tests/specs`, and `openspec validate --specs` (10/10) all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuzC47hXdohXyP6xzTH4V)_