### PR TITLE
feat(provider): cap generated tokens and fail fast when credit runs out

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "Token budget per model call before the diff is split into batches (any provider). Leave empty for the default (100000)."
     required: false
     default: ""
+  max_tokens:
+    description: "Cap the tokens each model call may generate (any provider). Leave empty to send no cap, so the model's own ceiling applies. Set it on a prepaid route like OpenRouter, which reserves prompt + max_tokens against your balance before generating and assumes the model's full ceiling when the request omits it."
+    required: false
+    default: ""
   max_concurrency:
     description: "Concurrent review calls across the whole fan-out (all batches and lenses share one pool). Leave empty for the provider-aware default: 8 for cloud providers, 1 for ollama and openai-compatible (a single-slot llama.cpp/LM Studio server wants 1; raise it explicitly for a batching vLLM server)."
     required: false
@@ -274,6 +278,7 @@ runs:
         INPUT_TEMPERATURE: ${{ inputs.temperature }}
         INPUT_NUM_CTX: ${{ inputs.num_ctx }}
         INPUT_MAX_INPUT_TOKENS: ${{ inputs.max_input_tokens }}
+        INPUT_MAX_TOKENS: ${{ inputs.max_tokens }}
         INPUT_MAX_CONCURRENCY: ${{ inputs.max_concurrency }}
         INPUT_RESOLVE_FIXED: ${{ inputs.resolve_fixed }}
         INPUT_RECURSIVE: ${{ inputs.recursive }}

--- a/docs/how-to/review-with-openrouter.md
+++ b/docs/how-to/review-with-openrouter.md
@@ -14,6 +14,7 @@ OpenRouter offers using its `vendor/model` name.
 - [GitHub Action](#github-action)
 - [Run locally](#run-locally)
 - [Choosing the model](#choosing-the-model)
+- [Credit reservations](#credit-reservations)
 - [Persist non-secret defaults](#persist-non-secret-defaults)
 
 ## Get an API key
@@ -63,6 +64,35 @@ quality bar, for example:
 
 Browse the full catalogue and per-model pricing at
 <https://openrouter.ai/models>.
+
+## Credit reservations
+
+OpenRouter checks your balance **before** it generates anything, costing the
+worst case: the prompt plus the most tokens the reply could use. A request that
+sends no cap is assumed to want the model's full output ceiling, so a review can
+be refused for credit it was never going to spend:
+
+```
+This request requires more credits, or fewer max_tokens.
+You requested up to 65536 tokens, but can only afford 25905.
+```
+
+Top up, or cap what each call may generate so the reservation matches a real
+findings payload:
+
+```yaml
+max_tokens: 8192
+```
+
+`--max-tokens 8192` does the same for one run, and `max_tokens` is a GitHub
+Action input too. Leave it unset and no cap is sent, which is the safe default:
+a cap sized too low truncates the findings JSON mid-object and the call fails to
+parse. Reasoning models spend this budget on thinking tokens as well, so give
+them more headroom than a plain model.
+
+lgtmaybe treats this refusal as permanent and stops after one attempt — your
+balance cannot grow mid-review, so retrying every lens would only waste runner
+time before reporting the same failure.
 
 ## Persist non-secret defaults
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -934,6 +934,7 @@ OpenRouter offers using its `vendor/model` name.
 - [GitHub Action](#github-action)
 - [Run locally](#run-locally)
 - [Choosing the model](#choosing-the-model)
+- [Credit reservations](#credit-reservations)
 - [Persist non-secret defaults](#persist-non-secret-defaults)
 
 ## Get an API key
@@ -983,6 +984,35 @@ quality bar, for example:
 
 Browse the full catalogue and per-model pricing at
 <https://openrouter.ai/models>.
+
+## Credit reservations
+
+OpenRouter checks your balance **before** it generates anything, costing the
+worst case: the prompt plus the most tokens the reply could use. A request that
+sends no cap is assumed to want the model's full output ceiling, so a review can
+be refused for credit it was never going to spend:
+
+```
+This request requires more credits, or fewer max_tokens.
+You requested up to 65536 tokens, but can only afford 25905.
+```
+
+Top up, or cap what each call may generate so the reservation matches a real
+findings payload:
+
+```yaml
+max_tokens: 8192
+```
+
+`--max-tokens 8192` does the same for one run, and `max_tokens` is a GitHub
+Action input too. Leave it unset and no cap is sent, which is the safe default:
+a cap sized too low truncates the findings JSON mid-object and the call fails to
+parse. Reasoning models spend this budget on thinking tokens as well, so give
+them more headroom than a plain model.
+
+lgtmaybe treats this refusal as permanent and stops after one attempt — your
+balance cannot grow mid-review, so retrying every lens would only waste runner
+time before reporting the same failure.
 
 ## Persist non-secret defaults
 
@@ -3195,6 +3225,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
+| `max_tokens` | integer / null | No | `null` | Max Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -3845,6 +3876,19 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"
+    },
+    "max_tokens": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Tokens"
     },
     "min_confidence": {
       "default": 0,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,6 +36,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
+| `max_tokens` | integer / null | No | `null` | Max Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
 | `model` | string | Yes | — | Model |
@@ -686,6 +687,19 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "minimum": 0,
       "title": "Max Review Seconds",
       "type": "integer"
+    },
+    "max_tokens": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Tokens"
     },
     "min_confidence": {
       "default": 0,

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -73,6 +73,13 @@ on `ProviderResult`.
   not retry it — an identical request against an identical budget can only fail the
   same way — while a configured fallback model is still tried
 
+#### Scenario: the account is out of prepaid credit
+- **WHEN** a route refuses the request because the balance cannot cover it —
+  prepaid routes reserve prompt + `max_tokens` before generating, so an uncapped
+  request reserves the model's full output ceiling
+- **THEN** it is treated as permanent and tried once, not retried per lens: the
+  balance cannot grow mid-review, so every retry fails identically
+
 #### Scenario: a failed call reports what it cost
 - **WHEN** a completion fails after exhausting its retries
 - **THEN** the raised error carries the attempt count, so instrumentation

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -204,6 +204,12 @@ def build_provider_engine(
     extra: dict[str, Any] = {}
     if cfg.provider is Provider.ollama and cfg.num_ctx is not None:
         extra["num_ctx"] = cfg.num_ctx
+    # An output cap is only sent when asked for: omitting it lets the model's own
+    # ceiling apply, so nothing truncates a long findings payload by default.
+    # Every provider honours it (litellm normalises the param), so unlike num_ctx
+    # it is not gated on the provider.
+    if cfg.max_tokens is not None:
+        extra["max_tokens"] = cfg.max_tokens
     # Announce the per-call budget AND where it came from, before any call runs.
     # A timeout failure reports the budget it blew ("provider request exceeded
     # 60s") but never its origin, so an explicit `timeout: 60` in a repo's
@@ -857,6 +863,7 @@ def action_inputs() -> dict[str, str | None]:
         "temperature": get("TEMPERATURE"),
         "num_ctx": get("NUM_CTX"),
         "max_input_tokens": get("MAX_INPUT_TOKENS"),
+        "max_tokens": get("MAX_TOKENS"),
         "max_concurrency": get("MAX_CONCURRENCY"),
         "resolve_fixed": get("RESOLVE_FIXED"),
         "recursive": get("RECURSIVE"),

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -172,6 +172,15 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "(any provider; raise it to send a big diff in fewer calls)",
 )
 @click.option(
+    "--max-tokens",
+    default=None,
+    type=click.IntRange(min=1),
+    help="Cap the tokens each model call may generate (any provider; unset = the "
+    "model's own ceiling). Set it on a prepaid route like OpenRouter, which "
+    "reserves prompt + max_tokens against your balance before generating and "
+    "assumes the model's full ceiling when the request omits it",
+)
+@click.option(
     "--num-ctx",
     default=None,
     type=int,
@@ -334,6 +343,7 @@ def review(
     unanchored_min_severity: str | None,
     max_files: int | None,
     max_input_tokens: int | None,
+    max_tokens: int | None,
     num_ctx: int | None,
     max_concurrency: int | None,
     base: str | None,
@@ -375,6 +385,7 @@ def review(
         unanchored_min_severity=unanchored_min_severity,
         max_files=max_files,
         max_input_tokens=max_input_tokens,
+        max_tokens=max_tokens,
         num_ctx=num_ctx,
         max_concurrency=max_concurrency,
         context_lines=context_lines,
@@ -535,6 +546,7 @@ def action() -> None:
         temperature=inputs["temperature"],
         num_ctx=inputs["num_ctx"],
         max_input_tokens=inputs["max_input_tokens"],
+        max_tokens=inputs["max_tokens"],
         max_concurrency=inputs["max_concurrency"],
         resolve_fixed=inputs["resolve_fixed"],
         recursive=inputs["recursive"],

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -580,6 +580,23 @@ class ReviewConfig(_Strict):
     # Sampling temperature for completions. Defaults to 0.0 for deterministic,
     # reproducible reviews (and steadier instruction-following on small models).
     temperature: float = 0.0
+    # Ceiling on the tokens each model call may GENERATE (the findings JSON) — the
+    # output counterpart to max_input_tokens. None (default) sends no cap, so the
+    # model's own ceiling applies and a long findings payload is never truncated.
+    #
+    # Set it on a PREPAID route (OpenRouter and friends), which reserves
+    # prompt + max_tokens against the balance BEFORE generating and falls back to
+    # the model's full output ceiling when the request omits the cap — so an
+    # uncapped review can be refused ("requires more credits ... you requested up
+    # to 65536 tokens, but can only afford N") for credit it was never going to
+    # spend. A cap sized to a real findings payload shrinks that reservation to
+    # what the review actually costs.
+    #
+    # Sized too low it truncates the JSON mid-object and the call parses as a
+    # failed lens, which is why it is opt-in rather than defaulted: reasoning
+    # models spend this budget on thinking tokens too, so a value that suits a
+    # plain model can starve a reasoning one.
+    max_tokens: int | None = Field(default=None, ge=1)
     # Run the self-reflection pass that filters low-confidence findings. Disable
     # it (--no-reflect) when a weaker model drops valid findings during reflection.
     reflect: bool = True

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -120,6 +120,20 @@ _QUOTA_MARKERS = (
     "check your plan and billing",
 )
 
+# Running out of prepaid credit is permanent, and it does NOT arrive as a
+# RateLimitError: OpenRouter (and other prepaid-balance routes) reject the request
+# up front with a generic APIError, so the type check above and the 429 check below
+# both miss it. The refusal is a *pre-flight reservation* failure — the route costs
+# prompt + max_tokens against the balance before generating a single token, and an
+# uncapped request reserves the model's full output ceiling — so the balance can't
+# grow mid-review and every retry is guaranteed to fail identically.
+_INSUFFICIENT_CREDIT_MARKERS = (
+    "requires more credits",
+    "can only afford",
+    "insufficient credits",
+    "insufficient_credits",
+)
+
 # An expired/invalid cloud credential is permanent — a retry can't refresh it, so
 # storming the backoff over every lens just delays an inevitable failure (the same
 # wasted-runner-time trap as a quota error). Unlike a bad *static* key (which
@@ -143,6 +157,12 @@ def _is_quota_rate_limit(exc: BaseException) -> bool:
     return any(marker in msg for marker in _QUOTA_MARKERS)
 
 
+def _is_insufficient_credit(exc: BaseException) -> bool:
+    """True when *exc* is a prepaid-balance refusal (permanent until topped up)."""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _INSUFFICIENT_CREDIT_MARKERS)
+
+
 def _is_expired_credential(exc: BaseException) -> bool:
     """True when *exc* is an expired/invalid ambient cloud credential (permanent)."""
     msg = str(exc).lower()
@@ -163,7 +183,7 @@ def _is_permanent(exc: BaseException) -> bool:
         return True
     if isinstance(exc, RateLimitError):
         return _is_quota_rate_limit(exc)
-    return _is_expired_credential(exc)
+    return _is_expired_credential(exc) or _is_insufficient_credit(exc)
 
 
 def _rejects_temperature(exc: Exception) -> bool:

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -291,3 +291,51 @@ def test_num_ctx_flag_is_ignored_for_hosted_provider(
 
     assert result.exit_code == 0, result.output
     assert "num_ctx" not in captured_completion[0]
+
+
+def test_max_tokens_flag_reaches_litellm(captured_completion: list[dict[str, Any]]) -> None:
+    """`--max-tokens` caps each completion. Prepaid routes (OpenRouter) reserve
+    prompt + max_tokens against the balance BEFORE generating, and fall back to the
+    model's full output ceiling when the request omits it — so an uncapped review
+    can be refused for credit it was never going to spend. The cap has to reach
+    litellm to shrink that reservation."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openrouter",
+            "--model",
+            "vendor/m",
+            "--api-key",
+            "sk-x",
+            "--no-reflect",
+            "--max-tokens",
+            "8192",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("max_tokens") == 8192
+
+
+def test_max_tokens_is_absent_by_default(captured_completion: list[dict[str, Any]]) -> None:
+    """Unset means uncapped — the request must carry no max_tokens at all, so the
+    model's own ceiling applies and nothing silently truncates a long findings
+    payload."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
+            "openai",
+            "--model",
+            "gpt-4o",
+            "--api-key",
+            "sk-x",
+            "--no-reflect",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "max_tokens" not in captured_completion[0]

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -527,6 +527,61 @@ class TestFailFastOnPermanentErrors:
 
         assert calls == 1
 
+    def test_openrouter_insufficient_credits_is_not_retried(self) -> None:
+        """OpenRouter reserves prompt + max_tokens against the balance BEFORE
+        generating, and refuses the request when the balance can't cover it. That
+        is a billing dead-end exactly like OpenAI's insufficient_quota — but it
+        arrives as a generic APIError, not a RateLimitError, so the type check
+        alone misses it and every lens retried it three times."""
+        calls = 0
+
+        def no_credit(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.APIError(
+                status_code=402,
+                message=(
+                    "litellm.APIError: APIError: OpenrouterException - "
+                    '{"error":{"message":"This request requires more credits, or fewer '
+                    "max_tokens. You requested up to 65536 tokens, but can only afford "
+                    '25905."}}'
+                ),
+                model="vendor/m",
+                llm_provider="openrouter",
+            )
+
+        with patch("litellm.completion", side_effect=no_credit):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.APIError):
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/vendor/m")
+
+        assert calls == 1
+
+    def test_transient_api_error_is_still_retried(self) -> None:
+        """A plain APIError (an upstream blip) stays transient — only the
+        credit-exhaustion message makes one permanent."""
+        good = _fake_response("ok after backoff")
+        calls = 0
+
+        def flaky(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise litellm.APIError(
+                    status_code=500,
+                    message="litellm.APIError: APIError: OpenrouterException - upstream error",
+                    model="vendor/m",
+                    llm_provider="openrouter",
+                )
+            return good
+
+        with patch("litellm.completion", side_effect=flaky):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openrouter/vendor/m")
+
+        assert result.text == "ok after backoff"
+        assert calls == 2
+
     def test_authentication_error_is_not_retried(self) -> None:
         """A bad key won't become good on a retry — fail fast."""
         calls = 0

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -543,6 +543,19 @@
       "title": "Max Review Seconds",
       "type": "integer"
     },
+    "max_tokens": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Tokens"
+    },
     "min_confidence": {
       "default": 0,
       "maximum": 10,


### PR DESCRIPTION
## The report

A review on #278 failed with every lens dead:

```
lgtmaybe review failed: review incomplete — every review call failed
(APIError: litellm.APIError: APIError: OpenrouterException -
{"error":{"message":"This request requires more credits, or fewer max_tokens.
You requested up to 65536 tokens, but can only afford 25905."}})
```

## What actually happened

**OpenRouter reserves credit before it generates.** It costs the worst case —
prompt tokens plus the most tokens the reply could use — and refuses up front if
the balance can't cover it. When a request omits `max_tokens`, the reservation
assumes the model's full output ceiling: 65,536 tokens here.

**lgtmaybe never sent a cap.** `complete` merges `timeout`, `num_retries`,
`prompt_cache_key`, `temperature` and `response_format`; there is no
`max_tokens` anywhere, and `ReviewConfig` had `max_input_tokens` (an input
budget) with no output counterpart. So every call reserved the ceiling against a
findings payload that in practice runs a few thousand tokens — refused for
credit it was never going to spend.

**And it retried.** `_is_permanent` classified quota-429s and expired cloud
credentials, but this refusal arrives as a generic `APIError`, so neither the
type check nor the message checks caught it. The `fast` preset fans out four
lenses, each burning three attempts: twelve doomed requests before the failure
surfaced.

## The fix

- **`ReviewConfig.max_tokens`** — CLI `--max-tokens`, Action input
  `max_tokens`. Caps what each call may generate and reaches litellm for every
  provider (unlike `num_ctx`, which stays ollama-only).
- **Opt-in, defaulting to no cap.** A cap sized too low truncates the findings
  JSON mid-object and the lens fails to parse, which is a worse failure than the
  one being fixed; reasoning models spend the same budget on thinking tokens, so
  a value that suits a plain model can starve one of those. Unset sends no
  `max_tokens` at all, so today's behaviour is byte-identical.
- **The refusal is now permanent.** `_INSUFFICIENT_CREDIT_MARKERS` matches it by
  message, the same way quota-429s and expired tokens already were. A balance
  can't grow mid-review, so every retry fails identically — one attempt, then
  surface it.

## Tests

`tests/providers/test_retry.py` — the OpenRouter credit refusal is tried exactly
once (fails on `main` at 4 attempts), and a plain `APIError` is still retried, so
the classification is keyed on the message and not on the type.

`tests/cli/test_provider_threading.py` — `--max-tokens 8192` reaches
`litellm.completion` through the real CLI → resolver → factory → engine wiring
(fails on `main`: no such option), and an unset cap sends no `max_tokens` key.

Full suite: 1540 passed. ruff, format and mypy clean; `tests/specs` and
`openspec validate --specs` green.

## Docs & specs

- `docs/how-to/review-with-openrouter.md` gains a "Credit reservations" section
  — the error, the fix, and why the default is uncapped.
- The `provider-gateway` spec gains a scenario for the permanent classification;
  `docs/reference/config.md`, `docs/llms-full.txt` and the `ReviewConfig` schema
  snapshot are regenerated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPA33BpHTR1BqtvqeMhpzz)_