### PR TITLE
fix(provider): report a truncated response as truncated, and stop retrying it

### DIFF
--- a/openspec/specs/hardening/spec.md
+++ b/openspec/specs/hardening/spec.md
@@ -79,9 +79,17 @@ placeholder left in the source.
 Model output SHALL be parsed as JSON with repair for common wrappers (fences,
 prose preamble), then validated against the strict finding schema — recovery
 never widens what is accepted, and unparseable output yields an error, not
-invented findings.
+invented findings. A reply that opens a JSON container and never closes it
+SHALL be reported as truncated rather than as unparseable — the two have
+different causes and different fixes.
 <!-- anchor: hardening.parse -->
 
 #### Scenario: model wraps JSON in a code fence
 - **WHEN** the reply is valid findings JSON inside markdown fences
 - **THEN** parsing succeeds; fields still validate against the strict schema
+
+#### Scenario: the reply is cut off mid-findings
+- **WHEN** a reply ends inside an unclosed array, so its earlier complete
+  objects parse but fail the strict schema
+- **THEN** it is reported as truncated, not as a schema violation — the missing
+  tail is the cause and the validation failure only its symptom

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -28,6 +28,12 @@ provider.param-drop:
     has: { field: name, regex: '^_drop_rejected_param$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.truncation:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_finish_reason$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.defaults:
   - rule:
       kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -122,6 +122,27 @@ stdout banner SHALL be suppressed, since stdout carries machine-readable output.
 - **WHEN** litellm maps a provider error while `--format json` is in force
 - **THEN** nothing is printed to stdout, so the findings array stays parseable
 
+### Requirement: A blown output ceiling is named, not retried
+
+A completion that stopped because it ran out of output tokens SHALL be raised
+as its own failure naming the ceiling reached and the knob that moves it, never
+passed on as content. It SHALL NOT be retried — at temperature 0 the identical
+request reaches the identical ceiling, and each attempt costs a full
+ceiling-length generation — while a configured fallback model is still tried.
+Detection reads the finish reason only where the route reports it plainly:
+litellm rewrites a reason it does not recognise to `stop`, so a route that
+names a ceiling hit its own way is caught downstream by the parser instead.
+<!-- anchor: provider.truncation -->
+
+#### Scenario: the model generates to its output limit
+- **WHEN** a completion returns with a `length` finish reason
+- **THEN** the call fails naming the token count reached, and is not retried
+
+#### Scenario: the route misreports why it stopped
+- **WHEN** a provider reports a ceiling hit under a name litellm maps to `stop`
+- **THEN** the response still reaches the parser, which reports the truncation
+  from the unclosed JSON itself
+
 ### Requirement: Defaults are provider-aware
 
 Timeouts SHALL default long for providers that may front a slow model —

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -28,6 +28,17 @@ class ProviderWallTimeout(TimeoutError):
     """
 
 
+class ProviderTruncated(Exception):
+    """Part of the provider contract: the answer ran out of output tokens.
+
+    Distinct from a model that answered badly. The response is cut off
+    mid-token, so it can never parse — but the cause is a ceiling, not a prompt,
+    and the two send a maintainer to different fixes. Reported as its own
+    failure so the notice on the PR names the ceiling and the knob that moves
+    it, rather than "unparseable model output".
+    """
+
+
 class ProviderClient(ABC):
     """Port: an LLM backend that returns a normalised completion."""
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1024,9 +1024,20 @@ class LLMReviewEngine(ReviewEngine):
         )
         try:
             findings = parse_findings(result.text)
-        except ParseError:
-            _log.warning("unparseable model output", extra={"lens": lens.id})
-            return [], "unparseable model output"
+        except ParseError as exc:
+            # A response cut off at the output ceiling is not a badly-behaved
+            # model, and saying "unparseable" sends the reader looking for a
+            # prompt bug instead of the ceiling they hit. The notice on the PR is
+            # the only place this is ever seen, so it names which fault it was.
+            reason = (
+                f"response truncated at the model's output limit after "
+                f"{result.output_tokens} tokens — lower `max_input_tokens`, or raise "
+                f"`max_tokens` if the model supports a higher ceiling"
+                if exc.truncated
+                else "unparseable model output"
+            )
+            _log.warning(reason, extra={"lens": lens.id})
+            return [], reason
         # Stamp the originating lens (engine-derived): it drives the security
         # label and category-matched finding_rules, and surfaces in JSON output.
         # A focused lens overwrites the model's value outright; a merged

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -30,7 +30,17 @@ from lgtmaybe.core.models import ReviewFinding
 
 
 class ParseError(Exception):
-    """Raised when the LLM response cannot be parsed into findings."""
+    """Raised when the LLM response cannot be parsed into findings.
+
+    ``truncated`` distinguishes the two faults behind that: a response cut off
+    mid-JSON (the model ran out of output tokens) versus one that is simply not
+    findings JSON (prose, or a schema violation). They send a maintainer to
+    different fixes, so the reviewer must not report them as the same thing.
+    """
+
+    def __init__(self, message: str, *, truncated: bool = False) -> None:
+        super().__init__(message)
+        self.truncated = truncated
 
 
 # Regex to strip trailing commas before ] or }
@@ -118,6 +128,40 @@ def iter_json_values(raw: str) -> Iterator[Any]:
                 yield from _try(span)
 
 
+def _is_unterminated(text: str) -> bool:
+    """True when *text* opens a JSON container it never closes.
+
+    The provider-independent truncation signal, and the only one available when
+    the route misreports why it stopped: litellm rewrites a finish reason it
+    doesn't recognise to ``stop`` (OpenRouter answers ``error`` on a ceiling
+    hit), so the response arrives looking clean and cut off in the same breath.
+
+    String-aware, so a bracket inside a ``suggestion`` or a prose aside
+    (``"reviewed [a, b"``) is data, not an unclosed container. Only consulted
+    once parsing has already failed — a balanced payload followed by stray
+    prose parses fine and never reaches here.
+    """
+    depth = 0
+    in_string = False
+    escaped = False
+    for ch in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in _CLOSER:
+            depth += 1
+        elif ch in _CLOSER.values():
+            depth -= 1
+    return depth > 0
+
+
 def _as_findings_list(data: Any) -> list[Any] | None:
     """Return *data* as a findings list if it is findings-shaped, else None.
 
@@ -164,6 +208,15 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
         except Exception as exc:
             last_error = exc
 
+    # Checked BEFORE the validation error below, which a truncated response can
+    # also produce: a cut-off array still contains complete earlier objects, and
+    # the first of those parses as a bare single finding and then fails schema
+    # validation. That failure is a symptom — the root cause is the missing tail,
+    # and reporting the symptom points at the wrong fix.
+    if _is_unterminated(_strip_think_blocks(raw)):
+        raise ParseError(
+            "Response ended mid-JSON — the model ran out of output tokens", truncated=True
+        )
     if last_error is not None:
         raise ParseError(f"Finding validation failed: {last_error}") from last_error
     raise ParseError("Cannot parse JSON findings from response")

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -37,7 +37,12 @@ from tenacity import (
 
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import ProviderResult, attempts_of, stamp_attempts
-from lgtmaybe.core.ports import Message, ProviderClient, ProviderWallTimeout
+from lgtmaybe.core.ports import (
+    Message,
+    ProviderClient,
+    ProviderTruncated,
+    ProviderWallTimeout,
+)
 
 _log = get_logger(__name__)
 
@@ -180,6 +185,12 @@ def _is_permanent(exc: BaseException) -> bool:
     # surfaced. One attempt, then say so — and let the fallback model (a genuinely
     # different request) still have its turn.
     if isinstance(exc, ProviderWallTimeout):
+        return True
+    # Nor is a blown output ceiling: at temperature 0 the identical request runs
+    # to the identical ceiling, and each attempt costs a full ceiling-length
+    # generation — 65,536 output tokens and 21 minutes, in the run that prompted
+    # this. Same bargain as above: one attempt, then say so, fallback still tried.
+    if isinstance(exc, ProviderTruncated):
         return True
     if isinstance(exc, RateLimitError):
         return _is_quota_rate_limit(exc)
@@ -481,6 +492,16 @@ class LiteLLMProvider(ProviderClient):
         usage = response.usage
         input_tokens: int = usage.prompt_tokens
         output_tokens: int = usage.completion_tokens
+        # A generation that stopped because it ran out of output tokens is cut off
+        # mid-token: it can never parse, and passing it on gets it reported as
+        # "unparseable model output", which points at the prompt rather than at
+        # the ceiling actually hit. Raised here so the failure names itself.
+        if _finish_reason(response) == "length":
+            raise ProviderTruncated(
+                f"response truncated at the model's output limit after {output_tokens} tokens — "
+                "lower `max_input_tokens` so each call has less to say about, or raise "
+                "`max_tokens` if the model supports a higher ceiling"
+            )
         cache_read, cache_creation = _cache_usage(usage)
         if cache_read or cache_creation:
             # Instrumentation: whether the static prefix hit or (re)wrote the
@@ -501,6 +522,22 @@ class LiteLLMProvider(ProviderClient):
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_creation,
         )
+
+
+def _finish_reason(response: Any) -> str | None:
+    """The response's finish reason, or None when the route doesn't report one.
+
+    Only ``length`` is acted on, and only when the provider says it plainly.
+    litellm normalises the field through a fixed map and quietly rewrites
+    anything it doesn't recognise to ``stop`` (it logs "Unmapped finish_reason
+    '<x>', defaulting to 'stop'"), so a route that reports a ceiling hit under
+    its own name — OpenRouter answers ``error`` — arrives here indistinguishable
+    from a clean finish. That case is caught downstream instead, by the parser
+    noticing the JSON never closed.
+    """
+    choice = response.choices[0]
+    reason = getattr(choice, "finish_reason", None)
+    return str(reason) if reason is not None else None
 
 
 def _prefix_cache_key(messages: list[Message]) -> str:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1098,6 +1098,37 @@ def test_partial_failure_notice_names_the_provider_error() -> None:
     assert "insufficient_quota" in summary
 
 
+def test_partial_failure_notice_distinguishes_a_truncated_response() -> None:
+    """A lens cut off at the output ceiling must not be reported as unparseable
+    prose: the notice on the PR is the only place a maintainer sees why a
+    quarter of the review is missing, and the two faults need different fixes."""
+
+    class _TruncatedLensProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            prompt = "\n".join(str(m.get("content", "")) for m in messages).lower()
+            if "owasp" in prompt:
+                f = ReviewFinding(
+                    path="a.py", line=1, severity=Severity.high, title="bug", body="x"
+                )
+                return ProviderResult(
+                    text=json.dumps([f.model_dump(mode="json")]), input_tokens=10, output_tokens=5
+                )
+            # Ran to the ceiling and stopped mid-object.
+            return ProviderResult(
+                text='{"findings": [{"path": "a.py", "line": 1, "ti',
+                input_tokens=13215,
+                output_tokens=65536,
+            )
+
+    engine = LLMReviewEngine(_TruncatedLensProvider())
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4.1-mini", reflect=False)
+
+    _, summary = engine.review(_CTX, cfg)
+
+    assert "truncated" in summary.lower()
+
+
 # ---------------------------------------------------------------------------
 # Custom ("BYO") lenses
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_parse.py
+++ b/tests/engine/test_parse.py
@@ -219,6 +219,52 @@ def test_whitespace_only_raises_parse_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# truncation — a response cut off mid-JSON is a different fault from prose, and
+# the reviewer must say which. Detected from the text itself because a provider
+# can misreport it: OpenRouter answered `finish_reason: 'error'` on a run that
+# hit the output ceiling, and litellm maps an unknown reason to 'stop'.
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_findings_array_is_flagged_as_truncated() -> None:
+    """The response ran out of output tokens mid-array: the envelope opens and
+    never closes, so no balanced span exists to parse."""
+    raw = '{"findings": [{"path": "a.py", "line": 1, "side": "RIGHT", "severity": "high", "ti'
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings(raw)
+    assert exc_info.value.truncated is True
+
+
+def test_truncated_bare_array_is_flagged_as_truncated() -> None:
+    raw = '[{"path": "a.py", "line": 1}, {"path": "b.py"'
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings(raw)
+    assert exc_info.value.truncated is True
+
+
+def test_prose_without_json_is_not_flagged_as_truncated() -> None:
+    """A model that answered in prose is a different fault — reporting it as a
+    truncation would send the user to the wrong knob."""
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings("this is not json at all, just prose, no brackets")
+    assert exc_info.value.truncated is False
+
+
+def test_complete_but_invalid_json_is_not_flagged_as_truncated() -> None:
+    """Balanced delimiters that fail validation are malformed, not cut off."""
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings('{"findings": [{"path": "a.py", "severity": "nope"}]}')
+    assert exc_info.value.truncated is False
+
+
+def test_string_containing_an_unclosed_bracket_is_not_truncated() -> None:
+    """A bracket inside a JSON string is data, not an unterminated container."""
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings('{"note": "reviewed [a, b"}')
+    assert exc_info.value.truncated is False
+
+
+# ---------------------------------------------------------------------------
 # schema enforcement — the model output is untrusted; reject drift loudly
 # ---------------------------------------------------------------------------
 

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -13,6 +13,7 @@ import litellm
 import pytest
 
 from lgtmaybe.core.models import attempts_of
+from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
 
@@ -353,6 +354,85 @@ class TestTemperatureRejection:
                 provider.complete(
                     [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
                 )
+
+
+class TestOutputCeilingTruncation:
+    """A generation that runs to the model's output ceiling comes back cut off
+    mid-JSON. Handing that to the parser reports it as "unparseable model
+    output", which sends the user hunting for a prompt bug instead of the
+    `max_tokens` ceiling they actually hit — and an identical re-send at
+    temperature 0 just runs to the ceiling again, at full price."""
+
+    @staticmethod
+    def _truncated(reason: str = "length") -> Any:
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"findings": [{"path": "a.py"'),
+                    finish_reason=reason,
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=13215, completion_tokens=65536),
+        )
+
+    def test_length_finish_reason_raises_truncated(self) -> None:
+        with patch("litellm.completion", return_value=self._truncated()):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        # The message must name the ceiling that was hit and the knob that moves
+        # it — the whole point is that "unparseable" told the user nothing.
+        assert "65536" in str(exc_info.value)
+        assert "max_tokens" in str(exc_info.value)
+
+    def test_truncation_is_not_retried(self) -> None:
+        """Permanent by design: the identical request against the identical
+        ceiling can only end the same way, and each attempt costs a full
+        ceiling-length generation (21 minutes, in the run that prompted this)."""
+        calls = 0
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            return self._truncated()
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated):
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert calls == 1
+
+    def test_truncation_still_falls_back_to_the_secondary_model(self) -> None:
+        """Permanent stops the *retry*, not the fallback — a different model is a
+        genuinely different request and may well fit its answer in budget."""
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if kwargs["model"] == "openrouter/deepseek":
+                return self._truncated()
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider(fallback_model="openrouter/backup")
+            result = provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert result.text == '{"findings": []}'
+
+    def test_stop_finish_reason_is_untouched(self) -> None:
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"), finish_reason="stop")],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=10),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            assert provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o").text
+
+    def test_absent_finish_reason_is_untouched(self) -> None:
+        """Not every route reports one; its absence is not a truncation."""
+        with patch("litellm.completion", return_value=_fake_response("ok")):
+            provider = LiteLLMProvider()
+            assert provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o").text
 
 
 class TestRejectedStructuredOutputParam:


### PR DESCRIPTION
Follow-up to the dogfood review on #303, which lost a quarter of itself and said only:

> ⚠️ 1 of 4 review calls failed (unparseable model output); results may be incomplete.

## What actually happened

From that job's profile:

```
call          batch tries   elapsed   in_tok  out_tok  cache_rd
correctness       1     2  1283.56s    13215    65536         0
artefacts         1     1    86.64s    11626     2261     11008
code-health       1     1    74.74s    11935     1748     11008
security          1     1    41.78s    11895     1458         0
```

`out_tok` is exactly **65,536** — the model's output ceiling, hit dead on. Immediately before it:

```
LiteLLM:WARNING: Unmapped finish_reason 'error', defaulting to 'stop'
```

The generation ran to the cap and came back cut off mid-JSON. **Nothing in the codebase read
`finish_reason`** (zero hits before this PR), so the adapter passed a failed generation on as
ordinary content and the parser blamed itself — sending a maintainer after a prompt bug instead
of the ceiling they hit.

The cost of that mislabelling: **21 minutes**, 65k output tokens on one lens against ~5.5k for
the other three combined, **1,284s of the review's 1,325s**, and a retry (`tries 2`) that also
lost its prompt cache — note `cache_rd 0` where the other late calls read 11,008.

## The fix — two detectors, because one isn't enough

**Adapter.** `_map_response` raises a new `ProviderTruncated` on a `length` finish reason, naming
the token count reached and the knob that moves it.

**Parser.** That alone would *not* have caught the run above: litellm normalises finish reasons
through a fixed map and rewrites anything unrecognised to `stop` — OpenRouter answered `error`.
So the parser independently flags a reply that opens a JSON container and never closes it. It's
string-aware, so a bracket inside a `suggestion` or a prose aside (`"reviewed [a, b"`) stays data
rather than an unterminated container.

That check runs **before** the validation-error branch. A cut-off array still holds complete
earlier objects; the first parses as a bare single finding and then fails the strict schema, so
without the ordering the symptom masks the cause. A test caught exactly that — it's why
`test_truncated_bare_array_is_flagged_as_truncated` exists.

**Truncation is permanent.** At temperature 0 the identical request reaches the identical
ceiling, and each attempt costs a full ceiling-length generation — retrying buys another 21
minutes and nothing else. The fallback model, a genuinely different request, is still tried.

The notice on a PR now reads:

> response truncated at the model's output limit after 65536 tokens — lower `max_input_tokens`,
> or raise `max_tokens` if the model supports a higher ceiling

## Deliberately not changed

`max_tokens` still defaults to `None`. Capping every review call by default would truncate
legitimately long output for every user — a behaviour change worth asking about rather than
smuggling into a bug fix. Worth considering separately: setting `max_tokens` in this repo's own
`.lgtmaybe.yml`, so a runaway on the dogfood job costs seconds rather than 21 minutes of runner
time.

Also not attempted: salvaging the complete findings from a truncated array. It's tempting — those
findings are real — but it means emitting half a lens's output as if it were all of it, and that
deserves its own decision.

## Tests

TDD, each watched fail first — 11 new cases:

- **Parser** — truncated envelope and truncated bare array flag `truncated`; prose, a complete-
  but-invalid payload, and a string containing an unclosed bracket do not.
- **Adapter** — `length` raises with the count and the knob named; not retried (1 call, not 4);
  the fallback model still runs; `stop` and an absent `finish_reason` are untouched.
- **Engine** — a partial failure's PR notice says "truncated", so the distinction survives all the
  way to where a maintainer actually reads it.

Full suite green (1689 passed, 3 skipped), ruff + mypy clean, `uv lock --check` clean,
`openspec validate --specs` green, spec anchors resolve.

## Spec

Two targeted edits: `hardening.parse` gains the truncated-versus-unparseable distinction, and a
new provider-gateway requirement — *"A blown output ceiling is named, not retried"* — anchored to
`_finish_reason`, recording why detection can't rely on the finish reason alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRfWx5iwAfXEnsPDS9NW1y)_