### PR TITLE
feat(cli): report what a local review spent

### DIFF
--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -43,6 +43,10 @@ Two built-in caps also keep any single run modest regardless of who starts it:
 `max_files` (default 50) and `max_input_tokens` (default 100k). See
 [What gets reviewed](what-gets-reviewed.md) for how the diff is bounded.
 
+To measure what a run actually spends and bring it down — triage, static
+analysis, prompt caching, and a hard `max_review_tokens` ceiling — see
+[Reduce review cost](../how-to/reduce-review-cost.md).
+
 ## How the choice is expressed
 
 The example workflows gate the `review` job on the triggering user's

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -1,0 +1,207 @@
+---
+description: Measure what a lgtmaybe review actually spends, then cut it — triage, static analysis, prompt caching, narrower lenses, and a hard token ceiling.
+---
+
+# Reduce Review Cost
+
+A review's token cost is a **product, not a sum**: every lens re-sends the whole
+diff, and every batch pays that again. On a hosted provider that multiplies into
+real money faster than most people expect, and the first you usually hear about
+it is the provider invoice.
+
+This guide shows you how to see the number, then how to bring it down without
+giving up the findings you actually want.
+
+> Deciding **who** can trigger a review is a related but separate question —
+> see [Trust and Cost](../explanation/trust-and-cost.md). Every setting below is
+> documented field-by-field in the [configuration reference](../reference/config.md).
+
+## Contents
+
+- [First, measure](#first-measure)
+- [Where the tokens go](#where-the-tokens-go)
+- [The levers, in order of payoff](#the-levers-in-order-of-payoff)
+- [Put a hard ceiling on it](#put-a-hard-ceiling-on-it)
+- [What isn't worth changing](#what-isnt-worth-changing)
+
+## First, measure
+
+Do not tune blind. Run once with `--profile`:
+
+```bash
+lgtmaybe review --profile
+```
+
+The last line is the meter:
+
+```
+tokens: 158,076 billable (154,200 in / 3,876 out) across 12 calls
+```
+
+Every local review prints that same line to stderr even without `--profile`, so
+the meter is always in view; redirect with `2>/dev/null` if you want it gone.
+
+`in` dwarfing `out` is normal and is the whole story: you are paying to *send*
+the diff, over and over, once per lens per batch. The per-call table above it
+shows exactly which lens and which batch each call belongs to, so you can see
+whether the cost is lens count, batch count, or one enormous file.
+
+In the GitHub Action, set `profile: true` and the same breakdown lands in the
+job log. Every provider call also emits a structured `provider call` log line
+with its own token counts, so you can total a run without the summary.
+
+## Where the tokens go
+
+For one review:
+
+```
+input tokens  ≈  batches × lenses × (diff + context padding + hints)
+```
+
+- **lenses** — the `fast` preset (the default) makes **four** calls per batch;
+  `full` makes one per category, up to nine. This is the biggest multiplier in
+  the formula.
+- **batches** — a diff larger than `max_input_tokens` (default 100k) is split,
+  and *each* batch pays the full lens fan-out again.
+- **reflection** — one more pass over the findings, on top.
+- **triage / describe / diagram** — extra calls when enabled.
+
+Two things that look expensive but are not: `max_concurrency` only changes how
+many calls run at once, never how many there are, and `temperature` costs
+nothing.
+
+## The levers, in order of payoff
+
+### 1. Turn on triage
+
+A cheap model reads every file first and drops the ones that plainly do not
+need a review; the expensive model only sees the survivors, riskiest first.
+
+```yaml
+triage_model: claude-haiku-4-5
+```
+
+This is usually the single biggest win on a repo with lots of low-substance
+churn (generated files, config bumps, test fixtures). A deterministic security
+floor always escalates past triage, any triage failure reviews everything, and
+skipped files are named in the summary — so it cannot quietly hide a problem.
+All three model slots share one provider and one set of credentials.
+
+### 2. Let deterministic tools do the deterministic work
+
+Findings a linter can prove do not need a language model at all:
+
+```bash
+pip install 'lgtmaybe[static-analysis]'
+```
+
+```yaml
+static_analysis:
+  enabled: true
+```
+
+Installed tools (ruff, bandit, mypy, semgrep with local rules) run over the
+changed files and their findings are fed to the lenses as hints to confirm or
+discard. The tools cost no tokens, and grounding the model tends to reduce
+low-value findings as well as spend.
+
+### 3. Check prompt caching is actually working
+
+`prompt_cache` is **on by default**, and when it works it takes most of the
+sting out of the lens multiplier: lenses 2..N read the shared system-preamble
+plus diff prefix from cache instead of paying full input price for it.
+
+Verify it from the profile's cache line:
+
+```
+cache: 412000 tokens read / 38000 created across 12 calls
+```
+
+Reads climbing across a run means it is working. **Reads stuck near zero means
+you are paying full price for every lens.** Caching needs an explicit
+breakpoint on some routes (anthropic, bedrock Claude/Nova, vertex, and several
+openrouter models) and identical prefixes on the rest — a route without either
+gets no benefit, which is a strong argument for picking one that has it.
+
+### 4. Narrow the lenses
+
+Each lens you drop removes one call per batch:
+
+```yaml
+categories: [security, correctness]
+```
+
+Keep the default `fast` preset unless you have a reason not to; `preset: full`
+roughly doubles the call count for a modest recall gain.
+
+### 5. Review less
+
+```yaml
+exclude_paths: ["**/migrations/**", "**/*.generated.ts"]
+max_files: 25
+```
+
+Generated, vendored and binary files are already skipped. Path filters cut the
+rest before any model call is made, so they are pure saving.
+
+### 6. Let re-runs be incremental
+
+On the Action's `synchronize` event, a re-run reviews only the commits since the
+last reviewed SHA rather than the whole PR again. That is the default — leave
+`incremental` unset. Use `/review full` when you deliberately want everything
+re-reviewed.
+
+Locally there is no such watermark: **every `lgtmaybe review` re-reviews the
+whole branch at full price.** If you are iterating, review only what you just
+changed:
+
+```bash
+lgtmaybe review --uncommitted    # working-tree edits vs HEAD
+```
+
+### 7. Right-size the model
+
+A smaller model on the common path with a stronger `--fallback-model` behind it
+is often indistinguishable in output and much cheaper. And if cost is the
+binding constraint rather than latency, ollama is free:
+
+```bash
+lgtmaybe review --provider ollama --model qwen2.5-coder:14b
+```
+
+## Put a hard ceiling on it
+
+Tuning changes the expected cost; a ceiling bounds the worst case.
+
+```yaml
+max_review_tokens: 300000
+```
+
+Once a run's billable tokens (input + output across every model call) reach the
+ceiling, no further calls are dispatched. In-flight calls finish, their findings
+post, and the summary says plainly that the budget stopped the run and how many
+calls were skipped. It never turns a failure into a silent `LGTM`.
+
+It is **off by default on purpose**: spend scales with diff size, lens count and
+batch count, so any figure that protects a small repo would silently truncate a
+large one's review. Read a real run's total with `--profile` first, then set the
+ceiling comfortably above it — it is a runaway guard, not a tuning knob.
+
+## What isn't worth changing
+
+**`context_lines`.** The obvious-looking saving is not there. Measured across
+four real multi-file commits in this repository, the padding that surrounds each
+hunk costs about **41% over sending no context at all** — but only about **17%
+between `context_lines: 5` and the default `20`**, because hunks with
+overlapping windows merge and the enclosing-definition reach does most of the
+useful widening either way:
+
+| `context_lines` | 0 | 5 | 10 | 20 (default) |
+| --- | --- | --- | --- | --- |
+| diff payload tokens | 28,316 | 34,265 | 36,072 | 40,041 |
+| vs. no context | 1.00× | 1.21× | 1.27× | 1.41× |
+
+Trading roughly a seventh of your input tokens for the model no longer seeing
+the function a change sits in is a bad deal — that context is what keeps
+findings anchored and cuts false positives. Turn the multiplier down (fewer
+lenses, triage, caching) before you turn the context down.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3135,6 +3135,214 @@ you are happy, then open your PR. To post reviews on the PR itself, wire up the
 
 ---
 
+<!-- Source: https://lgtmaybe.coles.codes/how-to/reduce-review-cost/ -->
+
+# Reduce Review Cost
+
+A review's token cost is a **product, not a sum**: every lens re-sends the whole
+diff, and every batch pays that again. On a hosted provider that multiplies into
+real money faster than most people expect, and the first you usually hear about
+it is the provider invoice.
+
+This guide shows you how to see the number, then how to bring it down without
+giving up the findings you actually want.
+
+> Deciding **who** can trigger a review is a related but separate question —
+> see [Trust and Cost](../explanation/trust-and-cost.md). Every setting below is
+> documented field-by-field in the [configuration reference](../reference/config.md).
+
+## Contents
+
+- [First, measure](#first-measure)
+- [Where the tokens go](#where-the-tokens-go)
+- [The levers, in order of payoff](#the-levers-in-order-of-payoff)
+- [Put a hard ceiling on it](#put-a-hard-ceiling-on-it)
+- [What isn't worth changing](#what-isnt-worth-changing)
+
+## First, measure
+
+Do not tune blind. Run once with `--profile`:
+
+```bash
+lgtmaybe review --profile
+```
+
+The last line is the meter:
+
+```
+tokens: 158,076 billable (154,200 in / 3,876 out) across 12 calls
+```
+
+Every local review prints that same line to stderr even without `--profile`, so
+the meter is always in view; redirect with `2>/dev/null` if you want it gone.
+
+`in` dwarfing `out` is normal and is the whole story: you are paying to *send*
+the diff, over and over, once per lens per batch. The per-call table above it
+shows exactly which lens and which batch each call belongs to, so you can see
+whether the cost is lens count, batch count, or one enormous file.
+
+In the GitHub Action, set `profile: true` and the same breakdown lands in the
+job log. Every provider call also emits a structured `provider call` log line
+with its own token counts, so you can total a run without the summary.
+
+## Where the tokens go
+
+For one review:
+
+```
+input tokens  ≈  batches × lenses × (diff + context padding + hints)
+```
+
+- **lenses** — the `fast` preset (the default) makes **four** calls per batch;
+  `full` makes one per category, up to nine. This is the biggest multiplier in
+  the formula.
+- **batches** — a diff larger than `max_input_tokens` (default 100k) is split,
+  and *each* batch pays the full lens fan-out again.
+- **reflection** — one more pass over the findings, on top.
+- **triage / describe / diagram** — extra calls when enabled.
+
+Two things that look expensive but are not: `max_concurrency` only changes how
+many calls run at once, never how many there are, and `temperature` costs
+nothing.
+
+## The levers, in order of payoff
+
+### 1. Turn on triage
+
+A cheap model reads every file first and drops the ones that plainly do not
+need a review; the expensive model only sees the survivors, riskiest first.
+
+```yaml
+triage_model: claude-haiku-4-5
+```
+
+This is usually the single biggest win on a repo with lots of low-substance
+churn (generated files, config bumps, test fixtures). A deterministic security
+floor always escalates past triage, any triage failure reviews everything, and
+skipped files are named in the summary — so it cannot quietly hide a problem.
+All three model slots share one provider and one set of credentials.
+
+### 2. Let deterministic tools do the deterministic work
+
+Findings a linter can prove do not need a language model at all:
+
+```bash
+pip install 'lgtmaybe[static-analysis]'
+```
+
+```yaml
+static_analysis:
+  enabled: true
+```
+
+Installed tools (ruff, bandit, mypy, semgrep with local rules) run over the
+changed files and their findings are fed to the lenses as hints to confirm or
+discard. The tools cost no tokens, and grounding the model tends to reduce
+low-value findings as well as spend.
+
+### 3. Check prompt caching is actually working
+
+`prompt_cache` is **on by default**, and when it works it takes most of the
+sting out of the lens multiplier: lenses 2..N read the shared system-preamble
+plus diff prefix from cache instead of paying full input price for it.
+
+Verify it from the profile's cache line:
+
+```
+cache: 412000 tokens read / 38000 created across 12 calls
+```
+
+Reads climbing across a run means it is working. **Reads stuck near zero means
+you are paying full price for every lens.** Caching needs an explicit
+breakpoint on some routes (anthropic, bedrock Claude/Nova, vertex, and several
+openrouter models) and identical prefixes on the rest — a route without either
+gets no benefit, which is a strong argument for picking one that has it.
+
+### 4. Narrow the lenses
+
+Each lens you drop removes one call per batch:
+
+```yaml
+categories: [security, correctness]
+```
+
+Keep the default `fast` preset unless you have a reason not to; `preset: full`
+roughly doubles the call count for a modest recall gain.
+
+### 5. Review less
+
+```yaml
+exclude_paths: ["**/migrations/**", "**/*.generated.ts"]
+max_files: 25
+```
+
+Generated, vendored and binary files are already skipped. Path filters cut the
+rest before any model call is made, so they are pure saving.
+
+### 6. Let re-runs be incremental
+
+On the Action's `synchronize` event, a re-run reviews only the commits since the
+last reviewed SHA rather than the whole PR again. That is the default — leave
+`incremental` unset. Use `/review full` when you deliberately want everything
+re-reviewed.
+
+Locally there is no such watermark: **every `lgtmaybe review` re-reviews the
+whole branch at full price.** If you are iterating, review only what you just
+changed:
+
+```bash
+lgtmaybe review --uncommitted    # working-tree edits vs HEAD
+```
+
+### 7. Right-size the model
+
+A smaller model on the common path with a stronger `--fallback-model` behind it
+is often indistinguishable in output and much cheaper. And if cost is the
+binding constraint rather than latency, ollama is free:
+
+```bash
+lgtmaybe review --provider ollama --model qwen2.5-coder:14b
+```
+
+## Put a hard ceiling on it
+
+Tuning changes the expected cost; a ceiling bounds the worst case.
+
+```yaml
+max_review_tokens: 300000
+```
+
+Once a run's billable tokens (input + output across every model call) reach the
+ceiling, no further calls are dispatched. In-flight calls finish, their findings
+post, and the summary says plainly that the budget stopped the run and how many
+calls were skipped. It never turns a failure into a silent `LGTM`.
+
+It is **off by default on purpose**: spend scales with diff size, lens count and
+batch count, so any figure that protects a small repo would silently truncate a
+large one's review. Read a real run's total with `--profile` first, then set the
+ceiling comfortably above it — it is a runaway guard, not a tuning knob.
+
+## What isn't worth changing
+
+**`context_lines`.** The obvious-looking saving is not there. Measured across
+four real multi-file commits in this repository, the padding that surrounds each
+hunk costs about **41% over sending no context at all** — but only about **17%
+between `context_lines: 5` and the default `20`**, because hunks with
+overlapping windows merge and the enclosing-definition reach does most of the
+useful widening either way:
+
+| `context_lines` | 0 | 5 | 10 | 20 (default) |
+| --- | --- | --- | --- | --- |
+| diff payload tokens | 28,316 | 34,265 | 36,072 | 40,041 |
+| vs. no context | 1.00× | 1.21× | 1.27× | 1.41× |
+
+Trading roughly a seventh of your input tokens for the model no longer seeing
+the function a change sits in is a bad deal — that context is what keeps
+findings anchored and cuts false positives. Turn the multiplier down (fewer
+lenses, triage, caching) before you turn the context down.
+
+---
+
 <!-- Source: https://lgtmaybe.coles.codes/how-to/releasing/ -->
 
 # Releasing lgtmaybe (maintainers)
@@ -5485,6 +5693,10 @@ want.
 Two built-in caps also keep any single run modest regardless of who starts it:
 `max_files` (default 50) and `max_input_tokens` (default 100k). See
 [What gets reviewed](what-gets-reviewed.md) for how the diff is bounded.
+
+To measure what a run actually spends and bring it down — triage, static
+analysis, prompt caching, and a hard `max_review_tokens` ceiling — see
+[Reduce review cost](../how-to/reduce-review-cost.md).
 
 ## How the choice is expressed
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,7 @@
 - [Add a custom review lens](https://lgtmaybe.coles.codes/how-to/add-a-custom-lens/): Add a custom review lens to lgtmaybe — a bring-your-own skill file that runs alongside the nine built-in lenses.
 - [Generate a change diagram](https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/): Post a compact Mermaid flowchart of a pull request's changes as a GitHub comment, or print one from the CLI.
 - [Fix findings with an AI agent](https://lgtmaybe.coles.codes/how-to/fix-findings-with-an-ai-agent/): Turn lgtmaybe findings into instructions an AI coding agent can apply, for a local review-and-fix loop before you push.
+- [Reduce review cost](https://lgtmaybe.coles.codes/how-to/reduce-review-cost/): Measure what a lgtmaybe review actually spends, then cut it — triage, static analysis, prompt caching, narrower lenses, and a hard token ceiling.
 - [Releasing](https://lgtmaybe.coles.codes/how-to/releasing/): Maintainer guide to publishing lgtmaybe with release-please, PyPI, GHCR, Homebrew, a Windows executable, and winget.
 
 ## Reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
           - Add a custom review lens: how-to/add-a-custom-lens.md
           - Generate a change diagram: how-to/generate-a-change-diagram.md
           - Fix findings with an AI agent: how-to/fix-findings-with-an-ai-agent.md
+          - Reduce review cost: how-to/reduce-review-cost.md
       - Maintainers:
           - Releasing: how-to/releasing.md
   - Reference:

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -516,6 +516,12 @@ def execute_local_review(
     click.echo(render_findings(findings, summary, fmt=fmt))
     if runtime.profile:
         click.echo(profiler.render())
+    elif profiler.total_tokens():
+        # The meter. A local review is the one that runs dozens of times a day
+        # against a metered API, so what it spent is reported by default rather
+        # than only under --profile (whose table already ends with this line —
+        # hence the elif). stderr keeps --json / --agent output pipeable.
+        click.echo(profiler.render_total(), err=True)
 
 
 def _execute_auxiliary(

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -168,13 +168,24 @@ class Profiler:
         read = sum(c.cache_read_tokens for c in calls)
         created = sum(c.cache_creation_tokens for c in calls)
         lines.append(f"cache: {read} tokens read / {created} created across {len(calls)} calls")
+        lines.append(self.render_total())
+        return "\n".join(lines)
+
+    def render_total(self) -> str:
+        """One line: what this run spent, formatted for a human.
+
+        Shared by the ``--profile`` table and the local CLI's footer so the two
+        can never drift into quoting different numbers for the same run.
+        """
+        with self._lock:
+            calls = list(self.calls)
         billed_in = sum(c.input_tokens for c in calls)
         billed_out = sum(c.output_tokens for c in calls)
-        lines.append(
-            f"tokens: {billed_in + billed_out} billable "
-            f"({billed_in} in / {billed_out} out) across {len(calls)} calls"
+        plural = "" if len(calls) == 1 else "s"
+        return (
+            f"tokens: {billed_in + billed_out:,} billable "
+            f"({billed_in:,} in / {billed_out:,} out) across {len(calls)} call{plural}"
         )
-        return "\n".join(lines)
 
 
 # The process-wide collection point. One review runs per CLI invocation, so a

--- a/tests/cli/test_token_footer.py
+++ b/tests/cli/test_token_footer.py
@@ -1,0 +1,132 @@
+"""A local review always reports what it spent.
+
+The meter used to live behind ``--profile``, so the common case — run the CLI
+all day against a hosted provider — gave no running indication of cost at all.
+The footer goes to stderr so machine-readable formats stay pipeable.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+import lgtmaybe.cli as cli
+from lgtmaybe.core.models import PRContext, Provider, ReviewConfig
+from lgtmaybe.engine.profiling import profiler
+
+_CTX = PRContext(
+    diff="@@ -1,3 +1,4 @@\n context\n+new line\n context\n",
+    changed_files=["a.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="local/local",
+    pr_number=0,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_profiler() -> None:
+    profiler.reset()
+
+
+class _StubEngine:
+    def review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+        # Stand in for the real fan-out: record the spend a run would have.
+        profiler.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=36_918,
+            output_tokens=1_286,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+        return [], "👍 LGTM!"
+
+
+@pytest.fixture
+def _local_run(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    """Run execute_local_review against stubbed git + provider plumbing."""
+    monkeypatch.setattr(cli, "local_file_reader", lambda: None)
+    monkeypatch.setattr(cli, "build_symbol_resolver", lambda _: None)
+    monkeypatch.setattr(cli, "build_provider_engine", lambda *a, **k: (_StubEngine(), object()))
+    monkeypatch.setattr(cli, "local_pr_context", lambda **k: _CTX)
+
+    def run(fmt: str = "human", profile: bool = False) -> None:
+        cli.execute_local_review(
+            ReviewConfig(provider=Provider.openai, model="m"),
+            cli.RuntimeOptions(profile=profile),
+            base=None,
+            working=False,
+            fmt=fmt,
+        )
+
+    return run
+
+
+class TestLocalTokenFooter:
+    def test_footer_reports_the_run_s_spend(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        _local_run()
+        err = capsys.readouterr().err
+        assert "38,204 billable" in err
+        assert "36,918 in" in err and "1,286 out" in err
+
+    def test_footer_goes_to_stderr_so_json_stays_pipeable(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        _local_run(fmt="json")
+        captured = capsys.readouterr()
+        assert "billable" not in captured.out, "stdout must stay machine-readable"
+        assert "billable" in captured.err
+
+    def test_a_run_that_called_no_model_prints_no_footer(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Nothing was spent, so there is nothing to report — a zero line is noise."""
+
+        class _FreeEngine:
+            def review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+                return [], "👍 LGTM!"
+
+        monkeypatch.setattr(cli, "local_file_reader", lambda: None)
+        monkeypatch.setattr(cli, "build_symbol_resolver", lambda _: None)
+        monkeypatch.setattr(cli, "build_provider_engine", lambda *a, **k: (_FreeEngine(), object()))
+        monkeypatch.setattr(cli, "local_pr_context", lambda **k: _CTX)
+        cli.execute_local_review(
+            ReviewConfig(provider=Provider.openai, model="m"),
+            cli.RuntimeOptions(),
+            base=None,
+            working=False,
+            fmt="human",
+        )
+        assert "billable" not in capsys.readouterr().err
+
+    def test_profile_does_not_double_report(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        """--profile already ends with the same total; one is enough."""
+        _local_run(profile=True)
+        err = capsys.readouterr().err
+        assert err.count("billable") == 0, "the profile table carries the total instead"
+
+    def test_a_failed_review_prints_no_footer(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The error is the message; a spend line under it is noise."""
+
+        class _BrokenEngine:
+            def review(self, ctx, cfg):  # type: ignore[no-untyped-def]
+                raise RuntimeError("provider exploded")
+
+        monkeypatch.setattr(cli, "local_file_reader", lambda: None)
+        monkeypatch.setattr(cli, "build_symbol_resolver", lambda _: None)
+        monkeypatch.setattr(
+            cli, "build_provider_engine", lambda *a, **k: (_BrokenEngine(), object())
+        )
+        monkeypatch.setattr(cli, "local_pr_context", lambda **k: _CTX)
+        with pytest.raises(click.ClickException):
+            cli.execute_local_review(
+                ReviewConfig(provider=Provider.openai, model="m"),
+                cli.RuntimeOptions(),
+                base=None,
+                working=False,
+                fmt="human",
+            )
+        assert "billable" not in capsys.readouterr().err

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -116,7 +116,7 @@ class TestProfiler:
         assert text.index("tests") < text.index("security")
         assert "RateLimitError" in text
         assert "900 tokens read / 200 created across 2 calls" in text
-        assert "tokens: 2100 billable (2000 in / 100 out) across 2 calls" in text
+        assert "tokens: 2,100 billable (2,000 in / 100 out) across 2 calls" in text
 
 
 class TestTotalTokens:


### PR DESCRIPTION
## Why

#297 gave the meter a stop. This makes the meter visible, and documents what to do about the number.

The token total currently lives behind `--profile` — the one place a user who isn't *already* worried about cost will never look. The local CLI is the run that happens dozens of times a day against a metered API, and it was the quietest thing in the tool.

## What changed

**A spend footer on every local review:**

```
tokens: 38,204 billable (36,918 in / 1,286 out) across 4 calls
```

- **stderr**, so `--json` / `--agent` output stays pipeable, and `2>/dev/null` suppresses it.
- **Suppressed under `--profile`**, whose table already ends with the same line.
- **Nothing printed** when a run made no model calls, or when the review failed — a zero line under an error message is noise.
- Rendered by one shared `Profiler.render_total()`, so the footer and the profile table can't drift into quoting different numbers for the same run. Thousands separators throughout (it's a cost figure; the one existing assertion was updated).

**`docs/how-to/reduce-review-cost.md`** — the guide that would actually have prevented the surprise:

- how to read the meter (`--profile`, the footer, the structured `provider call` log lines);
- where the tokens go — `batches × lenses × (diff + padding)`, i.e. cost is a **product, not a sum**, and the `fast` preset's four calls per batch is the dominant term;
- the levers in payoff order: `triage_model`, static analysis, **verifying prompt caching is actually live** (cache reads stuck near zero means you're paying full price per lens — worth checking before tuning anything else), narrower `categories`, path filters, incremental re-runs, right-sized models, and `--uncommitted` for local iteration;
- `max_review_tokens` last, framed as a runaway guard rather than a tuning knob.

Linked from `explanation/trust-and-cost.md`, which covers the adjacent *who can trigger a review* question.

## The section on what *not* to change

I originally argued `context_lines: 20` was a bad default. I measured it before touching it, and it isn't — so the guide now says so instead, with the numbers.

Running the real `split → expand_hunks → count_tokens` path over four real multi-file commits in this repo:

| `context_lines` | 0 | 5 | 10 | 20 (default) |
| --- | --- | --- | --- | --- |
| diff payload tokens | 28,316 | 34,265 | 36,072 | 40,041 |
| vs. no context | 1.00× | 1.21× | 1.27× | 1.41× |

Padding costs ~41% over no context at all, but only **~17% between 5 and the default 20** — overlapping hunk windows merge, and the enclosing-definition reach does the useful widening either way. Trading a seventh of input tokens for the model no longer seeing the function a change sits in is a bad deal, and it's not where a large bill comes from. **The default stands.**

## Tests

`tests/cli/test_token_footer.py` (new, 5 cases — written first, watched fail): the footer reports the run's spend, goes to stderr so `--json` stays parseable, prints nothing for a no-call run, prints nothing for a failed run, and doesn't double-report under `--profile`.

Full suite: **1671 passed, 3 skipped**. ruff, ruff format, mypy green; `mkdocs build --strict` green; `docs/llms*.txt` regenerated.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KeqxhbTe1VBgA5qKyVVe9)_