### PR TITLE
fix(prompt): stop asking lenses to flag our own redaction marker

### DIFF
--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -422,6 +422,15 @@ answer stays with the model: deprecated APIs, end-of-life runtimes, typosquats
 and licence conflicts. Demote osv-scanner to `hint` and the model takes those
 claims back.
 
+The same happens for **gitleaks**. When it is set to post findings, the review
+prompt **stops asking the model** for hardcoded secrets — and here the ask was
+close to unanswerable anyway: lgtmaybe redacts every secret it matches *before*
+the diff leaves for the provider, so the model was being asked to spot what it
+had been prevented from seeing, while gitleaks reads the unredacted file text
+and answers exactly. Secrets reaching a **log** are a different defect that no
+secret scanner reports, so the model keeps that one. Demote gitleaks to `hint`
+and the model takes the claim back.
+
 **semgrep now works out of the box.** It used to skip itself unless you set
 `semgrep_rules`, which almost nobody did — so the one multi-language tool never
 ran. It now falls back to a small, high-precision **MIT rule pack shipped with

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2466,6 +2466,15 @@ answer stays with the model: deprecated APIs, end-of-life runtimes, typosquats
 and licence conflicts. Demote osv-scanner to `hint` and the model takes those
 claims back.
 
+The same happens for **gitleaks**. When it is set to post findings, the review
+prompt **stops asking the model** for hardcoded secrets — and here the ask was
+close to unanswerable anyway: lgtmaybe redacts every secret it matches *before*
+the diff leaves for the provider, so the model was being asked to spot what it
+had been prevented from seeing, while gitleaks reads the unredacted file text
+and answers exactly. Secrets reaching a **log** are a different defect that no
+secret scanner reports, so the model keeps that one. Demote gitleaks to `hint`
+and the model takes the claim back.
+
 **semgrep now works out of the box.** It used to skip itself unless you set
 `semgrep_rules`, which almost nobody did — so the one multi-language tool never
 ran. It now falls back to a small, high-precision **MIT rule pack shipped with

--- a/openspec/specs/hardening/spec.md
+++ b/openspec/specs/hardening/spec.md
@@ -49,12 +49,18 @@ own neutralised marker family, framed as "confirm, contextualise, or discard".
 Diffs, intent text, and expanded context SHALL be redacted before leaving for
 the LLM: AWS/OpenAI/GitHub (classic + fine-grained)/Slack/Google/Stripe keys,
 PEM private-key blocks, and quoted password / `Authorization` /
-connection-string credentials.
+connection-string credentials. The prompt SHALL identify the replacement marker
+as the reviewer's own, so no lens reports it as a leaked secret or a
+placeholder left in the source.
 <!-- anchor: hardening.redact -->
 
 #### Scenario: a committed key would leave the machine
 - **WHEN** a diff hunk contains an AWS access key
 - **THEN** the provider receives the hunk with the key replaced, never the key
+
+#### Scenario: the marker reaches the model
+- **WHEN** a lens reads a diff that redaction has rewritten
+- **THEN** the prompt has told it the marker is not the author's code
 
 ### Requirement: Parsing recovers leniently, validates strictly
 

--- a/openspec/specs/prompt-and-lenses/spec.md
+++ b/openspec/specs/prompt-and-lenses/spec.md
@@ -100,19 +100,27 @@ SHALL return `null` rather than invent a causal story.
 
 ### Requirement: The model is not asked what a scanner answers better
 
-The review prompt SHALL drop the dependency claims that depend on knowledge
-published after training — whether a version has a known advisory, and whether a
-package is abandoned — from both the focused and the merged lens whenever a
-deterministic scanner reports those advisories itself. Claims a vulnerability database cannot
-answer (deprecated APIs, end-of-life runtimes, typosquats, licence conflicts)
-MUST remain. The decision SHALL derive from configuration, not from which
-binaries happen to be installed, so prompts stay reproducible.
+The review prompt SHALL drop an ask whenever a deterministic scanner is
+configured to report that class of finding itself. Dependency claims resting on
+knowledge published after training — whether a version has a known advisory,
+whether a package is abandoned — go when a vulnerability scanner reports them,
+from both the focused and the merged lens. The committed-secret ask goes when a
+secret scanner reports them: redaction has already rewritten matched secrets to
+the reviewer's own marker, so the lens is asked for what it was prevented from
+seeing. Claims no scanner answers (deprecated APIs, end-of-life runtimes,
+typosquats, licence conflicts; secrets reaching a log) MUST remain. The decision
+SHALL derive from configuration, not from which binaries happen to be installed,
+so prompts stay reproducible.
 <!-- anchor: prompt.dependency-health -->
 
 #### Scenario: a vulnerability scanner posts findings
 - **WHEN** a scanner is configured to report dependency advisories directly
 - **THEN** neither lens asks the model for advisory or abandonment claims
 
-#### Scenario: no scanner covers dependencies
+#### Scenario: a secret scanner posts findings
+- **WHEN** a scanner is configured to report committed secrets directly
+- **THEN** the security lens drops the hardcoded-secret ask, keeping the rest
+
+#### Scenario: no scanner covers the class
 - **WHEN** no such scanner will run
 - **THEN** the prompt is unchanged and the model reports them as before

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -183,13 +183,19 @@ def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
     # installed would make the prompt — and the shared prefix cache — vary by
     # machine. A configured-but-missing finding-mode tool warns instead.
     deps = not _scanner_covers_dependency_health(cfg)
+    # Likewise for committed secrets: redaction has already rewritten every
+    # secret it matched to `[REDACTED]` before the diff leaves, so a scanner
+    # reading the unredacted text answers this far better than the lens can.
+    secrets = not _scanner_covers_secrets(cfg)
     fast = cfg.preset is ReviewPreset.fast and list(cfg.categories) == list(ReviewCategory)
     if fast:
         lenses = [
             _Lens(
                 id=ReviewCategory.security.value,
-                system_prompt=build_system_prompt(ReviewCategory.security, cfg.language),
-                user_block=build_lens_block(ReviewCategory.security),
+                system_prompt=build_system_prompt(
+                    ReviewCategory.security, cfg.language, secret_scanning=secrets
+                ),
+                user_block=build_lens_block(ReviewCategory.security, secret_scanning=secrets),
             ),
         ]
         correctness_categories = (
@@ -219,8 +225,12 @@ def _build_lenses(cfg: ReviewConfig, *, has_intent: bool) -> list[_Lens]:
         lenses = [
             _Lens(
                 id=category.value,
-                system_prompt=build_system_prompt(category, cfg.language, dependency_health=deps),
-                user_block=build_lens_block(category, dependency_health=deps),
+                system_prompt=build_system_prompt(
+                    category, cfg.language, dependency_health=deps, secret_scanning=secrets
+                ),
+                user_block=build_lens_block(
+                    category, dependency_health=deps, secret_scanning=secrets
+                ),
                 carries_intent=category is ReviewCategory.intent,
             )
             for category in cfg.categories
@@ -1081,6 +1091,19 @@ def _scanner_covers_dependency_health(cfg: ReviewConfig) -> bool:
     """
     sa = cfg.static_analysis
     tool = StaticAnalysisTool.osv_scanner
+    return sa.enabled and tool in sa.tools and mode_for(tool, cfg) is ToolMode.finding
+
+
+def _scanner_covers_secrets(cfg: ReviewConfig) -> bool:
+    """Whether a deterministic scanner will report committed secrets itself.
+
+    When one will, the lens stops being asked for them. Redaction rewrites every
+    secret it matches to ``[REDACTED]`` before the diff is sent, so the model is
+    largely being asked to find what it has been prevented from seeing — while
+    gitleaks reads the unredacted head text and answers it exactly.
+    """
+    sa = cfg.static_analysis
+    tool = StaticAnalysisTool.gitleaks
     return sa.enabled and tool in sa.tools and mode_for(tool, cfg) is ToolMode.finding
 
 

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -382,7 +382,7 @@ classes, aligned with the OWASP Top 10, to watch for:
 - **CSRF & open redirect** — state-changing endpoints without CSRF protection;
   redirect targets taken from user input without validation.
 - **Hardcoded secrets** — API keys, passwords, tokens, or private keys committed
-  in the diff (even if they look redacted, flag the practice).
+  in the diff as literals.
 - **Broken authn / authz** — missing permission checks, IDOR, auth bypass,
   privilege escalation, trusting client-supplied identity, or JWT/session
   pitfalls: unverified signatures, `alg` confusion, missing expiry checks.
@@ -776,11 +776,26 @@ _CODE_HEALTH_SECTION_NO_ADVISORIES = _CODE_HEALTH_SECTION.replace(_ADVISORY_LINE
     "(`low` to `medium`,\nhigher when a security advisory is involved):", "(`low` to `medium`):"
 )
 
+# The committed-secret bullet. Dropped when a secret scanner runs: redaction has
+# already rewritten every secret it matched to `[REDACTED]` before the diff is
+# sent, so the lens is being asked for something it largely cannot see, while
+# gitleaks reads the unredacted file text and answers it exactly.
+_SECRET_BULLET = """\
+- **Hardcoded secrets** — API keys, passwords, tokens, or private keys committed
+  in the diff as literals.
+"""
 
-def _category_section(category: ReviewCategory, dependency_health: bool) -> str:
+_SECURITY_SECTION_NO_SECRETS = _SECURITY_SECTION.replace(_SECRET_BULLET, "")
+
+
+def _category_section(
+    category: ReviewCategory, dependency_health: bool, secret_scanning: bool = True
+) -> str:
     """The lens body, minus the claims a scanner answers better when one runs."""
     if category is ReviewCategory.deprecation and not dependency_health:
         return _DEPRECATION_SECTION_NO_ADVISORIES
+    if category is ReviewCategory.security and not secret_scanning:
+        return _SECURITY_SECTION_NO_SECRETS
     return _CATEGORY_SECTIONS[category]
 
 
@@ -866,6 +881,10 @@ verify (hedge, lower the severity), never as confident `high`/`critical` fixes �
   ("X was removed", "Y now takes a new parameter", "this method is now async") — narration
   that restates the diff is not a finding. If the content is only a restatement of the
   change with no problem attached, omit it entirely.
+- `[REDACTED]` is the reviewer's OWN marker: secrets were stripped from this diff before
+  it reached you. It is never the author's source code, so never report it as a hardcoded
+  secret, a leaked credential, a placeholder left behind, or a bug of any kind. The real
+  text it replaced is not available to you, and its absence is not a defect.
 - Return `{"findings": []}` only when there are genuinely no issues."""
 
 
@@ -898,8 +917,10 @@ _LENS_LEAD_IN = (
 )
 
 
-@lru_cache(maxsize=len(ReviewCategory))
-def build_lens_block(category: ReviewCategory, dependency_health: bool = True) -> str:
+@lru_cache(maxsize=len(ReviewCategory) * 4)
+def build_lens_block(
+    category: ReviewCategory, dependency_health: bool = True, secret_scanning: bool = True
+) -> str:
     """One built-in lens's user-message block for the split (cache-shaped) layout.
 
     The lens section plus its category-matched worked example, sent as the
@@ -907,7 +928,7 @@ def build_lens_block(category: ReviewCategory, dependency_health: bool = True) -
     outside the cached prefix while the expensive content in front of it is
     shared by every lens call.
     """
-    section = _category_section(category, dependency_health)
+    section = _category_section(category, dependency_health, secret_scanning)
     return f"{_LENS_LEAD_IN}\n\n{section}\n\n{_CATEGORY_EXAMPLES[category]}"
 
 
@@ -926,9 +947,12 @@ def build_custom_lens_block(lens: CustomLens) -> str:
     return f"{_LENS_LEAD_IN}\n\n{body}\n\n{example}"
 
 
-@lru_cache(maxsize=len(ReviewCategory) * 4)
+@lru_cache(maxsize=len(ReviewCategory) * 8)
 def build_system_prompt(
-    category: ReviewCategory, language: str | None = None, dependency_health: bool = True
+    category: ReviewCategory,
+    language: str | None = None,
+    dependency_health: bool = True,
+    secret_scanning: bool = True,
 ) -> str:
     """Return the system message for the review LLM's *category* lens.
 
@@ -940,7 +964,7 @@ def build_system_prompt(
     pre-language prompt when unset.
     """
     example = _CATEGORY_EXAMPLES[category]
-    body = _category_section(category, dependency_health)
+    body = _category_section(category, dependency_health, secret_scanning)
     return f"{_localised_header(language)}\n{example}\n\n{body}\n\n{_SHARED_RULES}\n"
 
 

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1961,3 +1961,67 @@ def test_dependency_findings_survive_the_off_diff_drop(monkeypatch) -> None:  # 
     findings, _summary = engine.review(_LOCKFILE_CTX, _sa_cfg())
 
     assert [(f.category, f.path) for f in findings] == [("scan:osv-scanner", "uv.lock")]
+
+
+# ---------------------------------------------------------------------------
+# secret scanning narrows the security lens
+# ---------------------------------------------------------------------------
+
+
+def _security_lens_text(cfg: ReviewConfig) -> str:
+    from lgtmaybe.engine.engine import _build_lenses
+
+    lenses = _build_lenses(cfg, has_intent=False)
+    lens = next(lo for lo in lenses if lo.id == ReviewCategory.security.value)
+    return (lens.system_prompt + lens.user_block).lower()
+
+
+def test_security_lens_asks_for_secrets_by_default() -> None:
+    """Static analysis is opt-in, so a default run's prompt is unchanged."""
+    cfg = ReviewConfig(provider=Provider.openai, model="m")
+
+    assert "hardcoded secrets" in _security_lens_text(cfg)
+
+
+def test_gitleaks_in_finding_mode_drops_the_secret_ask() -> None:
+    """gitleaks posts committed secrets itself, so the lens stops paying for
+    an ask that redaction has already made unanswerable."""
+    from lgtmaybe.core.models import StaticAnalysisConfig, StaticAnalysisTool
+
+    cfg = ReviewConfig(
+        provider=Provider.openai,
+        model="m",
+        static_analysis=StaticAnalysisConfig(enabled=True, tools=[StaticAnalysisTool.gitleaks]),
+    )
+
+    text = _security_lens_text(cfg)
+    assert "hardcoded secrets" not in text
+    # The rest of the lens is untouched.
+    assert "ssrf" in text and "owasp" in text
+
+
+def test_gitleaks_in_hint_mode_keeps_the_secret_ask() -> None:
+    """In hint mode the tool does not post, so the model must still look."""
+    from lgtmaybe.core.models import StaticAnalysisConfig, StaticAnalysisTool, ToolMode
+
+    cfg = ReviewConfig(
+        provider=Provider.openai,
+        model="m",
+        static_analysis=StaticAnalysisConfig(
+            enabled=True,
+            tools=[StaticAnalysisTool.gitleaks],
+            tool_mode={StaticAnalysisTool.gitleaks: ToolMode.hint},
+        ),
+    )
+
+    assert "hardcoded secrets" in _security_lens_text(cfg)
+
+
+def test_every_lens_is_told_the_redaction_marker_is_not_a_finding() -> None:
+    """redact() puts REDACTED_PLACEHOLDER in the diff the model reads; without
+    being told what it is, a lens reports our own marker as a leaked secret."""
+    cfg = ReviewConfig(provider=Provider.openai, model="m")
+    from lgtmaybe.engine.engine import _build_lenses
+
+    for lens in _build_lenses(cfg, has_intent=False):
+        assert REDACTED_PLACEHOLDER in lens.system_prompt

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -6,6 +6,7 @@ import pytest
 
 from lgtmaybe.core.models import CustomLens, ReviewCategory, ReviewFinding, Severity
 from lgtmaybe.engine.prompt import build_lens_prompt, build_shared_preamble, build_system_prompt
+from lgtmaybe.engine.redact import REDACTED_PLACEHOLDER
 
 
 def _union_prompt() -> str:
@@ -661,3 +662,71 @@ def test_the_merged_code_health_lens_narrows_too() -> None:
     assert "known-vulnerable" not in narrowed
     # The category attribution the fast preset depends on must survive.
     assert '"deprecation"' in build_group_block(CODE_HEALTH_GROUP, dependency_health=False)
+
+
+# ---------------------------------------------------------------------------
+# the redaction marker: lgtmaybe's own placeholder is not a finding
+# ---------------------------------------------------------------------------
+
+
+def test_shared_rules_name_the_redaction_marker() -> None:
+    """`redact()` rewrites every secret it matches to `[REDACTED]` before the
+    diff is sent, so that token is lgtmaybe's own marker, never source content.
+    Nothing in the prompt said so, and the security lens actively invited a
+    finding on it — a false positive manufactured by our own redaction."""
+    preamble = build_shared_preamble()
+
+    assert REDACTED_PLACEHOLDER in preamble
+
+
+def test_no_lens_is_told_to_flag_redacted_placeholders() -> None:
+    """The security lens used to say "even if they look redacted, flag the
+    practice" — which turns every redacted diff into a finding."""
+    for category in ReviewCategory:
+        prompt = build_system_prompt(category).lower()
+        assert "look redacted" not in prompt
+        assert "even if they look" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# secret scanning: the model stops guessing once gitleaks covers it
+# ---------------------------------------------------------------------------
+
+
+def test_hardcoded_secret_bullet_is_present_by_default() -> None:
+    """Static analysis is opt-in, so the default prompt is unchanged."""
+    prompt = build_system_prompt(ReviewCategory.security).lower()
+
+    assert "hardcoded secrets" in prompt
+
+
+def test_secret_claims_drop_when_a_scanner_covers_them() -> None:
+    """gitleaks reports committed secrets deterministically, and redaction has
+    already stripped them from the diff — so the lens cannot see what it is
+    being asked to find, while the ask still costs tokens on every call."""
+    narrowed = build_system_prompt(ReviewCategory.security, secret_scanning=False).lower()
+
+    assert "hardcoded secrets" not in narrowed
+
+
+def test_secret_narrowing_keeps_the_rest_of_the_security_lens() -> None:
+    """Only the bullet a scanner owns goes; the OWASP checklist stays."""
+    narrowed = build_system_prompt(ReviewCategory.security, secret_scanning=False).lower()
+
+    assert "owasp" in narrowed
+    assert "ssrf" in narrowed
+    assert "injection" in narrowed
+    # Secrets *reaching a log* are a different defect from a committed literal,
+    # and no secret scanner reports it — it must survive the narrowing.
+    assert "pii" in narrowed
+
+
+def test_secret_narrowing_applies_to_the_lens_block_too() -> None:
+    """The fast preset sends the lens as a user block, not a system prompt."""
+    from lgtmaybe.engine.prompt import build_lens_block
+
+    full = build_lens_block(ReviewCategory.security).lower()
+    narrowed = build_lens_block(ReviewCategory.security, secret_scanning=False).lower()
+
+    assert "hardcoded secrets" in full
+    assert "hardcoded secrets" not in narrowed


### PR DESCRIPTION
## The bug

`redact()` rewrites every secret it matches to `[REDACTED]` before the diff leaves for the provider. Nothing in the prompt said what that marker was — and the security lens went further:

```
- **Hardcoded secrets** — API keys, passwords, tokens, or private keys committed
  in the diff (even if they look redacted, flag the practice).
```

So the reviewer instructed the model to raise a finding on lgtmaybe's own redaction output. Any PR whose diff contained something redaction matched — an AWS key, a PEM block, a quoted password, an `Authorization` header — showed the model `[REDACTED]` under a rule telling it to flag exactly that.

It also quietly overstated what the lens can do. Redaction runs *first*, so for every secret the redactor catches, the model is being asked to find something it has been prevented from seeing.

## Changes

**The shared rules now name the marker.** It goes in the shared preamble rather than the security section because any lens can trip over it — a correctness lens calling `[REDACTED]` a placeholder left in the code is the same false positive:

> `[REDACTED]` is the reviewer's OWN marker: secrets were stripped from this diff before it reached you. It is never the author's source code, so never report it as a hardcoded secret, a leaked credential, a placeholder left behind, or a bug of any kind.

**The bullet no longer asks for redacted-looking values** — it now reads "committed in the diff as literals".

**The ask narrows away when a secret scanner covers it.** This follows the existing osv-scanner precedent exactly (`_scanner_covers_dependency_health` → `dependency_health`): with gitleaks in `finding` mode, `_scanner_covers_secrets` drops the bullet from the security lens entirely. gitleaks reads the unredacted head text and posts directly with no model call, so it answers the question the lens had been prevented from answering.

Kept deliberately narrow:

- Only **gitleaks** narrows. zizmor covers GitHub Actions but the CI/IaC bullet also spans IAM breadth, public buckets and privileged containers, which it does not report — so that bullet stays.
- Only the **committed-literal** claim goes. Secrets reaching a **log** are a different defect no secret scanner reports, so the sensitive-data-exposure bullet stays, as does the rest of the OWASP checklist.
- The decision is **config-derived**, not "is the binary installed", so prompts stay reproducible and the shared prefix cache does not vary by machine.

## Effect

Correctness first — this removes a manufactured false positive on every redacted PR. The token saving is small and only applies when gitleaks is enabled (static analysis is opt-in): the bullet is ~35 tokens off each security-lens call.

## Tests

Red-first; five failed before the change:

```
FAILED test_shared_rules_name_the_redaction_marker
FAILED test_no_lens_is_told_to_flag_redacted_placeholders
FAILED test_secret_claims_drop_when_a_scanner_covers_them
FAILED test_secret_narrowing_keeps_the_rest_of_the_security_lens
FAILED test_secret_narrowing_applies_to_the_lens_block_too
```

Covering: the marker is named in the preamble and reaches every built-in lens; no lens is told to flag redacted values; the bullet is present by default; gitleaks in `finding` mode drops it while `hint` mode keeps it (the tool does not post, so the model must still look); and the OWASP checklist plus the log-leak claim survive the narrowing.

Full suite green (1620 passed, 3 skipped), ruff + mypy clean. Specs updated — `prompt.dependency-health` generalised from "dependency claims" to "an ask a scanner answers better" with a secret-scanner scenario, and `hardening.redact` gained the marker rule. `openspec validate --specs` and `pytest tests/specs` pass; `docs/llms-full.txt` regenerated for the new how-to paragraph.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqYf2v9WEBxHRoEruQWBUe)_