### PR TITLE
fix(provider): survive a rejected response_format on Bedrock and keep --json stdout parseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,14 @@ lgtmaybe review \
 ```
 
 No GitHub token and no pull request needed — `lgtmaybe review` reads your local
-`git` diff and prints the findings. `lgtmaybe help` lists every command with
-usage examples; `lgtmaybe help review` shows the full option reference. To post
-reviews on real pull requests, wire up the
+`git` diff and prints the findings. Its companion, `lgtmaybe diagram`, takes the
+same flags and prints a C4-style picture of the components your change touches —
+`review` then `diagram` is the pair to run before opening a pull request. See
+[Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
+
+`lgtmaybe help` lists every command with usage examples; `lgtmaybe help review`
+shows the full option reference. To post reviews on real pull requests, wire up
+the
 [GitHub Action](#use-as-a-github-action). See
 [Getting Started](docs/tutorial/getting-started.md) for the full walkthrough.
 

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -124,4 +124,5 @@ bundles all three and wires up the OIDC/WIF auth for you.
 ## Next steps
 
 - Run your first local review: [Getting started](../tutorial/getting-started.md).
+- Diagram what a change touches: [Generate a change diagram](generate-a-change-diagram.md).
 - Post reviews on real pull requests: [Use as a GitHub Action](use-as-github-action.md).

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -164,6 +164,15 @@ account and region. For an inference-profile id (`us.`/`eu.`/`apac.`-prefixed),
 the policy must also allow the `inference-profile/*` ARN, not just
 `foundation-model/*`.
 
+**`output_config.format: Extra inputs are not permitted`** — the model's Converse
+route doesn't accept the structured-output field lgtmaybe asks for, and Bedrock
+rejects the whole request with a 400. lgtmaybe detects that rejection, re-sends
+without the field, and remembers the drop for the rest of the run, so no action
+is needed — the prompt asks for JSON anyway and the parser is lenient. If you're
+on a build from before that (the symptom is every lens failing at once, and the
+review reporting `every review call failed`), upgrade, or pass
+`--no-structured-output` / set `structured_output: false` as a stopgap.
+
 **`The provided model identifier is invalid`** — the `model` is not a Bedrock
 model id. Two common causes: (1) it's a non-Bedrock id such as `openai.gpt-5.5`
 or another provider's name — Bedrock hosts Claude / Nova / Llama / Mistral /

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -182,7 +182,27 @@ lgtmaybe review --provider ollama --model qwen3.6:27b \
 coding agent can read and apply, for a local review-and-fix loop — see
 [Fix findings with an AI agent](../how-to/fix-findings-with-an-ai-agent.md).
 
-## Step 5 — Post reviews on real pull requests
+## Step 5 — Diagram what you touched
+
+`lgtmaybe diagram` runs the same local diff through one model call and prints a
+C4-style picture of the components your change touches:
+
+```bash
+lgtmaybe diagram \
+  --provider ollama \
+  --model qwen3.6:27b \
+  --api-base http://localhost:11434
+```
+
+It takes the same `--base` / `--working` / `--uncommitted` flags as `review`, so
+`review` then `diagram` is a natural pair before you open a pull request: what's
+wrong with the change, then what the change reaches. The output is Mermaid
+source plus an ASCII rendering — the ASCII is what reads in a terminal; paste
+the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live) to see
+it drawn. See
+[Generate a change diagram](../how-to/generate-a-change-diagram.md).
+
+## Step 6 — Post reviews on real pull requests
 
 The CLI reviews local changes. To run lgtmaybe on actual pull requests — inline
 comments and a summary posted back to GitHub — add the GitHub Action to your
@@ -335,6 +355,7 @@ bundles all three and wires up the OIDC/WIF auth for you.
 ## Next steps
 
 - Run your first local review: [Getting started](../tutorial/getting-started.md).
+- Diagram what a change touches: [Generate a change diagram](generate-a-change-diagram.md).
 - Post reviews on real pull requests: [Use as a GitHub Action](use-as-github-action.md).
 
 ---
@@ -1291,6 +1312,15 @@ selected model, or the model is not enabled in the Bedrock console for your
 account and region. For an inference-profile id (`us.`/`eu.`/`apac.`-prefixed),
 the policy must also allow the `inference-profile/*` ARN, not just
 `foundation-model/*`.
+
+**`output_config.format: Extra inputs are not permitted`** — the model's Converse
+route doesn't accept the structured-output field lgtmaybe asks for, and Bedrock
+rejects the whole request with a 400. lgtmaybe detects that rejection, re-sends
+without the field, and remembers the drop for the rest of the run, so no action
+is needed — the prompt asks for JSON anyway and the parser is lenient. If you're
+on a build from before that (the symptom is every lens failing at once, and the
+review reporting `every review call failed`), upgrade, or pass
+`--no-structured-output` / set `structured_output: false` as a stopgap.
 
 **`The provided model identifier is invalid`** — the `model` is not a Bedrock
 model id. Two common causes: (1) it's a non-Bedrock id such as `openai.gpt-5.5`

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -89,7 +89,27 @@ lgtmaybe review --provider ollama --model qwen3.6:27b \
 coding agent can read and apply, for a local review-and-fix loop — see
 [Fix findings with an AI agent](../how-to/fix-findings-with-an-ai-agent.md).
 
-## Step 5 — Post reviews on real pull requests
+## Step 5 — Diagram what you touched
+
+`lgtmaybe diagram` runs the same local diff through one model call and prints a
+C4-style picture of the components your change touches:
+
+```bash
+lgtmaybe diagram \
+  --provider ollama \
+  --model qwen3.6:27b \
+  --api-base http://localhost:11434
+```
+
+It takes the same `--base` / `--working` / `--uncommitted` flags as `review`, so
+`review` then `diagram` is a natural pair before you open a pull request: what's
+wrong with the change, then what the change reaches. The output is Mermaid
+source plus an ASCII rendering — the ASCII is what reads in a terminal; paste
+the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live) to see
+it drawn. See
+[Generate a change diagram](../how-to/generate-a-change-diagram.md).
+
+## Step 6 — Post reviews on real pull requests
 
 The CLI reviews local changes. To run lgtmaybe on actual pull requests — inline
 comments and a summary posted back to GitHub — add the GitHub Action to your

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -22,6 +22,12 @@ provider.complete:
       stopBy: end
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.param-drop:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_drop_rejected_param$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.defaults:
   - rule:
       kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -95,6 +95,33 @@ on `ProviderResult`.
 - **WHEN** retries on the primary model are exhausted and a fallback is set
 - **THEN** the call completes on the fallback model instead of failing the review
 
+### Requirement: A rejected request param degrades, it does not fail the review
+
+The adapter SHALL drop a request param the model refuses and re-send once
+rather than fail — `temperature` when only the default value is accepted, and
+the structured-output `response_format` when the route rejects the field it
+becomes (Bedrock Converse answers `output_config.format: Extra inputs are not
+permitted`). `drop_params` cannot cover these: the capability map reports the
+param supported, and the refusal is only visible in the error. A dropped
+`response_format` SHALL be remembered for the provider's later calls. litellm's
+stdout banner SHALL be suppressed, since stdout carries machine-readable output.
+<!-- anchor: provider.param-drop -->
+
+#### Scenario: the route rejects the structured-output field
+- **WHEN** a Bedrock model 400s on the `output_config.format` field litellm
+  derived from `response_format`
+- **THEN** the call is re-sent without it and the rest of the lens fan-out skips
+  it up front, instead of every lens failing on a permanent 400
+
+#### Scenario: an unrelated error arrives on the same call
+- **WHEN** a failure under those params names neither a rejected param nor a
+  rejected value
+- **THEN** it propagates unchanged, rather than being retried bare and masked
+
+#### Scenario: a provider error is mapped during a machine-readable run
+- **WHEN** litellm maps a provider error while `--format json` is in force
+- **THEN** nothing is printed to stdout, so the findings array stays parseable
+
 ### Requirement: Defaults are provider-aware
 
 Timeouts SHALL default long for providers that may front a slow model —

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -892,6 +892,7 @@ Examples:
   lgtmaybe review --working                Include uncommitted edits too
   lgtmaybe review --provider ollama --model qwen3:27b
   lgtmaybe review --format json            Machine-readable findings
+  lgtmaybe diagram                         Diagram the components you touched
   lgtmaybe config init                     One-time provider/model setup
   lgtmaybe help COMMAND                    Detailed help for any command
 \b

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -186,6 +186,35 @@ def _is_permanent(exc: BaseException) -> bool:
     return _is_expired_credential(exc) or _is_insufficient_credit(exc)
 
 
+def _rejects_response_format(exc: Exception) -> bool:
+    """True when an API error means the model won't take our structured-output param.
+
+    Bedrock's Converse endpoint is the case that matters. For a model whose route
+    doesn't implement structured outputs, litellm still translates
+    ``response_format`` into a Converse ``output_config.format`` field, and the
+    service rejects the whole request: ``BedrockException - {"message":"The model
+    returned the following errors: output_config.format: Extra inputs are not
+    permitted"}``. That arrives as a 400 — permanent, so it is never retried —
+    and since every lens sends the same shape, one unsupported field failed the
+    entire review with "every review call failed".
+
+    ``drop_params`` cannot help here: it drops params litellm's capability map
+    says a model lacks, and for these models the map says the param is supported.
+    So the rejection is read off the error instead: the field name plus a
+    rejection phrase, matched loosely because the wording is the backend's, not
+    litellm's. A false positive costs one re-send without the param (the prompt
+    still asks for JSON and the parser is lenient); a false negative costs the
+    whole review.
+    """
+    msg = str(exc).lower()
+    if not any(field in msg for field in ("response_format", "output_config", "responseformat")):
+        return False
+    return any(
+        phrase in msg
+        for phrase in ("not permitted", "not supported", "unsupported", "unknown", "unexpected")
+    )
+
+
 def _rejects_temperature(exc: Exception) -> bool:
     """True when an API error means the model accepts the ``temperature`` param
     but not the value we sent (e.g. OpenAI's gpt-5.x: "'temperature' does not
@@ -206,6 +235,15 @@ def _rejects_temperature(exc: Exception) -> bool:
 # (ollama) and cloud models that do support them. The prompt also asks for JSON,
 # and the parser is lenient, so a dropped ``response_format`` still parses.
 litellm.drop_params = True
+
+# litellm prints a "Give Feedback / Get Help" + "LiteLLM.Info:" banner (and a
+# "Provider List:" one) straight to STDOUT whenever it maps a provider error.
+# stdout is our machine-readable channel: on `lgtmaybe review --json` the banner
+# lands in front of the findings array and breaks json.load on the output — and
+# it contains a "[", so even a "find the first bracket" recovery picks the wrong
+# one. Nothing is lost by silencing it: the error itself still surfaces through
+# the exception and our own structured logging, which goes to stderr.
+litellm.suppress_debug_info = True
 
 
 class LiteLLMProvider(ProviderClient):
@@ -338,24 +376,47 @@ class LiteLLMProvider(ProviderClient):
         kwargs: dict[str, Any],
         count_request: Callable[[], None] = lambda: None,
     ) -> ProviderResult:
-        """One litellm call, with the temperature-value-rejection fallback applied.
+        """One litellm call, re-sent without any param the model just rejected.
 
         ``count_request`` is called immediately before each request actually goes
         out, so the reported attempt count matches the number of model calls this
-        made — including the re-send below, which is a second billed request.
+        made — including the re-sends below, each a second billed request.
         """
-        count_request()
-        try:
-            response = _completion_with_wall_timeout(model, messages, kwargs)
-        except Exception as exc:
-            if "temperature" not in kwargs or not _rejects_temperature(exc):
-                raise
-            # Drop temperature for this and every subsequent retry, letting the
-            # model use its only supported value (its default).
-            kwargs.pop("temperature")
+        while True:
             count_request()
-            response = _completion_with_wall_timeout(model, messages, kwargs)
-        return self._map_response(response, model)
+            try:
+                return self._map_response(
+                    _completion_with_wall_timeout(model, messages, kwargs), model
+                )
+            except Exception as exc:
+                if not self._drop_rejected_param(exc, kwargs):
+                    raise
+
+    def _drop_rejected_param(self, exc: Exception, kwargs: dict[str, Any]) -> bool:
+        """Strip the one request param *exc* says this model won't take.
+
+        Two params are sent for review quality rather than necessity —
+        ``temperature`` (determinism) and ``response_format`` (structured output)
+        — and a model that refuses either would otherwise fail the whole review
+        over a preference. Both refusals are permanent 400s, so the recovery is
+        to drop the param and re-send; ``kwargs`` is the dict every later retry
+        of this call reuses, so the drop sticks for them too.
+
+        Returns True when something was dropped and the call is worth re-sending.
+        """
+        if "temperature" in kwargs and _rejects_temperature(exc):
+            # The param is accepted, only our value isn't — let the model use its
+            # own default.
+            kwargs.pop("temperature")
+            return True
+        if kwargs.get("response_format") is not None and _rejects_response_format(exc):
+            # Remembered for the whole provider, not just this call: the lens
+            # fan-out sends the same shape N times, and without this every one of
+            # them pays its own rejected round-trip first.
+            self._skip_response_format = True
+            kwargs.pop("response_format")
+            return True
+        return False
 
     def _with_cache_control(self, messages: list[Message], model: str) -> list[Message]:
         """Return *messages* shaped for the model's caching route, when it pays.

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -12,11 +12,21 @@ from lgtmaybe.cli import main
 def test_help_lists_commands_and_examples() -> None:
     result = CliRunner().invoke(main, ["help"])
     assert result.exit_code == 0
-    for command in ("review", "comment", "action", "config", "help"):
+    for command in ("review", "diagram", "comment", "action", "config", "help"):
         assert command in result.output
     assert "Examples:" in result.output
     assert "lgtmaybe review" in result.output
     assert "https://lgtmaybe.coles.codes/" in result.output
+
+
+def test_help_examples_cover_every_local_command() -> None:
+    """The worked examples are the suggested CLI workflow, so a local command
+    missing from them reads as one that doesn't exist — which is exactly how
+    `lgtmaybe diagram` got reported as unshipped."""
+    result = CliRunner().invoke(main, ["help"])
+    examples = result.output.split("Examples:", 1)[1]
+    for command in ("review", "diagram", "config"):
+        assert f"lgtmaybe {command}" in examples
 
 
 def test_help_command_matches_dash_dash_help() -> None:

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -6,11 +6,14 @@ calls are made.
 
 from __future__ import annotations
 
+import contextlib
+import io
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
 import litellm
+import pytest
 
 from lgtmaybe.core.models import ProviderResult
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
@@ -110,3 +113,22 @@ class TestLiteLLMProvider:
         ``openai.gpt-5.5``) drops them instead of failing the whole review,
         while models that support them keep them."""
         assert litellm.drop_params is True
+
+    def test_litellm_never_prints_its_banner_to_stdout(self) -> None:
+        """litellm prints a "Give Feedback / Get Help" + "LiteLLM.Info:" banner
+        straight to stdout when it maps a provider error. On ``lgtmaybe review
+        --json`` that lands in front of the findings array and breaks
+        ``json.load`` on the output — and the banner text contains a ``[``, so
+        even a naive "find the first bracket" recovery picks the wrong one.
+        Importing the provider suppresses it; the errors themselves still
+        surface, through the exception and our own stderr logging."""
+        assert litellm.suppress_debug_info is True
+
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured), pytest.raises(litellm.BadRequestError):
+            # A real (offline) litellm call through its error-mapping path — the
+            # code that does the printing. A flag assertion alone would still
+            # pass if litellm moved the banner behind a different switch.
+            litellm.completion(model="no-such-provider/x", messages=[{"role": "user", "x": "hi"}])
+
+        assert captured.getvalue() == ""

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -355,6 +355,128 @@ class TestTemperatureRejection:
                 )
 
 
+class TestRejectedStructuredOutputParam:
+    """Bedrock's Converse endpoint rejects the structured-output field outright
+    for some models: litellm still translates ``response_format`` into
+    ``output_config.format`` and the service 400s the whole request. A 400 is
+    permanent, so without a fallback every lens of the review dies at once and
+    the run reports "every review call failed"."""
+
+    BEDROCK_400 = (
+        "litellm.BadRequestError: BedrockException - "
+        '{"message":"The model returned the following errors: '
+        'output_config.format: Extra inputs are not permitted"}'
+    )
+
+    def test_bedrock_rejection_retries_without_response_format(self) -> None:
+        seen_response_format: list[bool] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            has_rf = "response_format" in kwargs
+            seen_response_format.append(has_rf)
+            if has_rf:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "bedrock/us.anthropic.claude-opus-4-8",
+                response_format={"type": "json_schema"},
+            )
+
+        assert result.text == '{"findings": []}'
+        assert seen_response_format == [True, False]
+
+    def test_rejection_makes_later_calls_skip_response_format_up_front(self) -> None:
+        """The drop is sticky, so the rest of the lens fan-out doesn't each pay a
+        wasted rejected round-trip first."""
+        seen_response_format: list[bool] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            has_rf = "response_format" in kwargs
+            seen_response_format.append(has_rf)
+            if has_rf:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            model = "bedrock/us.anthropic.claude-opus-4-8"
+            provider.complete([{"role": "user", "content": "a"}], model, response_format={"x": 1})
+            provider.complete([{"role": "user", "content": "b"}], model, response_format={"x": 1})
+
+        assert seen_response_format == [True, False, False]
+
+    def test_both_rejected_params_are_dropped_across_attempts(self) -> None:
+        """A model can reject the temperature value *and* the structured-output
+        field; each rejection drops one param, so the call still lands."""
+        seen: list[tuple[bool, bool]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            has_temp, has_rf = "temperature" in kwargs, "response_format" in kwargs
+            seen.append((has_temp, has_rf))
+            if has_rf:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            if has_temp:
+                raise RuntimeError(
+                    "litellm.BadRequestError: 'temperature' does not support 0 with this model."
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "bedrock/us.anthropic.claude-opus-4-8",
+                temperature=0.0,
+                response_format={"type": "json_schema"},
+            )
+
+        assert result.text == '{"findings": []}'
+        assert seen == [(True, True), (True, False), (False, False)]
+
+    def test_unrelated_bad_request_still_propagates(self) -> None:
+        """An error that merely happens under response_format must not be
+        swallowed as a param rejection — it surfaces as itself."""
+        with patch("litellm.completion", side_effect=RuntimeError("invalid api key")):
+            provider = LiteLLMProvider()
+            with pytest.raises(RuntimeError, match="invalid api key"):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    "bedrock/us.anthropic.claude-opus-4-8",
+                    response_format={"type": "json_schema"},
+                )
+
+    def test_rejection_without_response_format_is_not_retried(self) -> None:
+        """Nothing to drop → the error surfaces immediately, no retry loop."""
+        calls = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            raise litellm.BadRequestError(
+                message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+            )
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            with pytest.raises(litellm.BadRequestError):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    "bedrock/us.anthropic.claude-opus-4-8",
+                )
+
+        assert calls == 1
+
+
 class TestEmptyStructuredOutputFallback:
     """Some grammar-constrained backends (LM Studio fronting a thinking qwen
     model) return empty content under a response_format JSON schema. The provider


### PR DESCRIPTION
Three items from user feedback running `--provider bedrock` against
`us.anthropic.claude-opus-4-8` in us-west-2 (uv tool, Python 3.12, ambient AWS creds).

## 1. Structured output 400s the whole review on Bedrock

litellm translates our `response_format` into a Converse `output_config.format`
field the model's route does not accept, so Bedrock rejects the request:

```
BedrockException - {"message":"The model returned the following errors:
output_config.format: Extra inputs are not permitted"}
```

A 400 is permanent, so it is never retried — and every lens sends the same shape,
so one unsupported field failed the entire review with **"every review call failed"**.
`drop_params` cannot cover it: litellm's capability map reports the param
*supported*, and the refusal is only visible in the error text.

So the rejection is read off the error. `_drop_rejected_param` now strips whichever
param the model just refused — the `temperature` value (as before) or
`response_format` — and re-sends once. The structured-output drop is **sticky for the
provider**, so the rest of the lens fan-out skips the field up front instead of each
paying its own rejected round-trip. The prompt asks for JSON anyway and the parser is
lenient, so the re-send parses. An error naming neither param still propagates
unchanged rather than being retried bare.

`--no-structured-output` is no longer needed as a workaround.

## 2. litellm's banner corrupts `--format json`

litellm prints its "Give Feedback / Get Help" + `LiteLLM.Info:` banner (and a
"Provider List" one) straight to **stdout** whenever it maps a provider error. stdout
is the machine-readable channel: on `review --json` the banner lands in front of the
findings array and breaks `json.load` — and it contains a `[`, so even a naive
"find the first bracket" recovery picks the wrong one.

`litellm.suppress_debug_info = True` is now set alongside `drop_params`. Nothing is
lost: the error still surfaces through the exception and through our own structured
logging, which already goes to stderr.

## 3. `lgtmaybe diagram` reads as unshipped

The command has shipped since the C4 change-diagram feature landed and is registered
on the CLI group — but it appears in none of the worked examples `lgtmaybe help`
prints, nor in the quick start or the tutorial, so it reads as a command the docs
reference and the build lacks. It is now in the epilog examples, the README quick
start, and its own tutorial step next to `review`, whose `--base` / `--working` /
`--uncommitted` flags it shares.

If the reporter's installed build genuinely has no `diagram` subcommand, that build
predates the feature — `uv tool upgrade lgtmaybe` picks it up.

## Tests

TDD throughout — each test written and watched fail first:

- `TestRejectedStructuredOutputParam` (5 cases): the Bedrock 400 re-sends without the
  field; the drop is sticky across calls; temperature **and** `response_format`
  rejections compose in one call; an unrelated error still propagates; a rejection
  with nothing to drop is not retried.
- `test_litellm_never_prints_its_banner_to_stdout`: asserts the flag **and** drives a
  real (offline) litellm call through its error-mapping path with stdout captured — a
  flag assertion alone would still pass if litellm moved the banner behind a different
  switch.
- `test_help_examples_cover_every_local_command`: a local command missing from the
  worked examples now fails CI.

Full suite green (1678 passed, 3 skipped), ruff + mypy clean, `uv lock --check` clean,
`openspec validate --specs` green, spec anchors resolve.

## Spec

`provider.complete` was already at 38 of its 40-line cap, so this is a new requirement
rather than an append: **"A rejected request param degrades, it does not fail the
review"**, anchored to `_drop_rejected_param`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRfWx5iwAfXEnsPDS9NW1y)_