### PR TITLE
fix(workflows): stop lgtmaybe cancelling its own reviews

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -41,8 +41,17 @@ jobs:
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    # Two independent guards against cancelling our own review. The job scope
+    # keeps an ineligible run (a bot comment that fails the guard above) out of
+    # the group entirely. The event name in the key handles the rest: lgtmaybe
+    # posts comments during a review (the diagram, the inline findings) and those
+    # comments fire the issue_comment / pull_request_review_comment events this
+    # workflow subscribes to, so without it an eligible comment run shares this
+    # group and cancel-in-progress kills the review that posted the comment. A
+    # new push still cancels an in-flight review — two pushes are both
+    # pull_request_target, so they still collide.
     concurrency:
-      group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     # A healthy full review runs in a handful of minutes; cap it so a wedged

--- a/examples/workflows/review-anthropic.yml
+++ b/examples/workflows/review-anthropic.yml
@@ -14,8 +14,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -25,8 +25,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -18,8 +18,14 @@ permissions:
   pull-requests: write
   id-token: write # required for the OIDC token exchange (keyless auth)
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -19,8 +19,14 @@ permissions:
   contents: read
   id-token: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -19,8 +19,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-openai.yml
+++ b/examples/workflows/review-openai.yml
@@ -16,8 +16,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-openrouter.yml
+++ b/examples/workflows/review-openrouter.yml
@@ -14,8 +14,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-vertex.yml
+++ b/examples/workflows/review-vertex.yml
@@ -18,8 +18,14 @@ permissions:
   pull-requests: write
   id-token: write # required for the WIF token exchange (keyless auth)
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -14,8 +14,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# The event name is part of the key on purpose. lgtmaybe posts comments during a
+# review (the change diagram, the inline findings), and those comments fire the
+# issue_comment / pull_request_review_comment events this workflow subscribes to.
+# Without the event in the key those runs share this group and cancel-in-progress
+# kills the review that posted the comment. A new push still cancels an in-flight
+# review — two pushes are both pull_request_target, so they still collide.
 concurrency:
-  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -185,22 +185,30 @@ the least-privilege public App does not hold `checks: write`.
 - **WHEN** a review uses the built-in workflow token
 - **THEN** existing `github-actions[bot]` posting behavior remains unchanged
 
-### Requirement: Ineligible events cannot preempt active reviews
+### Requirement: lgtmaybe's own comments cannot preempt active reviews
 
-The dogfood workflow SHALL apply per-PR concurrency only to an event that passes
-the review job's eligibility guard. Eligible jobs for the same PR MUST retain
-newest-run-wins cancellation.
+Every workflow lgtmaybe ships or runs SHALL key its per-PR concurrency group on
+the event name as well as the PR, and the dogfood workflow SHALL additionally
+apply that group only to an event passing the review job's eligibility guard.
+Runs of the same event for the same PR MUST retain newest-run-wins cancellation.
+Posting SHALL be ordered so the review lands before any comment lgtmaybe emits.
 <!-- anchor: github.workflow-concurrency -->
 
 #### Scenario: lgtmaybe posts an automatic diagram
 
-- **WHEN** the GitHub App comment emits an `issue_comment` workflow run whose
-  author does not pass the review job guard
-- **THEN** that run does not enter the review concurrency group or cancel the
-  active review
+- **WHEN** the GitHub App comment emits an `issue_comment` workflow run
+- **THEN** that run's concurrency group differs from the active
+  `pull_request_target` review's, and at job scope an author failing the guard
+  does not enter a group at all
 
-#### Scenario: a newer eligible review starts
+#### Scenario: a newer push arrives mid-review
 
-- **WHEN** a newer PR event or trusted command passes the review job guard for
+- **WHEN** a newer `pull_request_target` event passes the review job guard for
   the same PR
-- **THEN** the newer job cancels the older eligible review job
+- **THEN** the newer job cancels the older review job for that PR
+
+#### Scenario: a review is cancelled by a mis-scoped consumer group
+
+- **WHEN** a consumer's group is not event-discriminated and lgtmaybe's own
+  comment cancels the run
+- **THEN** the review was already posted, because comments follow it

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -353,11 +353,6 @@ def run_review(
                 # Resolve-on-fix may only touch threads on files this run
                 # actually re-reviewed — absence elsewhere proves nothing.
                 set_scope(_diff_paths(review_ctx.diff))
-        # Pass the FULL PR diff (already fetched) so the commentable-line
-        # index is built from the diff the comments will anchor to — the
-        # incremental diff's context lines aren't necessarily in the PR diff.
-        with profiler.stage("post"):
-            github.post_review(findings, summary, diff=ctx.diff)
         if cfg.pr_labels:
             # Effort/risk labels from data already computed — best-effort,
             # and only on gateways that support them (fakes don't).
@@ -374,6 +369,16 @@ def run_review(
             if create_check_run is not None:
                 conclusion, title, check_summary = _fail_on_check(findings, cfg.fail_on)
                 create_check_run(ctx.head_sha, conclusion, title, check_summary)
+        # Last write of the run, on purpose: the inline comments this posts fire
+        # pull_request_review_comment events, so a consumer whose concurrency
+        # group isn't discriminated by event name can have the resulting run
+        # cancel this one. Nothing may follow that we would lose.
+        #
+        # Pass the FULL PR diff (already fetched) so the commentable-line
+        # index is built from the diff the comments will anchor to — the
+        # incremental diff's context lines aren't necessarily in the PR diff.
+        with profiler.stage("post"):
+            github.post_review(findings, summary, diff=ctx.diff)
 
     return findings, summary
 
@@ -529,6 +534,31 @@ def execute_local_diagram(
     click.echo(body)
 
 
+def _post_extras(
+    github: GitHubGateway,
+    provider: ProviderClient,
+    cfg: ReviewConfig,
+    ctx: PRContext,
+    *,
+    describe: bool,
+    diagram: bool,
+) -> None:
+    """Post the auto extras (description, diagram) over a prefetched context.
+
+    Each is independently best-effort: a failure is logged and swallowed so an
+    extra can never turn a completed review into a failed run.
+    """
+    for enabled, run, name in (
+        (describe, run_describe, "describe"),
+        (diagram, run_diagram, "diagram"),
+    ):
+        if enabled:
+            try:
+                run(github, provider, cfg, ctx=ctx)
+            except Exception:
+                _log.warning("auto-%s failed — continuing without it", name, exc_info=True)
+
+
 def execute_review(
     cfg: ReviewConfig,
     runtime: RuntimeOptions,
@@ -554,21 +584,13 @@ def execute_review(
     ctx: PRContext | None = None
     if describe or diagram:
         # The extras are best-effort and must never block the review. A failed
-        # prefetch just means run_review fetches (and surfaces) it itself.
+        # prefetch just means run_review fetches (and surfaces) it itself. The
+        # fetch happens here, before the review, so the review reuses it — only
+        # the posting is deferred (see _post_extras).
         try:
             ctx = github.get_pr_context()
         except Exception:
             _log.warning("PR context prefetch failed — extras skipped", exc_info=True)
-        if ctx is not None:
-            for enabled, run, name in (
-                (describe, run_describe, "describe"),
-                (diagram, run_diagram, "diagram"),
-            ):
-                if enabled:
-                    try:
-                        run(github, provider, cfg, ctx=ctx)
-                    except Exception:
-                        _log.warning("auto-%s failed — continuing without it", name, exc_info=True)
 
     # From here we have a gateway, so any failure is surfaced back to the PR as
     # a short comment rather than failing silently — then we exit non-zero.
@@ -577,6 +599,16 @@ def execute_review(
     except Exception as exc:
         _post_failure(github, exc)
         raise click.ClickException(f"review failed: {exc}") from exc
+    finally:
+        # Deferred deliberately: posting a comment fires an issue_comment
+        # workflow run, and a consumer whose concurrency group isn't
+        # discriminated by event name puts that run in the same group as this
+        # review — cancel-in-progress then kills the review that posted the
+        # comment. With the review already on the PR, such a cancellation is
+        # harmless. In a `finally` so a failed review still gets its extras,
+        # exactly as when they ran first.
+        if ctx is not None:
+            _post_extras(github, provider, cfg, ctx, describe=describe, diagram=diagram)
 
     if runtime.profile:
         click.echo(profiler.render())

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -185,6 +185,62 @@ class TestActionRouting:
         assert len(github.diagrams) == 1
         assert len(github.posted) == 1
 
+    def test_auto_extras_post_after_the_review(self, tmp_path, monkeypatch):
+        """The comments lgtmaybe posts itself go out after the review, never before.
+
+        Posting a comment fires an ``issue_comment`` workflow run. A consumer whose
+        concurrency group isn't discriminated by the event name puts that run in the
+        same group as the review, so ``cancel-in-progress`` kills the review that
+        posted the comment. Posting last makes such a cancellation harmless instead
+        of fatal — the review is already on the PR.
+        """
+        import lgtmaybe.cli as cli_module
+
+        class _OrderedGitHub(FakeGitHub):
+            def __init__(self) -> None:
+                super().__init__()
+                self.writes: list[str] = []
+
+            def post_review(self, findings, summary, diff=None):
+                self.writes.append("review")
+                super().post_review(findings, summary, diff)
+
+            def post_describe_comment(self, body: str) -> None:
+                self.writes.append("describe")
+                super().post_describe_comment(body)
+
+            def post_diagram_comment(self, body: str) -> None:
+                self.writes.append("diagram")
+                super().post_diagram_comment(body)
+
+        github = _OrderedGitHub()
+        provider = FakeProvider()
+        monkeypatch.setattr(
+            cli_module,
+            "build_review_context",
+            lambda cfg, runtime: (github, FakeEngine(provider), provider),
+        )
+
+        event = _write_event(
+            tmp_path,
+            {
+                "action": "opened",
+                "repository": {"full_name": "org/repo"},
+                "pull_request": {"number": 3},
+            },
+        )
+        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_target")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+        monkeypatch.setenv("INPUT_PROVIDER", "ollama")
+        monkeypatch.setenv("INPUT_MODEL", "llama3")
+        monkeypatch.setenv("INPUT_AUTO_DESCRIBE", "true")
+        monkeypatch.setenv("INPUT_AUTO_DIAGRAM", "true")
+
+        result = CliRunner().invoke(main, ["action"])
+
+        assert result.exit_code == 0, result.output
+        assert github.writes == ["review", "describe", "diagram"]
+
     def test_issue_comment_event_routes_slash_command(self, tmp_path, monkeypatch):
         github = FakeGitHub()
         provider = FakeProvider()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -276,6 +276,26 @@ class TestGitHubReviewErrorSurfacing:
         assert posted_findings == []
         assert "fail" in posted_summary.lower()
 
+    def test_auto_extras_still_post_when_the_review_fails(self, monkeypatch):
+        """Deferring the extras behind the review must not make them conditional on
+        it: a failed review still gets its diagram, exactly as when they ran first."""
+        import click
+
+        import lgtmaybe.cli as cli_module
+
+        github = FakeGitHub()
+        monkeypatch.setattr(
+            cli_module,
+            "build_review_context",
+            lambda cfg, runtime: (github, _BoomEngine(), FakeProvider()),
+        )
+
+        with pytest.raises(click.ClickException):
+            cli_module.execute_review(_default_cfg(), RuntimeOptions(pr_url="x"), diagram=True)
+
+        assert len(github.diagrams) == 1
+        assert "fail" in github.posted[0][1].lower()
+
     def test_post_review_failure_clears_the_reviewed_watermark(self, monkeypatch):
         """A failed post must not leave the reviewed watermark stamped — the
         failure notice would carry it and the next incremental run would skip

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -12,6 +12,38 @@ _PROJECT_VERSION = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encod
 ]["version"]
 _ACTION_REF = f"MattJColes/lgtmaybe@v{_PROJECT_VERSION.split('.', maxsplit=1)[0]}"
 _STARTER_WORKFLOWS = _REPO_ROOT / "examples" / "workflows"
+# The events lgtmaybe itself fires: posting a comment (auto-diagram, /ask, the
+# summary) emits issue_comment, and posting inline findings emits
+# pull_request_review_comment.
+_SELF_TRIGGERED_EVENTS = {
+    "issue_comment",
+    "pull_request_review",
+    "pull_request_review_comment",
+}
+
+
+def _workflows() -> list[Path]:
+    return [_DOGFOOD_WORKFLOW, *sorted(_STARTER_WORKFLOWS.glob("*.yml"))]
+
+
+def _triggers(workflow: dict) -> set[str]:
+    # YAML 1.1 parses the `on:` key as the boolean True, so the trigger mapping
+    # lands under True, not "on".
+    on = workflow.get("on", workflow.get(True))
+    if isinstance(on, str):
+        return {on}
+    return set(on or ())
+
+
+def _concurrency_blocks(workflow: dict) -> list[tuple[str, dict]]:
+    """Every concurrency block in the file: workflow-level and each job's."""
+    blocks = []
+    if isinstance(workflow.get("concurrency"), dict):
+        blocks.append(("workflow", workflow["concurrency"]))
+    for name, job in (workflow.get("jobs") or {}).items():
+        if isinstance(job.get("concurrency"), dict):
+            blocks.append((f"jobs.{name}", job["concurrency"]))
+    return blocks
 
 
 def test_supplied_workflows_rely_on_the_auto_diagram_default() -> None:
@@ -50,9 +82,36 @@ def test_dogfood_concurrency_only_applies_to_eligible_review_job() -> None:
     assert "concurrency" not in workflow
     assert "if" in review_job
     assert review_job["concurrency"] == {
-        "group": "lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}",
+        "group": (
+            "lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}"
+            "-${{ github.event_name }}"
+        ),
         "cancel-in-progress": True,
     }
+
+
+def test_self_triggered_workflows_discriminate_concurrency_by_event() -> None:
+    # lgtmaybe posts comments during a review, and those comments fire the very
+    # events these workflows subscribe to. A concurrency group keyed only on the
+    # PR number puts the resulting run in the same group as the review, so
+    # cancel-in-progress kills the review that posted the comment. The job-level
+    # `if` guard cannot prevent this at workflow scope: the run joins the group
+    # when it is created, before any job condition is evaluated. Keying the group
+    # on the event name as well keeps a new push cancelling an in-flight review
+    # while making lgtmaybe's own comments land in a different group.
+    for path in _workflows():
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        self_triggered = _triggers(workflow) & _SELF_TRIGGERED_EVENTS
+        if not self_triggered:
+            continue
+        for scope, block in _concurrency_blocks(workflow):
+            if not block.get("cancel-in-progress"):
+                continue
+            assert "github.event_name" in str(block.get("group", "")), (
+                f"{path.name} subscribes to {sorted(self_triggered)} and cancels in progress, "
+                f"but its {scope} concurrency group is not discriminated by event: "
+                f"{block.get('group')!r} — lgtmaybe's own comments will cancel its reviews"
+            )
 
 
 def test_dogfood_workflow_uses_the_public_app_identity() -> None:


### PR DESCRIPTION
## The bug

Nine of the ten shipped `examples/workflows/*.yml` keyed their concurrency group on the PR number alone, with `cancel-in-progress: true`. All ten also subscribe to `issue_comment` and `pull_request_review_comment` — the events lgtmaybe fires when it posts its auto-diagram comment and its inline findings — and every one of those events resolves to the *same* key (`pull_request_target` and `pull_request_review_comment` supply `github.event.pull_request.number`; `issue_comment` falls through to `github.event.issue.number`).

So the action posted a comment mid-run, that comment created a second run in the same group, and `cancel-in-progress` killed the review that posted it. Reproduced downstream on Akesios-AI/akesios-platform #1255, #1256 and #1258 — no review posted on any of the three.

The job-level `author_association` guard is not the protection. At workflow scope the run joins the group when it is created, before any job condition is evaluated; the run cancels its predecessor and *then* skips.

## What changed

**1. Event-discriminated concurrency group** — the nine affected examples, plus `.github/workflows/lgtmaybe.yml` (which keeps its job-level placement, so the two mitigations are independent):

```yaml
group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
```

A comment above each block explains why the event key is there, so it doesn't get simplified back out. Intent preserved: two pushes are both `pull_request_target`, so a new push still cancels an in-flight review. What is given up is *cross-event* cancellation — a trusted `/review` comment no longer cancels an in-flight push review.

`review-self-managed-github-app.yml` declares no `concurrency` block at all and is unchanged. No docs needed changing: the workflow snippets in `README.md`, `docs/how-to/use-as-github-action.md`, `docs/llms-full.txt` and the provider how-tos carry no `concurrency` block either (the `max_concurrency` hits in docs are the unrelated config key).

**2. Comments post after the review** — `execute_review` prefetched the PR context, posted the description/diagram, and *then* ran the review, so the diagram comment appeared before "review starting" in the logs. The prefetch stays where it is (the review still reuses it — one `get_pr_context` call); only the posting moved, into a `finally` so a failed review still gets its extras exactly as before. Deferring makes a mis-configured consumer's cancellation harmless instead of fatal.

Inline findings self-trigger the same way (`pull_request_review_comment`), but they *are* the deliverable, so they can't move. Instead the `pr_labels` and `fail_on` writes moved above `post_review`, making the review post the last GitHub write of the run — nothing follows that a cancellation could lose. `mark_reviewed` stays before it (the watermark is stamped into the body by `post_review`). No other engine behaviour changed.

**3. Regression guard** — `tests/test_workflow_examples.py`: any first-party workflow subscribing to a self-triggered event (`issue_comment`, `pull_request_review`, `pull_request_review_comment`) must have `github.event_name` in every `cancel-in-progress` group it declares, workflow-level or per job. Written red first — it failed on all nine examples and the dogfood workflow. Plus an ordering test in `tests/cli/test_action.py` (`["review", "describe", "diagram"]`) and one asserting the extras still post when the review fails.

## Verified vs assumed

Verified against this repo's own Actions history:

- **The self-trigger lands mid-review.** Run 288 ran 10:26:15→10:28:39 (26 Jul); run 289 — `issue_comment`, actor `lgtmaybe[bot]` — was created at 10:27:05, inside that window. Same shape twice more.
- **Cancellation latency matches the downstream report.** Across four cancelled runs, `updated_at` lands 16–18 s after the canceller's `created_at`. The #1256 signature (comment run created 10:52:40, review cancelled 10:52:53) is the same mechanism.
- **The guard only helps at job scope.** Run 231 survived bot run 233 for 7½ minutes under this repo's job-scoped group, then died 18 s after run 236 — an eligible `issue_comment` — entered the group.
- **Blast radius is App/PAT consumers.** 39 of 39 self-triggered runs are actored by `lgtmaybe[bot]`, none by `github-actions[bot]`, matching GitHub's suppression of triggers for `GITHUB_TOKEN`-authored events. `github_identity` defaults to `actions`, so the live exposure is the App-identity examples and any workflow a consumer adds `github_identity`/`app_id` to. All nine were fixed regardless.

Assumed, not verified: GitHub's own documentation of *when* a workflow-scope group is joined (`docs.github.com` returns 403 from this sandbox — every observation above is consistent with it and none contradicts it), and the downstream PR timings, which came from the task description.

## Consequences worth knowing

- The diagram now appears after the review on a freshly opened PR rather than ~2 min before it. It's contextual colour next to the review, not the deliverable — judged an acceptable trade, not a silent one.
- `pr_labels` / the `fail_on` check run now land even if `post_review` subsequently fails. Both are derived from findings that were genuinely computed, and the failure notice still posts.

## Checks

`uv lock --check`, `ruff check`, `ruff format --check`, `mypy` (strict), `pytest` — 1490 passed. `tests/specs` green, `openspec validate --specs` green, `scripts/check_spec_drift.py` reports no drift. The `github-posting` living spec section behind anchor `github.workflow-concurrency` was updated to match.

GitHub's scheduler can't be simulated locally, so the runtime check is the next dogfood PR: the diagram's `issue_comment` run should sit in a different group while the review completes, and a second push should still cancel the first review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SorXTg2UZddYo5dBFgrjjT)_