### PR TITLE
fix(engine): report a split piece that failed instead of claiming the batch was reviewed

### DIFF
--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -119,11 +119,17 @@ split level, with the shrink disclosed in the summary.
 
 #### Scenario: a single-file batch times out
 - **WHEN** the timed-out batch holds one file
-- **THEN** its hunks become the pieces, so an oversized lone file still shrinks
+- **THEN** its hunks are divided into two groups, one review call each, so an
+  oversized lone file still shrinks
 
 #### Scenario: a piece times out as well
 - **WHEN** a piece of an already-split batch also exceeds its budget
 - **THEN** it fails as an ordinary failed call — the split does not recurse
+
+#### Scenario: one piece answers and another fails
+- **WHEN** part of a split batch is reviewed and part fails
+- **THEN** the findings are kept AND the failure is reported, so the summary never
+  claims a shrunk batch was reviewed when some of it was not
 
 #### Scenario: the failure is not a timeout
 - **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -462,8 +462,14 @@ class LLMReviewEngine(ReviewEngine):
                 all_findings.extend(findings)
 
         # 5b. Fail loud: if EVERY call errored or returned unparseable output, we
-        #     have no signal — never pass that off as a clean review.
-        if total_calls > 0 and failed_calls == total_calls:
+        #     have no signal — never pass that off as a clean review. Findings are
+        #     part of that test now that a call can be partially successful: a
+        #     timed-out batch whose split produced findings from one piece and a
+        #     failure from another has real signal to post, and throwing it away to
+        #     raise "every review call failed" would lose a genuine finding. The
+        #     failure still reaches the summary through the incomplete-results
+        #     notice, so nothing is hidden either way.
+        if total_calls > 0 and failed_calls == total_calls and not all_findings:
             detail = errors[-1] if errors else "no usable output"
             raise ReviewIncompleteError(
                 f"review incomplete — every review call failed ({detail}). "
@@ -815,12 +821,16 @@ class LLMReviewEngine(ReviewEngine):
             findings.extend(piece_findings)
             if piece_error is not None:
                 errors.append(piece_error)
-        if len(errors) == len(pieces):
-            # Every piece failed too: report the split's own failure, not the
-            # original timeout, so the notice names what actually went wrong last.
-            return findings, errors[-1]
-        self._split_batches.add(batch_num)
-        return findings, None
+        if len(errors) < len(pieces):
+            # At least one piece answered, so the shrink did produce a review —
+            # only then is "reviewed in smaller pieces" a true claim.
+            self._split_batches.add(batch_num)
+        # ANY failed piece is still a failed call. Swallowing it because a sibling
+        # succeeded would drop the incomplete-results notice while the summary
+        # claimed the batch was reviewed — a clean bill of health for code no model
+        # ever saw. The last error is reported (the split's own failure, not the
+        # original timeout) so the notice names what actually went wrong.
+        return findings, errors[-1] if errors else None
 
     def _complete_lens(
         self,

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -138,6 +138,37 @@ def test_the_split_is_reported_not_silent() -> None:
     assert "timed out" in summary.lower()
 
 
+def test_a_piece_that_fails_is_still_reported() -> None:
+    """Half a batch reviewed is not a reviewed batch.
+
+    The split's whole risk: findings come back, so the run looks healthy, while a
+    piece nobody reviewed is silently missing. The failure has to reach the
+    incomplete-results notice — otherwise a shrunk batch can report a clean bill
+    of health for code no model ever saw.
+    """
+
+    class _OneHalfRefuses(FakeProvider):
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            if "one.py" in diff and "two.py" in diff:
+                raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+            if "two.py" in diff:
+                raise RuntimeError("insufficient_quota")
+            return ProviderResult(
+                text=_finding_json("one.py", "first_change = os.getcwd()"),
+                input_tokens=5,
+                output_tokens=5,
+            )
+
+    findings, summary = LLMReviewEngine(_OneHalfRefuses()).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert [f.path for f in findings] == ["one.py"]  # the half that answered
+    assert "results may be incomplete" in summary
+    assert "insufficient_quota" in summary  # naming the piece's real failure
+
+
 def test_a_single_file_batch_splits_by_hunk() -> None:
     """One file can still be too big; its hunks are the next unit down."""
 


### PR DESCRIPTION
Follow-up to #277 — this review feedback arrived after that PR merged, so it lands as its own change.

## The defect

#277 added the timeout split: a lens call that blows its whole wall budget has its batch halved and the pieces reviewed. When one piece answered and another failed, `_review_split` returned a successful outcome and dropped the piece's error. `failed_calls` never incremented, so the incomplete-results notice never fired — while the summary claimed the batch had been "reviewed in smaller pieces".

Half a batch reviewed is not a reviewed batch. That combination is a clean bill of health for code no model ever saw, which is precisely the failure mode the rest of this pipeline is built to avoid.

Any failed piece is now reported, and the "reviewed in smaller pieces" notice is only claimed when at least one piece actually answered.

## The consequence it exposed

That makes a call **partially successful** for the first time — findings *and* an error from one task. The fail-loud guard didn't anticipate it: with a single lens, one failed piece meant `failed_calls == total_calls`, so the run raised `ReviewIncompleteError` ("every review call failed") and discarded the finding the other piece had produced.

The guard now also requires that there be no findings. It still fires when there is genuinely no signal, and no longer throws away a real finding to report a failure that the summary's incomplete-results notice already carries.

## Spec accuracy

The single-file scenario said its hunks "become the pieces", implying one call per hunk; the implementation divides them into two groups. Reworded, so a five-hunk file isn't specified as five calls. Added a scenario for the partial-failure case above.

## Verification

- `test_a_piece_that_fails_is_still_reported` — written first, failed exactly as described (findings returned, no notice), passes now.
- `uv run pytest -q` → 1526 passed, 3 deselected
- `uv run ruff check .` / `uv run mypy src` clean; `uv run pytest tests/specs -q` → 17 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sa9Tjh6fkorxiDd2hgpBGG)_