### PR TITLE
chore(config): cap what one dogfood review call may generate

### DIFF
--- a/.lgtmaybe.yml
+++ b/.lgtmaybe.yml
@@ -7,3 +7,16 @@
 exclude_paths:
   - docs/llms*.txt            # whole-docs corpus + index (generate_llms_txt.py)
   - docs/reference/config.md  # generated from ReviewConfig (generate_reference.py)
+
+# Bound what one call may generate. A correctness lens once ran to this model's
+# full 65,536-token output ceiling and came back cut off mid-JSON — 21 minutes
+# and 65k tokens for a single lens, against ~5.5k for the other three combined.
+# The truncation is legible now (it names itself, and the findings it finished
+# emitting survive), but nothing bounded the cost of getting there.
+#
+# 16k is ~7x the largest output a healthy lens has produced here (2,261 tokens),
+# so an ordinary review — including a reasoning model's thinking tokens, which
+# come out of this same budget — never reaches it, while a runaway stops in
+# about a quarter of the time. It also shrinks the pre-flight reservation
+# OpenRouter charges against max_tokens before generating anything.
+max_tokens: 16384

--- a/tests/cli/test_action.py
+++ b/tests/cli/test_action.py
@@ -459,7 +459,13 @@ class TestActionRouting:
 
     def test_max_tokens_input_absent_leaves_generation_uncapped(self, tmp_path, monkeypatch):
         """An empty/unset input must stay None, not become a cap — the Action's
-        inputs default to "" and a coerced 0 would reject every request."""
+        inputs default to "" and a coerced 0 would reject every request.
+
+        Run from an empty directory: the config probe reads ``.lgtmaybe.yml``
+        relative to the cwd, and lgtmaybe's own sets ``max_tokens``, so a suite
+        run from the repo root would test that file instead of input coercion.
+        """
+        monkeypatch.chdir(tmp_path)
         captured: dict[str, object] = {}
 
         import lgtmaybe.cli as cli_module

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -16,6 +16,7 @@ litellm) is exercised.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -45,11 +46,17 @@ def _fake_response() -> SimpleNamespace:
 
 
 @pytest.fixture
-def captured_completion(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+def captured_completion(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list[dict[str, Any]]:
     """Mock litellm at the boundary and feed the engine a local diff.
 
     Returns the list of kwargs every ``litellm.completion`` call received.
+
+    Runs from an empty directory: the CLI probes ``.lgtmaybe.yml`` relative to
+    the cwd, so a suite run from the repo root would otherwise assert against
+    lgtmaybe's own dogfood config rather than against the defaults these tests
+    are about — silently, until someone adds a key to it.
     """
+    monkeypatch.chdir(tmp_path)
     calls: list[dict[str, Any]] = []
 
     def fake_completion(**kwargs: Any) -> SimpleNamespace:

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -167,3 +167,39 @@ def test_dogfood_workflow_uses_the_public_app_identity() -> None:
     assert inputs["github_identity"] == "lgtmaybe"
     assert "app_id" not in inputs
     assert "app_private_key" not in inputs
+
+
+# The largest output any healthy lens has been observed to generate on the
+# dogfood review (artefacts, 2,261 tokens; security and code-health were under
+# 1,800). The floor below is several times this, because `max_tokens` also pays
+# for a reasoning model's thinking tokens — a cap sized to a plain model's
+# findings payload would starve one that thinks first, and every lens would
+# truncate instead of the runaway this guards against.
+_OBSERVED_HEALTHY_OUTPUT = 2_261
+# The ceiling deepseek-v4-pro ran to when a lens went away: 65,536 tokens and
+# 21 minutes for a single call, against ~5.5k for the other three combined.
+_RUNAWAY_OUTPUT = 65_536
+
+
+def test_dogfood_config_caps_what_one_call_may_generate() -> None:
+    """A runaway generation is bounded, not just reported.
+
+    Truncation is now legible (it names itself and its salvaged findings survive),
+    but nothing stopped a lens burning a full output ceiling to get there. The cap
+    is what makes that cost seconds instead of minutes — and on a prepaid route
+    like OpenRouter it also shrinks the pre-flight reservation, which is charged
+    against `max_tokens` before a single token is generated.
+    """
+    config = yaml.safe_load((_REPO_ROOT / ".lgtmaybe.yml").read_text(encoding="utf-8"))
+    cap = config.get("max_tokens")
+
+    assert cap is not None, ".lgtmaybe.yml must cap max_tokens — see the reasoning above"
+    assert cap >= _OBSERVED_HEALTHY_OUTPUT * 3, (
+        f"max_tokens={cap} leaves too little headroom over the largest healthy lens "
+        f"({_OBSERVED_HEALTHY_OUTPUT} tokens) — a reasoning model spends this budget on "
+        "thinking too, and a starved cap truncates every lens rather than only a runaway"
+    )
+    assert cap < _RUNAWAY_OUTPUT, (
+        f"max_tokens={cap} does not bound the runaway it exists to bound "
+        f"({_RUNAWAY_OUTPUT} tokens, 21 minutes, one lens)"
+    )


### PR DESCRIPTION
The last follow-up from the truncation work. #305 and #306 made a runaway generation
**legible** — it names itself, and the findings it finished emitting survive — but nothing
**bounded** it. A correctness lens ran to deepseek-v4-pro's full 65,536-token ceiling and came
back cut off mid-JSON: 21 minutes and 65k output tokens for one lens, against ~5.5k for the
other three combined.

```yaml
max_tokens: 16384
```

## Why 16k, and not lower

The field's own docstring carries the caution that decides this:

> Sized too low it truncates the JSON mid-object and the call parses as a failed lens, which is
> why it is opt-in rather than defaulted: **reasoning models spend this budget on thinking tokens
> too**, so a value that suits a plain model can starve a reasoning one.

So the number comes from the observed data rather than from taste. The largest output a healthy
lens has produced on this repo is **2,261 tokens** (artefacts; security and code-health were
under 1,800). 16,384 is ~7× that — ample for a model that thinks before it answers — while still
cutting the worst case 4×, from ~21 minutes to ~5.

A bonus the docstring also notes: OpenRouter is a **prepaid** route and reserves
prompt + `max_tokens` against the balance *before generating a single token*, falling back to the
model's full ceiling when the request omits the cap. Capping shrinks a reservation that was being
made for credit the review was never going to spend.

The guard asserts that **band** — at least 3× the largest healthy lens, strictly below the
runaway — rather than the literal value, so the reasoning survives a future retune instead of
becoming a number nobody dares touch.

## Two tests failed on this, and they were right to

`test_max_tokens_input_absent_leaves_generation_uncapped` and `test_max_tokens_is_absent_by_default`
both assert an uncapped default **while running from the repo root** — where the CLI's
`.lgtmaybe.yml` probe reads lgtmaybe's own config. They were testing this file, not the input
coercion and defaults they document. Latent until a key they asserted on appeared in it.

Both now run from an empty directory. For the provider-threading one the fix went into the shared
`captured_completion` fixture, so the whole module is isolated rather than just the one test that
happened to break — every test in it was reading the repo config.

Verified the change actually takes effect in CI: the loader merges CLI/Action inputs only when
non-None, so the Action's unset `INPUT_MAX_TOKENS` does not clobber the file value.

Full suite green (1699 passed, 3 skipped), ruff + mypy clean, spec anchors resolve. No spec change
— this is configuration, not behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRfWx5iwAfXEnsPDS9NW1y)_