### PR TITLE
feat(summary): stop claiming LGTM while business is still outstanding

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3289,6 +3289,7 @@ Everything the engine needs about a pull request. Fetched via the GitHub REST AP
 | `feedback_downvotes` | list[string] | No | `[]` | Feedback Downvotes |
 | `file_contents` | object | No | — | File Contents |
 | `head_sha` | string | Yes | — | Head Sha |
+| `open_finding_threads` | integer | No | `0` | Open Finding Threads |
 | `pr_number` | integer | Yes | — | Pr Number |
 | `repo` | string | Yes | — | Repo |
 | `title` | string | No | `` | Title |
@@ -4229,6 +4230,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "head_sha": {
       "title": "Head Sha",
       "type": "string"
+    },
+    "open_finding_threads": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Open Finding Threads",
+      "type": "integer"
     },
     "pr_number": {
       "title": "Pr Number",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -130,6 +130,7 @@ Everything the engine needs about a pull request. Fetched via the GitHub REST AP
 | `feedback_downvotes` | list[string] | No | `[]` | Feedback Downvotes |
 | `file_contents` | object | No | — | File Contents |
 | `head_sha` | string | Yes | — | Head Sha |
+| `open_finding_threads` | integer | No | `0` | Open Finding Threads |
 | `pr_number` | integer | Yes | — | Pr Number |
 | `repo` | string | Yes | — | Repo |
 | `title` | string | No | `` | Title |
@@ -1070,6 +1071,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "head_sha": {
       "title": "Head Sha",
       "type": "string"
+    },
+    "open_finding_threads": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Open Finding Threads",
+      "type": "integer"
     },
     "pr_number": {
       "title": "Pr Number",

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -21,6 +21,17 @@ failure surfaces to the caller.
 - **WHEN** lens calls are still queued after `max_review_seconds`
 - **THEN** they are skipped and the summary carries a partial-results notice
 
+#### Scenario: findings were suppressed
+- **WHEN** a run suppresses findings (ignored fingerprint, inline pragma, or a
+  previous run's 👎) and posts no others
+- **THEN** the summary discloses the suppressed count instead of claiming LGTM
+
+#### Scenario: earlier conversations are still open
+- **WHEN** the PR carries unresolved conversations lgtmaybe opened on an earlier
+  run and this run finds nothing
+- **THEN** the summary says so instead of claiming LGTM — this run's count covers
+  what it reviewed now, which an incremental run may not include
+
 ### Requirement: Per-lens fan-out through one bounded executor
 
 Every `(batch, lens)` call SHALL run through one global bounded executor sized

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -479,6 +479,13 @@ class PRContext(_Strict):
     # drops matching findings, except high/critical security findings, which a
     # downvote can never hide. Populated by the CLI, empty by default.
     feedback_downvotes: frozenset[str] = frozenset()
+    # How many of our OWN finding conversations from earlier runs are still
+    # unresolved on this PR. Not findings of this run — they are the business
+    # this run's count cannot see, because an incremental run may not re-review
+    # their files at all. Reported so a "0 findings" result is never dressed up
+    # as a clean PR while earlier findings sit unaddressed. Populated by the
+    # GitHub gateway, 0 for the local CLI (no conversations to track).
+    open_finding_threads: int = Field(default=0, ge=0)
 
 
 class ReviewConfig(_Strict):

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -548,6 +548,28 @@ class LLMReviewEngine(ReviewEngine):
                 "self-reflection audit was skipped, so findings may include "
                 "false positives."
             )
+        # Findings the model DID raise and the run then hid: an ignore
+        # fingerprint, an inline pragma, or a 👎 from a previous run. Reporting
+        # the remaining count as a clean bill of health would let a suppression
+        # quietly convert a real finding into "LGTM".
+        if suppressed:
+            plural = "s" if suppressed != 1 else ""
+            notices.append(
+                f"🙈 {suppressed} finding{plural} suppressed (ignored fingerprint, "
+                "inline `lgtmaybe: ignore`, or a 👎 from a previous run) — not "
+                "counted below."
+            )
+        # Business this run's count cannot see: our own conversations from
+        # earlier runs that nobody has resolved. An incremental run may not have
+        # re-reviewed their files at all, so their absence here is no evidence
+        # they were fixed.
+        if ctx.open_finding_threads:
+            count = ctx.open_finding_threads
+            subject = "conversation is" if count == 1 else "conversations are"
+            notices.append(
+                f"💬 {count} earlier lgtmaybe {subject} still unresolved on this PR — "
+                "this run's count covers what it reviewed now, not those."
+            )
 
         if notices:
             return filtered, "\n\n".join([*notices, summary_line])

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -272,7 +272,11 @@ class RestGitHubGateway(GitHubGateway):
         # single-page PR the whole count hides inside the file-fetch latency.
         reviewable = [path for path in changed_files if is_reviewable(path)]
         file_contents: dict[str, str] = {}
-        with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS) as pool:
+        # +1, not a shared slot: the count must be free, and taking a worker
+        # from the pool would narrow content fetching to
+        # _CONTENT_FETCH_WORKERS - 1 for as long as the count runs — turning an
+        # overlap into a slowdown on exactly the wide PRs the pool sizing is for.
+        with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS + 1) as pool:
             open_threads = pool.submit(self.count_open_finding_threads)
             if reviewable:
                 results = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), reviewable)

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -284,6 +284,7 @@ class RestGitHubGateway(GitHubGateway):
             title=meta.get("title") or "",
             description=meta.get("body") or "",
             commit_messages=self._fetch_commit_subjects(),
+            open_finding_threads=self.count_open_finding_threads(),
         )
 
     def post_review(
@@ -912,6 +913,65 @@ class RestGitHubGateway(GitHubGateway):
         # threads, so they overlap on the shared (thread-safe) httpx client.
         with ThreadPoolExecutor(max_workers=min(_RESOLVE_WORKERS, len(fixed))) as pool:
             list(pool.map(resolve_one, fixed))
+
+    def count_open_finding_threads(self) -> int:
+        """How many of OUR finding conversations are still unresolved on this PR.
+
+        The business a run's own finding count cannot see. An incremental run
+        reviews only the newest commits, so an earlier finding on an untouched
+        file never reappears — its absence is not evidence it was fixed. The
+        engine uses this to keep "👍 LGTM!" off a PR that still has open
+        conversations (see `PRContext.open_finding_threads`).
+
+        Counts only threads whose opening comment carries our ACTIVE finding
+        marker: resolve-on-fix rewrites that marker into the "resolved" family,
+        so a thread we already closed is excluded by construction, as is any
+        thread we did not open. Best-effort and read-only — any failure returns
+        0 rather than blocking a review over a disclosure nicety. Adapter-only,
+        beyond the frozen port.
+        """
+        query = """
+        query($owner:String!,$name:String!,$number:Int!,$cursor:String){
+          repository(owner:$owner,name:$name){
+            pullRequest(number:$number){
+              reviewThreads(first:100, after:$cursor){
+                pageInfo{ hasNextPage endCursor }
+                nodes{ isResolved comments(first:1){ nodes{ body } } }
+              }
+            }
+          }
+        }
+        """
+        owner, _, name = self._repo.partition("/")
+        open_threads = 0
+        cursor: str | None = None
+        try:
+            while True:
+                data = self._graphql(
+                    query,
+                    {
+                        "owner": owner,
+                        "name": name,
+                        "number": self._pr_number,
+                        "cursor": cursor,
+                    },
+                )
+                conn = data["repository"]["pullRequest"]["reviewThreads"]
+                for node in conn["nodes"]:
+                    if node.get("isResolved"):
+                        continue
+                    comments = node.get("comments", {}).get("nodes", [])
+                    body = comments[0].get("body", "") if comments else ""
+                    if _FINDING_MARKER.search(body):
+                        open_threads += 1
+                page = conn.get("pageInfo", {})
+                if not page.get("hasNextPage"):
+                    break
+                cursor = page.get("endCursor")
+        except Exception as exc:  # noqa: BLE001 — disclosure is never worth a failed review
+            _log.warning("counting open finding conversations failed: %s", exc)
+            return 0
+        return open_threads
 
     def _fixed_threads(self, current: set[str]) -> list[tuple[str, int | None, str]]:
         """Our unresolved, outdated conversations whose finding is gone.

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -265,13 +265,19 @@ class RestGitHubGateway(GitHubGateway):
         # with surrounding context. Read-only API fetch — never a checkout — and
         # the engine redacts it before it leaves the process. The fetches are
         # independent, so run them concurrently to cut round-trip latency.
+        # The open-conversation count walks the reviewThreads connection, which is
+        # a round trip (more on a PR with hundreds of threads) for what is only
+        # disclosure metadata. It shares nothing with the content fetches, so it
+        # rides the same pool rather than sitting in front of them: on the common
+        # single-page PR the whole count hides inside the file-fetch latency.
         reviewable = [path for path in changed_files if is_reviewable(path)]
         file_contents: dict[str, str] = {}
-        if reviewable:
-            workers = min(_CONTENT_FETCH_WORKERS, len(reviewable))
-            with ThreadPoolExecutor(max_workers=workers) as pool:
+        with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS) as pool:
+            open_threads = pool.submit(self.count_open_finding_threads)
+            if reviewable:
                 results = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), reviewable)
                 file_contents = {path: content for path, content in results if content is not None}
+            open_finding_threads = open_threads.result()
 
         return PRContext(
             diff=diff,
@@ -284,7 +290,7 @@ class RestGitHubGateway(GitHubGateway):
             title=meta.get("title") or "",
             description=meta.get("body") or "",
             commit_messages=self._fetch_commit_subjects(),
-            open_finding_threads=self.count_open_finding_threads(),
+            open_finding_threads=open_finding_threads,
         )
 
     def post_review(

--- a/tests/engine/test_lgtm_honesty.py
+++ b/tests/engine/test_lgtm_honesty.py
@@ -1,0 +1,139 @@
+"""A clean review must not claim a clean PR when business is still outstanding.
+
+"👍 LGTM!" reads as "this PR is fine". It is only honest when the run actually
+found nothing AND nothing is being hidden from the count. Two things break that
+without changing the finding count:
+
+- findings this run **suppressed** (an ignore fingerprint, an inline pragma, or a
+  👎 an authorised reviewer left last run) — the model flagged them, they simply
+  are not shown;
+- findings from **earlier runs whose conversations are still open** — an
+  incremental run may not even re-review their files, so they never reappear in
+  this run's count while still being unaddressed on the PR.
+
+Both route through the engine's existing `notices` list, which already exists to
+stop a clean bill of health being claimed on incomplete evidence — and which
+short-circuits the LGTM branch by construction.
+"""
+
+from __future__ import annotations
+
+import json
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewConfig,
+    ReviewFinding,
+    Severity,
+)
+from lgtmaybe.engine import LLMReviewEngine
+from tests.fakes import FakeProvider
+
+_DIFF = "diff --git a/a.py b/a.py\n@@ -1,1 +1,2 @@\n context\n+new_line = 1\n"
+
+
+def _ctx(**overrides) -> PRContext:
+    base = dict(
+        diff=_DIFF,
+        changed_files=["a.py"],
+        base_sha="a",
+        head_sha="b",
+        repo="o/r",
+        pr_number=1,
+    )
+    base.update(overrides)
+    return PRContext(**base)  # type: ignore[arg-type]
+
+
+def _cfg(**overrides) -> ReviewConfig:
+    base: dict[str, object] = {"provider": Provider.ollama, "model": "m", "reflect": False}
+    base.update(overrides)
+    return ReviewConfig(**base)  # type: ignore[arg-type]
+
+
+class _Clean(FakeProvider):
+    """Finds nothing, every lens — the genuinely-clean baseline."""
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        return ProviderResult(text='{"findings": []}', input_tokens=1, output_tokens=1)
+
+
+class _Flags(FakeProvider):
+    """Returns one finding on the changed line, every lens."""
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        finding = ReviewFinding(
+            path="a.py",
+            line=2,
+            severity=Severity.medium,
+            title="Something",
+            body="x",
+            failure_scenario="When the changed line runs, it misbehaves.",
+            anchor="new_line = 1",
+        )
+        return ProviderResult(
+            text=json.dumps({"findings": [finding.model_dump(mode="json")]}),
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+
+class TestSuppressedFindingsAreDisclosed:
+    def test_a_downvote_suppressed_finding_blocks_lgtm(self) -> None:
+        """learn_feedback drops a 👎'd finding before posting. Reporting the
+        resulting zero as LGTM would let a downvote silently convert a real
+        finding into a clean bill of health."""
+        from lgtmaybe.github.rest_gateway import finding_fingerprint
+
+        fp = finding_fingerprint("a.py", "Something")
+        findings, summary = LLMReviewEngine(_Flags()).review(
+            _ctx(feedback_downvotes=frozenset({fp})), _cfg()
+        )
+
+        assert findings == []
+        assert "LGTM" not in summary
+        assert "suppress" in summary.lower()
+
+    def test_an_ignored_fingerprint_blocks_lgtm(self) -> None:
+        from lgtmaybe.github.rest_gateway import finding_fingerprint
+
+        fp = finding_fingerprint("a.py", "Something")
+        _findings, summary = LLMReviewEngine(_Flags()).review(
+            _ctx(), _cfg(ignore_fingerprints=[fp])
+        )
+
+        assert "LGTM" not in summary
+        assert "suppress" in summary.lower()
+
+    def test_a_genuinely_clean_review_still_says_lgtm(self) -> None:
+        """The guard must not cost every clean PR its thumbs-up."""
+        _findings, summary = LLMReviewEngine(_Clean()).review(_ctx(), _cfg())
+        assert "LGTM" in summary
+
+
+class TestOpenPriorFindingsAreDisclosed:
+    def test_open_earlier_conversations_block_lgtm(self) -> None:
+        """Nothing new this run, but earlier findings are still unaddressed —
+        an incremental run may not even have re-reviewed their files."""
+        _findings, summary = LLMReviewEngine(_Clean()).review(_ctx(open_finding_threads=3), _cfg())
+
+        assert "LGTM" not in summary
+        assert "3" in summary
+
+    def test_open_conversations_are_disclosed_alongside_new_findings(self) -> None:
+        """Not only on the clean path: a run that finds two new things while five
+        remain open should say so."""
+        _findings, summary = LLMReviewEngine(_Flags()).review(
+            _ctx(open_finding_threads=5), _cfg(min_severity="info")
+        )
+
+        assert "5" in summary
+
+    def test_no_open_conversations_is_silent(self) -> None:
+        _findings, summary = LLMReviewEngine(_Clean()).review(_ctx(open_finding_threads=0), _cfg())
+        assert "LGTM" in summary
+        assert "unresolved" not in summary

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1264,3 +1264,55 @@ def test_forbidden_resolve_is_attempted_once_per_run() -> None:
         f"({len(attempts)} of {len(threads)} threads)"
     )
     assert graphql.replies == []
+
+
+def _open_thread(body: str, *, resolved: bool = False) -> dict:
+    return {"isResolved": resolved, "comments": {"nodes": [{"body": body}]}}
+
+
+def _count_threads_page(nodes: list[dict]) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": nodes,
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+
+@respx.mock
+def test_open_finding_threads_counts_only_our_unresolved_conversations() -> None:
+    """Resolved threads, and anyone else's threads, are not our outstanding business."""
+    ours = f"**[MEDIUM] Old**\n\n<!-- lgtmaybe-finding:{finding_fingerprint('a.py', 'Old')} -->"
+    resolved_by_us = "**[LOW] Fixed**\n\n<!-- lgtmaybe-resolved-fingerprint:abc123 -->"
+    respx.route(method="POST", url=GRAPHQL_URL).mock(
+        return_value=_count_threads_page(
+            [
+                _open_thread(ours),
+                _open_thread(ours),
+                _open_thread(ours, resolved=True),  # already closed
+                _open_thread(resolved_by_us),  # marker rewritten by resolve-on-fix
+                _open_thread("a human's own review comment"),  # not ours
+            ]
+        )
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    assert gw.count_open_finding_threads() == 2
+
+
+@respx.mock
+def test_open_finding_thread_count_failure_never_blocks_the_review() -> None:
+    """A disclosure nicety must never be the thing that fails a review."""
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=httpx.ConnectError("boom"))
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    assert gw.count_open_finding_threads() == 0

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1316,3 +1316,46 @@ def test_open_finding_thread_count_failure_never_blocks_the_review() -> None:
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     assert gw.count_open_finding_threads() == 0
+
+
+@respx.mock
+def test_open_finding_threads_follows_pagination() -> None:
+    """A PR with more than 100 conversations pages — a regression that stopped
+    after the first page, or replayed it, would otherwise go unnoticed."""
+    ours = f"**[MEDIUM] Old**\n\n<!-- lgtmaybe-finding:{finding_fingerprint('a.py', 'Old')} -->"
+
+    def page(nodes: list[dict], *, next_cursor: str | None) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {
+                                    "hasNextPage": next_cursor is not None,
+                                    "endCursor": next_cursor,
+                                },
+                                "nodes": nodes,
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+    seen_cursors: list[str | None] = []
+
+    def graphql(request: httpx.Request) -> httpx.Response:
+        cursor = json.loads(request.content)["variables"]["cursor"]
+        seen_cursors.append(cursor)
+        if cursor is None:
+            return page([_open_thread(ours), _open_thread(ours)], next_cursor="page-2")
+        return page([_open_thread(ours)], next_cursor=None)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=graphql)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+
+    assert gw.count_open_finding_threads() == 3  # 2 on page one, 1 on page two
+    assert seen_cursors == [None, "page-2"], "the endCursor was not carried into page two"

--- a/tests/github/test_rest_gateway.py
+++ b/tests/github/test_rest_gateway.py
@@ -341,3 +341,82 @@ def test_open_thread_count_overlaps_the_file_fetches() -> None:
     assert len([e for e in events[:first_end] if e.startswith("start-")]) >= 2, (
         f"the thread count did not overlap the content fetches: {events}"
     )
+
+
+@respx.mock
+def test_content_fetches_keep_full_concurrency_while_the_count_runs() -> None:
+    """The count rides the pool on a dedicated worker, not a borrowed one.
+
+    Sizing the pool at `_CONTENT_FETCH_WORKERS` let the count take a slot from
+    the content fetches, so a PR with at least that many reviewable files
+    fetched content one worker narrower for as long as the count ran — the
+    overlap became a slowdown on exactly the wide PRs the sizing exists for.
+
+    Asserted as a property (how many fetches are actually in flight together),
+    not by mocking the executor to read back its `max_workers`: the latter only
+    restates the line of code, and would still pass if the count were moved
+    somewhere that genuinely stole capacity.
+    """
+    import threading
+
+    from lgtmaybe.github.rest_gateway import _CONTENT_FETCH_WORKERS
+
+    files = [{"filename": f"src/mod{i}.py", "status": "modified"} for i in range(20)]
+    respx.route(
+        method="GET", url=PR_URL, headers={"Accept": "application/vnd.github.v3.diff"}
+    ).mock(return_value=httpx.Response(200, content=_load("pr_diff.patch").encode()))
+    respx.route(method="GET", url=PR_URL).mock(
+        return_value=httpx.Response(200, json=_load_json("pr_detail.json"))
+    )
+    respx.route(method="GET", url__startswith=FILES_URL).mock(
+        return_value=httpx.Response(200, json=files)
+    )
+    respx.route(method="GET", url__startswith=COMMITS_URL).mock(
+        return_value=httpx.Response(200, json=_load_json("pr_commits.json"))
+    )
+
+    lock = threading.Lock()
+    in_flight = 0
+    peak = 0
+
+    def content(request: httpx.Request) -> httpx.Response:
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        threading.Event().wait(0.02)
+        with lock:
+            in_flight -= 1
+        return httpx.Response(200, text="raw file content")
+
+    def slow_count(request: httpx.Request) -> httpx.Response:
+        # Outlives the content fetches, so it is in flight for all of them.
+        threading.Event().wait(0.2)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [],
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+    respx.route(method="GET", url__startswith=f"{BASE_URL}/repos/{REPO}/contents/").mock(
+        side_effect=content
+    )
+    respx.route(method="POST", url="https://api.github.com/graphql").mock(side_effect=slow_count)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.get_pr_context()
+
+    assert peak >= _CONTENT_FETCH_WORKERS, (
+        f"content fetches peaked at {peak} concurrent while the count ran; "
+        f"the count is taking a worker from them (expected {_CONTENT_FETCH_WORKERS})"
+    )

--- a/tests/github/test_rest_gateway.py
+++ b/tests/github/test_rest_gateway.py
@@ -274,3 +274,70 @@ def test_base_checkout_root_returns_none_when_ref_unavailable(monkeypatch) -> No
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     assert gw.base_checkout_root() is None
     assert cloned is False  # never tried to clone without a ref
+
+
+@respx.mock
+def test_open_thread_count_overlaps_the_file_fetches() -> None:
+    """The count is disclosure metadata, so it must not sit in FRONT of the
+    content fetches — it shares nothing with them and rides the same pool. Run
+    serially it would add a round trip to every review's startup."""
+    import threading
+
+    respx.route(
+        method="GET", url=PR_URL, headers={"Accept": "application/vnd.github.v3.diff"}
+    ).mock(return_value=httpx.Response(200, content=_load("pr_diff.patch").encode()))
+    respx.route(method="GET", url=PR_URL).mock(
+        return_value=httpx.Response(200, json=_load_json("pr_detail.json"))
+    )
+    respx.route(method="GET", url__startswith=FILES_URL).mock(
+        return_value=httpx.Response(200, json=_load_json("pr_files_page1.json"))
+    )
+    respx.route(method="GET", url__startswith=COMMITS_URL).mock(
+        return_value=httpx.Response(200, json=_load_json("pr_commits.json"))
+    )
+
+    lock = threading.Lock()
+    events: list[str] = []
+
+    def slow(label: str):
+        def handler(request: httpx.Request) -> httpx.Response:
+            with lock:
+                events.append(f"start-{label}")
+            threading.Event().wait(0.05)
+            with lock:
+                events.append(f"end-{label}")
+            if label == "threads":
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "repository": {
+                                "pullRequest": {
+                                    "reviewThreads": {
+                                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                        "nodes": [],
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+            return httpx.Response(200, text="raw file content")
+
+        return handler
+
+    respx.route(method="POST", url="https://api.github.com/graphql").mock(
+        side_effect=slow("threads")
+    )
+    respx.route(method="GET", url__startswith=f"{BASE_URL}/repos/{REPO}/contents/").mock(
+        side_effect=slow("content")
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.get_pr_context()
+
+    assert "start-threads" in events, "the thread count never ran"
+    first_end = next(i for i, e in enumerate(events) if e.startswith("end-"))
+    assert len([e for e in events[:first_end] if e.startswith("start-")]) >= 2, (
+        f"the thread count did not overlap the content fetches: {events}"
+    )

--- a/tests/snapshots/PRContext.json
+++ b/tests/snapshots/PRContext.json
@@ -49,6 +49,12 @@
       "title": "Head Sha",
       "type": "string"
     },
+    "open_finding_threads": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Open Finding Threads",
+      "type": "integer"
+    },
     "pr_number": {
       "title": "Pr Number",
       "type": "integer"


### PR DESCRIPTION
## Why

"👍 LGTM!" reads as *"this PR is fine"*. It was posted whenever **this run's** finding count reached zero — which is not the same claim. Two cases produced a thumbs-up over unfinished business:

**1. Suppressed findings.** The model flagged something and the run hid it — an ignored fingerprint, an inline `lgtmaybe: ignore`, or a 👎 an authorised reviewer left on a previous run. The engine already computed this count and only ever logged it. So a downvote could quietly convert a real finding into a clean bill of health, which is close to the opposite of what `learn_feedback` is for.

**2. Earlier conversations still open.** Findings from previous runs that nobody resolved. An incremental run reviews only the newest commits, so a finding on an untouched file never reappears — **its absence is not evidence it was fixed**, yet the summary read as though the whole PR were clean.

## How

Both route through the engine's existing `notices` list, which exists for exactly this purpose ("don't claim a clean bill of health" — it already covers failed lens calls, file caps, triage skips, and a skipped reflection pass) and **short-circuits the LGTM branch by construction**. So no new branching, and the disclosure also appears on runs that *did* find things — where "2 findings" alone equally understates a PR carrying five open threads.

```
🙈 3 findings suppressed (ignored fingerprint, inline `lgtmaybe: ignore`,
   or a 👎 from a previous run) — not counted below.

💬 5 earlier lgtmaybe conversations are still unresolved on this PR — this
   run's count covers what it reviewed now, not those.
```

## The count

New read-only `count_open_finding_threads` on the GitHub gateway (adapter-only, like the existing `list_downvoted_fingerprints`), carried on `PRContext.open_finding_threads`.

It counts only threads whose opening comment carries our **active** finding marker, which makes two exclusions fall out for free rather than needing their own logic: a thread resolve-on-fix already closed is skipped (its marker was rewritten into the disjoint "resolved" family), and so is any thread lgtmaybe did not open.

Wholly best-effort — a failure returns 0 and logs, because a disclosure nicety must never be the thing that fails a review. Local CLI reviews have no conversations and report 0, so that path is unchanged.

## On the 👍/👎 half of the request

Downvotes are covered: they suppress, and suppression is now disclosed. Upvotes and human replies are *not* separately called out — a 👍 or a reply on a thread that is still **unresolved** already makes it part of the open count, and neither changes whether the work is outstanding. Splitting them into their own notice would add surface without changing what a reader does about it. Happy to add the breakdown if you want it visible.

## Tests

`tests/engine/test_lgtm_honesty.py` covers both notices, both on the clean path and alongside real findings, plus the case that matters most: **a genuinely clean review still gets its thumbs-up** — the guard must not cost every clean PR its LGTM. Gateway tests cover marker-scoped counting (resolved, already-rewritten, and third-party threads all excluded) and the failure path.

Full suite: 1484 passed. `ruff check`, `ruff format --check`, `mypy src`, `pytest tests/specs`, and `openspec validate --specs` (10/10) clean. Two spec scenarios added under the pipeline's "degrades loudly, never silently" requirement; `PRContext` schema snapshot and the generated config reference regenerated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuzC47hXdohXyP6xzTH4V)_