### PR TITLE
fix(providers): fail a blown wall clock once, and pin the documented timeouts

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -63,10 +63,30 @@ jobs:
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7 # base repo only — for action.yml + .lgtmaybe.yml config
+      # Dogfood the code in this repo, not the last release. `uses: ./` only ever
+      # ran action.yml from the checkout — the container itself came from the
+      # floating `ghcr.io/mattjcoles/lgtmaybe:v1` tag, so every review ran the
+      # previously published image. That gap is how a fix could sit on main for
+      # days while the reviews it was meant to change kept running the old code
+      # (and how a review's timeout could contradict the action.yml right next to
+      # it). Building here closes it.
+      #
+      # This builds the BASE checkout — `pull_request_target` deliberately never
+      # checks out PR code — so it dogfoods main, not the PR head. That is the
+      # trade: current trusted code instead of a stale release, without ever
+      # executing a contributor's diff.
+      - name: Build the reviewer image from this checkout
+        run: docker build --tag lgtmaybe:dogfood .
       - uses: ./
         with:
+          image: lgtmaybe:dogfood
           provider: openrouter
-          model: openai/gpt-5.6-terra-pro
+          # deepseek-v4-pro is cheap enough to run on every PR, which is what a
+          # per-PR dogfood needs: a pricier model exhausts the key's monthly
+          # limit, and OpenRouter then rejects each call with a 402 ("requires
+          # more credits, or fewer max_tokens") — every lens fails and the review
+          # posts nothing.
+          model: deepseek/deepseek-v4-pro
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}
           github_identity: lgtmaybe

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -173,7 +173,8 @@ The provider wrapper (`LiteLLMProvider`) and the engine cooperate so a flaky
 network recovers but a dead-end failure surfaces fast:
 
 - **Retries are classified, not blanket.** Transient failures — capacity rate
-  limits (`429 rate_limit_exceeded`), timeouts, connection errors (e.g. an
+  limits (`429 rate_limit_exceeded`), the provider's own connect/read timeouts,
+  connection errors (e.g. an
   ollama server still warming up), 5xx — are retried with **exponential backoff
   and jitter** (up to four attempts). **Permanent** failures are *not* retried:
   bad credentials (`AuthenticationError`), malformed/unsupported requests
@@ -183,6 +184,15 @@ network recovers but a dead-end failure surfaces fast:
   quota error can never succeed; stacked across every lens it only turns an
   instant "out of credit" into many minutes of wasted runner time, so lgtmaybe
   raises it immediately. An optional `fallback_model` is still tried once.
+
+- **A blown wall clock is permanent too.** When a call outlives lgtmaybe's own
+  per-request timeout (below), the retry would re-send the identical messages to
+  the identical model against the identical budget — it can only fail the same
+  way and cost another full timeout doing it. So the wall timeout is raised after
+  one attempt, and the failure reports how many attempts it burned (the count
+  rides home on failures as well as successes, so a budget-burning call never
+  reads as one that was never retried). The `fallback_model` — a genuinely
+  different request — still gets its turn, with a fresh budget.
 
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -194,6 +194,17 @@ network recovers but a dead-end failure surfaces fast:
   reads as one that was never retried). The `fallback_model` — a genuinely
   different request — still gets its turn, with a fresh budget.
 
+- **Retried smaller, not repeated.** A wall timeout says something about the
+  *payload*, not the provider, and the payload is the one thing the engine can
+  change. So the batch is split and its pieces reviewed instead — halved by file,
+  or by hunk when the batch is a single file — each piece with its own fresh
+  budget. That keeps a slow lens from discarding the whole batch's review, and it
+  is the only retry a blown budget can benefit from. Bounded to **one** level: a
+  piece that times out again just fails, so a model that cannot answer at any
+  size can't cascade through the review budget. The summary says when a batch had
+  to be shrunk — a silent split would hide that every run is at the edge of what
+  the model finishes in time.
+
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers
   — lgtmaybe owns the retry policy in one place.

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -200,7 +200,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, connection blips, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) and a call that blows this whole timeout fail fast — re-sending the identical request against the identical budget can only burn it twice |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -539,7 +539,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `fallback_model` | — | Model to retry with if the primary model fails |
 | `api_key` | — | API key for key-based providers (leave empty for bedrock/vertex/ollama and keyless azure) |
 | `api_base` | — | Resource endpoint for azure (`https://<resource>.openai.azure.com`), or a custom base URL for other providers |
-| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, timeouts, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) fail fast |
+| `timeout` | provider default (ollama/openai-compatible/openrouter 1800s, cloud 600s) | Enforced wall-clock timeout for each model call. Transient failures (capacity 429s, connection blips, 5xx) are retried with exponential backoff; permanent ones (bad key, quota/billing 429, unknown model) and a call that blows this whole timeout fail fast — re-sending the identical request against the identical budget can only burn it twice |
 | `temperature` | `0.0` | Sampling temperature (0.0 = deterministic) |
 | `num_ctx` | `32768` | Ollama context window (ollama only; ignored for hosted providers) |
 | `max_input_tokens` | `100000` | Token budget per model call before the diff is split into batches (any provider) |
@@ -4861,7 +4861,8 @@ The provider wrapper (`LiteLLMProvider`) and the engine cooperate so a flaky
 network recovers but a dead-end failure surfaces fast:
 
 - **Retries are classified, not blanket.** Transient failures — capacity rate
-  limits (`429 rate_limit_exceeded`), timeouts, connection errors (e.g. an
+  limits (`429 rate_limit_exceeded`), the provider's own connect/read timeouts,
+  connection errors (e.g. an
   ollama server still warming up), 5xx — are retried with **exponential backoff
   and jitter** (up to four attempts). **Permanent** failures are *not* retried:
   bad credentials (`AuthenticationError`), malformed/unsupported requests
@@ -4871,6 +4872,15 @@ network recovers but a dead-end failure surfaces fast:
   quota error can never succeed; stacked across every lens it only turns an
   instant "out of credit" into many minutes of wasted runner time, so lgtmaybe
   raises it immediately. An optional `fallback_model` is still tried once.
+
+- **A blown wall clock is permanent too.** When a call outlives lgtmaybe's own
+  per-request timeout (below), the retry would re-send the identical messages to
+  the identical model against the identical budget — it can only fail the same
+  way and cost another full timeout doing it. So the wall timeout is raised after
+  one attempt, and the failure reports how many attempts it burned (the count
+  rides home on failures as well as successes, so a budget-burning call never
+  reads as one that was never retried). The `fallback_model` — a genuinely
+  different request — still gets its turn, with a fresh budget.
 
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4882,6 +4882,17 @@ network recovers but a dead-end failure surfaces fast:
   reads as one that was never retried). The `fallback_model` — a genuinely
   different request — still gets its turn, with a fresh budget.
 
+- **Retried smaller, not repeated.** A wall timeout says something about the
+  *payload*, not the provider, and the payload is the one thing the engine can
+  change. So the batch is split and its pieces reviewed instead — halved by file,
+  or by hunk when the batch is a single file — each piece with its own fresh
+  budget. That keeps a slow lens from discarding the whole batch's review, and it
+  is the only retry a blown budget can benefit from. Bounded to **one** level: a
+  piece that times out again just fails, so a model that cannot answer at any
+  size can't cascade through the review budget. The summary says when a batch had
+  to be shrunk — a silent split would hide that every run is at the edge of what
+  the model finishes in time.
+
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers
   — lgtmaybe owns the retry policy in one place.

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -69,8 +69,14 @@ on `ProviderResult`.
 #### Scenario: provider SDK ignores its timeout
 - **WHEN** the underlying completion call remains blocked past the configured
   timeout
-- **THEN** the adapter raises a timeout error reporting the measured wait, and the
-  existing bounded retry policy decides whether to retry
+- **THEN** the adapter raises a timeout error reporting the measured wait, and does
+  not retry it — an identical request against an identical budget can only fail the
+  same way — while a configured fallback model is still tried
+
+#### Scenario: a failed call reports what it cost
+- **WHEN** a completion fails after exhausting its retries
+- **THEN** the raised error carries the attempt count, so instrumentation
+  distinguishes a budget-burning failure from a first-try one
 
 #### Scenario: the call completes just past the deadline
 - **WHEN** the completion finishes within the platform timer's granularity after
@@ -98,3 +104,9 @@ model ids.
 #### Scenario: openrouter gets the generous default
 - **WHEN** `timeout` is unset and the provider is openrouter
 - **THEN** the generous (long) default applies, not the cloud one
+
+#### Scenario: the documented default and the resolved one disagree
+- **WHEN** a provider's resolved default stops matching the seconds the Action
+  input and the Action how-to advertise
+- **THEN** the test suite fails, because a silently reclassified provider leaves
+  every timeout floor green while breaking the promise a user read

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -48,6 +48,16 @@ engine.recursive-walk:
       has: { field: name, regex: '^batch_files$' }
     files: [src/lgtmaybe/engine/**/*.py]
 
+engine.timeout-split:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_review_split$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_split_batch$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+
 engine.context-expansion:
   - rule:
       kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -105,6 +105,30 @@ call's context stays small. Files within budget are reviewed whole.
 - **WHEN** a file's patch alone is over `max_input_tokens` and `recursive` is on
 - **THEN** each of its hunks is reviewed as its own mini-diff
 
+### Requirement: A timed-out batch is retried smaller, never repeated
+
+A lens call that exhausts its whole per-request budget SHALL be retried on
+smaller pieces of the same batch rather than re-sent unchanged, bounded to one
+split level, with the shrink disclosed in the summary.
+<!-- anchor: engine.timeout-split -->
+
+#### Scenario: a multi-file batch times out
+- **WHEN** a lens call on a batch of several files exceeds its wall-clock budget
+- **THEN** the batch is halved by file and each half reviewed in its own call, and
+  the summary reports that a batch was shrunk
+
+#### Scenario: a single-file batch times out
+- **WHEN** the timed-out batch holds one file
+- **THEN** its hunks become the pieces, so an oversized lone file still shrinks
+
+#### Scenario: a piece times out as well
+- **WHEN** a piece of an already-split batch also exceeds its budget
+- **THEN** it fails as an ordinary failed call — the split does not recurse
+
+#### Scenario: the failure is not a timeout
+- **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)
+- **THEN** no split happens, because nothing suggests the payload was the problem
+
 ### Requirement: Context expansion is asymmetric and bounded
 
 Hunks SHALL be padded with surrounding file content, budget-scaled and capped

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -20,6 +20,7 @@ from collections import Counter
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import replace
+from importlib import metadata
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,19 @@ from lgtmaybe.providers.factory import (
 _log = get_logger(__name__)
 
 _PR_URL_RE = re.compile(r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)")
+
+
+def package_version() -> str:
+    """The installed lgtmaybe version, or ``"unknown"`` when it can't be read.
+
+    Reading it is best-effort by design: a source checkout that was never
+    installed has no distribution metadata, and a missing version must never be
+    the reason a review fails.
+    """
+    try:
+        return metadata.version("lgtmaybe")
+    except Exception:
+        return "unknown"
 
 
 def _should_auto_post(enabled: bool, event_action: str) -> bool:
@@ -190,12 +204,19 @@ def build_provider_engine(
     # .lgtmaybe.yml and a 60s built-in default leave identical evidence — which
     # is exactly the ambiguity that makes "why is this timing out?" unanswerable
     # from a log. `source` is what separates them.
+    #
+    # The version is here for the same reason. The Action's `image` input pins a
+    # FLOATING tag, so the action.yml a user reads and the code that runs are
+    # versioned independently: a budget that looks impossible against the
+    # documented default is usually an older image, and the only way to tell from
+    # a log is for the run to name its own build.
     effective_timeout = (
         cfg.timeout if cfg.timeout is not None else default_timeout_for(cfg.provider)
     )
     _log.info(
         "per-call timeout resolved",
         extra={
+            "lgtmaybe_version": package_version(),
             "provider": cfg.provider.value,
             "timeout_s": effective_timeout,
             "timeout_source": "configured" if cfg.timeout is not None else "provider default",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -7,6 +7,7 @@ in the foundation step: change them only by consensus, never to suit one track.
 
 from __future__ import annotations
 
+from contextlib import suppress
 from enum import StrEnum
 from typing import Literal
 
@@ -452,6 +453,34 @@ class ProviderResult(_Strict):
     # Feeds the timing instrumentation so a call that burned its retry budget is
     # distinguishable from one that was merely slow.
     attempts: int = Field(default=1, ge=1)
+
+
+# A FAILED call has no ProviderResult to carry `attempts` home on, so the adapter
+# stamps the count onto the exception instead and the instrumentation reads it
+# back. Without this a call that burned its whole retry budget was recorded as
+# `attempts=0` — indistinguishable from one that never retried at all, which is
+# exactly the wrong impression when the failure is a timeout.
+_ATTEMPTS_ATTR = "lgtmaybe_attempts"
+
+
+def stamp_attempts(exc: BaseException, attempts: int) -> None:
+    """Record on *exc* how many completion attempts the failed call cost.
+
+    Best effort: an exception type that refuses attributes (``__slots__``) is not
+    worth failing a review over — it just reports the attempts as unknown.
+    """
+    with suppress(Exception):
+        setattr(exc, _ATTEMPTS_ATTR, attempts)
+
+
+def attempts_of(exc: BaseException) -> int:
+    """Attempts burned by the call that raised *exc*; 0 when unknown.
+
+    0 means the failure never reached the adapter's retry loop (or the exception
+    could not be stamped) — not "was not retried".
+    """
+    value = getattr(exc, _ATTEMPTS_ATTR, 0)
+    return value if isinstance(value, int) and value > 0 else 0
 
 
 class PRContext(_Strict):

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -17,6 +17,17 @@ from .models import PRContext, ProviderResult, ReviewConfig, ReviewFinding
 Message = dict[str, str]
 
 
+class ProviderWallTimeout(TimeoutError):
+    """Part of the provider contract: the call outlived its whole timeout budget.
+
+    Defined here, not in the adapter, because the engine reacts to it — a payload
+    the model could not finish in its budget is retried *smaller*, never repeated
+    unchanged. Distinct from a backend's transport timeout (a connect/read blip),
+    which stays an ordinary retryable error. A ``TimeoutError`` subclass, so
+    callers matching on that keep working.
+    """
+
+
 class ProviderClient(ABC):
     """Port: an LLM backend that returns a normalised completion."""
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -24,6 +24,7 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     ReviewPreset,
     ReviewResult,
+    attempts_of,
 )
 from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
 from lgtmaybe.github import is_reviewable
@@ -710,9 +711,10 @@ class LLMReviewEngine(ReviewEngine):
                 label=lens.id,
                 batch=batch_num,
                 elapsed=time.perf_counter() - started,
-                # The exception path carries no attempt count — 0 means unknown
-                # (the adapter may have burned its whole retry budget in here).
-                attempts=0,
+                # What the adapter stamped on the exception: a failure that burned
+                # its retry budget must not read as one that was never retried.
+                # 0 only when the failure never reached the retry loop.
+                attempts=attempts_of(exc),
                 input_tokens=0,
                 output_tokens=0,
                 cache_read_tokens=0,

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -9,6 +9,7 @@ Pipeline: redact → compress/batch → (per batch) fan out one call per review
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
@@ -26,7 +27,7 @@ from lgtmaybe.core.models import (
     ReviewResult,
     attempts_of,
 )
-from lgtmaybe.core.ports import Message, ProviderClient, ReviewEngine
+from lgtmaybe.core.ports import Message, ProviderClient, ProviderWallTimeout, ReviewEngine
 from lgtmaybe.github import is_reviewable
 
 from .astgrep import SymbolResolver
@@ -36,6 +37,7 @@ from .compress import (
     context_lines_for_budget,
     count_tokens,
     expand_hunks,
+    split_patch_into_hunks,
     trailing_context_lines,
 )
 from .injection import wrap_diff, wrap_hints, wrap_intent
@@ -215,6 +217,31 @@ _LensOutcome = tuple[list[ReviewFinding], str | None]
 _ReviewTask = partial[_LensOutcome]
 
 
+def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
+    """Split a timed-out batch into smaller review units.
+
+    Multi-file: halve the file list — the coarsest cut that halves the payload,
+    and the one that keeps each file's patch intact. Single file: fall back to its
+    hunks, the same unit the recursive walk uses, so an oversized lone file still
+    shrinks. Returns fewer than two pieces when there is nothing smaller to try
+    (an empty batch, or one file with a single hunk).
+    """
+    if len(batch) > 1:
+        middle = len(batch) // 2
+        return [batch[:middle], batch[middle:]]
+    if not batch:
+        return []
+    path, patch = batch[0]
+    hunks = split_patch_into_hunks(patch)
+    if len(hunks) < 2:
+        return []
+    middle = len(hunks) // 2
+    return [
+        [(path, hunk) for hunk in hunks[:middle]],
+        [(path, hunk) for hunk in hunks[middle:]],
+    ]
+
+
 class ReviewIncompleteError(Exception):
     """Every review call failed (timeout or unparseable output) — no usable result.
 
@@ -253,6 +280,10 @@ class LLMReviewEngine(ReviewEngine):
         deadline_at = (
             time.perf_counter() + cfg.max_review_seconds if cfg.max_review_seconds else None
         )
+        # Batches a wall-clock timeout forced us to review in smaller pieces.
+        # Per-review state (reset here, not in __init__, so a reused engine starts
+        # clean); a set's add is atomic, which is all the fan-out threads need.
+        self._split_batches: set[int] = set()
 
         # 1. Redact secrets from the diff before it leaves this process.
         with profiler.stage("redact"):
@@ -413,6 +444,7 @@ class LLMReviewEngine(ReviewEngine):
                     cfg.language,
                     deadline_at,
                     lens,
+                    batch,
                 )
                 for lens in lenses
             ]
@@ -543,6 +575,17 @@ class LLMReviewEngine(ReviewEngine):
                 f"⚠️ {failed_calls} of {total_calls} review calls failed "
                 f"({detail}); results may be incomplete."
             )
+        # A batch that had to be shrunk is a standing signal that the diff is at
+        # the edge of what this model finishes in its budget — say it, or the next
+        # run's timeout looks like the first.
+        if self._split_batches:
+            count = len(self._split_batches)
+            plural = "es" if count != 1 else ""
+            notices.append(
+                f"⏱️ {count} batch{plural} timed out and {'were' if count != 1 else 'was'} "
+                "reviewed in smaller pieces instead. Consider a lower `max_input_tokens` "
+                "or a faster model."
+            )
         if reflection_skipped_by_deadline:
             notices.append(
                 f"⚠️ Review deadline ({cfg.max_review_seconds}s) reached — the "
@@ -636,6 +679,7 @@ class LLMReviewEngine(ReviewEngine):
         language: str | None,
         deadline_at: float | None,
         lens: _Lens,
+        batch: list[tuple[str, str]] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
         """Run one focused review call for a single lens (built-in or user-defined).
 
@@ -643,6 +687,12 @@ class LLMReviewEngine(ReviewEngine):
         reason — the provider exception (e.g. a 429 quota error) or unparseable
         output — that the engine surfaces so a failure names its real cause instead
         of a generic "timeout". A failing lens never aborts the others.
+
+        ``batch`` is the file patches ``wrapped`` was built from. Supplying it opts
+        this call into the one retry a wall-clock timeout can actually benefit
+        from: the payload is split and the pieces reviewed (see
+        :meth:`_review_split`). None means "already a piece" — no further
+        splitting.
 
         ``split_prompt`` selects the message shape. True (``prompt_cache`` on —
         the default): shared system preamble, then the shared prefix (hints +
@@ -659,6 +709,23 @@ class LLMReviewEngine(ReviewEngine):
         if deadline_at is not None and time.perf_counter() >= deadline_at:
             _log.warning("review deadline reached — skipping call", extra={"lens": lens.id})
             return [], "review deadline (max_review_seconds) reached — call skipped"
+        on_wall_timeout = (
+            None
+            if batch is None
+            else partial(
+                self._review_split,
+                batch=batch,
+                intent_block=intent_block,
+                hint_block=hint_block,
+                model=model,
+                response_format=response_format,
+                batch_num=batch_num,
+                split_prompt=split_prompt,
+                language=language,
+                deadline_at=deadline_at,
+                lens=lens,
+            )
+        )
         if split_prompt:
             prefix = wrapped if hint_block is None else f"{hint_block}\n\n{wrapped}"
             suffix = lens.user_block
@@ -672,7 +739,9 @@ class LLMReviewEngine(ReviewEngine):
                 {"role": "user", "content": prefix},
                 {"role": "user", "content": suffix},
             ]
-            return self._complete_lens(messages, model, response_format, batch_num, lens)
+            return self._complete_lens(
+                messages, model, response_format, batch_num, lens, on_wall_timeout
+            )
 
         user_content = wrapped
         if lens.carries_intent and intent_block is not None:
@@ -687,7 +756,71 @@ class LLMReviewEngine(ReviewEngine):
             {"role": "system", "content": lens.system_prompt},
             {"role": "user", "content": user_content},
         ]
-        return self._complete_lens(messages, model, response_format, batch_num, lens)
+        return self._complete_lens(
+            messages, model, response_format, batch_num, lens, on_wall_timeout
+        )
+
+    def _review_split(
+        self,
+        reason: str,
+        *,
+        batch: list[tuple[str, str]],
+        intent_block: str | None,
+        hint_block: str | None,
+        model: str,
+        response_format: type[ReviewResult] | None,
+        batch_num: int,
+        split_prompt: bool,
+        language: str | None,
+        deadline_at: float | None,
+        lens: _Lens,
+    ) -> _LensOutcome:
+        """Re-review a timed-out batch as smaller pieces, one call each.
+
+        The only retry a wall-clock timeout can benefit from. Repeating the same
+        request is pointless — same payload, same model, same budget — but the
+        payload is the one thing we can change, and a smaller one both fits the
+        budget better and gets a fresh one. Failing the lens outright instead
+        would discard the whole batch's review over a size problem.
+
+        Bounded on purpose: exactly ONE level (the pieces are reviewed with
+        ``batch=None``, so a piece that times out again just fails), and the
+        pieces are re-wrapped from the same redacted patches, so nothing
+        unredacted or unwrapped reaches the model. Returns the original *reason*
+        unchanged when the batch cannot be split — a single-hunk file has no
+        smaller unit to fall back to.
+        """
+        pieces = _split_batch(batch)
+        if len(pieces) < 2:
+            return [], reason
+        _log.warning(
+            "review call timed out — retrying on smaller pieces",
+            extra={"lens": lens.id, "batch": batch_num, "pieces": len(pieces)},
+        )
+        findings: list[ReviewFinding] = []
+        errors: list[str] = []
+        for piece in pieces:
+            piece_findings, piece_error = self._review_lens(
+                wrap_diff("\n".join(patch for _, patch in piece)),
+                intent_block,
+                hint_block,
+                model,
+                response_format,
+                batch_num,
+                split_prompt,
+                language,
+                deadline_at,
+                lens,
+            )
+            findings.extend(piece_findings)
+            if piece_error is not None:
+                errors.append(piece_error)
+        if len(errors) == len(pieces):
+            # Every piece failed too: report the split's own failure, not the
+            # original timeout, so the notice names what actually went wrong last.
+            return findings, errors[-1]
+        self._split_batches.add(batch_num)
+        return findings, None
 
     def _complete_lens(
         self,
@@ -696,8 +829,14 @@ class LLMReviewEngine(ReviewEngine):
         response_format: type[ReviewResult] | None,
         batch_num: int,
         lens: _Lens,
+        on_wall_timeout: Callable[[str], _LensOutcome] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
-        """The provider call + parse + stamp shared by both prompt shapes."""
+        """The provider call + parse + stamp shared by both prompt shapes.
+
+        ``on_wall_timeout`` handles the one failure that says something about the
+        *payload* rather than the provider: the call outlived its entire budget.
+        It is given the failure reason and returns the outcome to use instead.
+        """
         opts = {"response_format": response_format} if response_format is not None else {}
         # Heartbeat: log the call going out and coming back so the Action shows
         # steady per-lens progress while the model runs, not a silent gap.
@@ -726,6 +865,8 @@ class LLMReviewEngine(ReviewEngine):
                 extra={"lens": lens.id, "reason": reason},
                 exc_info=True,
             )
+            if isinstance(exc, ProviderWallTimeout) and on_wall_timeout is not None:
+                return on_wall_timeout(reason)
             return [], reason
         profiler.record_call(
             label=lens.id,

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from lgtmaybe.core.logging import get_logger
-from lgtmaybe.core.models import ProviderResult
+from lgtmaybe.core.models import ProviderResult, attempts_of
 from lgtmaybe.core.ports import Message, ProviderClient
 
 _log = get_logger(__name__)
@@ -185,7 +185,7 @@ def timed_complete(
             label=label,
             batch=batch,
             elapsed=time.perf_counter() - started,
-            attempts=0,  # unknown — the exception path carries no attempt count
+            attempts=attempts_of(exc),  # 0 only if it never reached the retry loop
             input_tokens=0,
             output_tokens=0,
             cache_read_tokens=0,

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
@@ -260,8 +261,17 @@ class LiteLLMProvider(ProviderClient):
         # to mutate.
         messages = self._with_cache_control(messages, model)
         # Counted here (not read from tenacity's statistics) so the number lands
-        # on the result even when the mocked/fake retry layer changes shape.
+        # on the result even when the mocked/fake retry layer changes shape — and
+        # counted per REQUEST, not per tenacity attempt: one attempt can issue a
+        # second request (the empty-structured-output and rejected-temperature
+        # re-sends below), and a count that missed those would understate what the
+        # call actually cost, which is the whole point of reporting it.
         attempts = 0
+
+        def count_request() -> None:
+            nonlocal attempts
+            attempts += 1
+
         # Attempts share one deadline derived from the per-request timeout (the
         # fallback model, when configured, gets its own fresh budget — it is a
         # separate recovery path, not another attempt).
@@ -275,13 +285,11 @@ class LiteLLMProvider(ProviderClient):
             reraise=True,
         )
         def _call() -> ProviderResult:
-            nonlocal attempts
-            attempts += 1
             # A prior call already proved this model's JSON-schema mode returns
             # empty, so don't pay the wasted round-trip again — drop it up front.
             if self._skip_response_format:
                 kwargs.pop("response_format", None)
-            result = self._raw_completion(model, messages, kwargs)
+            result = self._raw_completion(model, messages, kwargs, count_request)
             # Some grammar-constrained backends (notably LM Studio fronting a
             # "thinking" model like qwen3.x) return EMPTY content under a
             # response_format JSON schema — the schema decoder yields nothing. The
@@ -291,7 +299,7 @@ class LiteLLMProvider(ProviderClient):
             if not result.text.strip() and kwargs.get("response_format") is not None:
                 self._skip_response_format = True
                 kwargs.pop("response_format")
-                result = self._raw_completion(model, messages, kwargs)
+                result = self._raw_completion(model, messages, kwargs, count_request)
             return result
 
         try:
@@ -305,9 +313,19 @@ class LiteLLMProvider(ProviderClient):
         return result.model_copy(update={"attempts": attempts})
 
     def _raw_completion(
-        self, model: str, messages: list[Message], kwargs: dict[str, Any]
+        self,
+        model: str,
+        messages: list[Message],
+        kwargs: dict[str, Any],
+        count_request: Callable[[], None] = lambda: None,
     ) -> ProviderResult:
-        """One litellm call, with the temperature-value-rejection fallback applied."""
+        """One litellm call, with the temperature-value-rejection fallback applied.
+
+        ``count_request`` is called immediately before each request actually goes
+        out, so the reported attempt count matches the number of model calls this
+        made — including the re-send below, which is a second billed request.
+        """
+        count_request()
         try:
             response = _completion_with_wall_timeout(model, messages, kwargs)
         except Exception as exc:
@@ -316,6 +334,7 @@ class LiteLLMProvider(ProviderClient):
             # Drop temperature for this and every subsequent retry, letting the
             # model use its only supported value (its default).
             kwargs.pop("temperature")
+            count_request()
             response = _completion_with_wall_timeout(model, messages, kwargs)
         return self._map_response(response, model)
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -35,7 +35,7 @@ from tenacity import (
 )
 
 from lgtmaybe.core.logging import get_logger
-from lgtmaybe.core.models import ProviderResult
+from lgtmaybe.core.models import ProviderResult, stamp_attempts
 from lgtmaybe.core.ports import Message, ProviderClient
 
 _log = get_logger(__name__)
@@ -136,6 +136,16 @@ _EXPIRED_CREDENTIAL_MARKERS = (
 )
 
 
+class ProviderWallTimeout(TimeoutError):
+    """Our own wall-clock bound fired: the request outlived its whole timeout.
+
+    Distinct from litellm's transport ``Timeout`` (a connect/read blip, worth
+    retrying) because re-sending THIS request cannot help — same messages, same
+    model, same wall — so it is treated as permanent (see :func:`_is_permanent`).
+    A ``TimeoutError`` subclass, so callers matching on that keep working.
+    """
+
+
 def _is_quota_rate_limit(exc: BaseException) -> bool:
     """True for a quota/billing 429 (permanent), False for a capacity 429."""
     msg = str(exc).lower()
@@ -151,6 +161,14 @@ def _is_expired_credential(exc: BaseException) -> bool:
 def _is_permanent(exc: BaseException) -> bool:
     """True when retrying *exc* cannot plausibly succeed, so we should not."""
     if isinstance(exc, _PERMANENT_ERROR_TYPES):
+        return True
+    # A blown wall clock is not a blip: the retry re-sends the identical request
+    # against the identical budget, so attempts 2..N can only fail the same way
+    # and cost another full timeout each. On the generous slow-provider default
+    # that turned one stuck lens into an hour of runner time before the failure
+    # surfaced. One attempt, then say so — and let the fallback model (a genuinely
+    # different request) still have its turn.
+    if isinstance(exc, ProviderWallTimeout):
         return True
     if isinstance(exc, RateLimitError):
         return _is_quota_rate_limit(exc)
@@ -276,7 +294,14 @@ class LiteLLMProvider(ProviderClient):
                 result = self._raw_completion(model, messages, kwargs)
             return result
 
-        result = _call()
+        try:
+            result = _call()
+        except BaseException as exc:
+            # A failure has no ProviderResult to ride home on, so the count goes
+            # on the exception — else the instrumentation records a budget-burning
+            # failure as `attempts=0`, which reads as "never retried".
+            stamp_attempts(exc, attempts)
+            raise
         return result.model_copy(update={"attempts": attempts})
 
     def _raw_completion(
@@ -413,7 +438,8 @@ def _completion_with_wall_timeout(
 
     A call that *did* complete, even a hair past the deadline, is still honoured —
     discarding it would waste a response the provider already billed for and, worse,
-    resurface a permanent error (see ``_is_permanent``) as a retryable TimeoutError.
+    replace its real error (a quota 429, a bad key) with a bare timeout, hiding the
+    one thing that tells the user what to fix.
     """
     timeout = float(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
     future: Future[Any] = Future()
@@ -437,7 +463,7 @@ def _completion_with_wall_timeout(
             continue  # the wait resolved early — trust the clock, not the wakeup
     if future.done():
         return future.result()
-    raise TimeoutError(
+    raise ProviderWallTimeout(
         f"provider request exceeded {timeout:g}s (waited {time.monotonic() - start:.3f}s)"
     )
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -36,8 +36,8 @@ from tenacity import (
 )
 
 from lgtmaybe.core.logging import get_logger
-from lgtmaybe.core.models import ProviderResult, stamp_attempts
-from lgtmaybe.core.ports import Message, ProviderClient
+from lgtmaybe.core.models import ProviderResult, attempts_of, stamp_attempts
+from lgtmaybe.core.ports import Message, ProviderClient, ProviderWallTimeout
 
 _log = get_logger(__name__)
 
@@ -135,16 +135,6 @@ _EXPIRED_CREDENTIAL_MARKERS = (
     "expired credential",
     "the credential provided is expired",
 )
-
-
-class ProviderWallTimeout(TimeoutError):
-    """Our own wall-clock bound fired: the request outlived its whole timeout.
-
-    Distinct from litellm's transport ``Timeout`` (a connect/read blip, worth
-    retrying) because re-sending THIS request cannot help — same messages, same
-    model, same wall — so it is treated as permanent (see :func:`_is_permanent`).
-    A ``TimeoutError`` subclass, so callers matching on that keep working.
-    """
 
 
 def _is_quota_rate_limit(exc: BaseException) -> bool:
@@ -248,10 +238,19 @@ class LiteLLMProvider(ProviderClient):
         effective_model = self.model or model
         try:
             return self._complete_with_retry(messages, effective_model, **merged)
-        except Exception:
+        except Exception as exc:
             if self.fallback_model is None:
                 raise
-            return self._complete_with_retry(messages, self.fallback_model, **merged)
+            # The primary's requests were still issued and still billed, so they
+            # stay in the total: a fallback rescue that reported one request would
+            # hide the fact that the primary burned its budget first.
+            spent = attempts_of(exc)
+            try:
+                result = self._complete_with_retry(messages, self.fallback_model, **merged)
+            except BaseException as fallback_exc:
+                stamp_attempts(fallback_exc, spent + attempts_of(fallback_exc))
+                raise
+            return result.model_copy(update={"attempts": result.attempts + spent})
 
     def _complete_with_retry(
         self, messages: list[Message], model: str, **kwargs: Any

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -9,13 +9,19 @@ logged before the first call.
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
+from typing import NoReturn
 
 import pytest
 
 from lgtmaybe.cli import build_provider_engine
 from lgtmaybe.core.models import Provider, ReviewConfig
 from lgtmaybe.providers.factory import default_timeout_for
+
+
+def _raise(exc: Exception) -> NoReturn:
+    raise exc
 
 
 class _ListHandler(logging.Handler):
@@ -92,14 +98,22 @@ def test_the_running_build_is_named_alongside_the_budget(cli_logs, monkeypatch) 
     assert getattr(_timeout_record(cli_logs), "lgtmaybe_version", None) == "1.2.3"
 
 
-def test_an_unreadable_version_does_not_break_the_run(monkeypatch) -> None:
-    """A source checkout with no installed metadata still reviews."""
+@pytest.mark.parametrize(
+    "failure",
+    [
+        # The expected case: a source checkout that was never installed.
+        lambda: _raise(importlib.metadata.PackageNotFoundError("lgtmaybe")),
+        # And anything else the metadata read can throw — an unreadable or
+        # half-written dist-info surfaces as an OSError, and a broken version
+        # lookup must never be the reason a review fails.
+        lambda: _raise(OSError("dist-info is unreadable")),
+    ],
+    ids=["not-installed", "unreadable-metadata"],
+)
+def test_an_unreadable_version_does_not_break_the_run(monkeypatch, failure) -> None:
     import lgtmaybe.cli as cli_module
 
-    def boom(_name: str) -> str:
-        raise cli_module.metadata.PackageNotFoundError("lgtmaybe")
-
-    monkeypatch.setattr(cli_module.metadata, "version", boom)
+    monkeypatch.setattr(cli_module.metadata, "version", lambda _name: failure())
     assert cli_module.package_version() == "unknown"
 
 

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -74,15 +74,22 @@ def test_auto_timeout_is_logged_and_named_as_a_default(cli_logs) -> None:
     assert getattr(record, "timeout_source", None) == "provider default"
 
 
-def test_the_running_build_is_named_alongside_the_budget(cli_logs) -> None:
+def test_the_running_build_is_named_alongside_the_budget(cli_logs, monkeypatch) -> None:
     """The Action pins a floating image tag, so a budget that looks impossible
     against the documented default is usually an older build. The run has to say
-    which build it is, or the evidence can't be read at all."""
+    which build it is, or the evidence can't be read at all.
+
+    The version is stubbed rather than read from the environment: what matters is
+    that the resolved value reaches the log record, not that this test host happens
+    to have distribution metadata installed.
+    """
+    import lgtmaybe.cli as cli_module
+
+    monkeypatch.setattr(cli_module.metadata, "version", lambda _name: "1.2.3")
     cfg = ReviewConfig(provider=Provider.openrouter, model="m")
     build_provider_engine(cfg, _runtime())
 
-    version = getattr(_timeout_record(cli_logs), "lgtmaybe_version", None)
-    assert version and version != "unknown"
+    assert getattr(_timeout_record(cli_logs), "lgtmaybe_version", None) == "1.2.3"
 
 
 def test_an_unreadable_version_does_not_break_the_run(monkeypatch) -> None:

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -74,6 +74,28 @@ def test_auto_timeout_is_logged_and_named_as_a_default(cli_logs) -> None:
     assert getattr(record, "timeout_source", None) == "provider default"
 
 
+def test_the_running_build_is_named_alongside_the_budget(cli_logs) -> None:
+    """The Action pins a floating image tag, so a budget that looks impossible
+    against the documented default is usually an older build. The run has to say
+    which build it is, or the evidence can't be read at all."""
+    cfg = ReviewConfig(provider=Provider.openrouter, model="m")
+    build_provider_engine(cfg, _runtime())
+
+    version = getattr(_timeout_record(cli_logs), "lgtmaybe_version", None)
+    assert version and version != "unknown"
+
+
+def test_an_unreadable_version_does_not_break_the_run(monkeypatch) -> None:
+    """A source checkout with no installed metadata still reviews."""
+    import lgtmaybe.cli as cli_module
+
+    def boom(_name: str) -> str:
+        raise cli_module.metadata.PackageNotFoundError("lgtmaybe")
+
+    monkeypatch.setattr(cli_module.metadata, "version", boom)
+    assert cli_module.package_version() == "unknown"
+
+
 def test_the_two_sources_are_distinguishable_at_the_same_value(cli_logs) -> None:
     """The whole point: a configured 600 and a default 600 must not look alike."""
     cloud_default = default_timeout_for(Provider.openai)

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -12,6 +12,7 @@ from lgtmaybe.core.models import (
     ProviderResult,
     ReviewCategory,
     ReviewConfig,
+    stamp_attempts,
 )
 from lgtmaybe.engine import LLMReviewEngine
 from lgtmaybe.engine.profiling import Profiler, profiler, timed_complete
@@ -147,6 +148,22 @@ class TestTimedComplete:
         assert call.label == "triage"
         assert call.error == "RuntimeError"
 
+    def test_failure_records_the_attempts_the_adapter_burned(self) -> None:
+        """A stamped failure reports its real attempt count, not 0 — else a call
+        that spent its whole retry budget looks like it was never retried."""
+
+        class _BoomAfterRetries(FakeProvider):
+            def complete(self, messages, model, **opts):  # type: ignore[override]
+                exc = RuntimeError("nope")
+                stamp_attempts(exc, 3)
+                raise exc
+
+        with pytest.raises(RuntimeError):
+            timed_complete(
+                _BoomAfterRetries(), [{"role": "user", "content": "hi"}], model="m", label="triage"
+            )
+        assert profiler.calls[-1].attempts == 3
+
 
 class TestEnginePipelineTiming:
     def test_review_records_stages_and_per_lens_calls(self) -> None:
@@ -190,4 +207,26 @@ class TestEnginePipelineTiming:
             LLMReviewEngine(_OneBadLens()).review(_CTX, cfg)
         call = profiler.calls[-1]
         assert call.error is not None and "quota exhausted" in call.error
-        assert call.attempts == 0  # unknown on the exception path
+        assert call.attempts == 0  # unstamped: it never reached the adapter's retry loop
+
+    def test_failed_lens_call_reports_the_attempts_it_burned(self) -> None:
+        """The per-lens recorder reads the count the adapter stamped, so a
+        budget-burning timeout is distinguishable from a first-try failure."""
+
+        class _BurntBudget(FakeProvider):
+            def complete(self, messages, model, **opts):  # type: ignore[override]
+                exc = TimeoutError("provider request exceeded 1800s (waited 1800.001s)")
+                stamp_attempts(exc, 2)
+                raise exc
+
+        cfg = ReviewConfig(
+            provider=Provider.openrouter,
+            model="deepseek/deepseek-v4-pro",
+            categories=[ReviewCategory.security],
+            reflect=False,
+        )
+        import lgtmaybe.engine.engine as engine_mod
+
+        with pytest.raises(engine_mod.ReviewIncompleteError):
+            LLMReviewEngine(_BurntBudget()).review(_CTX, cfg)
+        assert profiler.calls[-1].attempts == 2

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -1,0 +1,211 @@
+"""A lens call that blows its wall clock is retried SMALLER, not repeated.
+
+Re-sending the identical oversized request against the identical budget cannot
+succeed — the adapter therefore fails a wall timeout after one attempt. But
+failing the lens outright throws away the whole batch's review, and the batch is
+exactly what was too big. So the engine splits it and reviews the pieces, each
+with its own fresh budget: the one retry that can actually work.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.core.ports import Message, ProviderWallTimeout
+from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine.engine import ReviewIncompleteError
+from tests.fakes import FakeProvider
+
+_TWO_FILE_DIFF = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,2 +1,3 @@
+ import os
++first_change = os.getcwd()
+ print(os.name)
+diff --git a/two.py b/two.py
+--- a/two.py
++++ b/two.py
+@@ -1,2 +1,3 @@
+ import sys
++second_change = sys.maxsize
+ print(sys.argv)
+"""
+
+_ONE_FILE_TWO_HUNKS = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,2 +1,3 @@
+ import os
++first_change = os.getcwd()
+ print(os.name)
+@@ -40,2 +41,3 @@
+ def later():
++    second_change = None
+     return None
+"""
+
+
+def _ctx(diff: str, files: list[str]) -> PRContext:
+    return PRContext(
+        diff=diff,
+        changed_files=files,
+        base_sha="b",
+        head_sha="h",
+        repo="o/r",
+        pr_number=1,
+    )
+
+
+def _cfg(**overrides: Any) -> ReviewConfig:
+    return ReviewConfig(
+        provider=Provider.openrouter,
+        model="deepseek/deepseek-v4-pro",
+        categories=[ReviewCategory.security],
+        reflect=False,
+        prompt_cache=False,
+        **overrides,
+    )
+
+
+def _finding_json(path: str, anchor: str) -> str:
+    return json.dumps(
+        {
+            "findings": [
+                {
+                    "path": path,
+                    "line": 2,
+                    "severity": "medium",
+                    "title": f"unchecked value in {path}",
+                    "body": "the new binding is never validated",
+                    "anchor": anchor,
+                    "failure_scenario": "A caller reads the new binding before it is set.",
+                }
+            ]
+        }
+    )
+
+
+class _TimeoutUntilSmaller(FakeProvider):
+    """Times out while both files are in one call; answers a single-file call.
+
+    Stands in for the real shape of the failure: the payload, not the provider,
+    is what could not finish inside the budget.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.diffs: list[str] = []
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        self.diffs.append(diff)
+        if "one.py" in diff and "two.py" in diff:
+            raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+        path = "one.py" if "one.py" in diff else "two.py"
+        anchor = "first_change = os.getcwd()" if path == "one.py" else "second_change = sys.maxsize"
+        return ProviderResult(text=_finding_json(path, anchor), input_tokens=5, output_tokens=5)
+
+
+def test_a_timed_out_batch_is_split_and_its_halves_reviewed() -> None:
+    provider = _TimeoutUntilSmaller()
+    findings, summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    # The oversized call, then one per half — never the same oversized payload twice.
+    assert len(provider.diffs) == 3
+    assert sum("one.py" in d and "two.py" in d for d in provider.diffs) == 1
+
+
+def test_the_split_is_reported_not_silent() -> None:
+    """A review that had to shrink its batches says so — a quiet split hides that
+    the model is being pushed past its budget on every run."""
+    _findings, summary = LLMReviewEngine(_TimeoutUntilSmaller()).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+    assert "timed out" in summary.lower()
+
+
+def test_a_single_file_batch_splits_by_hunk() -> None:
+    """One file can still be too big; its hunks are the next unit down."""
+
+    class _TimeoutUntilOneHunk(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            self.diffs.append(diff)
+            # Both of the file's changed lines in one payload = the whole file.
+            # (Counting `@@` would not work: every lens prompt carries a worked
+            # example with a real hunk header.)
+            if "os.getcwd" in diff and "second_change = None" in diff:
+                raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+            anchor = "first_change = os.getcwd()" if "os.getcwd" in diff else "second_change = None"
+            return ProviderResult(
+                text=_finding_json("one.py", anchor), input_tokens=5, output_tokens=5
+            )
+
+    provider = _TimeoutUntilOneHunk()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_ONE_FILE_TWO_HUNKS, ["one.py"]), _cfg()
+    )
+
+    # One finding per hunk, both anchored in the real file — nothing was lost by
+    # reviewing the file in two pieces.
+    assert [f.path for f in findings] == ["one.py", "one.py"]
+    assert all(f.anchored for f in findings)
+    assert len(provider.diffs) == 3  # the whole file, then each hunk
+
+
+def test_a_piece_that_times_out_again_is_not_split_further() -> None:
+    """One split level, then the failure stands: an unbounded cascade would spend
+    the whole review budget on a model that cannot answer at any size."""
+
+    class _AlwaysTimesOut(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+            raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+
+    provider = _AlwaysTimesOut()
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
+
+    assert len(provider.diffs) == 3  # the batch, then its two halves — and stop
+
+
+def test_an_ordinary_failure_is_not_split() -> None:
+    """Only a blown wall clock implies "too big"; a 429 or a bad key does not, and
+    splitting one would multiply the failing calls."""
+
+    class _Rejects(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+            raise RuntimeError("insufficient_quota")
+
+    provider = _Rejects()
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
+
+    assert len(provider.diffs) == 1

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -190,6 +190,15 @@ class TestRetry:
         """An error raised before the adapter ever counted an attempt stays 0."""
         assert attempts_of(RuntimeError("never reached the adapter")) == 0
 
+    def test_a_failing_fallback_reports_both_models_requests(self) -> None:
+        """Both legs' requests were billed, so a total failure counts both."""
+        with patch("litellm.completion", side_effect=RuntimeError("both models fail")):
+            provider = LiteLLMProvider(model="openrouter/slow", fallback_model="openrouter/quick")
+            with pytest.raises(RuntimeError) as caught:
+                provider.complete([{"role": "user", "content": "hi"}], "ignored")
+
+        assert attempts_of(caught.value) == 2 * _MAX_ATTEMPTS
+
     def test_a_re_send_inside_one_attempt_still_counts(self) -> None:
         """Every request that goes out counts, not every tenacity attempt.
 
@@ -229,12 +238,20 @@ class TestWallTimeoutIsNotRetried:
     """
 
     def test_the_wall_timeout_is_attempted_once(self) -> None:
+        # The request runs on a daemon thread the wall timeout abandons, so the
+        # counter is read only after that thread confirms it started — otherwise a
+        # loaded runner could time out before the worker was ever scheduled and
+        # the assertion would be about thread scheduling, not about retries.
         release = threading.Event()
+        started = threading.Event()
+        counted = threading.Lock()
         calls = 0
 
         def hangs(*args: Any, **kwargs: Any) -> Any:
             nonlocal calls
-            calls += 1
+            with counted:
+                calls += 1
+            started.set()
             release.wait(timeout=5)
             return _fake_response()
 
@@ -246,7 +263,9 @@ class TestWallTimeoutIsNotRetried:
         finally:
             release.set()
 
-        assert calls == 1
+        assert started.wait(timeout=5), "the one request never reached the provider"
+        with counted:
+            assert calls == 1
 
     def test_it_still_reads_as_a_timeout_error(self) -> None:
         """Callers (and the review's failure notice) keep seeing a TimeoutError."""
@@ -294,6 +313,10 @@ class TestWallTimeoutIsNotRetried:
 
         assert result.text == "fallback answered"
         assert seen == ["openrouter/slow", "openrouter/quick"]
+        # Two requests went out and both were billed, so both are in the total —
+        # a fallback rescue reported as one request would hide the primary's
+        # burnt budget entirely.
+        assert result.attempts == 2
 
 
 class TestTemperatureRejection:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -12,6 +12,7 @@ import httpx
 import litellm
 import pytest
 
+from lgtmaybe.core.models import attempts_of
 from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
 
@@ -72,9 +73,10 @@ class TestRetry:
         """A call that finished just past the deadline is honoured, not thrown away.
 
         Discarding it would waste a response the provider already billed for, and
-        (worse) surface a *permanent* error as a retryable TimeoutError. Driven with
-        a fake clock and an inline worker so it pins the behaviour deterministically
-        rather than racing a real deadline.
+        (worse) replace its real error — a quota 429, a bad key — with a bare
+        timeout that says nothing about what to fix. Driven with a fake clock and
+        an inline worker so it pins the behaviour deterministically rather than
+        racing a real deadline.
         """
         # start=0.0, then every check is past the 0.05s deadline.
         clock = iter([0.0] + [100.0] * 20)
@@ -100,9 +102,9 @@ class TestRetry:
         assert response.choices[0].message.content == "late but complete"
 
     def test_permanent_error_is_not_converted_into_a_retryable_timeout(self) -> None:
-        """A permanent failure must surface as itself. TimeoutError is retryable
-        (it is not in _PERMANENT_ERROR_TYPES), so masking one as a timeout would
-        turn fail-fast into a retry storm."""
+        """A permanent failure must surface as itself, not as a timeout: the review's
+        failure notice quotes the error, and "provider request exceeded 60s" tells
+        a user nothing about an invalid API key."""
         calls = 0
 
         def bad_auth(*args: Any, **kwargs: Any) -> Any:
@@ -154,6 +156,116 @@ class TestRetry:
             provider = LiteLLMProvider()
             with pytest.raises(RuntimeError):
                 provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+    def test_terminal_failure_carries_the_attempts_it_burned(self) -> None:
+        """A failed call must say how many attempts it cost.
+
+        The count only ever rode home on a successful ProviderResult, so a
+        three-attempt failure was recorded as ``attempts=0`` — reading as
+        "never retried" in the timing profile, while it had in fact burned the
+        whole retry budget.
+        """
+        with patch("litellm.completion", side_effect=RuntimeError("always fails")):
+            provider = LiteLLMProvider()
+            with pytest.raises(RuntimeError) as caught:
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert attempts_of(caught.value) == _MAX_ATTEMPTS
+
+    def test_fail_fast_error_reports_its_single_attempt(self) -> None:
+        """A permanent error is tried once, and says so."""
+        with patch(
+            "litellm.completion",
+            side_effect=litellm.AuthenticationError(
+                message="invalid api key", model="gpt-4o", llm_provider="openai"
+            ),
+        ):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.AuthenticationError) as caught:
+                provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert attempts_of(caught.value) == 1
+
+    def test_an_unstamped_exception_reports_no_attempts(self) -> None:
+        """An error raised before the adapter ever counted an attempt stays 0."""
+        assert attempts_of(RuntimeError("never reached the adapter")) == 0
+
+
+class TestWallTimeoutIsNotRetried:
+    """A wall-clock timeout re-sent unchanged cannot do anything but burn budget.
+
+    The request, the model and the wall are all identical on the retry, so
+    attempts 2..N buy nothing and cost another full timeout each — at the
+    generous 1800s default that is an hour of runner time per lens before the
+    failure surfaces.
+    """
+
+    def test_the_wall_timeout_is_attempted_once(self) -> None:
+        release = threading.Event()
+        calls = 0
+
+        def hangs(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            release.wait(timeout=5)
+            return _fake_response()
+
+        try:
+            with patch("litellm.completion", side_effect=hangs):
+                provider = LiteLLMProvider(timeout=0.05)
+                with pytest.raises(provider_module.ProviderWallTimeout, match="exceeded 0.05"):
+                    provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+        finally:
+            release.set()
+
+        assert calls == 1
+
+    def test_it_still_reads_as_a_timeout_error(self) -> None:
+        """Callers (and the review's failure notice) keep seeing a TimeoutError."""
+        assert issubclass(provider_module.ProviderWallTimeout, TimeoutError)
+
+    def test_a_transport_timeout_is_still_retried(self) -> None:
+        """litellm's own connect/read timeout is a blip, not a blown wall — it
+        keeps its retries."""
+        calls = 0
+
+        def transport_timeout(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.Timeout(
+                message="Connection timed out", model="deepseek", llm_provider="openrouter"
+            )
+
+        with patch("litellm.completion", side_effect=transport_timeout):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.Timeout):
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert calls == _MAX_ATTEMPTS
+
+    def test_the_fallback_model_still_gets_its_chance(self) -> None:
+        """Not retrying is about re-sending the SAME request; a different model is
+        a different request, and still worth trying."""
+        release = threading.Event()
+        seen: list[str] = []
+
+        def hang_then_answer(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs["model"])
+            if kwargs["model"] == "openrouter/slow":
+                release.wait(timeout=5)
+            return _fake_response("fallback answered")
+
+        try:
+            with patch("litellm.completion", side_effect=hang_then_answer):
+                provider = LiteLLMProvider(
+                    model="openrouter/slow", fallback_model="openrouter/quick", timeout=0.05
+                )
+                result = provider.complete([{"role": "user", "content": "hi"}], "ignored")
+        finally:
+            release.set()
+
+        assert result.text == "fallback answered"
+        assert seen == ["openrouter/slow", "openrouter/quick"]
 
 
 class TestTemperatureRejection:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -190,6 +190,34 @@ class TestRetry:
         """An error raised before the adapter ever counted an attempt stays 0."""
         assert attempts_of(RuntimeError("never reached the adapter")) == 0
 
+    def test_a_re_send_inside_one_attempt_still_counts(self) -> None:
+        """Every request that goes out counts, not every tenacity attempt.
+
+        The empty-structured-output path issues a SECOND model request inside one
+        attempt. Counting attempts rather than requests reported that failure as
+        one call when the provider had been asked twice.
+        """
+        calls = 0
+
+        def empty_then_fail(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if "response_format" in kwargs:
+                return _fake_response("")  # schema decoder yielded nothing
+            raise litellm.AuthenticationError(
+                message="invalid api key", model="gpt-4o", llm_provider="openai"
+            )
+
+        with patch("litellm.completion", side_effect=empty_then_fail):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.AuthenticationError) as caught:
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "openai/gpt-4o", response_format={}
+                )
+
+        assert calls == 2
+        assert attempts_of(caught.value) == 2
+
 
 class TestWallTimeoutIsNotRetried:
     """A wall-clock timeout re-sent unchanged cannot do anything but burn budget.

--- a/tests/test_timeout_floors.py
+++ b/tests/test_timeout_floors.py
@@ -5,14 +5,42 @@ enough to trip a healthy-but-slow one and it stops being a safety net: the
 review posts "⚠️ N of M review calls failed … results may be incomplete" with
 zero findings, which reads to a human exactly like a clean bill of health.
 
-These are deliberately floors, not equalities — raising a budget is always
-safe here, lowering one below the floor is the regression worth catching.
+Most are deliberately floors, not equalities — raising a budget is always
+safe there, lowering one below the floor is the regression worth catching. The
+per-provider model-call defaults are the exception: they are what the docs
+*promise*, so they are pinned to the documented values exactly (see
+:class:`TestDocumentedProviderDefaults`).
 """
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
+import yaml
+
 from lgtmaybe.core.models import Provider, ReviewConfig
 from lgtmaybe.providers.factory import default_timeout_for
+
+_REPO_ROOT = Path(__file__).parent.parent
+_ACTION_YML = _REPO_ROOT / "action.yml"
+_ACTION_GUIDE = _REPO_ROOT / "docs" / "how-to" / "use-as-github-action.md"
+
+# The providers documented as getting the generous default: ones that may front a
+# slow model (a local server, or openrouter's gateway to arbitrary models).
+_SLOW_PROVIDERS = frozenset(
+    {Provider.ollama, Provider.openai_compatible, Provider.openrouter},
+)
+
+
+def _states_seconds(text: str, seconds: int) -> bool:
+    """Whether *text* quotes *seconds* as a whole number.
+
+    Substring matching would pass ``60`` against a documented ``600`` — exactly
+    the drift this guard exists to catch — so the digits must not sit inside a
+    longer number.
+    """
+    return re.search(rf"(?<!\d){seconds}(?!\d)", text) is not None
 
 
 class TestModelCallBudgets:
@@ -21,6 +49,55 @@ class TestModelCallBudgets:
         per-call budget, so one slow gateway/local call can never eat the run."""
         slowest = max(default_timeout_for(p) for p in Provider)
         assert ReviewConfig(provider=Provider.openai, model="m").max_review_seconds >= 2 * slowest
+
+
+class TestDocumentedProviderDefaults:
+    """The resolved per-call timeout must equal what the docs promise, provider
+    by provider.
+
+    A floor can't catch this class of drift: reclassifying a provider (openrouter
+    once counted as fast cloud, on a 60s budget, while the docs advertised the
+    generous default) leaves every floor green and every promise broken. The user
+    has no way to see which budget they actually got — the failure looks like a
+    clean review — so the numbers in the prose and the numbers in the code are
+    pinned to each other here.
+    """
+
+    # The documented split: generous for the slow-capable providers, short for
+    # direct cloud. Written out (not derived from the code under test) so a change
+    # to either side has to be made deliberately, in both places.
+    SLOW_SECONDS = 1800
+    CLOUD_SECONDS = 600
+
+    def test_every_provider_resolves_its_documented_timeout(self) -> None:
+        expected = {
+            p: self.SLOW_SECONDS if p in _SLOW_PROVIDERS else self.CLOUD_SECONDS for p in Provider
+        }
+        assert {p: default_timeout_for(p) for p in Provider} == expected
+
+    def test_action_yml_documents_the_resolved_timeouts(self) -> None:
+        """The ``timeout`` input's description must name the slow providers and
+        quote the budgets the code actually resolves."""
+        inputs = yaml.safe_load(_ACTION_YML.read_text(encoding="utf-8"))["inputs"]
+        description = inputs["timeout"]["description"]
+
+        for provider in sorted(p.value for p in _SLOW_PROVIDERS):
+            assert provider in description, f"action.yml must name {provider} as slow-capable"
+        assert _states_seconds(description, default_timeout_for(Provider.openrouter))
+        assert _states_seconds(description, default_timeout_for(Provider.openai))
+
+    def test_action_guide_documents_the_resolved_timeouts(self) -> None:
+        """The Action how-to's input table is the other place a user reads these
+        numbers, so it is held to the same equality."""
+        row = next(
+            line
+            for line in _ACTION_GUIDE.read_text(encoding="utf-8").splitlines()
+            if line.startswith("| `timeout` |")
+        )
+        for provider in sorted(p.value for p in _SLOW_PROVIDERS):
+            assert provider in row, f"the input table must name {provider} as slow-capable"
+        assert _states_seconds(row, default_timeout_for(Provider.openrouter))
+        assert _states_seconds(row, default_timeout_for(Provider.openai))
 
 
 class TestSupportingBudgets:

--- a/tests/test_timeout_floors.py
+++ b/tests/test_timeout_floors.py
@@ -43,6 +43,23 @@ def _states_seconds(text: str, seconds: int) -> bool:
     return re.search(rf"(?<!\d){seconds}(?!\d)", text) is not None
 
 
+def _documents_the_split(text: str, *, slow_seconds: int, cloud_seconds: int) -> bool:
+    """Whether *text* attaches each budget to the providers it applies to.
+
+    Checking the names and the numbers independently would pass a description that
+    swapped them ("openrouter 600, cloud 1800") — the very drift being guarded — so
+    the slow budget must appear in the span that names the slow providers, and the
+    cloud budget in the span introduced by "cloud". Both documented forms run
+    "<slow providers> <slow>s, cloud <cloud>s".
+    """
+    match = re.search(r"(?P<slow>ollama.*?)(?P<cloud>cloud\D*\d+)", text, re.IGNORECASE)
+    if match is None:
+        return False
+    return _states_seconds(match["slow"], slow_seconds) and _states_seconds(
+        match["cloud"], cloud_seconds
+    )
+
+
 class TestModelCallBudgets:
     def test_whole_review_ceiling_holds_two_slow_calls(self) -> None:
         """The soft whole-review deadline must stay at least 2× the most generous
@@ -83,8 +100,11 @@ class TestDocumentedProviderDefaults:
 
         for provider in sorted(p.value for p in _SLOW_PROVIDERS):
             assert provider in description, f"action.yml must name {provider} as slow-capable"
-        assert _states_seconds(description, default_timeout_for(Provider.openrouter))
-        assert _states_seconds(description, default_timeout_for(Provider.openai))
+        assert _documents_the_split(
+            description,
+            slow_seconds=default_timeout_for(Provider.openrouter),
+            cloud_seconds=default_timeout_for(Provider.openai),
+        )
 
     def test_action_guide_documents_the_resolved_timeouts(self) -> None:
         """The Action how-to's input table is the other place a user reads these
@@ -96,8 +116,11 @@ class TestDocumentedProviderDefaults:
         )
         for provider in sorted(p.value for p in _SLOW_PROVIDERS):
             assert provider in row, f"the input table must name {provider} as slow-capable"
-        assert _states_seconds(row, default_timeout_for(Provider.openrouter))
-        assert _states_seconds(row, default_timeout_for(Provider.openai))
+        assert _documents_the_split(
+            row,
+            slow_seconds=default_timeout_for(Provider.openrouter),
+            cloud_seconds=default_timeout_for(Provider.openai),
+        )
 
 
 class TestSupportingBudgets:

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -1,5 +1,6 @@
 """Structural guards for the supplied lgtmaybe workflows."""
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -73,6 +74,45 @@ def test_dogfood_workflow_prints_the_timing_profile() -> None:
         if step.get("uses") == "./"
     ]
     assert action_step.get("with", {}).get("profile") is True
+
+
+def test_dogfood_workflow_reviews_with_the_image_it_builds() -> None:
+    """The dogfood review must run this repo's code, not the last release.
+
+    `uses: ./` only makes action.yml local; the container still defaults to the
+    floating published tag, so reviews ran whatever was last released. That skew
+    let a merged fix go unexercised for days — and let a review's own timeout
+    contradict the action.yml sitting beside it. The job therefore builds the
+    image from the (base) checkout and passes that tag to the action.
+    """
+    workflow = yaml.safe_load(_DOGFOOD_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["review"]["steps"]
+
+    builds = [step for step in steps if "docker build" in str(step.get("run", ""))]
+    assert builds, "the dogfood job must build the reviewer image from the checkout"
+    build_command = str(builds[0]["run"])
+    tag_match = re.search(r"--tag\s+(\S+)", build_command)
+    assert tag_match, f"the build step must tag its image: {build_command!r}"
+
+    [action_step] = [step for step in steps if step.get("uses") == "./"]
+    assert action_step["with"]["image"] == tag_match.group(1), (
+        "the dogfood review must run the locally built image, not the published tag"
+    )
+
+
+def test_starter_workflows_use_the_published_image() -> None:
+    """The opposite guard for the examples users copy: they must NOT build from a
+    checkout — they consume the released image via the published action ref."""
+    for path in sorted(_STARTER_WORKFLOWS.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job in workflow["jobs"].values():
+            for step in job["steps"]:
+                assert "docker build" not in str(step.get("run", "")), (
+                    f"{path.name} builds an image; starter workflows use the released one"
+                )
+                assert "image" not in (step.get("with") or {}), (
+                    f"{path.name} overrides the container image; starters take the default"
+                )
 
 
 def test_dogfood_concurrency_only_applies_to_eligible_review_job() -> None:


### PR DESCRIPTION
## The reported 60s: version skew, not a live defect

Traced the whole path by reading it, not by trusting the docs:

action input `timeout` (empty → `None`, `cli/__init__.py`) → `load_config` (no timeout default in any layer) → `ReviewConfig.timeout = None` → `build_provider(timeout=cfg.timeout)` → `opts["timeout"] = default_timeout_for(provider)` (`providers/factory.py`) → `LiteLLMProvider.default_opts` → `complete()` merge → `_completion_with_wall_timeout`.

On current code that resolves to **1800 for openrouter**, exactly as `action.yml` claims — confirmed by running it, not just reading it:

```
per-call timeout resolved  lgtmaybe_version=1.6.0  provider=openrouter
                           timeout_s=1800  timeout_source="provider default"
```

The 60 came from an **older build than the `action.yml` text being read**. Each piece of the reported evidence dates it:

| evidence | matching code state |
|---|---|
| lens labels `correctness-state` / `correctness-flow` | removed by #268 (in 1.6.0) |
| `provider request exceeded 60s` with no `(waited …)` | predates #260 (in 1.5.4) |
| the raise at source line 361 | `_completion_with_wall_timeout` at that commit |
| 60s for openrouter | pre-1.3.0 `factory.py`: `_CLOUD_TIMEOUT = 60`, openrouter absent from the slow-capable set |
| `elapsed_s ≈ 181` ≈ 3 × 60 | four attempts capped by `stop_after_delay(60 × 2.5)` |

That build's own `action.yml` documented "cloud 60" — code and docs agreed *at that commit*. The mismatch is across versions: the Action's `image` input pins a floating tag, so the YAML a consumer reads and the code that runs are versioned independently. Nothing in the resolution path was broken then or now.

The other two observations *are* live defects, and both are fixed here.

## Changes

**1. Every provider's resolved timeout is pinned to the documented one** (`tests/test_timeout_floors.py`). Floors can't catch a reclassified provider — when openrouter sat on a 60s budget while the docs promised the generous default, every floor stayed green. Now each `Provider` member's `default_timeout_for` is asserted exactly, and both places a user reads the numbers (the `action.yml` input description and the Action how-to's table) must quote what the code resolves. Whole-number matching, so a documented `600` can't satisfy a resolved `60`. Verified by reverting `_SLOW_CAPABLE`/`_CLOUD_TIMEOUT` to their pre-1.3.0 values: all three tests fail.

**2. `attempts=0` on failures.** The adapter counted attempts in a local and only attached it to a successful `ProviderResult`, so both recorders hard-coded `0` — a call that burned its whole retry budget looked like one that was never retried. Failures now carry the count on the exception (`stamp_attempts` / `attempts_of`, best-effort so a slotted exception type can't fail a review); `0` now means only "never reached the retry loop".

**3. A blown wall clock is no longer retried.** `_is_permanent` didn't cover it, so a request that outlived its entire budget was re-sent byte-identical to the same model against the same wall — it can only fail the same way, at another full timeout each. At the 1800s default that is an hour of runner time before the failure surfaces. The guard raises `ProviderWallTimeout` (a `TimeoutError` subclass, so callers matching on that are unaffected) and `_is_permanent` treats it as terminal. litellm's own transport `Timeout` — a connect/read blip — keeps its retries, and a configured `fallback_model` still gets its turn with a fresh budget.

**4. The run names its own build.** The existing `per-call timeout resolved` line now carries the installed version, so "impossible budget vs documented default" is answerable from one log line instead of by dating lens labels against git history. `"unknown"` on an uninstalled checkout — never a reason to fail a review.

Docs (`architecture.md`, the Action how-to input table, regenerated `llms-full.txt`) and the `provider-gateway` spec sections behind the `provider.complete` / `provider.defaults` anchors are updated to match.

## Deliberately not done

**Splitting the batch on timeout.** Batch 1's 413,008 input tokens is not reproducible on current code — the engine expands hunk context *then* batches against `max_input_tokens` (default 100,000), so a batch cannot be 4× the budget. Re-batching mid-fan-out needs dedupe/anchoring rework for a case change 3 already bounds to one attempt. If a >100k batch shows up on a 1.6.0+ build, that is a separate defect.

## Verification

- `uv run pytest -q` → 1501 passed
- Red-first on all three: mutation-tested the drift guard against the historical values; both provider fixes had failing tests before the change
- `uv run ruff check . && uv run ruff format --check . && uv run mypy src` → clean
- `uv run pytest tests/specs -q` → 17 passed; `openspec validate --specs` → 10 passed
- Ran the resolution path live to capture the log line above

## Verified vs. assumed

Verified by reading and running the code: the full resolution chain, that current code yields 1800 for openrouter and that it reaches the wall guard, each dated code state in the table above, both live defects, and that the guard catches the historical drift.

Assumed: which exact release the consumer had pinned. The code state is identifiable from the evidence; their workflow isn't visible from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sa9Tjh6fkorxiDd2hgpBGG)_