### PR TITLE
feat(engine): cap a review's spend with max_review_tokens

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: "Soft wall-clock ceiling for the whole review, in seconds (default 3600). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with the incomplete-results notice every failed or skipped call raises. Set 0 to disable."
     required: false
     default: ""
+  max_review_tokens:
+    description: "Soft billable-token ceiling for the whole review — input plus output summed across every model call (lens fan-out, triage, reflection). Once it passes, no further model calls are dispatched: in-flight calls finish, their findings post, and the review carries a notice naming this input. Empty or 0 (the default) disables it. There is no safe generous default because token spend scales with diff size and lens count — run once with profile: true, read the total, then set this above it."
+    required: false
+    default: ""
   temperature:
     description: "Sampling temperature (default 0.0 for deterministic reviews)."
     required: false
@@ -275,6 +279,7 @@ runs:
         INPUT_API_BASE: ${{ inputs.api_base }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_MAX_REVIEW_SECONDS: ${{ inputs.max_review_seconds }}
+        INPUT_MAX_REVIEW_TOKENS: ${{ inputs.max_review_tokens }}
         INPUT_TEMPERATURE: ${{ inputs.temperature }}
         INPUT_NUM_CTX: ${{ inputs.num_ctx }}
         INPUT_MAX_INPUT_TOKENS: ${{ inputs.max_input_tokens }}
@@ -310,7 +315,8 @@ runs:
           -e INPUT_LANGUAGE \
           -e INPUT_TRIAGE_MODEL \
           -e INPUT_API_KEY -e INPUT_API_BASE -e INPUT_CONFIG_PATH \
-          -e INPUT_TIMEOUT -e INPUT_MAX_REVIEW_SECONDS -e INPUT_TEMPERATURE \
+          -e INPUT_TIMEOUT -e INPUT_MAX_REVIEW_SECONDS -e INPUT_MAX_REVIEW_TOKENS \
+          -e INPUT_TEMPERATURE \
           -e INPUT_NUM_CTX -e INPUT_MAX_INPUT_TOKENS -e INPUT_MAX_TOKENS \
           -e INPUT_MAX_CONCURRENCY \
           -e INPUT_RESOLVE_FIXED \

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3321,6 +3321,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
+| `max_review_tokens` | integer | No | `0` | Max Review Tokens |
 | `max_tokens` | integer / null | No | `null` | Max Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
@@ -4013,6 +4014,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": 3600,
       "minimum": 0,
       "title": "Max Review Seconds",
+      "type": "integer"
+    },
+    "max_review_tokens": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Max Review Tokens",
       "type": "integer"
     },
     "max_tokens": {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,6 +36,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
+| `max_review_tokens` | integer | No | `0` | Max Review Tokens |
 | `max_tokens` | integer / null | No | `null` | Max Tokens |
 | `min_confidence` | integer | No | `0` | Min Confidence |
 | `min_severity` | `critical` / `high` / `info` / `low` / `medium` | No | `low` |  |
@@ -728,6 +729,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": 3600,
       "minimum": 0,
       "title": "Max Review Seconds",
+      "type": "integer"
+    },
+    "max_review_tokens": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Max Review Tokens",
       "type": "integer"
     },
     "max_tokens": {

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -13,9 +13,10 @@ filter — with budget behaviors that degrade loudly, never silently.
 
 `LLMReviewEngine.review` SHALL run the stages in order and, whenever any lens
 call fails or is skipped, return partial results with a notice plus a hidden
-incomplete marker — never a silent LGTM. A call skipped past the soft
-whole-review deadline (`max_review_seconds`) counts as a failed call, so the
-deadline is one contributor to that notice rather than its only source. Any
+incomplete marker — never a silent LGTM. A call skipped past either soft
+whole-review ceiling — the deadline (`max_review_seconds`) or the billable-token
+budget (`max_review_tokens`, off by default) — counts as a failed call, so the
+ceilings are contributors to that notice rather than its only source. Any
 stage failure surfaces to the caller.
 <!-- anchor: engine.review -->
 
@@ -28,6 +29,11 @@ stage failure surfaces to the caller.
 #### Scenario: deadline passes mid-review
 - **WHEN** lens calls are still queued after `max_review_seconds`
 - **THEN** they are skipped and the summary carries the same partial-results notice
+
+#### Scenario: token budget is exhausted mid-review
+- **WHEN** the run's billable tokens reach `max_review_tokens` with calls queued
+- **THEN** they are skipped and the summary names the budget alongside the
+  partial-results notice, so a spend stop is never read as a clean review
 
 #### Scenario: findings were suppressed
 - **WHEN** a run suppresses findings (ignored fingerprint, inline pragma, or a

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -855,6 +855,7 @@ def action_inputs() -> dict[str, str | None]:
         "api_base": get("API_BASE"),
         "timeout": get("TIMEOUT"),
         "max_review_seconds": get("MAX_REVIEW_SECONDS"),
+        "max_review_tokens": get("MAX_REVIEW_TOKENS"),
         "temperature": get("TEMPERATURE"),
         "num_ctx": get("NUM_CTX"),
         "max_input_tokens": get("MAX_INPUT_TOKENS"),

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -252,6 +252,15 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "review returns partial results with an incomplete-results notice. 0 disables",
 )
 @click.option(
+    "--max-review-tokens",
+    default=None,
+    type=click.IntRange(min=0),
+    help="Soft billable-token ceiling for the whole review — input + output "
+    "across every model call (0, the default, disables it). Past it, no further "
+    "model calls are dispatched and the review returns partial results with a "
+    "notice. Run once with --profile to see a real total, then set this above it",
+)
+@click.option(
     "--temperature",
     default=None,
     type=float,
@@ -356,6 +365,7 @@ def review(
     context_lines: int | None,
     timeout: int | None,
     max_review_seconds: int | None,
+    max_review_tokens: int | None,
     temperature: float | None,
     reflect: bool | None,
     learn_feedback: bool | None,
@@ -393,6 +403,7 @@ def review(
         context_lines=context_lines,
         timeout=timeout,
         max_review_seconds=max_review_seconds,
+        max_review_tokens=max_review_tokens,
         temperature=temperature,
         reflect=reflect,
         learn_feedback=learn_feedback,
@@ -545,6 +556,7 @@ def action() -> None:
         triage_model=inputs["triage_model"],
         timeout=inputs["timeout"],
         max_review_seconds=inputs["max_review_seconds"],
+        max_review_tokens=inputs["max_review_tokens"],
         temperature=inputs["temperature"],
         num_ctx=inputs["num_ctx"],
         max_input_tokens=inputs["max_input_tokens"],

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -788,6 +788,20 @@ class ReviewConfig(_Strict):
     # generous per-call timeout, so one slow gateway/local call can't eat the
     # whole review budget); 0 disables the ceiling entirely.
     max_review_seconds: int = Field(default=3600, ge=0)
+    # Soft billable-token ceiling for one review run (input + output summed
+    # across every model call: lens fan-out, triage, reflection). Behaves
+    # exactly like max_review_seconds — once passed, no further model calls are
+    # dispatched, in-flight calls finish, their findings post, and the summary
+    # carries a notice naming this knob. It can never turn a total failure into
+    # a silent LGTM.
+    #
+    # 0 (the default) disables it. Unlike the wall-clock ceiling there is no
+    # safe generous default: token spend scales with diff size, lens count and
+    # batch count, so any figure that protects a small repo silently truncates
+    # a large one's review. Measurement is always on (`--profile`, and the
+    # structured `provider call` log lines) — read a real run's total, then set
+    # this above it. See docs/how-to/reduce-review-cost.md.
+    max_review_tokens: int = Field(default=0, ge=0)
     # Ceiling on concurrent review calls across the WHOLE fan-out (every
     # (batch, lens) task shares one pool). None means auto: 8 for hosted cloud
     # providers (their retry layer absorbs a capacity 429, and on bedrock cache

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -127,6 +127,11 @@ _WARMUP_MIN_TOKENS = 2048
 # adapter matches on.
 INCOMPLETE_MARKER = "<!-- lgtmaybe-incomplete -->"
 
+# The reason string a call skipped by the token ceiling reports. Shared with the
+# summary step, which counts these to tell a budget stop (spend the user chose)
+# apart from the provider failures the generic incomplete notice covers.
+_BUDGET_SKIP_REASON = "token budget (max_review_tokens) reached — call skipped"
+
 
 def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
     """The fan-out pool size: the explicit cap, else the provider-aware default."""
@@ -317,6 +322,13 @@ class LLMReviewEngine(ReviewEngine):
         deadline_at = (
             time.perf_counter() + cfg.max_review_seconds if cfg.max_review_seconds else None
         )
+        # Soft whole-review token ceiling, the spend-shaped twin of the deadline
+        # above. Measured from the profiler's running total AT THIS INSTANT, not
+        # from zero: the profiler is a process-wide singleton, so a second review
+        # in one process must not inherit the first one's spend as its budget.
+        budget_at = (
+            profiler.total_tokens() + cfg.max_review_tokens if cfg.max_review_tokens else None
+        )
         # Batches a wall-clock timeout forced us to review in smaller pieces.
         # Per-review state (reset here, not in __init__, so a reused engine starts
         # clean); a set's add is atomic, which is all the fan-out threads need.
@@ -492,6 +504,7 @@ class LLMReviewEngine(ReviewEngine):
                     cfg.prompt_cache,
                     cfg.language,
                     deadline_at,
+                    budget_at,
                     lens,
                     batch,
                 )
@@ -588,16 +601,25 @@ class LLMReviewEngine(ReviewEngine):
         #    model talking itself into a false positive, and there is no model
         #    here to audit. Partitioned rather than filtered afterwards so they
         #    cost no reflection tokens and the auditor cannot drop them.
-        reflection_skipped_by_deadline = False
+        # None, or the name of the ceiling that stopped the audit — it feeds the
+        # notice below, so a skipped audit always says which knob to raise.
+        reflection_skipped: str | None = None
         scanned = [f for f in all_findings if _is_scan_finding(f)]
         all_findings = [f for f in all_findings if not _is_scan_finding(f)]
         if cfg.reflect and all_findings:
             if deadline_at is not None and time.perf_counter() >= deadline_at:
                 # Better unaudited findings with an honest notice than more
                 # minutes past the ceiling — and never a silent quality drop.
-                reflection_skipped_by_deadline = True
+                reflection_skipped = f"Review deadline ({cfg.max_review_seconds}s)"
                 _log.warning(
                     "review deadline reached — skipping reflection",
+                    extra={"findings": len(all_findings)},
+                )
+            elif budget_at is not None and profiler.total_tokens() >= budget_at:
+                # Same trade, spend instead of time.
+                reflection_skipped = f"Token budget (max_review_tokens = {cfg.max_review_tokens})"
+                _log.warning(
+                    "review token budget reached — skipping reflection",
                     extra={"findings": len(all_findings)},
                 )
             else:
@@ -651,6 +673,19 @@ class LLMReviewEngine(ReviewEngine):
                 f"🔎 Triage skipped {len(skipped_by_triage)} low-risk file{plural_files}: "
                 f"{listed}{more} (`/review full` reviews everything)."
             )
+        # A budget stop is not a fault — it is the spend ceiling the user asked
+        # for — so it gets its own notice naming the knob, ahead of the generic
+        # incomplete notice below (which still fires, because the review IS
+        # partial and that must never be softened into a clean bill of health).
+        budget_skips = sum(1 for e in errors if e == _BUDGET_SKIP_REASON)
+        if budget_skips:
+            plural = "s were" if budget_skips != 1 else " was"
+            notices.append(
+                f"💸 Token budget reached ({cfg.max_review_tokens} billable tokens) — "
+                f"{budget_skips} of {total_calls} review call{plural} skipped, so this "
+                "review is partial. Raise `max_review_tokens`, or spend less per run "
+                "(a `triage_model`, fewer `categories`, lower `context_lines`)."
+            )
         # Some — but not all — lenses failed: the result may be incomplete, so say
         # so and don't claim a clean bill of health. The hidden marker rides along
         # so the posting step can tell an incomplete run from a complete one
@@ -672,11 +707,10 @@ class LLMReviewEngine(ReviewEngine):
                 "reviewed in smaller pieces instead. Consider a lower `max_input_tokens` "
                 "or a faster model."
             )
-        if reflection_skipped_by_deadline:
+        if reflection_skipped:
             notices.append(
-                f"⚠️ Review deadline ({cfg.max_review_seconds}s) reached — the "
-                "self-reflection audit was skipped, so findings may include "
-                "false positives."
+                f"⚠️ {reflection_skipped} reached — the self-reflection audit was "
+                "skipped, so findings may include false positives."
             )
         # Findings the model DID raise and the run then hid: an ignore
         # fingerprint, an inline pragma, or a 👎 from a previous run. Reporting
@@ -774,6 +808,7 @@ class LLMReviewEngine(ReviewEngine):
         split_prompt: bool,
         language: str | None,
         deadline_at: float | None,
+        budget_at: int | None,
         lens: _Lens,
         batch: list[tuple[str, str]] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
@@ -805,6 +840,12 @@ class LLMReviewEngine(ReviewEngine):
         if deadline_at is not None and time.perf_counter() >= deadline_at:
             _log.warning("review deadline reached — skipping call", extra={"lens": lens.id})
             return [], "review deadline (max_review_seconds) reached — call skipped"
+        # Same check, spend instead of time: queued calls are dropped once the
+        # run's billable tokens pass the ceiling. Read at EXECUTION time so the
+        # figure includes everything that landed while this task sat in the pool.
+        if budget_at is not None and profiler.total_tokens() >= budget_at:
+            _log.warning("review token budget reached — skipping call", extra={"lens": lens.id})
+            return [], _BUDGET_SKIP_REASON
         on_wall_timeout = (
             None
             if batch is None
@@ -819,6 +860,7 @@ class LLMReviewEngine(ReviewEngine):
                 split_prompt=split_prompt,
                 language=language,
                 deadline_at=deadline_at,
+                budget_at=budget_at,
                 lens=lens,
             )
         )
@@ -869,6 +911,7 @@ class LLMReviewEngine(ReviewEngine):
         split_prompt: bool,
         language: str | None,
         deadline_at: float | None,
+        budget_at: int | None,
         lens: _Lens,
     ) -> _LensOutcome:
         """Re-review a timed-out batch as smaller pieces, one call each.
@@ -906,6 +949,7 @@ class LLMReviewEngine(ReviewEngine):
                 split_prompt,
                 language,
                 deadline_at,
+                budget_at,
                 lens,
             )
             findings.extend(piece_findings)

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -110,6 +110,22 @@ class Profiler:
             },
         )
 
+    def total_tokens(self) -> int:
+        """Billable tokens recorded so far: input + output across every call.
+
+        Cache reads/writes are deliberately NOT added on top. Providers differ
+        on whether a cached read is already inside the reported prompt count
+        (litellm's ``prompt_tokens_details.cached_tokens`` is a subset of
+        ``prompt_tokens``; Anthropic reports it alongside), so adding them would
+        double-count on some routes and not others. Input + output is the one
+        figure every route agrees on — which is what a budget needs to be.
+
+        Backs :attr:`ReviewConfig.max_review_tokens`, so it is read from the
+        fan-out threads: the lock is not decoration.
+        """
+        with self._lock:
+            return sum(c.input_tokens + c.output_tokens for c in self.calls)
+
     @contextmanager
     def stage(self, name: str) -> Iterator[None]:
         """Time one pipeline stage; records and logs even when the stage raises."""
@@ -152,6 +168,12 @@ class Profiler:
         read = sum(c.cache_read_tokens for c in calls)
         created = sum(c.cache_creation_tokens for c in calls)
         lines.append(f"cache: {read} tokens read / {created} created across {len(calls)} calls")
+        billed_in = sum(c.input_tokens for c in calls)
+        billed_out = sum(c.output_tokens for c in calls)
+        lines.append(
+            f"tokens: {billed_in + billed_out} billable "
+            f"({billed_in} in / {billed_out} out) across {len(calls)} calls"
+        )
         return "\n".join(lines)
 
 

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -116,6 +116,67 @@ class TestProfiler:
         assert text.index("tests") < text.index("security")
         assert "RateLimitError" in text
         assert "900 tokens read / 200 created across 2 calls" in text
+        assert "tokens: 2100 billable (2000 in / 100 out) across 2 calls" in text
+
+
+class TestTotalTokens:
+    """`total_tokens` backs the max_review_tokens ceiling, so it must count the
+    one figure every provider route agrees on and nothing else."""
+
+    def _record(self, p: Profiler, **usage: int) -> None:
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_read_tokens=usage.get("cache_read_tokens", 0),
+            cache_creation_tokens=usage.get("cache_creation_tokens", 0),
+        )
+
+    def test_empty_profiler_has_spent_nothing(self) -> None:
+        assert Profiler().total_tokens() == 0
+
+    def test_sums_input_and_output_across_calls(self) -> None:
+        p = Profiler()
+        self._record(p, input_tokens=1000, output_tokens=50)
+        self._record(p, input_tokens=300, output_tokens=7)
+        assert p.total_tokens() == 1357
+
+    def test_cache_counters_are_not_added_on_top(self) -> None:
+        """Routes disagree on whether a cached read sits inside the prompt count;
+        adding it would double-count on some and not others."""
+        p = Profiler()
+        self._record(
+            p,
+            input_tokens=1000,
+            output_tokens=50,
+            cache_read_tokens=800,
+            cache_creation_tokens=200,
+        )
+        assert p.total_tokens() == 1050
+
+    def test_a_failed_call_contributes_its_recorded_zero(self) -> None:
+        p = Profiler()
+        p.record_call(
+            label="tests",
+            batch=1,
+            elapsed=1.0,
+            attempts=2,
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            error="RateLimitError",
+        )
+        assert p.total_tokens() == 0
+
+    def test_reset_clears_the_running_total(self) -> None:
+        p = Profiler()
+        self._record(p, input_tokens=1000, output_tokens=50)
+        p.reset()
+        assert p.total_tokens() == 0
 
 
 class TestTimedComplete:

--- a/tests/engine/test_token_budget.py
+++ b/tests/engine/test_token_budget.py
@@ -1,0 +1,135 @@
+"""Tests for the soft whole-review token budget (max_review_tokens)."""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError
+from lgtmaybe.engine.profiling import profiler
+from tests.fakes import FakeProvider
+
+_CTX = PRContext(
+    diff="@@ -1,3 +1,4 @@\n context\n+new line\n context\n",
+    changed_files=["a.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="org/repo",
+    pr_number=1,
+)
+
+_FINDING_JSON = (
+    '[{"path": "a.py", "line": 1, "severity": "high", "title": "bug", "body": "broken",'
+    ' "failure_scenario": "When the changed line runs, the operation fails."}]'
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_profiler() -> None:
+    """The profiler is a module-level singleton; start every test from zero."""
+    profiler.reset()
+
+
+class _CostlyProvider(FakeProvider):
+    """Each completion reports a fixed token cost and returns one finding."""
+
+    def __init__(self, input_tokens: int = 600, output_tokens: int = 400) -> None:
+        super().__init__()
+        self._input = input_tokens
+        self._output = output_tokens
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        return ProviderResult(
+            text=_FINDING_JSON, input_tokens=self._input, output_tokens=self._output
+        )
+
+
+def _cfg(**overrides: object) -> ReviewConfig:
+    defaults: dict[str, object] = {
+        "provider": Provider.ollama,  # serial: calls execute one at a time
+        "model": "m",
+        "categories": [
+            ReviewCategory.security,
+            ReviewCategory.correctness,
+            ReviewCategory.performance,
+        ],
+        "reflect": False,
+    }
+    defaults.update(overrides)
+    return ReviewConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestReviewTokenBudget:
+    def test_calls_past_the_budget_are_skipped_with_a_notice(self) -> None:
+        """The first call spends the whole 1,000-token budget; the queued rest
+        must be skipped, the completed call's findings must still post, and the
+        summary must name the knob that stopped the run."""
+        provider = _CostlyProvider(input_tokens=600, output_tokens=400)
+        findings, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_review_tokens=1000))
+        assert len(provider.calls) == 1, "only the call that fit the budget ran"
+        assert findings, "the completed call's findings still post"
+        assert "max_review_tokens" in summary
+        assert "LGTM" not in summary
+
+    def test_budget_zero_disables_the_ceiling(self) -> None:
+        provider = _CostlyProvider()
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_review_tokens=0))
+        assert len(provider.calls) == 3
+        assert "max_review_tokens" not in summary
+
+    def test_off_by_default(self) -> None:
+        """Enforcement is opt-in: token spend varies far too much by repo for a
+        default cap to be anything but a silent quality regression."""
+        assert _cfg().max_review_tokens == 0
+        provider = _CostlyProvider()
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+        assert len(provider.calls) == 3
+        assert "max_review_tokens" not in summary
+
+    def test_a_generous_budget_never_trips_a_normal_run(self) -> None:
+        provider = _CostlyProvider()
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_review_tokens=1_000_000))
+        assert len(provider.calls) == 3
+        assert "max_review_tokens" not in summary
+
+    def test_budget_is_scoped_to_this_review_not_the_process(self) -> None:
+        """Spend from an earlier review in the same process must not eat this
+        one's budget — the ceiling is measured from where this run started."""
+        engine = LLMReviewEngine(_CostlyProvider())
+        engine.review(_CTX, _cfg(max_review_tokens=0))  # burns 3,000 tokens
+        provider = _CostlyProvider()
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_review_tokens=1_000_000))
+        assert len(provider.calls) == 3
+        assert "max_review_tokens" not in summary
+
+    def test_every_call_skipped_still_fails_loud(self) -> None:
+        """A budget must never turn a total failure into a silent LGTM."""
+
+        class _CostlyUnparseable(FakeProvider):
+            def complete(self, messages, model, **opts):  # type: ignore[override]
+                self.calls.append({"messages": messages, "model": model, "opts": opts})
+                return ProviderResult(text="no json", input_tokens=600, output_tokens=400)
+
+        with pytest.raises(ReviewIncompleteError):
+            LLMReviewEngine(_CostlyUnparseable()).review(_CTX, _cfg(max_review_tokens=1000))
+
+    def test_reflection_skipped_past_budget_with_an_honest_notice(self) -> None:
+        provider = _CostlyProvider()
+        cfg = _cfg(
+            categories=[ReviewCategory.security],
+            reflect=True,
+            max_review_tokens=1000,
+        )
+        findings, summary = LLMReviewEngine(provider).review(_CTX, cfg)
+        # One review call spends the budget; reflection would start past it.
+        assert len(provider.calls) == 1
+        assert findings, "kept unaudited rather than dropped"
+        assert "self-reflection audit was skipped" in summary
+        assert "max_review_tokens" in summary

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -584,6 +584,12 @@
       "title": "Max Review Seconds",
       "type": "integer"
     },
+    "max_review_tokens": {
+      "default": 0,
+      "minimum": 0,
+      "title": "Max Review Tokens",
+      "type": "integer"
+    },
     "max_tokens": {
       "anyOf": [
         {


### PR DESCRIPTION
## Why

lgtmaybe hands the user a metered bill with no meter and no ceiling.

A review's cost is a product, not a sum: `batches × lenses × (diff + context padding)`, plus reflection, plus triage. The `fast` preset makes four calls per batch and each one re-sends the whole padded diff; `full` makes up to nine. Nothing in a run reports the total, and nothing stops it. The first you hear about the number is the provider invoice.

This adds the spend-shaped twin of the `max_review_seconds` deadline that already exists.

## What changed

**`ReviewConfig.max_review_tokens`** (default `0` = off). Once a run's billable tokens reach the ceiling, no further model calls are dispatched: in-flight calls finish, their findings post, and the summary carries a notice naming the knob. Reflection is gated the same way. The `ReviewIncompleteError` path is untouched — a budget stop can never turn a total failure into a silent LGTM.

Deliberate design calls, all covered by tests:

- **Billable = input + output.** Cache counters are *not* added on top. Routes disagree on whether a cached read already sits inside the reported prompt count (litellm's `prompt_tokens_details.cached_tokens` is a subset of `prompt_tokens`; Anthropic reports it alongside), so including them would double-count on some routes and not others. Input + output is the one figure every route agrees on, which is what a budget needs to be.
- **Measured from review start, not from zero.** The profiler is a process-wide singleton, so a second review in one process must not inherit the first one's spend as its budget.
- **Checked at execution time**, not queue time — so the figure includes everything that landed while the task sat in the pool. Same place the deadline check lives.
- **A budget stop gets its own notice** ahead of the generic incomplete notice, because it is the ceiling the user asked for rather than a fault. The generic notice still fires: the review *is* partial and that must not be softened.

**Off by default, on purpose.** Unlike the wall-clock ceiling there is no safe generous default — spend scales with diff size, lens count and batch count, so any figure that protects a small repo silently truncates a large one's review. What ships on by default is *measurement*: `--profile` now prints a billable-token total, so you can read a real run and set the ceiling above it.

## Surface

`--max-review-tokens` (CLI) · `max_review_tokens` (Action input, `INPUT_MAX_REVIEW_TOKENS`) · `max_review_tokens` (`.lgtmaybe.yml`). The `action.yml` parity tests caught the container-forwarding line, which is included.

## Tests

`tests/engine/test_token_budget.py` (new, 7 cases — written first, watched fail) covers: queued calls skipped with the notice, `0` disables, off by default, a generous budget never trips, the budget is scoped to the review rather than the process, every-call-skipped still raises `ReviewIncompleteError`, and reflection skipped with an honest notice. `tests/engine/test_profiling.py` gains a `TestTotalTokens` class pinning the no-double-count rule.

Full suite: **1664 passed, 3 skipped**. ruff, ruff format, mypy, `openspec validate --specs` and `tests/specs` all green. Regenerated `docs/reference/config.md`, `docs/llms*.txt` and `tests/snapshots/ReviewConfig.json`; updated the `engine.review` spec section, which anchors this behavior.

## Follow-ups (separate PRs)

- A `docs/how-to/reduce-review-cost.md` explaining the multiplier stack and the existing knobs (`triage_model`, `static_analysis`, `context_lines`, narrower `categories`) — the thing that would actually have prevented the surprise.
- Revisiting the `context_lines: 20` default with measured token numbers.

Cost in currency is still not computed or reported — that stays a deliberate decision (pricing tables go stale). This makes the meter readable and gives it a stop.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KeqxhbTe1VBgA5qKyVVe9)_