### PR TITLE
fix(prompt): bind suggestion names to the file being changed

### DIFF
--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -60,6 +60,15 @@ replace them, indented to match, and nothing else. It is not a place for prose �
 drop-in code change (the fix is structural, spans code you cannot see, or is a \
 judgement call), set `suggestion` to null and make the recommendation in `body`.
 
+Every name in a `suggestion` must resolve in **the file being changed** — use the \
+imports, aliases, and spellings that file actually has, never the ones from a worked \
+example in this prompt. The same fix is spelled differently under different imports: \
+a file with `import datetime` needs `datetime.timezone.utc`, while one with \
+`from datetime import datetime` does not — there `datetime` is the class, and \
+`datetime.timezone` raises AttributeError. When the fix needs a name the file has not \
+imported, name the import to add in `body`. A suggestion is committed verbatim, so one \
+that reaches for an unimported name replaces working code with a crash.
+
 ### How to fill `line`, `side`, and `anchor`
 
 `line` is a real file line number, not a position within the diff. Compute it from the

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -111,6 +111,28 @@ def test_contract_requires_suggestion_to_be_replacement_code() -> None:
     assert "prose" in prompt
 
 
+def test_contract_binds_suggestion_names_to_the_target_file() -> None:
+    """A suggestion is committed verbatim, so its names must resolve in the file
+    being changed — not in whichever worked example this prompt happened to show.
+
+    The failure this guards against is real and example-seeded: the deprecation
+    example fixes `datetime.utcnow()` in a file that does `import datetime`, so it
+    suggests `datetime.timezone.utc`. Shown a file that does
+    `from datetime import datetime`, a model carried that qualifier across and
+    produced `datetime.now(tz=datetime.timezone.utc)` — an AttributeError, since
+    there `datetime` is the class, not the module. Committing that suggestion
+    replaces working code with a crash.
+    """
+    # Asserted on BOTH prompt shapes: prompt_cache defaults on, so the shared
+    # preamble is the one production actually sends. A rule that lived only in
+    # the legacy system prompt would be absent from every default review.
+    for prompt in (_union_prompt().lower(), build_shared_preamble().lower()):
+        # The contract must scope name resolution to the file under review...
+        assert "imports" in prompt
+        # ...and say what to do when the fix needs a name the file lacks.
+        assert "import" in prompt and "body" in prompt
+
+
 def test_worked_example_suggestions_are_code_not_prose() -> None:
     """Every non-null worked-example suggestion must read as code, not an English
     instruction — the model copies these verbatim."""


### PR DESCRIPTION
## The bug

A `suggestion` is rendered as a one-click committable change, so a name that doesn't resolve in the target file doesn't just produce a bad review — it replaces working code with a crash if anyone clicks commit.

Observed on a real review. The model emitted:

```python
"generated_at": datetime.now(tz=datetime.timezone.utc).isoformat(),
```

into a file whose import is `from datetime import datetime`. There `datetime` is the class, not the module, so `datetime.timezone` raises `AttributeError`. The *finding* was correct — `datetime.utcnow()` really is deprecated — but its suggestion doesn't run.

## Why it happened

This isn't random. It's seeded by our own worked example.

The deprecation lens example (`prompt.py`) fixes `datetime.utcnow()` in a file whose diff shows `import datetime`, so its suggestion is `datetime.datetime.now(datetime.timezone.utc)` — correct *there*. Shown a file with a different import, the model kept the target file's `datetime.now(` and pasted the example's `datetime.timezone.utc` qualifier. The two halves are each locally plausible and the blend is broken.

The contract explained what a suggestion must *be* (literal replacement code, indented to match, no prose) but never said which file's namespace it is written against — so nothing told the model the example's spelling doesn't travel.

## The fix

State it in the contract: names in a `suggestion` must resolve against the imports and aliases **the changed file actually has**, never those of a worked example, and a fix needing an unimported name must name that import in `body`.

I did not add a suggestion validator. The failure is name resolution, not syntax — a parser wouldn't catch it, and a suggestion fragment (here, a dict entry) isn't standalone-parseable anyway. Checking it properly means resolving names against the file's import graph, which is a lot of machinery to catch a class of error better fixed at the source. A validator that wrongly drops good suggestions would be worse than the bug.

## Tests

Red-then-green, one new test in `tests/engine/test_prompt.py` documenting the observed failure so the reasoning survives.

It asserts on **both** prompt shapes. `prompt_cache` defaults on, so `build_shared_preamble` is what production actually sends — a rule asserted only against the legacy `build_system_prompt` would be absent from every default review and the test would still pass. Verified the text lands in both.

Full gate green locally: ruff, ruff format, mypy, 1550 tests including `tests/specs`. No spec section describes the suggestion content contract, so nothing there went stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZWoC1C4StgoEHfhzZNz7V)_