### PR TITLE
fix(identity): stop asking for branded identity on an event that cannot mint it

### DIFF
--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -72,7 +72,17 @@ review findings.
 Selecting `github_identity: lgtmaybe` is explicit: if `id-token: write` is
 missing, the App is not installed on the repository, the workflow is not
 trusted, or the identity service is unavailable, the job fails with setup
-guidance. It does not fall back to `github-actions[bot]`.
+guidance. A misconfiguration is never papered over with `github-actions[bot]`.
+
+The one exception is `pull_request_review_comment`, the trigger that answers
+replies in a finding thread (`answer_replies`). GitHub runs that event from the
+**pull request's branch** rather than the default branch, so the broker cannot
+mint branded identity for it — and that check is doing real work: it is what
+stops a contributor editing the workflow on their own branch and minting an App
+token from it. Replies are therefore posted by `github-actions[bot]`, announced
+with a notice in the job log. Reviews, `/review`, `/describe` and `/diagram` all
+arrive on `pull_request_target` or `issue_comment`, which do run from the
+default branch, so they still post as `lgtmaybe[bot]`.
 
 To remove access, uninstall the App from the repository or remove that
 repository from the installation. Remove `github_identity: lgtmaybe` and

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -65,7 +65,10 @@ the diff). This needs the `pull_request_review_comment` trigger in your workflow
 (the example workflows include it), and it never answers itself — only a freshly
 created reply from a human author, on a thread lgtmaybe started, is answered. It
 is on by default; set `answer_replies: false` to leave finding threads
-unanswered.
+unanswered. With `github_identity: lgtmaybe`, replies post as
+`github-actions[bot]` rather than `lgtmaybe[bot]` — GitHub runs this event from
+the PR's branch, so branded identity cannot be minted for it (see
+[Post as lgtmaybe\[bot\]](post-as-a-github-app.md)).
 
 > **Note on cost.** With ollama the model runs on your own hardware, so reviews
 > are free. On a hosted provider each run uses tokens you pay for, so it's worth

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -404,7 +404,10 @@ the diff). This needs the `pull_request_review_comment` trigger in your workflow
 (the example workflows include it), and it never answers itself — only a freshly
 created reply from a human author, on a thread lgtmaybe started, is answered. It
 is on by default; set `answer_replies: false` to leave finding threads
-unanswered.
+unanswered. With `github_identity: lgtmaybe`, replies post as
+`github-actions[bot]` rather than `lgtmaybe[bot]` — GitHub runs this event from
+the PR's branch, so branded identity cannot be minted for it (see
+[Post as lgtmaybe\[bot\]](post-as-a-github-app.md)).
 
 > **Note on cost.** With ollama the model runs on your own hardware, so reviews
 > are free. On a hosted provider each run uses tokens you pay for, so it's worth
@@ -720,7 +723,17 @@ review findings.
 Selecting `github_identity: lgtmaybe` is explicit: if `id-token: write` is
 missing, the App is not installed on the repository, the workflow is not
 trusted, or the identity service is unavailable, the job fails with setup
-guidance. It does not fall back to `github-actions[bot]`.
+guidance. A misconfiguration is never papered over with `github-actions[bot]`.
+
+The one exception is `pull_request_review_comment`, the trigger that answers
+replies in a finding thread (`answer_replies`). GitHub runs that event from the
+**pull request's branch** rather than the default branch, so the broker cannot
+mint branded identity for it — and that check is doing real work: it is what
+stops a contributor editing the workflow on their own branch and minting an App
+token from it. Replies are therefore posted by `github-actions[bot]`, announced
+with a notice in the job log. Reviews, `/review`, `/describe` and `/diagram` all
+arrive on `pull_request_target` or `issue_comment`, which do run from the
+default branch, so they still post as `lgtmaybe[bot]`.
 
 To remove access, uninstall the App from the repository or remove that
 repository from the installation. Remove `github_identity: lgtmaybe` and

--- a/openspec/specs/github-app-identity/anchors.yml
+++ b/openspec/specs/github-app-identity/anchors.yml
@@ -38,7 +38,13 @@ github-app.boundary:
   files: [services/github_app_identity/**/*.py]
 
 github-app.failure:
-  rule:
-    kind: function_definition
-    has: { field: name, regex: '^_http_error_message$' }
-  files: [scripts/github-app-identity.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_http_error_message$' }
+    files: [scripts/github-app-identity.py]
+  # The one sanctioned fallback: the exchange is skipped for an event GitHub
+  # does not run from the default branch, so the broker is never asked.
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^exchange$' }
+    files: [scripts/github-app-identity.py]

--- a/openspec/specs/github-app-identity/spec.md
+++ b/openspec/specs/github-app-identity/spec.md
@@ -75,9 +75,17 @@ OIDC or installation tokens.
 ### Requirement: Branded identity fails loud
 
 The Action SHALL NOT fall back to `github-actions[bot]` after a user explicitly
-selects lgtmaybe identity.
+selects lgtmaybe identity: a misconfiguration, an uninstalled App, or an
+unavailable broker fails loud with guidance. The sole exception is an event
+GitHub does not run from the repository's default branch, where the broker's
+default-branch check can never pass and the exchange is therefore not attempted
+— the workflow token is used and the downgrade is announced in the job log.
 <!-- anchor: github-app.failure -->
 
 #### Scenario: Broker is unavailable
 - **WHEN** the bounded exchange cannot complete
 - **THEN** the Action fails with setup or service guidance before posting
+
+#### Scenario: Event cannot run from the default branch
+- **WHEN** the workflow is triggered by a reply in a review thread
+- **THEN** no exchange is attempted and the reply posts as `github-actions[bot]`

--- a/scripts/github-app-identity.py
+++ b/scripts/github-app-identity.py
@@ -17,6 +17,19 @@ OIDC_AUDIENCE = "https://lgtmaybe.coles.codes/github-app-identity"
 GITHUB_API_URL = "https://api.github.com"
 TIMEOUT_SECONDS = 10.0
 
+# Events whose workflow run does NOT come from the repository's default branch,
+# so the broker's default-branch assertion can never be satisfied.
+#
+# That assertion is not an obstacle to work around — it is what stops a
+# contributor from editing `.github/workflows/` on their own PR branch and
+# minting an lgtmaybe App token from it. The right response is therefore not to
+# ask: attempting the exchange only turns a reply into a failed review job.
+#
+# `issue_comment` and `pull_request_target` are deliberately absent. Both DO run
+# from the default branch and mint branded identity normally, so widening this
+# set would downgrade identity for the review path that works today.
+_NON_DEFAULT_BRANCH_EVENTS = frozenset({"pull_request_review_comment"})
+
 
 class IdentitySetupError(RuntimeError):
     """A user-actionable GitHub identity configuration error."""
@@ -57,6 +70,17 @@ def exchange(
     opener: Opener = _open_url,
     stdout: IO[str] = sys.stdout,
 ) -> None:
+    if env.get("GITHUB_EVENT_NAME", "") in _NON_DEFAULT_BRANCH_EVENTS:
+        # Write no token: action.yml falls back to the workflow token via
+        # `steps.lgtmaybe-token.outputs.token || ... || inputs.github_token`,
+        # and the revoke step stays skipped because it guards on that output.
+        stdout.write(
+            "::notice::lgtmaybe posts as github-actions[bot] on this event. "
+            "Branded App identity needs a workflow run from the default branch, "
+            "which this event does not provide.\n"
+        )
+        return
+
     oidc_url = env.get("ACTIONS_ID_TOKEN_REQUEST_URL")
     oidc_request_token = env.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
     if not oidc_url or not oidc_request_token:

--- a/services/github_app_identity/broker.py
+++ b/services/github_app_identity/broker.py
@@ -16,6 +16,15 @@ OIDC_JWKS_URL = f"{OIDC_ISSUER}/.well-known/jwks"
 INSTALL_URL = "https://github.com/apps/lgtmaybe/installations/new"
 GITHUB_API = "https://api.github.com"
 GITHUB_API_VERSION = "2022-11-28"
+# NOTE: `pull_request_review_comment` is accepted here but, in practice, GitHub
+# runs that event from the pull request's branch rather than the default branch,
+# so it always fails `_validate_repository`'s default-branch assertion below.
+# That rejection is correct — the assertion is what stops a contributor editing
+# `.github/workflows/` on their own branch and minting an App token from it — so
+# the action skips the exchange for that event client-side and falls back to the
+# workflow token (see scripts/github-app-identity.py). The entry stays so a
+# request that does somehow arrive is rejected by the branch check with its
+# specific message, rather than by the coarser pre-mint event check.
 ALLOWED_EVENTS = frozenset({"pull_request_target", "issue_comment", "pull_request_review_comment"})
 TOKEN_PERMISSIONS = {
     "contents": "read",

--- a/tests/docs/test_github_app_identity.py
+++ b/tests/docs/test_github_app_identity.py
@@ -52,9 +52,15 @@ def test_docs_explain_permissions_privacy_failure_and_uninstall() -> None:
         "issues: write",
         "cannot be combined with `fail_on`",
         "never receives your diff",
-        "does not fall back",
+        "never papered over",
         "uninstall",
     ):
+        assert phrase in guide
+
+    # The one sanctioned downgrade must be documented, not discovered in a log:
+    # a reply in a review thread runs from the PR's branch, so branded identity
+    # cannot be minted and the reply posts as github-actions[bot].
+    for phrase in ("pull_request_review_comment", "github-actions[bot]"):
         assert phrase in guide
 
     assert not re.search(r"copy (?:our|the lgtmaybe) private key", guide)

--- a/tests/identity/test_action_script.py
+++ b/tests/identity/test_action_script.py
@@ -169,3 +169,74 @@ def test_revoke_is_best_effort_and_never_prints_the_token() -> None:
     assert request_seen[0].method == "DELETE"
     assert request_seen[0].headers["Authorization"] == "Bearer ghs_scoped"
     assert "ghs_scoped" not in stdout.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# events that cannot run from the default branch
+# ---------------------------------------------------------------------------
+
+
+def test_exchange_skips_an_event_that_cannot_mint_branded_identity(tmp_path: Path) -> None:
+    """`pull_request_review_comment` runs from the PR branch, not the default
+    branch, so the broker's default-branch assertion can never be satisfied.
+
+    That guard is correct — it is what stops a contributor editing the workflow
+    on their own branch and minting an App token — so the client must not ask.
+    Asking anyway failed the whole review job every time somebody replied to a
+    finding, which is how `answer_replies` came to be dead on GitHub.
+    """
+    module = _module()
+    output = tmp_path / "github-output"
+    stdout = io.StringIO()
+
+    def open_request(request: Request, *, timeout: float):
+        raise AssertionError("no identity exchange should be attempted")
+
+    module.exchange(
+        {
+            "GITHUB_EVENT_NAME": "pull_request_review_comment",
+            "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token?x=1",
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+            "IDENTITY_BROKER_URL": "https://identity.example/token",
+            "GITHUB_OUTPUT": str(output),
+        },
+        opener=open_request,
+        stdout=stdout,
+    )
+
+    # No token output — action.yml's `|| inputs.github_token` chain then falls
+    # back to the workflow token, and the revoke step stays skipped.
+    assert not output.exists() or "token=" not in output.read_text(encoding="utf-8")
+    # The downgrade is announced, never silent.
+    assert "::notice::" in stdout.getvalue()
+    assert "github-actions[bot]" in stdout.getvalue()
+
+
+def test_exchange_still_runs_for_events_that_use_the_default_branch(tmp_path: Path) -> None:
+    """issue_comment and pull_request_target do run from the default branch and
+    mint branded identity normally — the skip must not widen to them."""
+    module = _module()
+
+    for event in ("issue_comment", "pull_request_target", ""):
+        calls: list[Request] = []
+
+        def open_request(request: Request, *, timeout: float, _c: list[Request] = calls):
+            _c.append(request)
+            if len(_c) == 1:
+                return Response({"value": "oidc-token"})
+            return Response({"token": "ghs_scoped"})
+
+        output = tmp_path / f"out-{event or 'unset'}"
+        module.exchange(
+            {
+                "GITHUB_EVENT_NAME": event,
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.example/token?x=1",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "IDENTITY_BROKER_URL": "https://identity.example/token",
+                "GITHUB_OUTPUT": str(output),
+            },
+            opener=open_request,
+            stdout=io.StringIO(),
+        )
+
+        assert output.read_text(encoding="utf-8") == "token=ghs_scoped\n", event


### PR DESCRIPTION
## The bug

Replying to a lgtmaybe review comment fails the whole review job:

```
##[error]The lgtmaybe identity exchange must run from the repository's default branch.
##[error]Process completed with exit code 1.
```

`pull_request_review_comment` is in the broker's `ALLOWED_EVENTS`, in this repo's workflow triggers, and in the post-as-a-GitHub-App how-to — but GitHub runs that event from the **pull request's branch**, so `_validate_repository`'s default-branch assertion can never pass. `answer_replies` (on by default) has therefore been dead on GitHub for App users, and every reply burns a failing run.

Reproducible and pre-existing — it fires on unrelated branches too:

```
30230434566  event=pull_request_review_comment  head_branch=claude/reduce-token-cost-defaults-f7rl0n  failure
30226015121  event=pull_request_review_comment  head_branch=claude/opensource-cli-scan-tools-naoqxi   failure
```

`_validate_pre_mint` produces a *different* message, so its passing tells us the event was allowed and the workflow prefix matched. The only way to reach this error is `workflow_ref` not ending in `@refs/heads/main`.

## Why the obvious fix is the wrong one

Relaxing that assertion would be a privilege-escalation hole. It is precisely what stops a contributor editing `.github/workflows/lgtmaybe.yml` on their own PR branch and minting an lgtmaybe App token from it. The guard is correct. The defect is asking it a question it is obliged to refuse.

## The fix

Skip the exchange client-side for that event and write no token. `action.yml` already has the fallback:

```yaml
GITHUB_TOKEN: ${{ steps.lgtmaybe-token.outputs.token || steps.app-token.outputs.token || inputs.github_token }}
```

so the workflow token is used, and the revoke step stays skipped because it guards on the same output. No new fallback machinery, no server-side change, no change to what the broker will accept.

The downgrade is announced, not silent:

```
::notice::lgtmaybe posts as github-actions[bot] on this event. Branded App
identity needs a workflow run from the default branch, which this event does
not provide.
```

**Scoped to exactly one event.** `issue_comment` and `pull_request_target` do run from the default branch — the run history shows **4 successful `issue_comment` exchanges against 0 failures**, all with `head_branch=main` — so widening the skip would downgrade identity for the path that works today. The set is a named constant with that reasoning attached.

## Honesty about the contract

The App guide promised *"It does not fall back to `github-actions[bot]`"*, and `github-app.failure` specified the same. That is no longer strictly true, so both are corrected to name the single exception rather than left as a claim the code does not honour. `ALLOWED_EVENTS` keeps the entry — a request that somehow arrives should still be rejected by the specific branch check rather than the coarser pre-mint one — with a comment explaining why it is accepted there but never used.

## Tests

Red-first — `test_exchange_skips_an_event_that_cannot_mint_branded_identity` failed on an opener that asserts it is never called:

```
E       AssertionError: no identity exchange should be attempted
```

Added:
- the skip writes no token output and emits the `::notice::`
- `issue_comment`, `pull_request_target` and an unset event still mint normally — pinning the scope so a future edit cannot quietly widen it
- the docs test now pins the documented exception (`pull_request_review_comment`, `github-actions[bot]`) instead of the withdrawn phrase

Full suite green (1654 passed, 3 skipped), ruff + mypy clean, `pytest tests/specs` and `openspec validate --specs` pass. `github-app.failure` gained the exception and a scenario, plus an anchor rule binding it to `exchange`; `docs/llms-full.txt` regenerated.

## Verifying it

This one cannot be proven from CI on this PR — the failure only reproduces when somebody replies to a review comment. After merge, replying to any lgtmaybe finding thread should post an answer as `github-actions[bot]` with the notice in the log, instead of a red job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqYf2v9WEBxHRoEruQWBUe)_