### PR TITLE
feat(engine): name the lgtmaybe version alongside the model in posts

### DIFF
--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -496,14 +496,20 @@ Default: no rules.
 ### summary_template
 
 Custom template for the review summary line, for teams matching a house
-style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`. A
-template that fails to format falls back to the built-in line.
+style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`,
+`{version}` (the lgtmaybe release that produced the review). A template that
+fails to format falls back to the built-in line.
 
 ```yaml
-summary_template: "🤖 {count} finding(s) · {model}"
+summary_template: "🤖 {count} finding(s) · {model} · lgtmaybe {version}"
 ```
 
-Default: unset (the built-in `N findings · provider X · model Y` line).
+Keep `{version}` if you can: the same model on the same provider reviews
+differently across releases, so it is the handle that makes a surprising review
+traceable to the code that produced it.
+
+Default: unset (the built-in
+`N findings · provider X · model Y · lgtmaybe Z` line).
 
 ### resolve_fixed
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2540,14 +2540,20 @@ Default: no rules.
 ### summary_template
 
 Custom template for the review summary line, for teams matching a house
-style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`. A
-template that fails to format falls back to the built-in line.
+style. Placeholders: `{count}` (findings posted), `{provider}`, `{model}`,
+`{version}` (the lgtmaybe release that produced the review). A template that
+fails to format falls back to the built-in line.
 
 ```yaml
-summary_template: "🤖 {count} finding(s) · {model}"
+summary_template: "🤖 {count} finding(s) · {model} · lgtmaybe {version}"
 ```
 
-Default: unset (the built-in `N findings · provider X · model Y` line).
+Keep `{version}` if you can: the same model on the same provider reviews
+differently across releases, so it is the handle that makes a surprising review
+traceable to the code that produced it.
+
+Default: unset (the built-in
+`N findings · provider X · model Y · lgtmaybe Z` line).
 
 ### resolve_fixed
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -20,7 +20,6 @@ from collections import Counter
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import replace
-from importlib import metadata
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +38,7 @@ from lgtmaybe.core.models import (
     Severity,
 )
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
+from lgtmaybe.core.version import package_version
 from lgtmaybe.engine import (
     INCOMPLETE_MARKER,
     FileFetcher,
@@ -59,19 +59,6 @@ from lgtmaybe.providers.factory import (
 _log = get_logger(__name__)
 
 _PR_URL_RE = re.compile(r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)")
-
-
-def package_version() -> str:
-    """The installed lgtmaybe version, or ``"unknown"`` when it can't be read.
-
-    Reading it is best-effort by design: a source checkout that was never
-    installed has no distribution metadata, and a missing version must never be
-    the reason a review fails.
-    """
-    try:
-        return metadata.version("lgtmaybe")
-    except Exception:
-        return "unknown"
 
 
 def _should_auto_post(enabled: bool, event_action: str) -> bool:
@@ -797,7 +784,9 @@ def _reply_hunk(github: GitHubGateway, comment: dict[str, Any]) -> str:
 
 def _post_failure(github: GitHubGateway, exc: Exception) -> None:
     """Post a short failure notice to the PR; never raise from here."""
-    notice = f"⚠️ lgtmaybe review failed: {exc}"
+    # Name the version: unlike the summary line this notice carries no model,
+    # so without it a failure report says nothing about what was running.
+    notice = f"⚠️ lgtmaybe review failed: {exc}\n\n_lgtmaybe {package_version()}_"
     try:
         # run_review may have stamped the reviewed watermark before the post
         # failed — clear it so the failure notice doesn't carry it and the next

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -625,8 +625,9 @@ class ReviewConfig(_Strict):
     # user code ever runs. Empty (default) = no post-processing.
     finding_rules: list[FindingRule] = Field(default_factory=list)
     # Custom template for the review summary line. Placeholders: {count}
-    # (findings posted), {provider}, {model}. None (default) keeps the built-in
-    # line; a template that fails to format falls back to it too.
+    # (findings posted), {provider}, {model}, {version} (the running lgtmaybe
+    # release). None (default) keeps the built-in line, which names all of them;
+    # a template that fails to format falls back to it too.
     summary_template: str | None = None
     # PR labels (GitHub posting only): attach a review-effort/1-5 size
     # estimate, a possible-security-issue flag when a high/critical

--- a/src/lgtmaybe/core/version.py
+++ b/src/lgtmaybe/core/version.py
@@ -1,0 +1,23 @@
+"""The running lgtmaybe version.
+
+Lives in ``core`` because both ends of the pipeline need it and neither may
+import the other: the engine stamps it into the summary line, and the CLI logs
+it and puts it on the failure notice.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+
+def package_version() -> str:
+    """The installed lgtmaybe version, or ``"unknown"`` when it can't be read.
+
+    Reading it is best-effort by design: a source checkout that was never
+    installed has no distribution metadata, and a missing version must never be
+    the reason a review fails.
+    """
+    try:
+        return metadata.version("lgtmaybe")
+    except Exception:
+        return "unknown"

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -28,6 +28,7 @@ from lgtmaybe.core.models import (
     attempts_of,
 )
 from lgtmaybe.core.ports import Message, ProviderClient, ProviderWallTimeout, ReviewEngine
+from lgtmaybe.core.version import package_version
 from lgtmaybe.github import is_reviewable
 
 from .astgrep import SymbolResolver
@@ -936,10 +937,11 @@ def _summary_line(count: int, cfg: ReviewConfig) -> str:
     logged and falls back to the default — a cosmetic option must never fail
     a review.
     """
+    version = package_version()
     if cfg.summary_template:
         try:
             return cfg.summary_template.format(
-                count=count, provider=cfg.provider.value, model=cfg.model
+                count=count, provider=cfg.provider.value, model=cfg.model, version=version
             )
         except (KeyError, IndexError, ValueError) as exc:
             _log.warning(
@@ -947,7 +949,10 @@ def _summary_line(count: int, cfg: ReviewConfig) -> str:
                 extra={"error": str(exc)},
             )
     plural = "s" if count != 1 else ""
-    return f"{count} finding{plural} · provider {cfg.provider} · model {cfg.model}"
+    return (
+        f"{count} finding{plural} · provider {cfg.provider} · model {cfg.model} "
+        f"· lgtmaybe {version}"
+    )
 
 
 def passes_path_filters(path: str, *, include: list[str], exclude: list[str]) -> bool:

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -89,9 +89,9 @@ def test_the_running_build_is_named_alongside_the_budget(cli_logs, monkeypatch) 
     that the resolved value reaches the log record, not that this test host happens
     to have distribution metadata installed.
     """
-    import lgtmaybe.cli as cli_module
+    import lgtmaybe.core.version as version_module
 
-    monkeypatch.setattr(cli_module.metadata, "version", lambda _name: "1.2.3")
+    monkeypatch.setattr(version_module.metadata, "version", lambda _name: "1.2.3")
     cfg = ReviewConfig(provider=Provider.openrouter, model="m")
     build_provider_engine(cfg, _runtime())
 
@@ -111,10 +111,10 @@ def test_the_running_build_is_named_alongside_the_budget(cli_logs, monkeypatch) 
     ids=["not-installed", "unreadable-metadata"],
 )
 def test_an_unreadable_version_does_not_break_the_run(monkeypatch, failure) -> None:
-    import lgtmaybe.cli as cli_module
+    import lgtmaybe.core.version as version_module
 
-    monkeypatch.setattr(cli_module.metadata, "version", lambda _name: failure())
-    assert cli_module.package_version() == "unknown"
+    monkeypatch.setattr(version_module.metadata, "version", lambda _name: failure())
+    assert version_module.package_version() == "unknown"
 
 
 def test_the_two_sources_are_distinguishable_at_the_same_value(cli_logs) -> None:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -18,6 +18,7 @@ from lgtmaybe.core.models import (
     ReviewResult,
     Severity,
 )
+from lgtmaybe.core.version import package_version
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
 from lgtmaybe.engine.compress import count_tokens
 from lgtmaybe.engine.engine import passes_path_filters
@@ -1722,6 +1723,53 @@ def test_bad_summary_template_falls_back_to_default() -> None:
     _findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
 
     assert "provider ollama · model llama3" in summary
+
+
+def test_summary_line_names_the_lgtmaybe_version() -> None:
+    """The built-in line carries the running version alongside the model.
+
+    Provider + model alone don't identify a review: the same model on the same
+    provider behaves differently across lgtmaybe releases (prompt, lenses,
+    reflection all move), so troubleshooting a surprising review needs the
+    version that produced it.
+    """
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+
+    _findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert f"lgtmaybe {package_version()}" in summary
+
+
+def test_summary_template_can_name_the_version() -> None:
+    """A restyled line can keep the version — otherwise opting into a template
+    silently costs you the troubleshooting handle."""
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        summary_template="{count} issue(s) via {model} (lgtmaybe {version})",
+    )
+
+    _findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert f"issue(s) via llama3 (lgtmaybe {package_version()})" in summary
+
+
+def test_clean_review_summary_names_the_version() -> None:
+    """👍 LGTM! carries it too — a clean review is exactly the outcome someone
+    doubts, so it needs the version that produced it."""
+    provider = _provider_for([], reflection_keeps_all=True)
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3")
+
+    findings, summary = engine.review(_CTX_WITH_CONTENT, cfg)
+
+    assert findings == []
+    assert "LGTM" in summary
+    assert f"lgtmaybe {package_version()}" in summary
 
 
 def test_finding_rules_run_before_the_summary_count(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_incomplete_visibility.py
+++ b/tests/test_incomplete_visibility.py
@@ -167,6 +167,18 @@ def test_total_failure_notice_is_visible() -> None:
     assert "provider quota exhausted" in github.comments[0]
 
 
+def test_failure_notice_names_the_version() -> None:
+    """The failure notice is the post most likely to start a bug report, and
+    it names no model — so the version is the only handle it can carry."""
+    from lgtmaybe.core.version import package_version
+
+    github = FakeGitHub(_CTX)
+
+    _post_failure(github, RuntimeError("provider quota exhausted"))
+
+    assert f"lgtmaybe {package_version()}" in github.comments[0]
+
+
 def test_total_failure_notice_posts_even_when_the_review_body_update_fails() -> None:
     """The two writes are independent, and deliberately so.
 


### PR DESCRIPTION
## Why

Provider and model alone don't identify a review. The same model on the same provider reviews differently across lgtmaybe releases — the prompt, the lens grouping, and reflection all move between them — so troubleshooting a surprising review starts with working out which build produced it. Until now, no post said.

This came out of a dogfood run on a deliberately-flawed test PR: reading the review meant cross-referencing the workflow run to find out what was actually running.

## What changed

The summary line now ends with `· lgtmaybe <version>`:

```
18 findings · provider openrouter · model deepseek/deepseek-v4-pro · lgtmaybe 1.7.0
```

That one line feeds both the review summary and the clean-review `👍 LGTM!`, so both carry it.

`summary_template` gains a matching `{version}` placeholder, so restyling the line doesn't silently cost you the handle:

```yaml
summary_template: "🤖 {count} finding(s) · {model} · lgtmaybe {version}"
```

The **failure notice** gets it too. That post names no model at all, so the version is the only identifying detail it can carry — and it's the post most likely to start a bug report.

`package_version()` moves from `cli` to a new `core.version`. The engine stamps the summary line and the CLI writes the failure notice, and neither package may import the other. It keeps its best-effort contract: an uninstalled source checkout reports `unknown` rather than failing a review.

## Not in scope

The describe and diagram comments are untouched. They name no model today — only a hidden marker — and that marker is the idempotency key for their upsert, so putting a version in it would orphan every existing comment on the next run. Happy to add a visible footer to them separately if you want it.

## Tests

Red-then-green, four new tests: the default line names the version, `{version}` works in a template, the clean-review `LGTM` summary carries it, and the failure notice does. The two existing tests that monkeypatched `cli.metadata` now patch `core.version.metadata`.

Full gate green locally: ruff, ruff format, mypy, and 1549 tests including `tests/specs`. No spec section covers the summary line, so no spec edit was needed. `docs/llms-full.txt` regenerated for the config how-to change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZWoC1C4StgoEHfhzZNz7V)_