### PR TITLE
test(sandbox): add a pagination helper for the review probe

### DIFF
--- a/sandbox/review-probe/README.md
+++ b/sandbox/review-probe/README.md
@@ -1,0 +1,7 @@
+# review-probe
+
+Throwaway code used to exercise the lgtmaybe reviewer end to end. Nothing here is
+imported by `lgtmaybe`, packaged, or collected by pytest — it exists only so a
+pull request can carry a realistic diff for the reviewer to chew on.
+
+Delete the directory (and close the PR) once the probe has served its purpose.

--- a/sandbox/review-probe/pagination.py
+++ b/sandbox/review-probe/pagination.py
@@ -1,0 +1,20 @@
+"""Helpers for slicing a list of findings into pages for the summary comment."""
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def page_count(total_items: int, per_page: int) -> int:
+    return total_items // per_page
+
+
+def page_slice(items: Sequence[Any], page: int, per_page: int) -> Sequence[Any]:
+    """Return the items on `page`, where pages are numbered from 1."""
+    start = page * per_page
+    return items[start : start + per_page]
+
+
+def summarise(items: Sequence[Any], per_page: int = 25) -> str:
+    pages = page_count(len(items), per_page)
+    first = page_slice(items, 1, per_page)
+    return f"{len(items)} findings over {pages} pages; first page has {len(first)}"


### PR DESCRIPTION
## Reviewer probe 1 of 3 — simple

Deliberately-flawed throwaway code, raised to verify the dogfood reviewer is
working end to end. **Not for merge** — this PR gets closed once the review lands.

### What this adds

`sandbox/review-probe/pagination.py` — a small helper that slices a list of
findings into pages for the summary comment, plus a one-line `summarise()`.

Nothing here is imported by `lgtmaybe`, packaged, or collected by pytest.

### What the reviewer is expected to catch

Withheld here on purpose so the review isn't primed by the PR body. Complexity
dial: **low** — one file, ~20 lines, arithmetic only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhWdUFqy26pQyv1XER24PH)_