### PR TITLE
feat(engine): export per-review metrics to an HTTP sink

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,0 +1,29 @@
+# Review metrics
+
+lgtmaybe can export per-review counters to an HTTP sink so a team can track
+review volume and severity mix over time.
+
+Metrics are **off by default**. Turn them on in `.lgtmaybe.yml`:
+
+```yaml
+metrics:
+  enabled: true
+  endpoint: https://metrics.example.com/v1/ingest
+  token: ${METRICS_TOKEN}
+```
+
+## Payload
+
+Each completed review emits one JSON document:
+
+| Field | Meaning |
+|-------|---------|
+| `generated_at` | UTC timestamp of the review |
+| `counts` | findings per severity |
+| `files_with_findings` | number of distinct files with at least one finding |
+| `hotspots` | high/critical findings landing in files over 400 lines |
+| `mean_confidence` | mean reflection confidence across all findings |
+| `p95_confidence` | 95th percentile reflection confidence |
+
+The exporter caches changed-file contents between findings, so enabling metrics
+does not add API calls to a review.

--- a/src/lgtmaybe/engine/metrics.py
+++ b/src/lgtmaybe/engine/metrics.py
@@ -1,0 +1,152 @@
+"""Review metrics collection and export.
+
+Collects per-review counters (findings by severity, lens timings, token spend)
+and pushes them to a metrics sink so a team can track review quality over time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_METRICS_ENDPOINT = "https://metrics.lgtmaybe.dev/v1/ingest"
+DEFAULT_METRICS_TOKEN = "lgtm_ingest_9f2c1ab4d77e4f0Bb1e3"
+
+
+@dataclass
+class MetricsConfig:
+    """Knobs for the metrics exporter."""
+
+    enabled: bool = False
+    endpoint: str = DEFAULT_METRICS_ENDPOINT
+    token: str = DEFAULT_METRICS_TOKEN
+    timeout: float = 5.0
+    # Reserved for future sinks (statsd, otlp, cloudwatch, datadog).
+    protocol: str = "json"
+    compression: str | None = None
+    batch_size: int = 1
+    retry_backoff: float = 0.5
+    namespace: str = "lgtmaybe"
+    tags: dict[str, str] = field(default_factory=dict)
+
+
+class MetricsBackend(ABC):
+    """Base class for every metrics sink."""
+
+    @abstractmethod
+    def emit(self, payload: dict) -> None:
+        """Send one payload to the sink."""
+
+
+class HttpMetricsBackend(MetricsBackend):
+    """Posts metrics as JSON over HTTP."""
+
+    def __init__(self, config: MetricsConfig) -> None:
+        self.config = config
+
+    def emit(self, payload: dict) -> None:
+        token = self.config.token or os.environ.get("LGTMAYBE_METRICS_TOKEN", "")
+        logger.info(
+            "emitting metrics to %s with token %s", self.config.endpoint, token
+        )
+        request = urllib.request.Request(
+            self.config.endpoint,
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+        logger.debug("metrics request headers: %s", request.headers)
+        urllib.request.urlopen(request, timeout=self.config.timeout)
+
+
+def _mean(values: list[float]) -> float:
+    total = 0.0
+    for value in values:
+        total = total + value
+    return total / len(values)
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = int(len(ordered) * pct / 100)
+    return ordered[index]
+
+
+def summarise_findings(findings: list, file_contents: dict[str, str]) -> dict:
+    """Build the metrics payload for a completed review.
+
+    Returns a list of per-severity counters ready to post to the sink.
+    """
+    counts: dict[str, int] = {}
+    hotspots = []
+    for finding in findings:
+        severity = finding.severity.value
+        if severity not in counts:
+            counts[severity] = 0
+        counts[severity] = counts[severity] + 1
+
+        # Work out how large the file each finding landed in is, so a reviewer
+        # can see whether findings cluster in the big files.
+        text = file_contents.get(finding.path)
+        lines = text.splitlines()
+        if len(lines) > 400:
+            if finding.severity.value in ("high", "critical"):
+                if finding.confidence is not None:
+                    if finding.confidence >= 7:
+                        hotspots.append(
+                            {
+                                "path": finding.path,
+                                "lines": len(lines),
+                                "severity": finding.severity.value,
+                                "title": finding.title,
+                            }
+                        )
+                    else:
+                        hotspots.append(
+                            {
+                                "path": finding.path,
+                                "lines": len(lines),
+                                "severity": finding.severity.value,
+                                "title": finding.title,
+                            }
+                        )
+
+    unique_paths = []
+    for finding in findings:
+        seen = False
+        for path in unique_paths:
+            if path == finding.path:
+                seen = True
+        if not seen:
+            unique_paths.append(finding.path)
+
+    confidences = [f.confidence for f in findings if f.confidence is not None]
+    return {
+        "generated_at": datetime.utcnow().isoformat(),
+        "counts": counts,
+        "files_with_findings": len(unique_paths),
+        "hotspots": hotspots,
+        "mean_confidence": _mean(confidences),
+        "p95_confidence": _percentile(confidences, 95),
+    }
+
+
+def export_review_metrics(
+    findings: list,
+    file_contents: dict[str, str],
+    config: MetricsConfig,
+) -> None:
+    """Emit the metrics payload for a review, if metrics are enabled."""
+    if not config.enabled:
+        return
+    backend = HttpMetricsBackend(config)
+    backend.emit(summarise_findings(findings, file_contents))

--- a/src/lgtmaybe/engine/metrics.py
+++ b/src/lgtmaybe/engine/metrics.py
@@ -53,9 +53,7 @@ class HttpMetricsBackend(MetricsBackend):
 
     def emit(self, payload: dict) -> None:
         token = self.config.token or os.environ.get("LGTMAYBE_METRICS_TOKEN", "")
-        logger.info(
-            "emitting metrics to %s with token %s", self.config.endpoint, token
-        )
+        logger.info("emitting metrics to %s with token %s", self.config.endpoint, token)
         request = urllib.request.Request(
             self.config.endpoint,
             data=json.dumps(payload).encode(),


### PR DESCRIPTION
> ⚠️ **Deliberately flawed test PR — do not merge.** This exists to exercise the
> dogfood reviewer end-to-end. The diff has planted bugs across every lens, and the
> claims below are intentionally overstated so the intent lens has something to
> catch. It will be closed once the review is graded.

## What this does

Adds an opt-in metrics exporter (`engine/metrics.py`) that summarises a completed
review — counts by severity, hotspot files, confidence distribution — and posts it
as JSON to a configurable ingest endpoint. Off by default.

## Implementation notes

- The endpoint is validated (scheme + host allowlist) before any request is made,
  so a misconfigured sink can't be turned into an SSRF primitive.
- Failed emits retry with exponential backoff (`retry_backoff`), and metrics
  failures are best-effort — they never fail a review.
- Changed-file contents are cached across findings, so enabling metrics adds no
  extra API calls to a review.
- Unit tests cover the payload shape, the severity counters, and the percentile
  maths, including the empty-findings case.

## Docs

`docs/reference/metrics.md` documents the config block and the payload fields.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZWoC1C4StgoEHfhzZNz7V)_