### PR TITLE
fix(context): only pad to a definition that still contains the hunk

### DIFF
--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -157,7 +157,8 @@ line) after — the enclosing signature explains a change better than what
 follows. Inline positions stay bound to the real diff, so context-only lines
 never carry comments. Hunks whose padded windows meet are merged into one, with
 the span between them filled in as context, so the patch stays monotonic and no
-line is emitted twice.
+line is emitted twice. A definition widens the leading pad only while it still
+CONTAINS the hunk — one that closed above it encloses nothing.
 <!-- anchor: engine.context-expansion -->
 
 #### Scenario: context lines never take comments
@@ -167,6 +168,10 @@ line is emitted twice.
 #### Scenario: two nearby hunks are padded into each other
 - **WHEN** a hunk's leading pad reaches the previous hunk's trailing pad
 - **THEN** both are emitted as one hunk whose header describes what it holds
+
+#### Scenario: the change sits below a closed definition
+- **WHEN** a hunk is on module-level code after a function has ended
+- **THEN** the pad does not reach back into that function's body
 
 ### Requirement: Triage never skips past the security floor
 

--- a/src/lgtmaybe/engine/boundaries.py
+++ b/src/lgtmaybe/engine/boundaries.py
@@ -50,14 +50,19 @@ _LANG_DEFS: dict[str, tuple[str, tuple[str, ...]]] = {
 }
 
 
-def definition_starts(
+def definition_spans(
     text: str,
     path: str,
     *,
     runner: BoundaryRunner | None = None,
     find_binary: Callable[[], str | None] = _find_binary,
-) -> list[int]:
-    """Sorted 1-based start lines of function/class definitions in *text*.
+) -> list[tuple[int, int]]:
+    """Sorted 1-based ``(start, end)`` lines of definitions in *text*, inclusive.
+
+    The END matters as much as the start: a definition that has already closed
+    does not enclose a later line. Without it, module-level code sitting after a
+    function looked "enclosed" by that function, and the caller padded a hunk
+    back into an unrelated body.
 
     ``[]`` whenever boundaries can't be found cheaply and safely: unsupported
     extension, no ast-grep binary, or any scan/parse failure — the caller then
@@ -77,14 +82,20 @@ def definition_starts(
         target = Path(tmp) / f"file{Path(path).suffix.lower()}"
         target.write_text(text, encoding="utf-8")
         stdout = run(binary, rule, target)
-    return _parse_starts(stdout)
+    return _parse_spans(stdout)
 
 
-def _parse_starts(stdout: str) -> list[int]:
-    """1-based, de-duplicated, sorted start lines from ast-grep's match array."""
-    starts: set[int] = set()
+def _parse_spans(stdout: str) -> list[tuple[int, int]]:
+    """1-based, de-duplicated, sorted ``(start, end)`` spans from ast-grep's matches.
+
+    A match whose range is missing, malformed, or inverted is dropped rather
+    than guessed at — a wrong span would pad a hunk to the wrong place.
+    """
+    spans: set[tuple[int, int]] = set()
     for match in iter_matches(stdout):
-        line = match.get("range", {}).get("start", {}).get("line")
-        if isinstance(line, int) and line >= 0:
-            starts.add(line + 1)  # ast-grep lines are 0-based
-    return sorted(starts)
+        span = match.get("range", {})
+        start = span.get("start", {}).get("line")
+        end = span.get("end", {}).get("line")
+        if isinstance(start, int) and isinstance(end, int) and 0 <= start <= end:
+            spans.add((start + 1, end + 1))  # ast-grep lines are 0-based
+    return sorted(spans)

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -6,6 +6,7 @@ Provides a dynamic context-line calculator for the remaining budget.
 
 from __future__ import annotations
 
+import sys
 from bisect import bisect_right
 from dataclasses import dataclass
 from functools import lru_cache
@@ -233,20 +234,35 @@ def context_lines_for_budget(remaining_tokens: int) -> int:
     return max(0, min(remaining_tokens // _SCALE, _MAX_CONTEXT_LINES))
 
 
-def _enclosing_boundary(boundaries: list[int], new_start: int) -> int | None:
-    """The nearest definition start at or above *new_start*, if within reach.
+def _enclosing_boundary(boundaries: list[tuple[int, int]], new_start: int) -> int | None:
+    """The start line of the innermost definition CONTAINING *new_start*.
 
-    *boundaries* is sorted ascending; the enclosing candidate is the last one
-    ``<= new_start``. None when there is none, or when it sits more than
-    :data:`_MAX_BOUNDARY_REACH` lines above (padding to it would drown the diff).
+    *boundaries* is a sorted list of inclusive ``(start, end)`` spans. A
+    definition encloses *new_start* only when it has not already closed above
+    it: matching on start alone made module-level code look enclosed by
+    whatever function happened to sit above it, padding the hunk back into an
+    unrelated body. Walking back from the nearest start yields the innermost
+    enclosing definition (a method before its class).
+
+    None when nothing encloses it, or when the enclosing definition begins more
+    than :data:`_MAX_BOUNDARY_REACH` lines above (padding would drown the diff).
     """
-    idx = bisect_right(boundaries, new_start) - 1
-    if idx < 0:
-        return None
-    candidate = boundaries[idx]
-    if new_start - candidate > _MAX_BOUNDARY_REACH:
-        return None
-    return candidate
+    idx = bisect_right(boundaries, (new_start, _UNBOUNDED_END)) - 1
+    while idx >= 0:
+        start, end = boundaries[idx]
+        if new_start - start > _MAX_BOUNDARY_REACH:
+            # Sorted by start, so everything left of here is further away still.
+            return None
+        if end >= new_start:
+            return start
+        idx -= 1
+    return None
+
+
+# Sentinel upper bound for the bisect probe: pairs compare element-wise, so this
+# has to sort above any real end line for the probe to find every span whose
+# start is at or below the hunk.
+_UNBOUNDED_END = sys.maxsize
 
 
 def trailing_context_lines(before: int) -> int:
@@ -274,7 +290,7 @@ def expand_hunks(
     file_content: str | None,
     n: int,
     after: int,
-    boundaries: list[int] | None = None,
+    boundaries: list[tuple[int, int]] | None = None,
 ) -> str:
     """Pad each hunk in *patch* with surrounding lines from *file_content*.
 
@@ -284,12 +300,14 @@ def expand_hunks(
     definitions around a change. Hunk headers are rewritten so each hunk's
     start/length still describes the lines it now contains.
 
-    ``boundaries`` (sorted 1-based definition start lines, from
-    :func:`~lgtmaybe.engine.boundaries.definition_starts`) extends the LEADING
-    pad up to the enclosing function/class signature when it sits above the
-    fixed window and within :data:`_MAX_BOUNDARY_REACH` lines — the enclosing
-    signature explains a change better than an arbitrary cut. A boundary can
-    only ever widen the window, never shrink it.
+    ``boundaries`` (sorted 1-based inclusive ``(start, end)`` definition spans,
+    from :func:`~lgtmaybe.engine.boundaries.definition_spans`) extends the
+    LEADING pad up to the enclosing function/class signature when it sits above
+    the fixed window and within :data:`_MAX_BOUNDARY_REACH` lines — the
+    enclosing signature explains a change better than an arbitrary cut. Only a
+    definition that still CONTAINS the hunk counts, so module-level code after a
+    function is not padded back into it. A boundary can only ever widen the
+    window, never shrink it.
 
     Hunks whose padded windows meet or overlap are **merged into one**, with the
     lines between them filled in as context. Padded independently they would
@@ -358,7 +376,7 @@ def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
     return preamble, hunks
 
 
-def _lead_start(hunk: _Hunk, n: int, boundaries: list[int] | None) -> int:
+def _lead_start(hunk: _Hunk, n: int, boundaries: list[tuple[int, int]] | None) -> int:
     """The first new-file line *hunk*'s leading pad should reach back to."""
     lead_start = max(1, hunk.new_start - n)
     if boundaries:
@@ -388,7 +406,7 @@ def _group_hunks(
     content_lines: list[str],
     n: int,
     n_after: int,
-    boundaries: list[int] | None,
+    boundaries: list[tuple[int, int]] | None,
 ) -> list[_Group]:
     """Group *hunks* into runs whose padded windows touch, in file order.
 

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -413,6 +413,12 @@ def _group_hunks(
     A group is rendered as a single merged hunk. Two hunks join when the later
     one's leading pad reaches the earlier one's trailing pad (or the line just
     after it) — the point at which independent padding would double up.
+
+    When they reach but the gap CANNOT be filled — head text shorter than the
+    hunk positions, so merging would drop lines the merged header still claims —
+    the later hunk instead starts its own group with its leading pad trimmed to
+    clear the previous group. The pad is decoration; an overlapping header is
+    not, and the non-overlap invariant has to hold in the degenerate case too.
     """
     groups: list[_Group] = []
     for hunk in hunks:
@@ -420,15 +426,13 @@ def _group_hunks(
         if groups:
             previous = groups[-1].hunks[-1]
             trail_end = min(len(content_lines), previous.last_new + n_after)
-            # The gap between the two is filled from the head text, so only
-            # merge when that text actually reaches — a file shorter than the
-            # hunk positions (stale or redacted) would otherwise drop lines the
-            # merged header still claims.
             reaches = lead_start <= trail_end + 1
             fillable = hunk.new_start - 1 <= len(content_lines)
             if reaches and fillable:
                 groups[-1].hunks.append(hunk)
                 continue
+            if reaches:
+                lead_start = max(lead_start, trail_end + 1)
         groups.append(_Group(hunks=[hunk], lead_start=lead_start))
     return groups
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -34,7 +34,7 @@ from lgtmaybe.core.version import package_version
 from lgtmaybe.github import is_reviewable
 
 from .astgrep import SymbolResolver
-from .boundaries import definition_starts
+from .boundaries import definition_spans
 from .compress import (
     batch_files,
     context_lines_for_budget,
@@ -415,7 +415,7 @@ class LLMReviewEngine(ReviewEngine):
                             # Enclosing function/class boundaries (ast-grep; [] on
                             # any failure) so the leading pad reaches the signature.
                             boundaries=(
-                                definition_starts(ctx.file_contents.get(path, ""), path)
+                                definition_spans(ctx.file_contents.get(path, ""), path)
                                 if cfg.function_context and ctx.file_contents.get(path)
                                 else None
                             ),

--- a/tests/engine/test_boundaries.py
+++ b/tests/engine/test_boundaries.py
@@ -112,7 +112,13 @@ def test_definition_spans_report_where_a_definition_ends() -> None:
 
 
 def test_module_level_code_is_enclosed_by_nothing() -> None:
-    """A hunk on module-level code after a function is inside no definition."""
+    """A hunk on module-level code after a function is inside no definition.
+
+    Deliberately white-box: pairing the real ast-grep spans with the consumer
+    pins down which line the lookup resolves to, which the behavioural test in
+    test_compress.py (through the public ``expand_hunks``) can only show
+    indirectly. Both exist on purpose — this one names the cause.
+    """
     from lgtmaybe.engine.compress import _enclosing_boundary
 
     spans = definition_spans(_PY_TRAILING_MODULE_CODE, "src/sample.py")

--- a/tests/engine/test_boundaries.py
+++ b/tests/engine/test_boundaries.py
@@ -1,8 +1,8 @@
 """Function/class boundary detection for context expansion (P4 remainder).
 
-``definition_starts`` uses ast-grep (already a core dependency — the same tool
+``definition_spans`` uses ast-grep (already a core dependency — the same tool
 symbol resolution uses, never a second AST stack) to find the 1-based start
-lines of function/class definitions in a file's head text, so hunk expansion
+spans of function/class definitions in a file's head text, so hunk expansion
 can pad up to the enclosing signature instead of a fixed line count. Best
 effort throughout: an unknown language, a missing binary, or any ast-grep
 failure returns [] and the caller keeps the fixed-line pad.
@@ -11,7 +11,7 @@ failure returns [] and the caller keeps the fixed-line pad.
 from __future__ import annotations
 
 import lgtmaybe.engine.boundaries as boundaries
-from lgtmaybe.engine.boundaries import definition_starts
+from lgtmaybe.engine.boundaries import definition_spans
 
 _PY = """\
 import os
@@ -34,24 +34,27 @@ class Thing:
 """
 
 
-def test_python_definition_starts_found_with_real_ast_grep() -> None:
-    starts = definition_starts(_PY, "src/sample.py")
+def test_python_definition_spans_found_with_real_ast_grep() -> None:
+    spans = definition_spans(_PY, "src/sample.py")
 
-    # def outer (line 6), class Thing (line 14), def method (line 15).
-    assert starts == [6, 14, 15]
+    # def outer (6..12), class Thing (14..17), def method (15..17).
+    assert [start for start, _ in spans] == [6, 14, 15]
+    # Every span closes at or after it opens, and outer() ends before Thing.
+    assert all(end >= start for start, end in spans)
+    assert dict(spans)[6] < 14
 
 
 def test_unknown_extension_returns_nothing() -> None:
-    assert definition_starts("whatever", "notes.txt") == []
+    assert definition_spans("whatever", "notes.txt") == []
 
 
 def test_missing_binary_returns_nothing() -> None:
-    assert definition_starts(_PY, "src/sample.py", find_binary=lambda: None) == []
+    assert definition_spans(_PY, "src/sample.py", find_binary=lambda: None) == []
 
 
 def test_runner_failure_returns_nothing() -> None:
     assert (
-        definition_starts(_PY, "src/sample.py", runner=lambda binary, rule, path: "not json") == []
+        definition_spans(_PY, "src/sample.py", runner=lambda binary, rule, path: "not json") == []
     )
 
 
@@ -65,7 +68,7 @@ def test_boundaries_temp_directory_ignores_cleanup_errors(monkeypatch) -> None: 
 
     monkeypatch.setattr(boundaries.tempfile, "TemporaryDirectory", recording_temp_directory)
 
-    definition_starts(
+    definition_spans(
         _PY,
         "src/sample.py",
         runner=lambda *_args: "[]",
@@ -73,3 +76,55 @@ def test_boundaries_temp_directory_ignores_cleanup_errors(monkeypatch) -> None: 
     )
 
     assert captured["ignore_cleanup_errors"] is True
+
+
+# ---------------------------------------------------------------------------
+# spans: a definition that has already ENDED does not enclose a later hunk
+# ---------------------------------------------------------------------------
+
+_PY_TRAILING_MODULE_CODE = """\
+import os
+
+
+def helper(a):
+    x = a + 1
+    y = x * 2
+    return y
+
+
+CONFIG = {
+    "alpha": 1,
+    "beta": 2,
+}
+"""
+
+
+def test_definition_spans_report_where_a_definition_ends() -> None:
+    """Only the start line was captured, so a caller could not tell whether a
+    definition still contained a given line — ast-grep reports the end too."""
+    spans = definition_spans(_PY_TRAILING_MODULE_CODE, "src/sample.py")
+
+    assert spans, "expected at least the helper() definition"
+    start, end = spans[0]
+    assert start == 4  # def helper(a)
+    # helper() ends at `return y` (line 7) — well before the module-level dict.
+    assert end == 7
+
+
+def test_module_level_code_is_enclosed_by_nothing() -> None:
+    """A hunk on module-level code after a function is inside no definition."""
+    from lgtmaybe.engine.compress import _enclosing_boundary
+
+    spans = definition_spans(_PY_TRAILING_MODULE_CODE, "src/sample.py")
+
+    # Line 12 is `"beta": 2,` in the module-level CONFIG dict.
+    assert _enclosing_boundary(spans, 12) is None
+
+
+def test_a_line_inside_a_definition_still_resolves() -> None:
+    from lgtmaybe.engine.compress import _enclosing_boundary
+
+    spans = definition_spans(_PY_TRAILING_MODULE_CODE, "src/sample.py")
+
+    # Line 6 is `y = x * 2`, inside helper().
+    assert _enclosing_boundary(spans, 6) == 4

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -581,18 +581,26 @@ def test_module_level_hunk_is_not_padded_into_a_closed_definition() -> None:
     to sit above it: wrong context for the model, and paid for on every lens.
     """
     content = "\n".join(
+        # 1: import os   2: (blank)   3: def helper(a)   4..23: step_1..step_20
         ["import os", ""]
         + ["def helper(a):"]
         + [f"    step_{i}()" for i in range(1, 21)]
+        # 24: return a   25,26: (blank)   27: CONFIG = {   28: alpha  29: beta  30: }
         + ["    return a", "", "", "CONFIG = {", '    "alpha": 1,', '    "beta": 2,', "}"]
     )
-    # helper() spans lines 3..23; CONFIG starts at line 26.
-    patch = 'diff --git a/f.py b/f.py\n@@ -28,1 +28,1 @@\n     "beta": 2,\n'
+    # helper() spans lines 3..24; the change is on line 29, inside CONFIG.
+    patch = 'diff --git a/f.py b/f.py\n@@ -29,1 +29,1 @@\n     "beta": 2,\n'
 
-    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[(3, 23)])
+    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[(3, 24)])
 
     assert "def helper" not in expanded
-    assert "step_1()" not in expanded
+    assert "step_20()" not in expanded
+    # The pad is still doing its job — the two lines above the change and the
+    # one below are there, so an expansion that broke entirely (or returned an
+    # empty string) could not pass on the absences alone.
+    assert "CONFIG = {" in expanded
+    assert '"alpha": 1,' in expanded
+    assert expanded.rstrip().endswith("}")
 
 
 def test_innermost_enclosing_definition_wins() -> None:
@@ -602,3 +610,23 @@ def test_innermost_enclosing_definition_wins() -> None:
     assert _enclosing_boundary(spans, 15) == 10
     # Above the method but still inside the class body.
     assert _enclosing_boundary(spans, 5) == 1
+
+
+def test_no_overlap_when_head_text_is_shorter_than_the_hunks() -> None:
+    """The non-overlap invariant must hold on truncated/stale head text too.
+
+    When two hunks' pads reach each other but the gap cannot be filled — the
+    file is shorter than the hunk positions — they cannot be merged without
+    dropping lines the merged header would claim. The later hunk's leading pad
+    is trimmed to clear the previous one instead. Found by fuzzing.
+    """
+    content = "\n".join(f"c{i}" for i in range(1, 42))  # 41 lines
+    patch = "diff --git a/f.py b/f.py\n@@ -45,1 +45,1 @@\n x45\n@@ -47,1 +47,1 @@\n x47\n"
+
+    expanded = expand_hunks(patch, content, 16, after=4)
+
+    ranges = _hunk_ranges(expanded)
+    for (_, prev_end), (next_start, _) in zip(ranges, ranges[1:], strict=False):
+        assert next_start > prev_end, f"hunks overlap: {ranges}"
+    # Both changes survive the trim.
+    assert "x45" in expanded and "x47" in expanded

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from lgtmaybe.core.diffparse import HunkHeader, parse_hunk_header
 from lgtmaybe.engine.compress import (
+    _enclosing_boundary,
     _token_encoder,
     batch_files,
     count_tokens,
@@ -306,7 +307,7 @@ def test_boundary_extends_the_leading_pad_to_the_enclosing_def() -> None:
     # line 3 — well above the fixed window, within reach.
     patch = "diff --git a/f.py b/f.py\n@@ -20,1 +20,1 @@\n step_17()\n"
 
-    expanded = expand_hunks(patch, _FN_CONTENT, 2, after=1, boundaries=[3])
+    expanded = expand_hunks(patch, _FN_CONTENT, 2, after=1, boundaries=[(3, 29)])
 
     assert "\ndef handler(req):\n" in expanded or "\n def handler(req):\n" in expanded
     # Header start moved up to the boundary line.
@@ -316,7 +317,7 @@ def test_boundary_extends_the_leading_pad_to_the_enclosing_def() -> None:
 def test_boundary_inside_the_fixed_window_changes_nothing() -> None:
     patch = "diff --git a/f.py b/f.py\n@@ -4,1 +4,1 @@\n step_1()\n"
 
-    with_boundary = expand_hunks(patch, _FN_CONTENT, 5, after=1, boundaries=[3])
+    with_boundary = expand_hunks(patch, _FN_CONTENT, 5, after=1, boundaries=[(3, 29)])
     without = expand_hunks(patch, _FN_CONTENT, 5, after=1)
 
     # The def on line 3 is already inside the 5-line fixed pad — the boundary
@@ -329,7 +330,7 @@ def test_boundary_beyond_reach_is_ignored() -> None:
     content = "\n".join(lines)
     patch = "diff --git a/f.py b/f.py\n@@ -300,1 +300,1 @@\n l299\n"
 
-    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[1])
+    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[(1, 400)])
 
     assert "def far_away" not in expanded  # 299 lines up: past the reach cap
 
@@ -570,3 +571,34 @@ def test_distant_hunks_stay_separate() -> None:
     expanded = expand_hunks(patch, _LONG_CONTENT, 2, after=1)
 
     assert len(_hunk_ranges(expanded)) == 2
+
+
+def test_module_level_hunk_is_not_padded_into_a_closed_definition() -> None:
+    """A definition that has already ended does not enclose a later hunk.
+
+    Matching on the nearest start alone pulled module-level code — constants,
+    config tables, registries — back into the body of whatever function happened
+    to sit above it: wrong context for the model, and paid for on every lens.
+    """
+    content = "\n".join(
+        ["import os", ""]
+        + ["def helper(a):"]
+        + [f"    step_{i}()" for i in range(1, 21)]
+        + ["    return a", "", "", "CONFIG = {", '    "alpha": 1,', '    "beta": 2,', "}"]
+    )
+    # helper() spans lines 3..23; CONFIG starts at line 26.
+    patch = 'diff --git a/f.py b/f.py\n@@ -28,1 +28,1 @@\n     "beta": 2,\n'
+
+    expanded = expand_hunks(patch, content, 2, after=1, boundaries=[(3, 23)])
+
+    assert "def helper" not in expanded
+    assert "step_1()" not in expanded
+
+
+def test_innermost_enclosing_definition_wins() -> None:
+    """A method inside a class resolves to the method, not the class."""
+    spans = [(1, 40), (10, 20)]  # class 1..40, method 10..20
+
+    assert _enclosing_boundary(spans, 15) == 10
+    # Above the method but still inside the class body.
+    assert _enclosing_boundary(spans, 5) == 1

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1891,7 +1891,7 @@ _FN_CTX = PRContext(
 
 
 def test_function_context_pads_to_the_enclosing_def(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    monkeypatch.setattr("lgtmaybe.engine.engine.definition_starts", lambda text, path: [1])
+    monkeypatch.setattr("lgtmaybe.engine.engine.definition_spans", lambda text, path: [(1, 1000)])
     provider = _provider_for([], reflection_keeps_all=True)
     engine = LLMReviewEngine(provider)
     cfg = ReviewConfig(provider=Provider.ollama, model="llama3", context_lines=3)
@@ -1903,7 +1903,7 @@ def test_function_context_pads_to_the_enclosing_def(monkeypatch) -> None:  # typ
 
 
 def test_function_context_off_keeps_the_fixed_pad(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    monkeypatch.setattr("lgtmaybe.engine.engine.definition_starts", lambda text, path: [1])
+    monkeypatch.setattr("lgtmaybe.engine.engine.definition_spans", lambda text, path: [(1, 1000)])
     provider = _provider_for([], reflection_keeps_all=True)
     engine = LLMReviewEngine(provider)
     cfg = ReviewConfig(

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -76,7 +76,7 @@ def test_no_default_encoding_io() -> None:
         from lgtmaybe.config.store import load, save
         from lgtmaybe.core.models import ReviewConfig, StaticAnalysisTool
         from lgtmaybe.engine.astgrep import _default_runner
-        from lgtmaybe.engine.boundaries import definition_starts
+        from lgtmaybe.engine.boundaries import definition_spans
         from lgtmaybe.engine.static_analysis import _run_tool, _write_corpus
         from lgtmaybe.local import _git
         from scripts.check_spec_drift import run_scan
@@ -99,7 +99,7 @@ def test_no_default_encoding_io() -> None:
             load_config(config_path=config)
 
             _write_corpus(root / "corpus", {"src/app.py": "print('👍')\\n"})
-            definition_starts(
+            definition_spans(
                 "def f():\\n    pass\\n",
                 "src/app.py",
                 runner=lambda *_args: "[]",


### PR DESCRIPTION
## The bug

`definition_starts` returned start lines and threw ast-grep's `range.end` away. `_enclosing_boundary` then treated **the nearest definition start above a hunk** as enclosing it — whether or not that definition had already closed.

So for a hunk on module-level code sitting below a function, the "enclosing signature" it padded back to was an unrelated function that ended lines earlier:

```python
def helper(a):      # line 4  <- pad reached back to here
    x = a + 1
    y = x * 2
    return y        # line 7  <- helper ends

CONFIG = {
    "alpha": 1,
    "beta": 2,      # line 13 <- the actual change
}
```

Reproduced directly against the real ast-grep:

```
definition starts: [4]
claimed enclosing for line 13: 4
-> helper() spans lines 4..8 and ended long before line 13
```

The model was handed `helper()`'s whole body as the context explaining a change to a constant. Constants, config tables, registries and dispatch maps sit below function definitions in most files, so this is not a rare shape — and the pad reaches up to `_MAX_BOUNDARY_REACH` (120 lines).

## The fix

`definition_spans` returns inclusive `(start, end)` spans — ast-grep already reported the end, it was simply discarded. `_enclosing_boundary` walks back from the nearest start to the **innermost definition that still contains** the hunk (so a method wins over its enclosing class), or gives up and keeps the fixed-line pad.

The walk stays bounded: spans are sorted by start, so once one begins further than `_MAX_BOUNDARY_REACH` above the hunk, everything left of it is further still and the search stops.

A malformed or inverted range from ast-grep is dropped rather than guessed at — a wrong span pads to the wrong place.

## Second fix: the non-overlap invariant leaked

While fuzzing the merge logic added in #290 I found a case it does not cover. When two hunks' pads reach each other but the gap **cannot be filled** — head text shorter than the hunk positions, so merging would drop lines the merged header still claims — the later hunk started its own group with its full leading pad, which still overlapped the previous one.

4000 random cases, 217 overlapping:

```
OVERLAP nlines=41 n=16 starts=[45, 47, 78] ranges=[(32, 46), (36, 47), (78, 78)]
```

The later hunk's leading pad is now trimmed to clear the previous group. The pad is decoration; an overlapping header is not. Re-fuzzed: 0 overlapping cases. Locked in by `test_no_overlap_when_head_text_is_shorter_than_the_hunks`.

## Token effect: roughly neutral, and that is the honest answer

Measured across seven recent commits of this repo, default config, uncached input for a whole run:

| commit | before | after | |
|---|---:|---:|---:|
| `ea84ba4` | 55,216 | 53,059 | -3.9% |
| `2d81f5e` | 93,020 | 89,727 | -3.5% |
| `1cddf6b` | 180,084 | 173,987 | -3.4% |
| `b8f8739` | 58,680 | 58,403 | -0.5% |
| `4eee72c` | 134,812 | 135,147 | +0.2% |
| `a295cd8` | 40,096 | 40,431 | +0.8% |
| `f03c4bf` | 55,648 | 56,347 | +1.3% |
| **total** | **617,556** | **607,101** | **-1.7%** |

Some diffs get *bigger*, and that is correct. Removing the bogus pad into a closed function saves; but a hunk that genuinely does sit in an outer scope — between two methods of a class, say — now correctly reaches that class's signature, which is sometimes further back than the closed sibling method it used to stop at. This PR is a correctness fix that happens to be slightly cheaper, not a cost optimisation.

## Tests

Red-first — three new boundary tests failed on the missing `definition_spans`, then on containment. Added:

- `definition_spans` reports where a definition ends (against the real ast-grep binary)
- module-level code after a function is enclosed by nothing
- a line genuinely inside a definition still resolves
- a module-level hunk is not padded into a closed definition (behavioural, through `expand_hunks`)
- the innermost enclosing definition wins — a method before its class
- no overlap when the head text is shorter than the hunks (from the fuzz case)

Existing boundary tests moved to the span API; the `list[int]` → `list[tuple[int, int]]` change is threaded through `expand_hunks`, `_lead_start` and `_group_hunks`.

### Review feedback (both addressed in 111c032)

- **Assertion-light test.** Correct, and it earned its keep: adding the positive assertions immediately failed, exposing that the fixture's hunk header pointed at line 28 (`"alpha": 1,`) while its body read `"beta": 2,`. The test was passing on a patch that did not describe its own content. Line numbers corrected and annotated inline.
- **Private-API coupling.** Comment added, coupling kept deliberately — the public-API test already exists in `test_compress.py`; what it cannot do is name *which line* the lookup resolved to, so the two are complementary. The docstring now says so.

Full suite green (1650 passed, 3 skipped), ruff + mypy clean, `pytest tests/specs` and `openspec validate --specs` pass. The `engine.context-expansion` spec section gained the containment rule and a scenario.