### PR TITLE
perf(context): size the enclosing-definition reach against the fixed pad

### DIFF
--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -282,7 +282,14 @@ def trailing_context_lines(before: int) -> int:
 # How far above a hunk the enclosing-definition pad may reach (lines). Beyond
 # this the "enclosing function" is so far away that padding to it would drown
 # the diff; the fixed-line pad applies instead.
-_MAX_BOUNDARY_REACH = 120
+#
+# Sized against `_MAX_CONTEXT_LINES`, because the two pads compete for the same
+# attention. Reaching the signature is worth a pad somewhat larger than the
+# fixed one — but the reach reproduces EVERY intervening line, not just the
+# signature, so at several times the fixed pad a hunk stops gaining context and
+# starts being buried in an unrelated function body. Twice the largest fixed pad
+# keeps the signature of a normal-sized function in view while bounding that.
+_MAX_BOUNDARY_REACH = 2 * _MAX_CONTEXT_LINES
 
 
 def expand_hunks(

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -630,3 +630,32 @@ def test_no_overlap_when_head_text_is_shorter_than_the_hunks() -> None:
         assert next_start > prev_end, f"hunks overlap: {ranges}"
     # Both changes survive the trim.
     assert "x45" in expanded and "x47" in expanded
+
+
+def test_boundary_reach_is_proportionate_to_the_fixed_pad() -> None:
+    """The enclosing-definition pad may not dwarf the pad it widens.
+
+    The reach exists so a hunk deep in a function still sees the signature. But
+    it pads with every intervening line, not just the signature, so a reach many
+    times `_MAX_CONTEXT_LINES` stops adding context and starts replacing the
+    diff with an unrelated function body — the very thing the cap exists to
+    prevent. Keep it a small multiple of the largest fixed pad.
+    """
+    from lgtmaybe.engine.compress import _MAX_BOUNDARY_REACH, _MAX_CONTEXT_LINES
+
+    assert _MAX_BOUNDARY_REACH <= 2 * _MAX_CONTEXT_LINES
+
+
+def test_a_definition_far_above_the_hunk_is_out_of_reach() -> None:
+    """A hunk 60 lines into a long function keeps the fixed pad."""
+    content = "\n".join(["def long_one():"] + [f"    l{i}" for i in range(1, 100)])
+
+    expanded = expand_hunks(
+        "diff --git a/f.py b/f.py\n@@ -61,1 +61,1 @@\n     l60\n",
+        content,
+        2,
+        after=1,
+        boundaries=[(1, 100)],
+    )
+
+    assert "def long_one" not in expanded


### PR DESCRIPTION
## What

`_MAX_BOUNDARY_REACH` was 120 lines — six times `_MAX_CONTEXT_LINES` (20), the ceiling on the fixed pad it exists to widen.

The reach is there so a hunk deep inside a function still sees the signature that explains it. But it reproduces **every intervening line**, not just the signature. Past a few multiples of the fixed pad, a hunk stops gaining context and starts being buried in the body around it — which is the outcome the cap was introduced to prevent. The constant's own comment already said so:

```python
# How far above a hunk the enclosing-definition pad may reach (lines). Beyond
# this the "enclosing function" is so far away that padding to it would drown
# the diff; the fixed-line pad applies instead.
_MAX_BOUNDARY_REACH = 120
```

…while being set well past the point it describes. At 120, one changed line in a long function could pull in 119 lines of unrelated body, then get sent to all four lenses.

## How

Tied to `_MAX_CONTEXT_LINES` at 2× rather than left as a free-floating literal, so the two pads cannot drift apart again:

```python
_MAX_BOUNDARY_REACH = 2 * _MAX_CONTEXT_LINES
```

Twice the largest fixed pad still reaches the signature of a normal-sized function, which is the case the feature was built for.

## Token effect

Default config, uncached input for a whole run, measured on this repo:

| commit | before | after | |
|---|---:|---:|---:|
| `a295cd8` | 40,431 | 34,775 | **-14.0%** |
| `ea84ba4` | 53,059 | 50,083 | -5.6% |
| `1cddf6b` | 173,987 | 166,263 | -4.4% |
| `4eee72c` | 135,147 | 130,967 | -3.1% |
| `f03c4bf` | 56,347 | 55,215 | -2.0% |
| `b8f8739` | 58,403 | 58,403 | 0.0% |
| `2d81f5e` | 89,727 | 89,727 | 0.0% |
| **total** | **607,101** | **585,433** | **-3.6%** |

Two of the seven are unchanged, which is the expected shape after #294: now that a hunk only resolves to a definition genuinely containing it, most resolve to something well inside the new reach, and the cap never binds. The saving concentrates where a long function dominated the diff — `a295cd8` at -14%.

Cumulatively across #290, #293, #294 and this PR, a default run's input on these seven commits drops **674,512 → 585,433 (-13.2%)**.

## Trade-off

This is a tuning change, not a defect fix, so it is worth naming what it costs: a hunk sitting 40–120 lines below its enclosing signature no longer sees that signature and falls back to the fixed pad. That is the case where the pad was contributing the most lines and the least explanation — but it is a real reduction in context, not a free win, and I could not run `evals/` here to measure recall (no provider key in this environment). Worth a `python -m evals.run` against your usual model before it ships if you want the recall side confirmed.

## Tests

Red-first; both failed before the change:

- `test_boundary_reach_is_proportionate_to_the_fixed_pad` — pins the relationship to `_MAX_CONTEXT_LINES` rather than the literal, so the invariant survives a future retune of either.
- `test_a_definition_far_above_the_hunk_is_out_of_reach` — a hunk 60 lines into a long function keeps the fixed pad.

The existing `test_boundary_beyond_reach_is_ignored` (299-line gap) and `test_boundary_extends_the_leading_pad_to_the_enclosing_def` (17-line gap) still pass unchanged, bracketing the new value from both sides.

Full suite green (1652 passed, 3 skipped), ruff + mypy clean, `openspec validate --specs` passes. No spec change needed — `engine.context-expansion` states the rule in terms of the constant, not its value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqYf2v9WEBxHRoEruQWBUe)_