### PR TITLE
fix(compress): merge hunks whose context pads overlap

### DIFF
--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -149,12 +149,18 @@ Hunks SHALL be padded with surrounding file content, budget-scaled and capped
 by `context_lines`: the full budget before the hunk, a quarter (floored at one
 line) after — the enclosing signature explains a change better than what
 follows. Inline positions stay bound to the real diff, so context-only lines
-never carry comments.
+never carry comments. Hunks whose padded windows meet are merged into one, with
+the span between them filled in as context, so the patch stays monotonic and no
+line is emitted twice.
 <!-- anchor: engine.context-expansion -->
 
 #### Scenario: context lines never take comments
 - **WHEN** a finding lands on an expansion-only line
 - **THEN** it maps to nothing in the real diff and is dropped, never mis-posted
+
+#### Scenario: two nearby hunks are padded into each other
+- **WHEN** a hunk's leading pad reaches the previous hunk's trailing pad
+- **THEN** both are emitted as one hunk whose header describes what it holds
 
 ### Requirement: Triage never skips past the security floor
 

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -7,6 +7,7 @@ Provides a dynamic context-line calculator for the remaining budget.
 from __future__ import annotations
 
 from bisect import bisect_right
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
@@ -214,6 +215,13 @@ def expand_hunks(
     signature explains a change better than an arbitrary cut. A boundary can
     only ever widen the window, never shrink it.
 
+    Hunks whose padded windows meet or overlap are **merged into one**, with the
+    lines between them filled in as context. Padded independently they would
+    each reach into the other's span, emitting a later hunk header that points
+    above where the previous one ended — a non-monotonic patch that breaks the
+    line arithmetic the model is asked to do, and that shows the same position
+    twice with two different contents (once changed, once as stale context).
+
     This is best-effort: with ``n <= 0`` or no file content the patch is returned
     unchanged, and reads are clamped to the file's bounds. The result is for the
     model only — inline-comment positions are always computed from the real diff.
@@ -223,56 +231,144 @@ def expand_hunks(
     n_after = max(0, after)
 
     content_lines = file_content.splitlines()
-    out: list[str] = []
-    pending_trailing: list[str] = []
+    preamble, hunks = _parse_hunks(patch)
+    if not hunks:
+        return patch
 
+    out = list(preamble)
+    for group in _group_hunks(hunks, content_lines, n, n_after, boundaries):
+        out.extend(_render_group(group, content_lines, n_after))
+    return "\n".join(out) + "\n"
+
+
+@dataclass(frozen=True)
+class _Hunk:
+    """One parsed hunk: its header positions plus its verbatim body lines."""
+
+    old_start: int
+    old_len: int
+    new_start: int
+    new_len: int
+    section: str
+    body: list[str]
+
+    @property
+    def last_new(self) -> int:
+        """The hunk's final new-file line number."""
+        return self.new_start + self.new_len - 1
+
+
+def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
+    """Split *patch* into its leading file-header lines and its hunks."""
+    preamble: list[str] = []
+    hunks: list[_Hunk] = []
     for line in patch.splitlines():
         header = parse_hunk_header(line)
-        if header is None:
-            out.append(line)
-            continue
+        if header is not None:
+            hunks.append(
+                _Hunk(
+                    old_start=header.old_start,
+                    old_len=header.old_len,
+                    new_start=header.new_start,
+                    new_len=header.new_len,
+                    section=header.section,
+                    body=[],
+                )
+            )
+        elif hunks:
+            hunks[-1].body.append(line)
+        else:
+            preamble.append(line)
+    return preamble, hunks
 
-        # A new hunk starts: flush the previous hunk's trailing context first.
-        out.extend(f" {text}" for text in pending_trailing)
 
-        old_start = header.old_start
-        old_len = header.old_len
-        new_start = header.new_start
-        new_len = header.new_len
-        section = header.section
+def _lead_start(hunk: _Hunk, n: int, boundaries: list[int] | None) -> int:
+    """The first new-file line *hunk*'s leading pad should reach back to."""
+    lead_start = max(1, hunk.new_start - n)
+    if boundaries:
+        enclosing = _enclosing_boundary(boundaries, hunk.new_start)
+        if enclosing is not None and enclosing < lead_start:
+            # The enclosing definition starts above the fixed window and
+            # within reach — widen the pad up to its signature line.
+            lead_start = enclosing
+    # The rewritten header's old start is `old_start - len(leading)`: when
+    # earlier hunks net-added lines, old_start sits far below new_start, so an
+    # unclamped pad drives it negative — an invalid header that
+    # parse_hunk_header rejects, mis-numbering every line downstream. Clamp the
+    # pad (after any boundary widening) so the old start stays >= 1.
+    return max(lead_start, hunk.new_start - (hunk.old_start - 1))
 
-        # Lines immediately before the hunk and after its last new-file line.
-        lead_start = max(1, new_start - n)
-        if boundaries:
-            enclosing = _enclosing_boundary(boundaries, new_start)
-            if enclosing is not None and enclosing < lead_start:
-                # The enclosing definition starts above the fixed window and
-                # within reach — widen the pad up to its signature line.
-                lead_start = enclosing
-        # The rewritten header's old start is `old_start - len(leading)`: when
-        # earlier hunks net-added lines, old_start sits far below new_start, so
-        # an unclamped pad drives it negative — an invalid header that
-        # parse_hunk_header rejects, mis-numbering every line downstream. Clamp
-        # the pad (after any boundary widening) so the old start stays >= 1.
-        lead_start = max(lead_start, new_start - (old_start - 1))
-        # Clamp reads to the file's real bounds: redaction or stale head text
-        # can leave the file shorter than the hunk positions — degrade to less
-        # padding, never an IndexError.
-        lead_end = min(new_start, len(content_lines) + 1)
-        leading = [content_lines[i - 1] for i in range(min(lead_start, lead_end), lead_end)]
-        last_new = new_start + new_len - 1
-        trailing = [
-            content_lines[i - 1]
-            for i in range(last_new + 1, min(len(content_lines), last_new + n_after) + 1)
-        ]
-        pending_trailing = trailing
 
-        pad = len(leading) + len(trailing)
-        out.append(
-            f"@@ -{old_start - len(leading)},{old_len + pad} "
-            f"+{new_start - len(leading)},{new_len + pad} @@{section}"
-        )
-        out.extend(f" {text}" for text in leading)
+@dataclass
+class _Group:
+    """A run of hunks rendered as one merged hunk, with its leading pad start."""
 
-    out.extend(f" {text}" for text in pending_trailing)
-    return "\n".join(out) + "\n"
+    hunks: list[_Hunk]
+    lead_start: int
+
+
+def _group_hunks(
+    hunks: list[_Hunk],
+    content_lines: list[str],
+    n: int,
+    n_after: int,
+    boundaries: list[int] | None,
+) -> list[_Group]:
+    """Group *hunks* into runs whose padded windows touch, in file order.
+
+    A group is rendered as a single merged hunk. Two hunks join when the later
+    one's leading pad reaches the earlier one's trailing pad (or the line just
+    after it) — the point at which independent padding would double up.
+    """
+    groups: list[_Group] = []
+    for hunk in hunks:
+        lead_start = _lead_start(hunk, n, boundaries)
+        if groups:
+            previous = groups[-1].hunks[-1]
+            trail_end = min(len(content_lines), previous.last_new + n_after)
+            # The gap between the two is filled from the head text, so only
+            # merge when that text actually reaches — a file shorter than the
+            # hunk positions (stale or redacted) would otherwise drop lines the
+            # merged header still claims.
+            reaches = lead_start <= trail_end + 1
+            fillable = hunk.new_start - 1 <= len(content_lines)
+            if reaches and fillable:
+                groups[-1].hunks.append(hunk)
+                continue
+        groups.append(_Group(hunks=[hunk], lead_start=lead_start))
+    return groups
+
+
+def _render_group(group: _Group, content_lines: list[str], n_after: int) -> list[str]:
+    """Render one group of hunks as a single padded hunk, header included.
+
+    Header lengths are counted off the emitted body rather than derived
+    arithmetically, so a merged hunk's counts cannot drift from what it holds.
+    """
+    first, last = group.hunks[0], group.hunks[-1]
+
+    # Clamp reads to the file's real bounds: redaction or stale head text can
+    # leave the file shorter than the hunk positions — degrade to less padding,
+    # never an IndexError.
+    lead_end = min(first.new_start, len(content_lines) + 1)
+    leading = content_lines[min(group.lead_start, lead_end) - 1 : lead_end - 1]
+
+    body: list[str] = []
+    for index, hunk in enumerate(group.hunks):
+        if index:
+            # Fill the gap between the previous hunk's last line and this one
+            # with the head text, as ordinary context.
+            previous_end = group.hunks[index - 1].last_new
+            body.extend(f" {text}" for text in content_lines[previous_end : hunk.new_start - 1])
+        body.extend(hunk.body)
+
+    trailing = content_lines[last.last_new : min(len(content_lines), last.last_new + n_after)]
+
+    lines = [f" {text}" for text in leading] + body + [f" {text}" for text in trailing]
+    # An empty body line is git's rendering of an empty context line, so it
+    # counts on both sides; "\ No newline at end of file" counts on neither.
+    old_len = sum(1 for line in lines if line[:1] in {" ", "-", ""})
+    new_len = sum(1 for line in lines if line[:1] in {" ", "+", ""})
+    old_start = first.old_start - len(leading)
+    new_start = first.new_start - len(leading)
+    return [f"@@ -{old_start},{old_len} +{new_start},{new_len} @@{first.section}", *lines]

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from lgtmaybe.core.diffparse import HunkHeader, parse_hunk_header
 from lgtmaybe.engine.compress import (
     _token_encoder,
     batch_files,
@@ -188,15 +189,16 @@ _CONTENT = "\n".join("abcdefghij")  # lines 1..10: a, b, c, ... j
 
 def test_expand_hunks_adds_surrounding_lines() -> None:
     # Hunk covers new-file lines 5..6 (e, E2); ask for 2 lines either side.
-    patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
+    patch = "diff --git a/f.py b/f.py\n@@ -5,1 +5,2 @@\n e\n+E2\n"
 
     expanded = expand_hunks(patch, _CONTENT, 2, after=2)
 
     # Two leading lines (c, d) and two trailing lines (g, h) are added as context.
     assert "\n c\n d\n" in expanded
     assert "\n g\n h\n" in expanded
-    # Header line/length counts are widened by the added context on both sides.
-    assert "@@ -3,6 +3,6 @@" in expanded
+    # Header line/length counts are widened by the added context on both sides:
+    # one old line + 4 pads, two new lines + 4 pads, both starting two lines up.
+    assert "@@ -3,5 +3,6 @@" in expanded
 
 
 def test_expand_hunks_noop_when_n_zero() -> None:
@@ -224,7 +226,7 @@ def test_expand_hunks_clamps_at_file_edges() -> None:
 def test_expand_hunks_asymmetric_pads_fewer_after() -> None:
     # The code BEFORE a change (signature, setup) explains it better than the
     # code after, so an explicit `after` pads the two sides differently.
-    patch = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
+    patch = "diff --git a/f.py b/f.py\n@@ -5,1 +5,2 @@\n e\n+E2\n"
 
     expanded = expand_hunks(patch, _CONTENT, 3, after=1)
 
@@ -232,8 +234,8 @@ def test_expand_hunks_asymmetric_pads_fewer_after() -> None:
     assert "\n b\n c\n d\n" in expanded
     assert "\n g\n" in expanded
     assert " h\n" not in expanded
-    # Header widened by 3 leading + 1 trailing = 4.
-    assert "@@ -2,6 +2,6 @@" in expanded
+    # Header widened by 3 leading + 1 trailing = 4 on each side.
+    assert "@@ -2,5 +2,6 @@" in expanded
 
 
 def test_trailing_context_lines_ratio() -> None:
@@ -262,8 +264,10 @@ def test_expand_hunks_header_old_start_never_below_one() -> None:
 
     expanded = expand_hunks(patch, content, 20, after=5)
 
+    # The second hunk sits within the first one's trailing pad, so the two are
+    # emitted as one merged hunk — the clamp still has to hold for its header.
     headers = [ln for ln in expanded.splitlines() if ln.startswith("@@")]
-    assert len(headers) == 2
+    assert headers
     for line in headers:
         header = parse_hunk_header(line)
         assert header is not None, f"unparseable rewritten header: {line!r}"
@@ -347,3 +351,101 @@ def test_count_tokens_memoizes_repeated_text() -> None:
     info = count_tokens.cache_info()
     assert info.hits >= 1
     assert info.misses == 1
+
+
+# ---------------------------------------------------------------------------
+# overlapping expansion
+# ---------------------------------------------------------------------------
+
+_LONG_CONTENT = "\n".join(f"line{i}" for i in range(1, 61))
+
+# Two hunks ten lines apart. A 15-line leading pad on the second reaches back
+# past the first hunk's own body, so unmerged expansion emits the span twice.
+_NEARBY_HUNKS = (
+    "diff --git a/f.py b/f.py\n"
+    "@@ -20,2 +20,2 @@\n line20\n-line21\n+CHANGED21\n"
+    "@@ -30,2 +30,2 @@\n line30\n-line31\n+CHANGED31\n"
+)
+
+
+def _hunk_ranges(expanded: str) -> list[tuple[int, int]]:
+    """(start, end) new-file line range of every hunk in *expanded*."""
+    ranges = []
+    for line in expanded.splitlines():
+        header = parse_hunk_header(line)
+        if header is not None:
+            ranges.append((header.new_start, header.new_start + header.new_len - 1))
+    return ranges
+
+
+def test_expanded_hunks_never_overlap() -> None:
+    """Expansion must not emit hunks whose line ranges overlap.
+
+    Each hunk is padded independently, so two nearby hunks can each reach into
+    the other's span. That yields a non-monotonic patch — a later hunk header
+    pointing *above* where the previous one ended — which breaks the line
+    arithmetic the model is asked to do, on top of paying for the span twice.
+    """
+    expanded = expand_hunks(_NEARBY_HUNKS, _LONG_CONTENT, 15, after=3)
+
+    ranges = _hunk_ranges(expanded)
+    for (_, prev_end), (next_start, _) in zip(ranges, ranges[1:], strict=False):
+        assert next_start > prev_end, f"hunks overlap: {ranges}"
+
+
+def test_expanded_hunks_do_not_repeat_context_lines() -> None:
+    """No source line may appear twice in the expanded patch.
+
+    Beyond the wasted tokens, a changed line repeated as unmerged context shows
+    the model the same position with two different contents.
+    """
+    expanded = expand_hunks(_NEARBY_HUNKS, _LONG_CONTENT, 15, after=3)
+
+    body = [ln[1:] for ln in expanded.splitlines() if ln[:1] in {" ", "+", "-"}]
+    assert len(body) == len(set(body)), f"duplicated lines: {expanded}"
+
+
+def test_merged_hunk_keeps_every_change() -> None:
+    """Merging two overlapping hunks keeps both changes, in file order."""
+    expanded = expand_hunks(_NEARBY_HUNKS, _LONG_CONTENT, 15, after=3)
+
+    assert expanded.count("+CHANGED21") == 1
+    assert expanded.count("+CHANGED31") == 1
+    assert expanded.index("CHANGED21") < expanded.index("CHANGED31")
+    assert expanded.count("-line21") == 1
+    assert expanded.count("-line31") == 1
+
+
+def _hunks_with_bodies(expanded: str) -> list[tuple[HunkHeader, list[str]]]:
+    """Every hunk in *expanded* paired with the body lines that follow it."""
+    hunks: list[tuple[HunkHeader, list[str]]] = []
+    for line in expanded.splitlines():
+        header = parse_hunk_header(line)
+        if header is not None:
+            hunks.append((header, []))
+        elif hunks:
+            hunks[-1][1].append(line)
+    return hunks
+
+
+def test_merged_hunk_header_counts_match_its_body() -> None:
+    """A merged hunk's header lengths must describe the lines it really holds."""
+    expanded = expand_hunks(_NEARBY_HUNKS, _LONG_CONTENT, 15, after=3)
+
+    hunks = _hunks_with_bodies(expanded)
+    assert hunks
+    for header, body in hunks:
+        assert header.old_len == sum(1 for ln in body if ln[:1] in {" ", "-"})
+        assert header.new_len == sum(1 for ln in body if ln[:1] in {" ", "+"})
+
+
+def test_distant_hunks_stay_separate() -> None:
+    """Hunks whose padded windows do not meet keep their own headers."""
+    patch = (
+        "diff --git a/f.py b/f.py\n"
+        "@@ -5,1 +5,1 @@\n-line5\n+CHANGED5\n"
+        "@@ -50,1 +50,1 @@\n-line50\n+CHANGED50\n"
+    )
+    expanded = expand_hunks(patch, _LONG_CONTENT, 2, after=1)
+
+    assert len(_hunk_ranges(expanded)) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1293,7 +1293,7 @@ wheels = [
 
 [[package]]
 name = "lgtmaybe"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },


### PR DESCRIPTION
## What

`expand_hunks` padded each hunk independently. When two hunks sit close together, each one's pad reaches into the other's span — and the result was emitted as two separate hunks anyway.

Two things went wrong with that, one correctness and one cost.

**The patch stopped being monotonic.** A later hunk header pointed *above* where the previous hunk ended:

```
@@ -5,20 +5,20 @@     <- covers new lines 5..24
 ...
-line21
+CHANGED21
 ...
@@ -15,20 +15,20 @@    <- covers new lines 15..34, starting inside the hunk above
```

Every lens prompt tells the model to count diff lines to place a finding, and `_snap_findings` re-anchors against the real diff afterwards. A patch whose line numbers go backwards mid-file breaks the arithmetic the model is doing.

**The overlap showed the same line twice, with two different contents.** In the example above line 21 appears once as `+CHANGED21` and once as plain context — the pad is drawn from the head text, so the model sees one position asserted two ways.

**And the duplicated span was paid for on every lens call.** The `fast` preset sends the diff to four lenses, so every duplicated line is billed four times.

## How

Hunks whose padded windows meet (or are adjacent) are merged into a single hunk, with the span between them filled in from the head text as ordinary context.

Header lengths are now counted off the emitted body rather than derived arithmetically (`old_len + pad`), so a merged hunk's counts cannot drift from what it actually holds.

Hunks whose windows do not meet are still emitted separately, unchanged.

## Token effect

Measured across seven recent commits of this repo, default config (`fast` preset, `context_lines: 20`, `function_context: true`), uncached input tokens for a whole run:

| commit | before | after | |
|---|---:|---:|---:|
| `1cddf6b` (31 files) | 205,032 | 180,084 | **-12.2%** |
| `4eee72c` (21 files) | 151,880 | 134,812 | **-11.2%** |
| `2d81f5e` (22 files) | 99,624 | 93,020 | -6.6% |
| `a295cd8` (8 files) | 42,576 | 40,096 | -5.8% |
| `f03c4bf` (7 files) | 57,820 | 55,648 | -3.8% |
| `b8f8739` (13 files) | 60,740 | 58,680 | -3.4% |
| `ea84ba4` (11 files) | 56,840 | 55,216 | -2.9% |

The saving scales with hunk density — files edited in several nearby places overlap most, which is also where the malformed output was worst.

## Tests

Red-first. `test_expanded_hunks_never_overlap` and `test_expanded_hunks_do_not_repeat_context_lines` both failed before the change:

```
E       assert 42 == 32   # 42 emitted body lines, 32 distinct
```

Added: no overlapping ranges, no repeated lines, both changes survive a merge in file order, merged header counts match the body, and distant hunks stay separate.

Two existing fixtures declared hunk headers inconsistent with their own bodies (`@@ -5,2 +5,2 @@` for a body holding one old line and two new). The old arithmetic propagated that error into its output; counting from the body does not, so those fixtures are corrected to well-formed headers and their expected results updated.

Full suite green (1610 passed, 3 skipped), ruff + mypy clean, `pytest tests/specs` and `openspec validate --specs` pass. The `engine.context-expansion` spec section gained the merge rule and a scenario.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqYf2v9WEBxHRoEruQWBUe)_