### PR TITLE
fix(parse): keep the findings a truncated response finished emitting

### DIFF
--- a/openspec/specs/hardening/spec.md
+++ b/openspec/specs/hardening/spec.md
@@ -93,3 +93,13 @@ different causes and different fixes.
   objects parse but fail the strict schema
 - **THEN** it is reported as truncated, not as a schema violation — the missing
   tail is the cause and the validation failure only its symptom
+
+#### Scenario: findings survive the cut
+- **WHEN** a truncated reply contains whole findings before the cut
+- **THEN** every one that validates is recovered and posted, the half-written
+  trailing object is not, and the recovery travels with the truncation report
+  so the lens is never read as complete
+
+#### Scenario: one finding, nothing cut off
+- **WHEN** a complete reply is a single bare finding object
+- **THEN** it parses as the whole answer, unchanged by the recovery path

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1022,44 +1022,68 @@ class LLMReviewEngine(ReviewEngine):
             cache_read_tokens=result.cache_read_tokens,
             cache_creation_tokens=result.cache_creation_tokens,
         )
+        salvaged = 0
         try:
             findings = parse_findings(result.text)
         except ParseError as exc:
+            if not exc.truncated:
+                _log.warning("unparseable model output", extra={"lens": lens.id})
+                return [], "unparseable model output"
             # A response cut off at the output ceiling is not a badly-behaved
             # model, and saying "unparseable" sends the reader looking for a
             # prompt bug instead of the ceiling they hit. The notice on the PR is
-            # the only place this is ever seen, so it names which fault it was.
+            # the only place this is ever seen, so it names which fault it was —
+            # and how much of the lens survived, because "3 findings recovered"
+            # and "0 recovered" are very different states to be told about.
+            findings, salvaged = exc.recovered, len(exc.recovered)
+            recovered_note = (
+                f"; {salvaged} finding{'s' if salvaged != 1 else ''} completed before the cut "
+                f"{'are' if salvaged != 1 else 'is'} included"
+                if salvaged
+                else ""
+            )
             reason = (
                 f"response truncated at the model's output limit after "
                 f"{result.output_tokens} tokens — lower `max_input_tokens`, or raise "
-                f"`max_tokens` if the model supports a higher ceiling"
-                if exc.truncated
-                else "unparseable model output"
+                f"`max_tokens` if the model supports a higher ceiling{recovered_note}"
             )
-            _log.warning(reason, extra={"lens": lens.id})
-            return [], reason
-        # Stamp the originating lens (engine-derived): it drives the security
-        # label and category-matched finding_rules, and surfaces in JSON output.
-        # A focused lens overwrites the model's value outright; a merged
-        # (fast-preset) lens covers several categories, so a model-supplied
-        # value from its member set is kept and anything else falls back to
-        # the lens id.
-        allowed = lens.allowed_categories
-        fallback_category = lens.finding_category or lens.id
-        findings = [
-            f.model_copy(
-                update={
-                    "category": (
-                        f.category
-                        if allowed is not None and f.category in allowed
-                        else fallback_category
-                    )
-                }
-            )
-            for f in findings
-        ]
+            _log.warning(reason, extra={"lens": lens.id, "recovered": salvaged})
+            # The findings fall through to be stamped like any others, but the
+            # reason travels with them: the call still counts as failed, so the
+            # incomplete notice fires and a partial lens is never read as a clean
+            # one. Returning the salvage without it would be the silent
+            # half-answer this whole path exists to prevent.
+            return _stamp_categories(findings, lens), reason
+        findings = _stamp_categories(findings, lens)
         _log.info("lens reviewed", extra={"lens": lens.id, "findings": len(findings)})
         return findings, None
+
+
+def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[ReviewFinding]:
+    """Stamp the originating lens on each finding (engine-derived).
+
+    It drives the security label and category-matched `finding_rules`, and
+    surfaces in JSON output. A focused lens overwrites the model's value
+    outright; a merged (fast-preset) lens covers several categories, so a
+    model-supplied value from its member set is kept and anything else falls
+    back to the lens id. Applied to salvaged findings too — a finding recovered
+    from a truncated response is posted like any other, so it must be labelled
+    like any other.
+    """
+    allowed = lens.allowed_categories
+    fallback_category = lens.finding_category or lens.id
+    return [
+        f.model_copy(
+            update={
+                "category": (
+                    f.category
+                    if allowed is not None and f.category in allowed
+                    else fallback_category
+                )
+            }
+        )
+        for f in findings
+    ]
 
 
 def _summary_line(count: int, cfg: ReviewConfig) -> str:

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -36,11 +36,23 @@ class ParseError(Exception):
     mid-JSON (the model ran out of output tokens) versus one that is simply not
     findings JSON (prose, or a schema violation). They send a maintainer to
     different fixes, so the reviewer must not report them as the same thing.
+
+    ``recovered`` carries the findings the model finished emitting before a
+    truncation — real, schema-valid work worth posting. It rides on the error
+    rather than being returned, because a caller must not be able to take the
+    salvage without also seeing that the lens was cut short.
     """
 
-    def __init__(self, message: str, *, truncated: bool = False) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        truncated: bool = False,
+        recovered: list[ReviewFinding] | None = None,
+    ) -> None:
         super().__init__(message)
         self.truncated = truncated
+        self.recovered = recovered or []
 
 
 # Regex to strip trailing commas before ] or }
@@ -180,6 +192,39 @@ def _as_findings_list(data: Any) -> list[Any] | None:
     return None
 
 
+def _is_container(value: Any) -> bool:
+    """Whether *value* is a whole findings payload rather than one finding.
+
+    The ``{"findings": [...]}`` envelope or a bare array — both of which a model
+    can only emit once it has closed them, so seeing one means nothing was cut
+    off. A lone object is the ambiguous case: the entire answer when the model
+    found exactly one issue, or the first survivor of a truncated array.
+    """
+    if isinstance(value, list):
+        return True
+    return isinstance(value, dict) and isinstance(value.get("findings"), list)
+
+
+def _recover_complete_findings(raw: str) -> list[ReviewFinding]:
+    """Every valid finding the model finished emitting before it was cut off.
+
+    Findings already generated, already paid for, and already validated against
+    the strict schema — dropping them loses real signal, and a half-written
+    trailing object simply fails validation and is left out rather than guessed
+    at. Order follows the response, so the salvaged findings read as the model
+    emitted them.
+    """
+    recovered: list[ReviewFinding] = []
+    for value in iter_json_values(raw):
+        if not isinstance(value, dict) or _is_container(value):
+            continue
+        try:
+            recovered.append(ReviewFinding.model_validate(value))
+        except Exception:  # noqa: S110 — a non-finding object is simply not one
+            continue
+    return recovered
+
+
 def parse_findings(raw: str) -> list[ReviewFinding]:
     """Parse *raw* LLM text into a list of ReviewFinding objects.
 
@@ -199,24 +244,38 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
     # later candidates instead of aborting on the first that doesn't validate, so
     # the real `{"findings": [...]}` that follows is still recovered.
     last_error: Exception | None = None
+    # A bare object is only the whole answer when nothing was cut off. In a
+    # truncated array it is the FIRST of several complete findings, and returning
+    # it here would report a fraction of the lens as the whole of it — silently,
+    # with no notice, which is the one outcome worth more than the findings.
+    # Held back until the truncation question is settled below.
+    single: list[ReviewFinding] | None = None
     for value in iter_json_values(raw):
         items = _as_findings_list(value)
         if items is None:
             continue
         try:
-            return [ReviewFinding.model_validate(item) for item in items]
+            parsed = [ReviewFinding.model_validate(item) for item in items]
         except Exception as exc:
             last_error = exc
+            continue
+        if _is_container(value):
+            return parsed
+        single = single if single is not None else parsed
 
-    # Checked BEFORE the validation error below, which a truncated response can
-    # also produce: a cut-off array still contains complete earlier objects, and
-    # the first of those parses as a bare single finding and then fails schema
-    # validation. That failure is a symptom — the root cause is the missing tail,
-    # and reporting the symptom points at the wrong fix.
+    # Checked BEFORE returning a bare object or reporting the validation error
+    # below, both of which a truncated response also produces: a cut-off array
+    # still holds complete earlier objects, and the first of those parses as a
+    # bare single finding — validating (and masking the truncation) or failing
+    # the schema (a symptom reported in place of the cause).
     if _is_unterminated(_strip_think_blocks(raw)):
         raise ParseError(
-            "Response ended mid-JSON — the model ran out of output tokens", truncated=True
+            "Response ended mid-JSON — the model ran out of output tokens",
+            truncated=True,
+            recovered=_recover_complete_findings(raw),
         )
+    if single is not None:
+        return single
     if last_error is not None:
         raise ParseError(f"Finding validation failed: {last_error}") from last_error
     raise ParseError("Cannot parse JSON findings from response")

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1169,6 +1169,50 @@ def test_findings_completed_before_a_truncation_are_kept() -> None:
     assert "LGTM" not in summary
 
 
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        "I reviewed everything and it looks fine to me.",
+        '{"findings": [{"path": "a.py", "severity": "nope"}]}',
+    ],
+    ids=["prose", "schema-violation"],
+)
+def test_a_parse_failure_that_is_not_a_truncation_says_so(bad_output: str) -> None:
+    """The negative of the truncation notice, and the reason it is worth pinning
+    in both directions: telling a maintainer their output was cut off when the
+    model actually answered in prose (or broke the schema) sends them to
+    `max_tokens` when the fix is the prompt."""
+
+    class _BadOutputProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            prompt = "\n".join(str(m.get("content", "")) for m in messages).lower()
+            if "owasp" in prompt:
+                f = ReviewFinding(
+                    path="a.py",
+                    line=1,
+                    severity=Severity.high,
+                    title="sec",
+                    body="x",
+                    failure_scenario="an unescaped id reaches the query",
+                )
+                return ProviderResult(
+                    text=json.dumps([f.model_dump(mode="json")]), input_tokens=10, output_tokens=5
+                )
+            return ProviderResult(text=bad_output, input_tokens=10, output_tokens=5)
+
+    engine = LLMReviewEngine(_BadOutputProvider())
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4.1-mini", reflect=False)
+
+    findings, summary = engine.review(_CTX, cfg)
+
+    # The healthy lens still posts, so this is a partial review either way —
+    # what must differ is which fault it names.
+    assert [f.title for f in findings] == ["sec"]
+    assert "unparseable" in summary.lower()
+    assert "truncated" not in summary.lower()
+
+
 def test_a_wholly_truncated_review_that_salvaged_findings_is_not_an_error() -> None:
     """Every call truncated, but findings came back: that is real signal, so it
     posts as a partial review rather than raising "every review call failed"."""

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1129,6 +1129,76 @@ def test_partial_failure_notice_distinguishes_a_truncated_response() -> None:
     assert "truncated" in summary.lower()
 
 
+def test_findings_completed_before_a_truncation_are_kept() -> None:
+    """A lens cut off at the ceiling has usually already emitted real findings.
+    They are validated work the run has paid for, so they post — but the call
+    still counts as failed, so the notice never softens into a clean review."""
+
+    class _PartiallyTruncatedProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            prompt = "\n".join(str(m.get("content", "")) for m in messages).lower()
+            if "owasp" in prompt:
+                f = ReviewFinding(
+                    path="a.py", line=1, severity=Severity.high, title="sec", body="x"
+                )
+                return ProviderResult(
+                    text=json.dumps([f.model_dump(mode="json")]), input_tokens=10, output_tokens=5
+                )
+            done = ReviewFinding(
+                path="b.py",
+                line=2,
+                severity=Severity.medium,
+                title="salvaged",
+                body="y",
+                failure_scenario="a None id reaches the query and raises",
+            )
+            return ProviderResult(
+                text='{"findings": [' + json.dumps(done.model_dump(mode="json")) + ', {"path": "c',
+                input_tokens=13215,
+                output_tokens=65536,
+            )
+
+    engine = LLMReviewEngine(_PartiallyTruncatedProvider())
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4.1-mini", reflect=False)
+
+    findings, summary = engine.review(_CTX, cfg)
+
+    assert "salvaged" in [f.title for f in findings]
+    assert "truncated" in summary.lower()
+    assert "LGTM" not in summary
+
+
+def test_a_wholly_truncated_review_that_salvaged_findings_is_not_an_error() -> None:
+    """Every call truncated, but findings came back: that is real signal, so it
+    posts as a partial review rather than raising "every review call failed"."""
+
+    class _AllTruncatedProvider(FakeProvider):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            done = ReviewFinding(
+                path="b.py",
+                line=2,
+                severity=Severity.medium,
+                title="salvaged",
+                body="y",
+                failure_scenario="a None id reaches the query and raises",
+            )
+            return ProviderResult(
+                text='{"findings": [' + json.dumps(done.model_dump(mode="json")) + ', {"path": "c',
+                input_tokens=10,
+                output_tokens=65536,
+            )
+
+    engine = LLMReviewEngine(_AllTruncatedProvider())
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4.1-mini", reflect=False)
+
+    findings, summary = engine.review(_CTX, cfg)
+
+    assert [f.title for f in findings] == ["salvaged"]
+    assert "truncated" in summary.lower()
+
+
 # ---------------------------------------------------------------------------
 # Custom ("BYO") lenses
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_parse.py
+++ b/tests/engine/test_parse.py
@@ -257,6 +257,63 @@ def test_complete_but_invalid_json_is_not_flagged_as_truncated() -> None:
     assert exc_info.value.truncated is False
 
 
+def _truncated_after(findings: list[dict], tail: str) -> str:  # type: ignore[type-arg]
+    """A ``{"findings": [...]}`` envelope cut off partway through *tail*."""
+    complete = ", ".join(json.dumps(f) for f in findings)
+    return f'{{"findings": [{complete}, {tail}'
+
+
+def test_complete_findings_before_the_cut_are_recovered() -> None:
+    """The findings the model finished emitting are real work, already validated
+    — throwing them away loses genuine signal the run has already paid for."""
+    second = {**_VALID_FINDING, "path": "src/other.py", "title": "off by one"}
+    raw = _truncated_after([_VALID_FINDING, second], '{"path": "src/third.py", "li')
+
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings(raw)
+
+    recovered = exc_info.value.recovered
+    assert [f.path for f in recovered] == ["src/app.py", "src/other.py"]
+    assert all(isinstance(f, ReviewFinding) for f in recovered)
+    assert recovered[1].title == "off by one"
+
+
+def test_the_incomplete_finding_itself_is_not_recovered() -> None:
+    """Only whole objects — a half-written finding is not silently completed."""
+    raw = _truncated_after([_VALID_FINDING], '{"path": "src/third.py", "severity": "hi')
+
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings(raw)
+
+    assert [f.path for f in exc_info.value.recovered] == ["src/app.py"]
+
+
+def test_truncation_before_any_complete_finding_recovers_nothing() -> None:
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings('{"findings": [{"path": "src/app.py", "li')
+
+    assert exc_info.value.recovered == []
+
+
+def test_a_non_truncated_parse_error_recovers_nothing() -> None:
+    """Recovery is the truncation path only; prose has nothing to salvage."""
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings("no json here at all")
+
+    assert exc_info.value.recovered == []
+
+
+def test_recovery_skips_objects_that_are_not_findings() -> None:
+    """A chatter object before the envelope is not a finding, and strict
+    validation is what keeps it out — recovery never widens the schema."""
+    raw = '{"note": "found 1 issue"} {"findings": [' + json.dumps(_VALID_FINDING) + ', {"path": "x'
+
+    with pytest.raises(ParseError) as exc_info:
+        parse_findings(raw)
+
+    assert [f.path for f in exc_info.value.recovered] == ["src/app.py"]
+
+
 def test_string_containing_an_unclosed_bracket_is_not_truncated() -> None:
     """A bracket inside a JSON string is data, not an unterminated container."""
     with pytest.raises(ParseError) as exc_info:


### PR DESCRIPTION
The follow-up flagged in #305: a lens cut off at its output ceiling has usually already
produced real findings — generated, billed, and schema-valid — and dropping them threw away
signal the run had paid for.

## What investigating it turned up

Something worse than the drop. **The bare-object branch already salvaged, silently and badly.**

A cut-off array's first complete object parses as a lone finding, `_as_findings_list` treats any
bare dict as a single finding, and `parse_findings` returned it and **reported success**. One
finding out of several, presented as the whole lens, with no notice and no incomplete marker —
the one outcome worse than losing all of them.

The test written for the new behaviour is what surfaced it: `test_recovery_skips_objects_that_are_not_findings`
failed with `DID NOT RAISE ParseError`, not with the wrong recovery.

## The fix

Recovery is now explicit and complete:

- A **bare object is only the whole answer once the text is known to be terminated.** Held back
  until the truncation question is settled, instead of short-circuiting to success.
- Otherwise `_recover_complete_findings` collects **every** complete object that validates, in
  response order. A half-written trailing object fails validation and is left out — never
  guessed at, and the strict schema is never widened to admit it.
- The salvage rides home **on the `ParseError`**, not as a return value. A caller cannot take the
  findings without also seeing that the lens was cut short.

`_is_container` draws the line that makes this safe: a `{"findings": [...]}` envelope or a bare
array can only exist once the model closed it, so seeing one proves nothing was cut off. That
keeps a complete reply trailed by prose with a stray bracket (`"...see above ["`) on its existing
path rather than mislabelling it as truncated.

## What a maintainer sees

The engine posts the recovered findings **and still counts the call failed**, so the incomplete
notice fires and names how much survived:

> ⚠️ 1 of 4 review calls failed (response truncated at the model's output limit after 65536
> tokens — lower `max_input_tokens`, or raise `max_tokens` if the model supports a higher
> ceiling; 3 findings completed before the cut are included); results may be incomplete.

A wholly-truncated review that recovered findings is a **partial review**, not "every review call
failed" — the fail-loud check already tests findings as well as errors, and its comment
anticipated exactly this shape.

Category stamping moved to `_stamp_categories` and is applied to salvaged findings too: a
recovered finding posts like any other, so it must be labelled like any other (it drives the
security label and category-matched `finding_rules`).

## Tests

TDD, each watched fail first — 7 new cases:

- **Parser** — complete findings before the cut are recovered in order; the incomplete trailing
  object is not; truncation before any whole finding recovers nothing; a non-truncated error
  recovers nothing; a chatter object is excluded by strict validation.
- **Engine** — salvaged findings reach the review while the summary still says truncated and
  never says LGTM; an all-truncated run that salvaged findings posts as partial rather than
  raising.

One thing the run itself caught: the log line read *"1 finding … are included"*. Fixed the plural.

Full suite green (1696 passed, 3 skipped), ruff + mypy clean, `openspec validate --specs` green,
spec anchors resolve.

## Spec

`hardening.parse` gains two scenarios — findings surviving the cut, and the single-bare-finding
case staying unchanged — holding the section at 29 of its 40-line cap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRfWx5iwAfXEnsPDS9NW1y)_