### PR TITLE
feat(static-analysis): add mypy to the fusion runner

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -248,7 +248,7 @@ confidence score, filtered by `min_confidence`), and loud failure surfacing (a
 stage and model call is timed; `--profile` prints the breakdown.
 
 **Grounding** — optional static-analysis fusion (`static_analysis`, default
-off): installed deterministic linters (ruff, bandit, semgrep with local rules)
+off): installed deterministic linters (ruff, bandit, mypy, semgrep with local rules)
 run over the fetched changed-file texts in a sandboxed, network-less
 subprocess, and their findings enter each lens prompt as untrusted hints to
 confirm or discard — never posted verbatim.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ pattern, event bus, plugin framework.
      the Action's `synchronize` event, full elsewhere; Action input
      `incremental`); `/review full` forces a full re-review.
    - **Static-analysis fusion (default off):** with `static_analysis.enabled`,
-     installed deterministic tools (ruff, bandit, semgrep-with-local-rules —
+     installed deterministic tools (ruff, bandit, mypy, semgrep-with-local-rules —
      `pip install lgtmaybe[static-analysis]`) run over the already-fetched
      changed-file texts in a temp dir (`engine/static_analysis.py`; sandboxed
      subprocess: scrubbed env, no network — semgrep only ever runs with local

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ everywhere:
 
 Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **compact change diagram** — an automatically laid-out Mermaid flowchart of the components the PR touches, with changes marked on nodes, rendered natively in the comment, with an ASCII fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
 
-On re-runs and big PRs the review stays cheap: a `synchronize` push triggers an **incremental review** of just the new commits, an optional cheap **triage model** (`triage_model`) skips plainly-non-substantive files before the strong model runs, and optional **static-analysis fusion** (`static_analysis`) feeds ruff/bandit/semgrep hints into the review as untrusted context.
+On re-runs and big PRs the review stays cheap: a `synchronize` push triggers an **incremental review** of just the new commits, an optional cheap **triage model** (`triage_model`) skips plainly-non-substantive files before the strong model runs, and optional **static-analysis fusion** (`static_analysis`) feeds ruff/bandit/mypy/semgrep hints into the review as untrusted context.
 
 <p align="center">
   <img src="docs/assets/marketplace/marketplace-screenshot-1.png" alt="An inline lgtmaybe review comment on a GitHub pull request flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a suggested parameterized-query fix" width="640">

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ inputs:
     required: false
     default: ""
   static_analysis:
-    description: "Run installed deterministic linters (ruff, bandit, semgrep with local rules) over the changed files in a sandboxed, network-less subprocess and feed their findings to the model as untrusted hints to confirm or discard. Off by default; tools not present in the image are skipped silently."
+    description: "Run installed deterministic linters (ruff, bandit, mypy, semgrep with local rules) over the changed files in a sandboxed, network-less subprocess and feed their findings to the model as untrusted hints to confirm or discard. Off by default; tools not present in the image are skipped silently."
     required: false
     default: ""
   auto_describe:

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -376,9 +376,17 @@ Static-analysis fusion: run fast, deterministic linters over the changed files
 and feed their findings to the model as **hints to confirm, contextualise, or
 discard**. This raises recall on exactly the mechanical bugs LLMs miss without
 posting raw linter noise — only findings the model itself confirms are
-reported. Supported tools: **ruff** and **bandit** (Python), and **semgrep**
-(multi-language) when you point `semgrep_rules` at local rules — semgrep's
-registry configs need the network, which the sandbox forbids.
+reported. Supported tools: **ruff**, **bandit**, and **mypy** (Python), and
+**semgrep** (multi-language) when you point `semgrep_rules` at local rules —
+semgrep's registry configs need the network, which the sandbox forbids.
+
+**mypy** earns its place on unguarded-`Optional` bugs: a `dict.get()` narrowed
+to `str | None` and then dereferenced is a crash a review lens reads straight
+past, and mypy proves it from the file's own text in seconds. It runs with
+`--ignore-missing-imports --follow-imports=skip`, because the sandbox holds only
+the changed files and everything they import is absent by construction —
+so it reports what it can prove from a single file, and stays quiet about the
+rest (untyped code and unresolvable imports produce nothing).
 
 The tools run against the already-fetched file texts in a throwaway directory
 (never a checkout, never executing PR code), in a subprocess with a scrubbed
@@ -392,7 +400,7 @@ injection-wrapped before it reaches the model. CLI:
 ```yaml
 static_analysis:
   enabled: true
-  tools: [ruff, bandit]        # default: ruff, bandit, semgrep
+  tools: [ruff, bandit, mypy]  # default: ruff, bandit, semgrep, mypy
   min_severity: low            # floor on mapped tool severity (default info)
   tool_min_severity:           # per-tool overrides of the global floor
     ruff: medium               # only medium+ from ruff; bandit keeps `low`

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -215,7 +215,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
-| `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
+| `static_analysis` | `false` | Run installed linters (ruff, bandit, mypy, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
 | `auto_diagram` | `true` | Post a compact Mermaid flowchart comment when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -554,7 +554,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
-| `static_analysis` | `false` | Run installed linters (ruff, bandit, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
+| `static_analysis` | `false` | Run installed linters (ruff, bandit, mypy, semgrep with local rules) sandboxed over the changed files and feed their findings to the model as untrusted hints |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
 | `auto_diagram` | `true` | Post a compact Mermaid flowchart comment when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |
@@ -2420,9 +2420,17 @@ Static-analysis fusion: run fast, deterministic linters over the changed files
 and feed their findings to the model as **hints to confirm, contextualise, or
 discard**. This raises recall on exactly the mechanical bugs LLMs miss without
 posting raw linter noise — only findings the model itself confirms are
-reported. Supported tools: **ruff** and **bandit** (Python), and **semgrep**
-(multi-language) when you point `semgrep_rules` at local rules — semgrep's
-registry configs need the network, which the sandbox forbids.
+reported. Supported tools: **ruff**, **bandit**, and **mypy** (Python), and
+**semgrep** (multi-language) when you point `semgrep_rules` at local rules —
+semgrep's registry configs need the network, which the sandbox forbids.
+
+**mypy** earns its place on unguarded-`Optional` bugs: a `dict.get()` narrowed
+to `str | None` and then dereferenced is a crash a review lens reads straight
+past, and mypy proves it from the file's own text in seconds. It runs with
+`--ignore-missing-imports --follow-imports=skip`, because the sandbox holds only
+the changed files and everything they import is absent by construction —
+so it reports what it can prove from a single file, and stays quiet about the
+rest (untyped code and unresolvable imports produce nothing).
 
 The tools run against the already-fetched file texts in a throwaway directory
 (never a checkout, never executing PR code), in a subprocess with a scrubbed
@@ -2436,7 +2444,7 @@ injection-wrapped before it reaches the model. CLI:
 ```yaml
 static_analysis:
   enabled: true
-  tools: [ruff, bandit]        # default: ruff, bandit, semgrep
+  tools: [ruff, bandit, mypy]  # default: ruff, bandit, semgrep, mypy
   min_severity: low            # floor on mapped tool severity (default info)
   tool_min_severity:           # per-tool overrides of the global floor
     ruff: medium               # only medium+ from ruff; bandit keeps `low`
@@ -3244,7 +3252,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `reflect` | boolean | No | `True` | Reflect |
 | `reflect_model` | string / null | No | `null` | Reflect Model |
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
-| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
+| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep', 'mypy'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
@@ -3698,7 +3706,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": [
             "ruff",
             "bandit",
-            "semgrep"
+            "semgrep",
+            "mypy"
           ],
           "items": {
             "$ref": "#/$defs/StaticAnalysisTool"
@@ -3715,7 +3724,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "enum": [
         "ruff",
         "bandit",
-        "semgrep"
+        "semgrep",
+        "mypy"
       ],
       "title": "StaticAnalysisTool",
       "type": "string"
@@ -3977,7 +3987,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "tools": [
           "ruff",
           "bandit",
-          "semgrep"
+          "semgrep",
+          "mypy"
         ]
       }
     },

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -49,7 +49,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `reflect` | boolean | No | `True` | Reflect |
 | `reflect_model` | string / null | No | `null` | Reflect Model |
 | `resolve_fixed` | boolean | No | `True` | Resolve Fixed |
-| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
+| `static_analysis` | StaticAnalysisConfig | No | `{'enabled': False, 'tools': ['ruff', 'bandit', 'semgrep', 'mypy'], 'min_severity': 'info', 'tool_min_severity': {}, 'semgrep_rules': None}` |  |
 | `structured_output` | boolean | No | `True` | Structured Output |
 | `summary_template` | string / null | No | `null` | Summary Template |
 | `symbol_resolution` | boolean | No | `True` | Symbol Resolution |
@@ -503,7 +503,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
           "default": [
             "ruff",
             "bandit",
-            "semgrep"
+            "semgrep",
+            "mypy"
           ],
           "items": {
             "$ref": "#/$defs/StaticAnalysisTool"
@@ -520,7 +521,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "enum": [
         "ruff",
         "bandit",
-        "semgrep"
+        "semgrep",
+        "mypy"
       ],
       "title": "StaticAnalysisTool",
       "type": "string"
@@ -782,7 +784,8 @@ The canonical machine-readable schemas. These are the source of truth for provid
         "tools": [
           "ruff",
           "bandit",
-          "semgrep"
+          "semgrep",
+          "mypy"
         ]
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ static-analysis = [
     "ruff>=0.5",
     "bandit>=1.7",
     "semgrep>=1.60",
+    # --output json landed in mypy 1.11; the runner parses that shape only.
+    "mypy>=1.11",
 ]
 # Hosted identity broker only; not installed by CLI or Action users.
 identity-broker = [

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -308,7 +308,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
 @click.option(
     "--static-analysis/--no-static-analysis",
     default=None,
-    help="Run installed deterministic linters (ruff, bandit, semgrep with local "
+    help="Run installed deterministic linters (ruff, bandit, mypy, semgrep with local "
     "rules) over the changed files and feed their findings to the model as "
     "untrusted hints to confirm or discard (default off; tools not installed "
     "are skipped silently — pip install lgtmaybe[static-analysis])",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -136,6 +136,7 @@ class StaticAnalysisTool(StrEnum):
     ruff = "ruff"
     bandit = "bandit"
     semgrep = "semgrep"
+    mypy = "mypy"
 
 
 class StaticAnalysisConfig(_Strict):
@@ -159,7 +160,8 @@ class StaticAnalysisConfig(_Strict):
     tools: list[StaticAnalysisTool] = Field(default=list(StaticAnalysisTool))
     # Floor on the MAPPED severity of tool findings (ruff → low; bandit
     # LOW/MEDIUM/HIGH → low/medium/high; semgrep INFO/WARNING/ERROR →
-    # info/medium/high). Hints below it are dropped before prompting.
+    # info/medium/high; mypy error → medium, note → info). Hints below it are
+    # dropped before prompting.
     min_severity: Severity = Severity.info
     # Per-tool overrides of `min_severity` — e.g. keep every bandit hit but
     # take only medium+ from ruff. A tool without an entry uses the global

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -1,8 +1,9 @@
 """Static-analysis fusion (F1): deterministic tool findings as LLM grounding.
 
-Runs fast linters/SAST (ruff, bandit, and semgrep with local rules) over the
-**already-fetched changed-file texts**, written to a throwaway temp dir — never
-a checkout, never executing PR code (linting is parsing, like ast-grep). The
+Runs fast linters/SAST (ruff, bandit, mypy, and semgrep with local rules) over
+the **already-fetched changed-file texts**, written to a throwaway temp dir —
+never a checkout, never executing PR code (linting and type checking are
+parsing plus inference, like ast-grep; no module is ever imported). The
 findings are formatted as untrusted HINTS for the lens prompts ("confirm,
 contextualise, or discard"), raising recall on the deterministic bugs LLMs miss
 while letting the model suppress raw linter noise.
@@ -165,6 +166,27 @@ def _run_tool(tool: StaticAnalysisTool, root: Path, cfg: ReviewConfig) -> list[T
         argv = [binary, "check", "--output-format", "json", "--exit-zero", "--no-cache", "."]
     elif tool is StaticAnalysisTool.bandit:
         argv = [binary, "-f", "json", "-q", "-r", "."]
+    elif tool is StaticAnalysisTool.mypy:
+        # The corpus holds only the CHANGED files, so everything they import is
+        # absent by construction. Without these flags mypy reports one error per
+        # unresolvable import and the real findings drown: --ignore-missing-imports
+        # silences the absent third-party/stdlib stubs, --follow-imports=skip stops
+        # it chasing sibling modules that were never fetched. What survives is
+        # exactly what it can prove from a single file's own text — which is where
+        # the unguarded-Optional bugs live.
+        argv = [
+            binary,
+            "--output",
+            "json",
+            "--ignore-missing-imports",
+            "--follow-imports=skip",
+            "--no-error-summary",
+            "--no-color-output",
+            # Never read or write a cache: the corpus is a throwaway temp dir and
+            # a stale cache keyed to another run's files would be worse than none.
+            "--no-incremental",
+            ".",
+        ]
     else:  # semgrep
         rules = cfg.static_analysis.semgrep_rules
         if not rules:
@@ -240,6 +262,11 @@ def _scrubbed_env(root: Path) -> dict[str, str]:
 
 
 def _parse_output(tool: StaticAnalysisTool, stdout: str, root: Path) -> list[ToolFinding]:
+    # mypy is the odd one out: JSON Lines, one object per diagnostic, where the
+    # others emit a single document. Parsed as one it raises and the tool
+    # degrades to silence.
+    if tool is StaticAnalysisTool.mypy:
+        return [_mypy_finding(json.loads(line)) for line in stdout.splitlines() if line.strip()]
     data = json.loads(stdout)
     if tool is StaticAnalysisTool.ruff:
         return [_ruff_finding(item, root) for item in data]
@@ -279,6 +306,25 @@ def _bandit_finding(item: dict[str, Any]) -> ToolFinding:
         rule=str(item.get("test_id", "")),
         message=str(item.get("issue_text", "")),
         severity=_BANDIT_SEVERITY.get(str(item.get("issue_severity", "")).upper(), Severity.low),
+    )
+
+
+def _mypy_finding(item: dict[str, Any]) -> ToolFinding:
+    severity = str(item.get("severity", "")).lower()
+    return ToolFinding(
+        tool="mypy",
+        path=_posix_rel(str(item.get("file", ""))),
+        line=int(item.get("line") or 1),
+        # A diagnostic without an error code is a `note` — mypy's follow-up
+        # explanation of the error above it. Keep the tie to its parent visible
+        # rather than rendering an empty rule.
+        rule=str(item.get("code") or "note"),
+        message=str(item.get("message", "")),
+        # A type error is a provable contradiction in the code as written, so it
+        # outranks a ruff lint (low) — but mypy on a single file out of its
+        # project also can't see every runtime guard, so it is not automatically
+        # high. Notes only elaborate on the error they follow: info.
+        severity=Severity.medium if severity == "error" else Severity.info,
     )
 
 

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -25,6 +25,8 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import lgtmaybe.engine.static_analysis as static_analysis
 from lgtmaybe.core.models import Provider, ReviewConfig, Severity, StaticAnalysisTool
 from lgtmaybe.engine.static_analysis import (
@@ -53,6 +55,34 @@ def _ruff_output(root: str) -> str:
                 "location": {"row": 1, "column": 1},
             }
         ]
+    )
+
+
+def _mypy_output() -> str:
+    """mypy --output json: JSON Lines, one object per diagnostic."""
+    return (
+        json.dumps(
+            {
+                "file": "src/app.py",
+                "line": 9,
+                "column": 16,
+                "message": 'Item "None" of "str | None" has no attribute "splitlines"',
+                "code": "union-attr",
+                "severity": "error",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "file": "src/app.py",
+                "line": 9,
+                "column": 16,
+                "message": "Consider using an explicit None check",
+                "code": None,
+                "severity": "note",
+            }
+        )
+        + "\n"
     )
 
 
@@ -184,6 +214,75 @@ def test_bandit_findings_parsed_with_severity_mapping(monkeypatch) -> None:  # t
     assert findings[0].line == 2
     assert findings[0].rule == "B307"
     assert findings[0].severity is Severity.medium
+
+
+def test_mypy_findings_parsed_from_json_lines(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """mypy emits JSON Lines — one object per line, not an array like ruff.
+
+    Parsed with json.loads over the whole payload it raises, and the tool would
+    degrade to silence with only a warning in the log.
+    """
+    run = _FakeRun(outputs={"mypy": _mypy_output()})
+    _patch_tools(monkeypatch, run, present={"mypy"})
+
+    findings = run_static_analysis(FILES, _cfg(tools=[StaticAnalysisTool.mypy]))
+
+    assert [(f.rule, f.line, f.severity) for f in findings] == [
+        ("union-attr", 9, Severity.medium),
+        ("note", 9, Severity.info),
+    ]
+    assert findings[0].path == "src/app.py"
+    assert findings[0].tool == "mypy"
+
+
+def test_mypy_blank_lines_are_skipped(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A clean run prints nothing; a trailing newline must not parse as garbage
+    and take the whole tool's findings down with it."""
+    run = _FakeRun(outputs={"mypy": "\n\n"})
+    _patch_tools(monkeypatch, run, present={"mypy"})
+
+    assert run_static_analysis(FILES, _cfg(tools=[StaticAnalysisTool.mypy])) == []
+
+
+def test_mypy_runs_isolated_from_the_wider_codebase(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The corpus is only the CHANGED files, so mypy must not treat every
+    unresolvable import as an error — that noise would bury the real hits and
+    blow the MAX_HINTS cap on any normal PR."""
+    run = _FakeRun(outputs={"mypy": ""})
+    _patch_tools(monkeypatch, run, present={"mypy"})
+
+    run_static_analysis(FILES, _cfg(tools=[StaticAnalysisTool.mypy]))
+
+    argv = [str(a) for a in run.calls[0]["argv"]]  # type: ignore[union-attr]
+    assert "--ignore-missing-imports" in argv
+    assert "--follow-imports=skip" in argv
+    # Never reuse or write a cache keyed to another run's corpus.
+    assert "--no-incremental" in argv
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy not installed")
+def test_mypy_really_catches_an_unguarded_none_deref(tmp_path: Path) -> None:
+    """The regression this tool was added for, run against the real binary.
+
+    A faked subprocess proves we parse mypy's output; it cannot prove the flags
+    we pass still surface the finding. This is the bug a live review missed and
+    mypy caught: `dict.get()` narrows to `str | None`, and `.splitlines()` on it
+    crashes at runtime.
+    """
+    files = {
+        "src/metrics.py": (
+            "def summarise(findings: list, file_contents: dict[str, str]) -> int:\n"
+            "    total = 0\n"
+            "    for finding in findings:\n"
+            "        text = file_contents.get(finding.path)\n"
+            "        total += len(text.splitlines())\n"
+            "    return total\n"
+        )
+    }
+
+    findings = run_static_analysis(files, _cfg(tools=[StaticAnalysisTool.mypy]))
+
+    assert any(f.rule == "union-attr" and f.line == 5 for f in findings), findings
 
 
 def test_min_severity_floor_drops_weak_hints(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -358,7 +358,8 @@
           "default": [
             "ruff",
             "bandit",
-            "semgrep"
+            "semgrep",
+            "mypy"
           ],
           "items": {
             "$ref": "#/$defs/StaticAnalysisTool"
@@ -375,7 +376,8 @@
       "enum": [
         "ruff",
         "bandit",
-        "semgrep"
+        "semgrep",
+        "mypy"
       ],
       "title": "StaticAnalysisTool",
       "type": "string"
@@ -637,7 +639,8 @@
         "tools": [
           "ruff",
           "bandit",
-          "semgrep"
+          "semgrep",
+          "mypy"
         ]
       }
     },

--- a/uv.lock
+++ b/uv.lock
@@ -1319,6 +1319,7 @@ identity-broker = [
 ]
 static-analysis = [
     { name = "bandit" },
+    { name = "mypy" },
     { name = "ruff" },
     { name = "semgrep" },
 ]
@@ -1361,6 +1362,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'identity-broker'", specifier = ">=0.28.1" },
     { name = "litellm", marker = "python_full_version < '3.14'", specifier = ">=1.87.1" },
     { name = "litellm", marker = "python_full_version >= '3.14'", specifier = ">=1.87.1,<1.94" },
+    { name = "mypy", marker = "extra == 'static-analysis'", specifier = ">=1.11" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'identity-broker'", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
## Why

A live review missed this:

```python
text = file_contents.get(finding.path)   # -> str | None
lines = text.splitlines()                # AttributeError when the file isn't in the map
```

It caught three *narrower* crash paths in the same function — an empty-list `ZeroDivisionError`, an empty-list `IndexError`, a percentile index overrun — and read straight past the widest one. mypy proves it from the file's own text in seconds:

```
src/lgtmaybe/engine/metrics.py:98: error: Item "None" of "str | None" has no attribute "splitlines"  [union-attr]
```

That's precisely the division of labour fusion exists for: unguarded-`Optional` is provable, and a type checker doesn't get bored. mypy was the obvious tool missing from the runner.

## What changed

`mypy` joins `StaticAnalysisTool`, so it runs by default wherever `static_analysis.enabled` is on and the binary is present (skipped silently otherwise, like the others). Same posture as the rest: sandboxed subprocess, scrubbed environment, no network, hard timeout, never a checkout — type checking is parsing plus inference, no module is imported. Findings map onto the shared severity scale and enter the prompt as untrusted hints to confirm, contextualise, or discard; raw output is never posted.

**Severity:** `error` → `medium`, `note` → `info`. A type error is a provable contradiction, so it outranks a ruff lint (`low`) — but mypy seeing one file out of its project can't see every runtime guard, so it isn't automatically `high`.

## Two wrinkles the other three don't have

**mypy emits JSON Lines**, not a single document. `json.loads` over the whole payload raises, and because per-tool failures degrade to silence, that would have shipped as "mypy contributes nothing" with only a log line to show for it. Parsed per line, blank lines skipped.

**The corpus is only the changed files**, so everything they import is absent by construction. Left alone, mypy reports one error per unresolvable import and the real findings drown — on a normal PR that would blow the `MAX_HINTS` cap with pure noise. `--ignore-missing-imports --follow-imports=skip` keep it to what a single file's own text proves. I measured this before wiring it up: a file with unresolvable third-party, package, and relative imports plus wholly untyped functions produced **zero** output, while the `None`-deref fixture still produced its one finding.

## Tests

Red-then-green, four new tests: JSON Lines parsing, blank-line handling, the isolation flags, and — against the **real binary**, skipped if absent — the exact `union-attr` regression that motivated this. A faked subprocess proves the parser; only a live run proves the flags still surface the finding.

Full gate green locally: ruff, ruff format, mypy, `uv lock --check`, and 1554 tests including `tests/specs`. `ReviewConfig` schema snapshot, `docs/reference/config.md`, and `docs/llms-full.txt` regenerated; tool lists updated in the config how-to, the Action how-to, `action.yml`, the CLI help, README, ARCHITECTURE.md, and CLAUDE.md.

## Note

`mypy>=1.11` is added to the `static-analysis` extra (`--output json` landed in 1.11). It's already a dev dependency, so contributors get it either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZWoC1C4StgoEHfhzZNz7V)_