### PR TITLE
feat(diagram): add a sequence view beside the change flowchart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,8 +168,8 @@ minified, vendored, generated, binary).
 repo `.lgtmaybe.yml` → CLI flags / Action inputs); the user store deliberately
 refuses to persist API keys.
 
-**CLI (`cli/`)** — the Click surface: `review` (local), `diagram` (local C4
-change diagram), `comment` (issue_comment slash commands), `action` (the
+**CLI (`cli/`)** — the Click surface: `review` (local), `diagram` (local change
+diagrams — structure and sequence), `comment` (issue_comment slash commands), `action` (the
 container entrypoint that routes by event), and a `config` group. Slash commands
 (`/review`, `/improve`, `/ask`, `/describe`, `/diagram`) route to the same
 engine/provider.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,16 +185,21 @@ pattern, event bus, plugin framework.
      edits our previous description in place. `ReviewConfig.auto_describe`
      (default off; Action input `auto_describe`) posts it automatically on a
      freshly opened/reopened PR, best-effort, before the review. `/diagram`
-     posts a **C4-style change diagram** (`engine/diagram.py`: a Mermaid C4
-     diagram of the components the PR touches — rendered natively by GitHub —
-     plus an ASCII rendering that is both the terminal view and the fallback
-     when the Mermaid can't render; one structured call, `_mermaid_ok` prefix
-     check, raw-text fallback) via `post_diagram_comment` — its own idempotent
+     posts a **change diagram** (`engine/diagram.py`: from one structured call
+     returning typed nodes/edges/steps, lgtmaybe renders a Mermaid **flowchart**
+     of the components the PR touches *and* a Mermaid **sequence diagram** of the
+     run-time flow it alters — structure answers "what does this touch", sequence
+     answers "what happens, in what order"; the sequence view is omitted when the
+     model returns no steps, which is also when the `Structure`/`Sequence`
+     headings drop away. Both render natively on GitHub, each with a text
+     rendering that is the terminal view and the fallback; model-authored Mermaid
+     never reaches a fence, and sequence labels are escaped with Mermaid entity
+     codes) via `post_diagram_comment` — its own idempotent
      upsert with a disjoint marker family. `ReviewConfig.auto_diagram` (default
      **on**; Action input `auto_diagram`, set false to opt out) posts it
      automatically on freshly opened/reopened PRs. The local `lgtmaybe diagram` command prints the same body
-     (no GitHub) — a terminal can't render Mermaid, which is what the ASCII is
-     for. **No D2:** GitHub doesn't render it in Markdown.
+     (no GitHub) — a terminal can't render Mermaid, which is what the text
+     rendering is for. **No D2:** GitHub doesn't render it in Markdown.
    - **Guards (in the engine):** generated/binary files skipped via
      `is_reviewable`; the user's `include_paths` allowlist / `exclude_paths`
      denylist globs applied right after it (`engine.passes_path_filters`;

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ everywhere:
 - **On a GitHub PR** — an inline comment on the exact changed line for each finding, plus one summary comment naming the model used. Re-running updates the same comments instead of duplicating them, auto-resolves a conversation once its finding is fixed, and a clean PR gets a 👍 **LGTM!**.
 - **On the CLI** — `lgtmaybe review` reads your local `git` diff and prints the findings (a readable listing, a JSON array with `--json`, or `--format agent` for an AI coding agent to read and apply); nothing is posted to GitHub.
 
-Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **compact change diagram** — an automatically laid-out Mermaid flowchart of the components the PR touches, with changes marked on nodes, rendered natively in the comment, with an ASCII fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
+Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **compact change diagram** — an automatically laid-out Mermaid flowchart of the components the PR touches, with changes marked on nodes, plus a Mermaid **sequence diagram** of the run-time flow the change alters (omitted when there isn't one), both rendered natively in the comment, with a text fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
 
 On re-runs and big PRs the review stays cheap: a `synchronize` push triggers an **incremental review** of just the new commits, an optional cheap **triage model** (`triage_model`) skips plainly-non-substantive files before the strong model runs, and optional **static-analysis fusion** (`static_analysis`) runs deterministic tools over the changed files — ruff/bandit/mypy/semgrep feed the review as untrusted hints, while gitleaks (secrets), zizmor (GitHub Actions workflow security), ast-grep (your own structural rules) and osv-scanner (known dependency vulnerabilities) post findings directly with no model call. semgrep ships with a small MIT rule pack, so it works without configuration.
 
@@ -136,8 +136,9 @@ lgtmaybe review \
 
 No GitHub token and no pull request needed — `lgtmaybe review` reads your local
 `git` diff and prints the findings. Its companion, `lgtmaybe diagram`, takes the
-same flags and prints a C4-style picture of the components your change touches —
-`review` then `diagram` is the pair to run before opening a pull request. See
+same flags and prints a picture of the components your change touches and the
+flow it alters — `review` then `diagram` is the pair to run before opening a
+pull request. See
 [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
 
 `lgtmaybe help` lists every command with usage examples; `lgtmaybe help review`

--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ inputs:
     required: false
     default: ""
   auto_diagram:
-    description: "On a freshly opened (or reopened) PR, post a C4-style change diagram comment — a Mermaid C4 diagram of the components the PR touches (rendered natively by GitHub), with an ASCII fallback — before the review runs, updated in place by later /diagram runs. On by default; set to false to opt out."
+    description: "On a freshly opened (or reopened) PR, post a change diagram comment — a Mermaid flowchart of the components the PR touches plus a Mermaid sequence diagram of the run-time flow it alters (both rendered natively by GitHub), with a text fallback — before the review runs, updated in place by later /diagram runs. On by default; set to false to opt out."
     required: false
     default: ""
   answer_replies:

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -50,8 +50,8 @@ The optional **description** (`/describe`, `auto_describe`) and **change
 diagram** (`/diagram`, `auto_diagram`) features send exactly the same inputs —
 the redacted diff and, when present, the redacted stated intent. They add no new
 data flows; they only ask the model for a different output. The diagram comment
-does include an "Open full screen" [mermaid.live](https://mermaid.live) link
-whose URL fragment embeds the diagram source — but that source is the
+does include an "Open full screen" [mermaid.live](https://mermaid.live) link per
+diagram, whose URL fragment embeds that diagram's source — but that source is the
 already-public, post-redaction comment body, the fragment is decoded
 client-side (browsers never send fragments to a server), and nothing is fetched
 unless a reader clicks the link.

--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -1,17 +1,18 @@
 ---
-description: Post a compact Mermaid flowchart of a pull request's changes as a GitHub comment, or print one from the CLI.
+description: Post compact Mermaid diagrams of a pull request's changes — a flowchart of the structure and a sequence diagram of the flow — as a GitHub comment, or print them from the CLI.
 ---
 
 # Generate a change diagram
 
-lgtmaybe can post a **compact flowchart of what a pull request changes** — the
-components the PR touches plus their immediate relationships — so a reviewer
-gets a visual overview before they read the diff. It's a separate concern from
-the review and the description: enable any of them independently.
+lgtmaybe can post a **compact picture of what a pull request changes** — the
+components the PR touches and the run-time flow it alters — so a reviewer gets a
+visual overview before they read the diff. It's a separate concern from the
+review and the description: enable any of them independently.
 
 ## Contents
 
 - [What you get](#what-you-get)
+- [Structure and sequence](#structure-and-sequence)
 - [On GitHub: `/diagram` and `auto_diagram`](#on-github-diagram-and-auto_diagram)
 - [Locally: `lgtmaybe diagram`](#locally-lgtmaybe-diagram)
 - [Why Mermaid (and what the ASCII is for)](#why-mermaid-and-what-the-ascii-is-for)
@@ -19,12 +20,17 @@ the review and the description: enable any of them independently.
 
 ## What you get
 
-One model call returns two renderings of the same graph:
+One model call returns up to two diagrams, each in two renderings:
 
-- a **Mermaid flowchart**, which GitHub renders natively inside the comment —
-  no image, no external hosting; and
-- a **plain-text ASCII** rendering of the same diagram, which is what shows in a
-  terminal and serves as the fallback if the Mermaid can't be rendered.
+- a **Mermaid flowchart** of the structure — what the change touches and how
+  those pieces connect;
+- a **Mermaid sequence diagram** of the flow — what happens at run time, and in
+  what order — included only when the change actually alters a flow;
+- a **plain-text rendering** of each, which is what shows in a terminal and
+  serves as the fallback if the Mermaid can't be rendered.
+
+GitHub renders both Mermaid diagrams natively inside the comment — no image, no
+external hosting.
 
 The flowchart is intentionally sparse: it uses at most six nodes, short
 relationship labels, and Mermaid's automatic layout. Changed elements are
@@ -43,6 +49,8 @@ front of a user service — the Mermaid renders in place, with the ASCII tucked
 in a collapsible "Text version" underneath:
 
 > **Cache user lookups in Redis**
+
+> ### Structure
 
 ```mermaid
 flowchart LR
@@ -69,7 +77,60 @@ flowchart LR
 
 </details>
 
+> ### Sequence
+
+```mermaid
+sequenceDiagram
+    participant client as Client
+    participant api as User API (changed)
+    participant cache as Redis cache (new)
+    participant db as User DB
+    client->>api: GET /users/{id}
+    api->>cache: read cached row
+    cache-->>api: miss
+    api->>db: SELECT user
+    api->>cache: store row, 60s TTL
+    api-->>client: user JSON
+```
+
+<details>
+<summary>Text version</summary>
+
+```
+1. [Client] -> [User API (changed)]: GET /users/{id}
+2. [User API (changed)] -> [Redis cache (new)]: read cached row
+3. [Redis cache (new)] --> [User API (changed)]: miss
+4. [User API (changed)] -> [User DB]: SELECT user
+5. [User API (changed)] -> [Redis cache (new)]: store row, 60s TTL
+6. [User API (changed)] --> [Client]: user JSON
+```
+
+</details>
+
 > *The User DB link is inferred from an import, not shown in the diff.*
+
+## Structure and sequence
+
+The two diagrams answer different questions, which is why lgtmaybe draws both:
+
+| | Answers | Best on |
+|---|---|---|
+| **Flowchart** (structure) | What does this change touch, and what talks to what? | Structural PRs — a component added, a dependency introduced, a service split |
+| **Sequence** | What happens at run time, in what order, and where did that change? | Behavioural PRs — a retry added, an ordering fixed, a signal now handled |
+
+Most pull requests are behavioural, and structure alone under-describes them: a
+PR that fixes terminal restoration on `SIGTERM` might touch two files and draw
+three boxes, while its sequence diagram — signal, flag set, loop exit, guard
+dropped, terminal restored — *is* the explanation of the fix. A PR that puts a
+cache in front of a service is the opposite: the new box is the headline, and
+the flow shows how a request now reaches it.
+
+The sequence view is **omitted entirely** when the change has no meaningful
+run-time flow — documentation, configuration, formatting — rather than inventing
+one. When only the flowchart renders, the `Structure` / `Sequence` headings drop
+away too, so a small change stays a small comment. Both diagrams share one model
+call, one PR comment, and the same six-component budget; the sequence view adds
+at most eight ordered steps.
 
 ## On GitHub: `/diagram` and `auto_diagram`
 
@@ -110,25 +171,30 @@ $ lgtmaybe diagram --provider ollama --model llama3
 It diffs your branch against the base (the same base resolution as `lgtmaybe
 review`; `--base` overrides, `--working` includes uncommitted edits,
 `--uncommitted` reviews only the working-tree edits). The output is the same
-Markdown body the `/diagram` comment carries — the Mermaid source first, then
-the ASCII rendering (which reads fine in a terminal) in a collapsed "Text
-version" block. Paste the Mermaid into a GitHub comment,
+Markdown body the `/diagram` comment carries — each diagram's Mermaid source
+first, then its text rendering (which reads fine in a terminal) in a collapsed
+"Text version" block. Paste the Mermaid into a GitHub comment,
 [mermaid.live](https://mermaid.live), or a Markdown file to render it.
 
 ## Why Mermaid (and what the ASCII is for)
 
-GitHub renders **Mermaid** natively in comments and Markdown, so a `mermaid`
-fenced flowchart renders in the comment with no image to generate or host.
-That matters for a `pull_request_target` reviewer: hosting an image would mean
-committing a file or calling an external service, neither of which fits a
-fork-safe, idempotently-updated comment.
+GitHub renders **Mermaid** natively in comments and Markdown — both flowcharts
+and sequence diagrams — so a `mermaid` fence renders in the comment with no
+image to generate or host. That matters for a `pull_request_target` reviewer:
+hosting an image would mean committing a file or calling an external service,
+neither of which fits a fork-safe, idempotently-updated comment.
 
-A terminal, though, can't render Mermaid — which is exactly why the same call
-also returns **ASCII art**. Both the CLI output and the GitHub comment show the
-Mermaid with the ASCII tucked in a collapsible "Text version" — the ASCII is
+A terminal, though, can't render Mermaid — which is exactly why each diagram
+also comes as **plain text**. Both the CLI output and the GitHub comment show
+the Mermaid with the text tucked in a collapsible "Text version" — the text is
 what you actually read in a terminal, and it doubles as the fallback body, so a
 reviewer never sees a red "unable to render" box if a diagram comes back
 malformed.
+
+The model never writes Mermaid. It returns typed graph data — components,
+relationships, ordered steps — and lgtmaybe renders the syntax itself, escaping
+every label, so a diff that tries to smuggle diagram source or markup into a
+label can't reach the fence.
 
 D2 isn't used because GitHub doesn't render it in Markdown, so it would show as
 source anyway.

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -21,7 +21,8 @@ default shape.
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
 `auto_diagram` is on by default, so newly opened or reopened pull requests
-receive a compact Mermaid flowchart automatically. Set it to `false` if you do
+receive a compact Mermaid flowchart — and, when the change alters a run-time
+flow, a sequence diagram beside it — automatically. Set it to `false` if you do
 not want the extra model call.
 ollama runs the model on your own machine, so it is local-only — use the
 [CLI](run-locally-with-ollama.md) rather than a posting workflow.
@@ -220,7 +221,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
-| `auto_diagram` | `true` | Post a compact Mermaid flowchart comment when a PR is opened/reopened, before the review; set `false` to opt out |
+| `auto_diagram` | `true` | Post a compact change-diagram comment (Mermaid flowchart, plus a sequence diagram when the change alters a flow) when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
 | `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,9 @@ line. A clean change just gets a 👍 **LGTM!**.
 ![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a committable parameterized-query suggestion](assets/marketplace/marketplace-screenshot-1.png){ width="720" }
 
 Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
-**`/describe`** writes a structured overview, **`/diagram`** draws a
-[compact flowchart of the change](how-to/generate-a-change-diagram.md), and
+**`/describe`** writes a structured overview, **`/diagram`** draws
+[the change](how-to/generate-a-change-diagram.md) — a flowchart of what it
+touches, plus a sequence diagram of the flow it alters — and
 **`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
 map locally before you push.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -40,8 +40,9 @@ line. A clean change just gets a 👍 **LGTM!**.
 ![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability, with an explanation and a committable parameterized-query suggestion](assets/marketplace/marketplace-screenshot-1.png){ width="720" }
 
 Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
-**`/describe`** writes a structured overview, **`/diagram`** draws a
-[compact flowchart of the change](how-to/generate-a-change-diagram.md), and
+**`/describe`** writes a structured overview, **`/diagram`** draws
+[the change](how-to/generate-a-change-diagram.md) — a flowchart of what it
+touches, plus a sequence diagram of the flow it alters — and
 **`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
 map locally before you push.
 
@@ -185,7 +186,8 @@ coding agent can read and apply, for a local review-and-fix loop — see
 ## Step 5 — Diagram what you touched
 
 `lgtmaybe diagram` runs the same local diff through one model call and prints a
-C4-style picture of the components your change touches:
+picture of the components your change touches — plus, when your change alters a
+run-time flow, a sequence diagram of that flow:
 
 ```bash
 lgtmaybe diagram \
@@ -196,10 +198,10 @@ lgtmaybe diagram \
 
 It takes the same `--base` / `--working` / `--uncommitted` flags as `review`, so
 `review` then `diagram` is a natural pair before you open a pull request: what's
-wrong with the change, then what the change reaches. The output is Mermaid
-source plus an ASCII rendering — the ASCII is what reads in a terminal; paste
-the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live) to see
-it drawn. See
+wrong with the change, then what the change reaches and what it does. The output
+is Mermaid source plus a text rendering — the text is what reads in a terminal;
+paste the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live)
+to see it drawn. See
 [Generate a change diagram](../how-to/generate-a-change-diagram.md).
 
 ## Step 6 — Post reviews on real pull requests
@@ -381,7 +383,8 @@ default shape.
 Ready-to-copy workflows for every cloud and API-key provider live in
 [`examples/workflows/`](https://github.com/MattJColes/lgtmaybe/tree/main/examples/workflows).
 `auto_diagram` is on by default, so newly opened or reopened pull requests
-receive a compact Mermaid flowchart automatically. Set it to `false` if you do
+receive a compact Mermaid flowchart — and, when the change alters a run-time
+flow, a sequence diagram beside it — automatically. Set it to `false` if you do
 not want the extra model call.
 ollama runs the model on your own machine, so it is local-only — use the
 [CLI](run-locally-with-ollama.md) rather than a posting workflow.
@@ -580,7 +583,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
-| `auto_diagram` | `true` | Post a compact Mermaid flowchart comment when a PR is opened/reopened, before the review; set `false` to opt out |
+| `auto_diagram` | `true` | Post a compact change-diagram comment (Mermaid flowchart, plus a sequence diagram when the change alters a flow) when a PR is opened/reopened, before the review; set `false` to opt out |
 | `answer_replies` | `true` | Answer a PR author's reply in a finding thread (a `pull_request_review_comment` event), using the finding and its diff hunk as context; the reply is untrusted input. Set `false` to leave threads unanswered |
 | `pr_labels` | `false` | Attach derived labels: `review-effort/1-5`, `possible-security-issue`, `consider-splitting` (best-effort, no extra model calls) |
 | `fail_on` | — (off) | Merge-gate threshold (`info`/`low`/`medium`/`high`/`critical`). Creates a `lgtmaybe` Check Run that **fails** when any finding is at or above this severity — make it a required check to block merges. See [Gate merges on findings](#gate-merges-on-findings) |
@@ -2942,14 +2945,15 @@ your lenses.
 
 # Generate a change diagram
 
-lgtmaybe can post a **compact flowchart of what a pull request changes** — the
-components the PR touches plus their immediate relationships — so a reviewer
-gets a visual overview before they read the diff. It's a separate concern from
-the review and the description: enable any of them independently.
+lgtmaybe can post a **compact picture of what a pull request changes** — the
+components the PR touches and the run-time flow it alters — so a reviewer gets a
+visual overview before they read the diff. It's a separate concern from the
+review and the description: enable any of them independently.
 
 ## Contents
 
 - [What you get](#what-you-get)
+- [Structure and sequence](#structure-and-sequence)
 - [On GitHub: `/diagram` and `auto_diagram`](#on-github-diagram-and-auto_diagram)
 - [Locally: `lgtmaybe diagram`](#locally-lgtmaybe-diagram)
 - [Why Mermaid (and what the ASCII is for)](#why-mermaid-and-what-the-ascii-is-for)
@@ -2957,12 +2961,17 @@ the review and the description: enable any of them independently.
 
 ## What you get
 
-One model call returns two renderings of the same graph:
+One model call returns up to two diagrams, each in two renderings:
 
-- a **Mermaid flowchart**, which GitHub renders natively inside the comment —
-  no image, no external hosting; and
-- a **plain-text ASCII** rendering of the same diagram, which is what shows in a
-  terminal and serves as the fallback if the Mermaid can't be rendered.
+- a **Mermaid flowchart** of the structure — what the change touches and how
+  those pieces connect;
+- a **Mermaid sequence diagram** of the flow — what happens at run time, and in
+  what order — included only when the change actually alters a flow;
+- a **plain-text rendering** of each, which is what shows in a terminal and
+  serves as the fallback if the Mermaid can't be rendered.
+
+GitHub renders both Mermaid diagrams natively inside the comment — no image, no
+external hosting.
 
 The flowchart is intentionally sparse: it uses at most six nodes, short
 relationship labels, and Mermaid's automatic layout. Changed elements are
@@ -2981,6 +2990,8 @@ front of a user service — the Mermaid renders in place, with the ASCII tucked
 in a collapsible "Text version" underneath:
 
 > **Cache user lookups in Redis**
+
+> ### Structure
 
 ```mermaid
 flowchart LR
@@ -3007,7 +3018,60 @@ flowchart LR
 
 </details>
 
+> ### Sequence
+
+```mermaid
+sequenceDiagram
+    participant client as Client
+    participant api as User API (changed)
+    participant cache as Redis cache (new)
+    participant db as User DB
+    client->>api: GET /users/{id}
+    api->>cache: read cached row
+    cache-->>api: miss
+    api->>db: SELECT user
+    api->>cache: store row, 60s TTL
+    api-->>client: user JSON
+```
+
+<details>
+<summary>Text version</summary>
+
+```
+1. [Client] -> [User API (changed)]: GET /users/{id}
+2. [User API (changed)] -> [Redis cache (new)]: read cached row
+3. [Redis cache (new)] --> [User API (changed)]: miss
+4. [User API (changed)] -> [User DB]: SELECT user
+5. [User API (changed)] -> [Redis cache (new)]: store row, 60s TTL
+6. [User API (changed)] --> [Client]: user JSON
+```
+
+</details>
+
 > *The User DB link is inferred from an import, not shown in the diff.*
+
+## Structure and sequence
+
+The two diagrams answer different questions, which is why lgtmaybe draws both:
+
+| | Answers | Best on |
+|---|---|---|
+| **Flowchart** (structure) | What does this change touch, and what talks to what? | Structural PRs — a component added, a dependency introduced, a service split |
+| **Sequence** | What happens at run time, in what order, and where did that change? | Behavioural PRs — a retry added, an ordering fixed, a signal now handled |
+
+Most pull requests are behavioural, and structure alone under-describes them: a
+PR that fixes terminal restoration on `SIGTERM` might touch two files and draw
+three boxes, while its sequence diagram — signal, flag set, loop exit, guard
+dropped, terminal restored — *is* the explanation of the fix. A PR that puts a
+cache in front of a service is the opposite: the new box is the headline, and
+the flow shows how a request now reaches it.
+
+The sequence view is **omitted entirely** when the change has no meaningful
+run-time flow — documentation, configuration, formatting — rather than inventing
+one. When only the flowchart renders, the `Structure` / `Sequence` headings drop
+away too, so a small change stays a small comment. Both diagrams share one model
+call, one PR comment, and the same six-component budget; the sequence view adds
+at most eight ordered steps.
 
 ## On GitHub: `/diagram` and `auto_diagram`
 
@@ -3048,25 +3112,30 @@ $ lgtmaybe diagram --provider ollama --model llama3
 It diffs your branch against the base (the same base resolution as `lgtmaybe
 review`; `--base` overrides, `--working` includes uncommitted edits,
 `--uncommitted` reviews only the working-tree edits). The output is the same
-Markdown body the `/diagram` comment carries — the Mermaid source first, then
-the ASCII rendering (which reads fine in a terminal) in a collapsed "Text
-version" block. Paste the Mermaid into a GitHub comment,
+Markdown body the `/diagram` comment carries — each diagram's Mermaid source
+first, then its text rendering (which reads fine in a terminal) in a collapsed
+"Text version" block. Paste the Mermaid into a GitHub comment,
 [mermaid.live](https://mermaid.live), or a Markdown file to render it.
 
 ## Why Mermaid (and what the ASCII is for)
 
-GitHub renders **Mermaid** natively in comments and Markdown, so a `mermaid`
-fenced flowchart renders in the comment with no image to generate or host.
-That matters for a `pull_request_target` reviewer: hosting an image would mean
-committing a file or calling an external service, neither of which fits a
-fork-safe, idempotently-updated comment.
+GitHub renders **Mermaid** natively in comments and Markdown — both flowcharts
+and sequence diagrams — so a `mermaid` fence renders in the comment with no
+image to generate or host. That matters for a `pull_request_target` reviewer:
+hosting an image would mean committing a file or calling an external service,
+neither of which fits a fork-safe, idempotently-updated comment.
 
-A terminal, though, can't render Mermaid — which is exactly why the same call
-also returns **ASCII art**. Both the CLI output and the GitHub comment show the
-Mermaid with the ASCII tucked in a collapsible "Text version" — the ASCII is
+A terminal, though, can't render Mermaid — which is exactly why each diagram
+also comes as **plain text**. Both the CLI output and the GitHub comment show
+the Mermaid with the text tucked in a collapsible "Text version" — the text is
 what you actually read in a terminal, and it doubles as the fallback body, so a
 reviewer never sees a red "unable to render" box if a diagram comes back
 malformed.
+
+The model never writes Mermaid. It returns typed graph data — components,
+relationships, ordered steps — and lgtmaybe renders the syntax itself, escaping
+every label, so a diff that tries to smuggle diagram source or markup into a
+label can't reach the fence.
 
 D2 isn't used because GitHub doesn't render it in Markdown, so it would show as
 source anyway.
@@ -5577,8 +5646,8 @@ The optional **description** (`/describe`, `auto_describe`) and **change
 diagram** (`/diagram`, `auto_diagram`) features send exactly the same inputs —
 the redacted diff and, when present, the redacted stated intent. They add no new
 data flows; they only ask the model for a different output. The diagram comment
-does include an "Open full screen" [mermaid.live](https://mermaid.live) link
-whose URL fragment embeds the diagram source — but that source is the
+does include an "Open full screen" [mermaid.live](https://mermaid.live) link per
+diagram, whose URL fragment embeds that diagram's source — but that source is the
 already-public, post-redaction comment body, the fragment is decoded
 client-side (browsers never send fragments to a server), and nothing is fetched
 unless a reader clicks the link.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -22,7 +22,7 @@
 - [Other OpenAI-compatible servers](https://lgtmaybe.coles.codes/how-to/use-a-custom-openai-compatible-endpoint/): Point lgtmaybe at any OpenAI-compatible server — vLLM, llama.cpp, LM Studio, DeepSeek — with --api-base; the key is optional.
 - [Configure .lgtmaybe.yml](https://lgtmaybe.coles.codes/how-to/configure-lgtmaybe-yml/): Configure lgtmaybe with a .lgtmaybe.yml file — provider, model, severity floor, lenses, caps, and other non-secret defaults.
 - [Add a custom review lens](https://lgtmaybe.coles.codes/how-to/add-a-custom-lens/): Add a custom review lens to lgtmaybe — a bring-your-own skill file that runs alongside the nine built-in lenses.
-- [Generate a change diagram](https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/): Post a compact Mermaid flowchart of a pull request's changes as a GitHub comment, or print one from the CLI.
+- [Generate a change diagram](https://lgtmaybe.coles.codes/how-to/generate-a-change-diagram/): Post compact Mermaid diagrams of a pull request's changes — a flowchart of the structure and a sequence diagram of the flow — as a GitHub comment, or print them from the CLI.
 - [Fix findings with an AI agent](https://lgtmaybe.coles.codes/how-to/fix-findings-with-an-ai-agent/): Turn lgtmaybe findings into instructions an AI coding agent can apply, for a local review-and-fix loop before you push.
 - [Reduce review cost](https://lgtmaybe.coles.codes/how-to/reduce-review-cost/): Measure what a lgtmaybe review actually spends, then cut it — triage, static analysis, prompt caching, narrower lenses, and a hard token ceiling.
 - [Releasing](https://lgtmaybe.coles.codes/how-to/releasing/): Maintainer guide to publishing lgtmaybe with release-please, PyPI, GHCR, Homebrew, a Windows executable, and winget.

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -92,7 +92,8 @@ coding agent can read and apply, for a local review-and-fix loop — see
 ## Step 5 — Diagram what you touched
 
 `lgtmaybe diagram` runs the same local diff through one model call and prints a
-C4-style picture of the components your change touches:
+picture of the components your change touches — plus, when your change alters a
+run-time flow, a sequence diagram of that flow:
 
 ```bash
 lgtmaybe diagram \
@@ -103,10 +104,10 @@ lgtmaybe diagram \
 
 It takes the same `--base` / `--working` / `--uncommitted` flags as `review`, so
 `review` then `diagram` is a natural pair before you open a pull request: what's
-wrong with the change, then what the change reaches. The output is Mermaid
-source plus an ASCII rendering — the ASCII is what reads in a terminal; paste
-the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live) to see
-it drawn. See
+wrong with the change, then what the change reaches and what it does. The output
+is Mermaid source plus a text rendering — the text is what reads in a terminal;
+paste the Mermaid into a GitHub comment or [mermaid.live](https://mermaid.live)
+to see it drawn. See
 [Generate a change diagram](../how-to/generate-a-change-diagram.md).
 
 ## Step 6 — Post reviews on real pull requests

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -22,6 +22,12 @@ cli.slash:
       has: { field: name, regex: '^dispatch$' }
     files: [src/lgtmaybe/cli/**/*.py]
 
+cli.diagram-sequence:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_sequence_views$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
 cli.review-reply:
   rule:
     kind: function_definition

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -62,6 +62,27 @@ stack.
 - **THEN** the C4 source is not posted as Mermaid and the ASCII rendering is
   shown instead
 
+### Requirement: Change diagrams show structure and sequence
+
+The change diagram SHALL render two complementary views from the one structured
+call: a Mermaid flowchart of the components the change touches, and a Mermaid
+sequence diagram of the ordered run-time interactions it alters. Steps
+referencing unknown components SHALL be dropped, the step count SHALL be
+bounded, participant and message text SHALL be escaped with Mermaid entity
+codes, and the sequence view SHALL be omitted — section headings included —
+when the model reports no run-time flow.
+<!-- anchor: cli.diagram-sequence -->
+
+#### Scenario: change alters a run-time flow
+- **WHEN** the provider returns ordered steps between known components
+- **THEN** a `sequenceDiagram` renders beside the flowchart under `Structure`
+  and `Sequence` headings, each view with its own text version and link
+
+#### Scenario: change has no run-time flow
+- **WHEN** the provider returns no steps
+- **THEN** the comment carries the flowchart alone, with no sequence section
+  and no headings
+
 ### Requirement: Finding-thread replies are answered in-thread
 
 A `pull_request_review_comment` reply in a finding thread lgtmaybe opened SHALL

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -452,11 +452,26 @@ class DiagramEdge(_Strict):
     label: str = ""
 
 
+class DiagramStep(_Strict):
+    """One ordered run-time interaction between two diagram node ids.
+
+    Where an edge says two components are related, a step says what happens and
+    when — the behaviour view of the same change. ``reply`` renders the dashed
+    return arrow.
+    """
+
+    source: str
+    target: str
+    label: str = ""
+    reply: bool = False
+
+
 class DiagramResult(_Strict):
     """Structured-output envelope for the change-diagram pass.
 
-    The model returns presentation-agnostic nodes and edges. lgtmaybe renders
-    both Mermaid and ASCII locally so model-authored syntax never reaches a
+    The model returns presentation-agnostic nodes, edges, and ordered steps.
+    lgtmaybe renders Mermaid (a flowchart of the structure, a sequence diagram
+    of the flow) and text locally so model-authored syntax never reaches a
     Mermaid fence. ``ascii`` remains only as a compatibility fallback for weak
     models that return the legacy C4-plus-text shape.
     """
@@ -464,6 +479,7 @@ class DiagramResult(_Strict):
     title: str = ""
     nodes: list[DiagramNode] = Field(default_factory=list)
     edges: list[DiagramEdge] = Field(default_factory=list)
+    steps: list[DiagramStep] = Field(default_factory=list)
     ascii: str = ""
     notes: str = ""
 

--- a/src/lgtmaybe/engine/diagram.py
+++ b/src/lgtmaybe/engine/diagram.py
@@ -1,8 +1,14 @@
-"""Change diagram: a compact Mermaid flowchart of a PR's changes.
+"""Change diagram: compact Mermaid views of a PR's changes.
 
-The provider returns presentation-agnostic components and relationships.
-``build_diagram`` renders both Mermaid and plain text from that validated graph,
-so model-authored syntax never reaches a Mermaid fence.
+The provider returns presentation-agnostic components, relationships, and
+ordered interactions. ``build_diagram`` renders both Mermaid and plain text from
+that validated graph, so model-authored syntax never reaches a Mermaid fence.
+
+Two views, because they answer different questions: a **flowchart** shows what
+the change touches and how the pieces connect, while a **sequence diagram**
+shows what happens at run time and in what order — the one that explains a
+change to control flow. The sequence view is omitted when the model reports no
+meaningful run-time flow (docs, config, formatting).
 
 GitHub renders Mermaid natively in a comment, while the local CLI and a
 collapsed ``<details>`` block use the text view. The full-screen mermaid.live
@@ -19,7 +25,7 @@ import base64
 import html
 import json
 import zlib
-from typing import Any
+from typing import Any, NamedTuple
 
 from lgtmaybe.core.models import DiagramResult, PRContext, ReviewConfig
 from lgtmaybe.core.ports import ProviderClient
@@ -35,12 +41,22 @@ Return ONLY a JSON object with these keys:
   "description", and "change" ("unchanged", "changed", or "new");
 - "edges": a list of relationship objects with "source", "target", and "label";
   "source" and "target" MUST match node ids;
+- "steps": an ordered list of run-time interaction objects with "source",
+  "target", "label", and "reply" (true for a response going back to the caller);
+  "source" and "target" MUST match node ids, and may be the same id for work a
+  component does on itself;
 - "notes": one or two sentences of caveats or a legend, or an empty string.
 
 Rules:
 - Use a maximum of six nodes. Keep each node label short, with optional technology
   and one short description in their separate fields.
 - Use short relationship labels of at most three words.
+- The nodes and edges answer "what does this change touch"; the steps answer
+  "what happens, in what order". Use at most eight steps, ordered as they happen
+  at run time, covering the flow the change alters. Return an empty list for
+  "steps" when the change has no meaningful run-time flow (documentation,
+  configuration, formatting) — never invent a flow to fill the diagram.
+- Step labels may name the call, event, or signal: at most six words.
 - Mark changed and new components through the node's "change" field, never in an
   edge label.
 - Return graph data only. lgtmaybe owns Mermaid and ASCII syntax; do not return
@@ -60,7 +76,11 @@ Example:
 "label": "Release assets", "technology": "", "description": "stores downloads",
 "change": "unchanged"}], "edges": [{"source": "release", "target": "build",
 "label": "triggers"}, {"source": "build", "target": "assets",
-"label": "uploads"}], "notes": ""}
+"label": "uploads"}], "steps": [{"source": "release", "target": "build",
+"label": "starts binary build", "reply": false}, {"source": "build",
+"target": "assets", "label": "uploads executable", "reply": false},
+{"source": "build", "target": "release", "label": "reports build result",
+"reply": true}], "notes": ""}
 """
 
 
@@ -68,8 +88,8 @@ def _language_directive(language: str) -> str:
     """Tell the model which graph prose to translate."""
     return (
         '\nWrite the "title", node "label", "technology", "description", edge '
-        f'"label", and "notes" in {language}. Keep node ids and "change" enum '
-        "values unchanged.\n"
+        f'"label", step "label", and "notes" in {language}. Keep node ids and '
+        '"change" enum values unchanged.\n'
     )
 
 
@@ -79,6 +99,7 @@ _DIFF_PREAMBLE = (
 )
 _TASK_SUFFIX = "\n\nReturn the diagram JSON object."
 _MAX_NODES = 6
+_MAX_STEPS = 8
 
 
 def _fullscreen_url(mermaid: str) -> str:
@@ -125,9 +146,18 @@ def _single_line(value: str) -> str:
     return " ".join(value.split())
 
 
-def _graph_views(diagram: DiagramResult) -> tuple[str, str]:
-    """Render Mermaid and text from the same validated, bounded graph."""
-    nodes: list[tuple[str, str, str]] = []
+class _Node(NamedTuple):
+    """One validated component, pre-rendered for every view that shows it."""
+
+    id: str  # the stable rendered id (n0, n1, …)
+    plain: str  # text view: label, technology, change marker
+    card: str  # flowchart card: the same, plus the description, escaped
+    short: str  # sequence participant: label plus change marker
+
+
+def _prepare_nodes(diagram: DiagramResult) -> tuple[list[_Node], dict[str, str]]:
+    """Validate and bound the model's components; map its ids onto stable ones."""
+    nodes: list[_Node] = []
     node_ids: dict[str, str] = {}
     for node in diagram.nodes:
         source_id = node.id.strip()
@@ -137,29 +167,36 @@ def _graph_views(diagram: DiagramResult) -> tuple[str, str]:
 
         rendered_id = f"n{len(nodes)}"
         marker = "" if node.change == "unchanged" else f"({node.change})"
-        plain = " ".join(part for part in (label, _single_line(node.technology), marker) if part)
-        mermaid_label = "<br/>".join(
-            html.escape(part, quote=True)
-            for part in (
-                label,
-                _single_line(node.technology),
-                _single_line(node.description),
-                marker,
-            )
-            if part
-        )
+        technology = _single_line(node.technology)
         node_ids[source_id] = rendered_id
-        nodes.append((rendered_id, plain, mermaid_label))
+        nodes.append(
+            _Node(
+                id=rendered_id,
+                plain=" ".join(part for part in (label, technology, marker) if part),
+                card="<br/>".join(
+                    html.escape(part, quote=True)
+                    for part in (label, technology, _single_line(node.description), marker)
+                    if part
+                ),
+                short=" ".join(part for part in (label, marker) if part),
+            )
+        )
         if len(nodes) == _MAX_NODES:
             break
+    return nodes, node_ids
 
+
+def _graph_views(
+    diagram: DiagramResult, nodes: list[_Node], node_ids: dict[str, str]
+) -> tuple[str, str]:
+    """Render Mermaid and text from the same validated, bounded graph."""
     if not nodes:
         return "", ""
 
     mermaid_lines = ["flowchart LR"]
-    mermaid_lines.extend(f'    {rendered_id}["{label}"]' for rendered_id, _, label in nodes)
+    mermaid_lines.extend(f'    {node.id}["{node.card}"]' for node in nodes)
 
-    plain_by_id = {rendered_id: plain for rendered_id, plain, _ in nodes}
+    plain_by_id = {node.id: node.plain for node in nodes}
     text_lines: list[str] = []
     referenced: set[str] = set()
     for edge in diagram.edges:
@@ -179,9 +216,56 @@ def _graph_views(diagram: DiagramResult) -> tuple[str, str]:
         text_lines.append(f"[{plain_by_id[source]}]{arrow}[{plain_by_id[target]}]")
         referenced.update((source, target))
 
-    text_lines.extend(
-        f"[{plain}]" for rendered_id, plain, _ in nodes if rendered_id not in referenced
+    text_lines.extend(f"[{node.plain}]" for node in nodes if node.id not in referenced)
+    return "\n".join(mermaid_lines), "\n".join(text_lines)
+
+
+# In a sequence diagram both participant aliases and message text run to the end
+# of the line, so Mermaid's own entity codes are the escape hatch.
+_SEQUENCE_ESCAPES = str.maketrans(
+    {"#": "#35;", ";": "#59;", "<": "#60;", ">": "#62;", '"': "#quot;"}
+)
+
+
+def _sequence_label(value: str) -> str:
+    """Make one line of model prose safe to sit in a sequence-diagram line."""
+    return _single_line(value).translate(_SEQUENCE_ESCAPES)
+
+
+def _sequence_views(
+    diagram: DiagramResult, nodes: list[_Node], node_ids: dict[str, str]
+) -> tuple[str, str]:
+    """Render the ordered run-time flow, or ("", "") when the PR has none."""
+    short_by_id = {node.id: node.short for node in nodes}
+    steps: list[tuple[str, str, str, bool]] = []
+    participants: list[str] = []
+    for step in diagram.steps:
+        source = node_ids.get(step.source.strip())
+        target = node_ids.get(step.target.strip())
+        if source is None or target is None:
+            continue
+
+        steps.append((source, target, _single_line(step.label), step.reply))
+        participants.extend(node for node in (source, target) if node not in participants)
+        if len(steps) == _MAX_STEPS:
+            break
+
+    if not steps:
+        return "", ""
+
+    mermaid_lines = ["sequenceDiagram"]
+    mermaid_lines.extend(
+        f"    participant {node} as {_sequence_label(short_by_id[node])}" for node in participants
     )
+    text_lines: list[str] = []
+    for index, (source, target, label, reply) in enumerate(steps, start=1):
+        arrow = "-->>" if reply else "->>"
+        mermaid_lines.append(f"    {source}{arrow}{target}: {_sequence_label(label) or '—'}")
+        text_arrow = "-->" if reply else "->"
+        suffix = f": {label}" if label else ""
+        text_lines.append(
+            f"{index}. [{short_by_id[source]}] {text_arrow} [{short_by_id[target]}]{suffix}"
+        )
     return "\n".join(mermaid_lines), "\n".join(text_lines)
 
 
@@ -189,18 +273,30 @@ def _fenced(body: str, lang: str = "") -> list[str]:
     return [f"```{lang}", body, "```"]
 
 
+def _view(mermaid: str, text: str) -> list[str]:
+    """One rendered diagram: the Mermaid fence, its link, and the text version."""
+    lines = [*_fenced(mermaid, "mermaid"), "", f"[⛶ Open full screen]({_fullscreen_url(mermaid)})"]
+    if text:
+        lines += ["", "<details><summary>Text version</summary>", ""]
+        lines += [*_fenced(text), "", "</details>"]
+    return lines
+
+
 def _render(diagram: DiagramResult) -> str:
     """Render a validated graph, or a legacy ASCII-only response."""
     title = _single_line(diagram.title) or "Architecture of this change"
     lines = [f"## {title}", ""]
-    mermaid, ascii_art = _graph_views(diagram)
+    nodes, node_ids = _prepare_nodes(diagram)
+    mermaid, ascii_art = _graph_views(diagram, nodes, node_ids)
+    sequence, sequence_text = _sequence_views(diagram, nodes, node_ids)
 
     if mermaid:
-        lines += _fenced(mermaid, "mermaid")
-        lines += ["", f"[⛶ Open full screen]({_fullscreen_url(mermaid)})"]
-        if ascii_art:
-            lines += ["", "<details><summary>Text version</summary>", ""]
-            lines += [*_fenced(ascii_art), "", "</details>"]
+        # Headings only earn their space when there are two views to tell apart.
+        if sequence:
+            lines += ["### Structure", ""]
+        lines += _view(mermaid, ascii_art)
+        if sequence:
+            lines += ["", "### Sequence", "", *_view(sequence, sequence_text)]
     elif diagram.ascii.strip():
         lines += _fenced(diagram.ascii.strip())
     else:

--- a/tests/engine/test_diagram.py
+++ b/tests/engine/test_diagram.py
@@ -93,6 +93,27 @@ def _graph_provider(**overrides: object) -> FakeProvider:
     )
 
 
+def _sequence_provider(**overrides: object) -> FakeProvider:
+    payload = {
+        "title": "Retry flow after this change",
+        "nodes": [
+            {"id": "client", "label": "Client", "change": "unchanged"},
+            {"id": "app", "label": "App", "technology": "Python", "change": "changed"},
+        ],
+        "edges": [{"source": "client", "target": "app", "label": "calls"}],
+        "steps": [
+            {"source": "client", "target": "app", "label": "POST /orders"},
+            {"source": "app", "target": "app", "label": "retries on 503"},
+            {"source": "app", "target": "client", "label": "201 Created", "reply": True},
+        ],
+        "notes": "",
+    }
+    payload.update(overrides)
+    return FakeProvider(
+        result=ProviderResult(text=json.dumps(payload), input_tokens=5, output_tokens=5)
+    )
+
+
 def test_parenthesized_change_marker_is_rendered_inside_a_quoted_node() -> None:
     body = build_diagram(_CTX, _CFG, _graph_provider())
 
@@ -272,6 +293,79 @@ def test_unparseable_output_uses_safe_fallback() -> None:
 
     assert "couldn't produce a valid change diagram" in body
     assert "Just prose" not in body
+
+
+def test_ordered_steps_render_a_sequence_diagram_beside_the_flowchart() -> None:
+    """Structure (what the change touches) and sequence (what happens, in what
+    order) are complementary, so both render in the one diagram comment."""
+    body = build_diagram(_CTX, _CFG, _sequence_provider())
+
+    assert "### Structure" in body
+    assert "### Sequence" in body
+    assert "```mermaid\nsequenceDiagram" in body
+    assert "    participant n0 as Client" in body
+    assert "    participant n1 as App (changed)" in body
+    assert "    n0->>n1: POST /orders" in body
+    assert "    n1->>n1: retries on 503" in body
+    assert "    n1-->>n0: 201 Created" in body
+
+
+def test_sequence_text_version_numbers_the_steps() -> None:
+    body = build_diagram(_CTX, _CFG, _sequence_provider())
+
+    assert "1. [Client] -> [App (changed)]: POST /orders" in body
+    assert "3. [App (changed)] --> [Client]: 201 Created" in body
+
+
+def test_no_sequence_section_without_steps() -> None:
+    """A change with no meaningful runtime flow keeps the flowchart-only body."""
+    body = build_diagram(_CTX, _CFG, _structured_provider())
+
+    assert "sequenceDiagram" not in body
+    assert "### Sequence" not in body
+    assert "### Structure" not in body
+
+
+def test_sequence_steps_are_capped_validated_and_escaped() -> None:
+    body = build_diagram(
+        _CTX,
+        _CFG,
+        _sequence_provider(
+            steps=[
+                {"source": "client", "target": "app", "label": 'issue #7 <b>"now"</b>; go'},
+                *[
+                    {"source": "app", "target": "client", "label": f"step {index}"}
+                    for index in range(9)
+                ],
+                {"source": "client", "target": "missing", "label": "dangling"},
+            ]
+        ),
+    )
+
+    assert "n0->>n1: issue #35;7 #60;b#62;#quot;now#quot;#60;/b#62;#59; go" in body
+    assert "step 6" in body
+    assert "step 7" not in body  # capped at eight steps
+    assert "dangling" not in body
+
+
+def test_sequence_diagram_gets_its_own_full_screen_link() -> None:
+    body = build_diagram(_CTX, _CFG, _sequence_provider())
+
+    sequence = body.split("```mermaid\nsequenceDiagram", 1)[1].split("\n```", 1)[0]
+    encoded = body.rsplit("#pako:", 1)[1].split(")", 1)[0]
+    state = json.loads(zlib.decompress(base64.urlsafe_b64decode(encoded)))
+    assert state["code"] == "sequenceDiagram" + sequence
+
+
+def test_prompt_asks_for_ordered_steps() -> None:
+    provider = _sequence_provider()
+
+    build_diagram(_CTX, _CFG, provider)
+
+    system = provider.calls[0]["messages"][0]["content"].lower()
+    assert '"steps"' in system
+    assert "at most eight steps" in system
+    assert "empty list" in system
 
 
 def test_diff_is_redacted_before_prompting() -> None:


### PR DESCRIPTION
## Why

The change diagram today draws structure: what components the PR touches and how they connect. That answers *"what does this change reach"* — but most pull requests are behavioural, and the question a reviewer actually has is *"what happens, in what order, and where did that change"*.

The two views are complementary, not competing:

| | Answers | Best on |
|---|---|---|
| **Flowchart** (structure) | What does this touch, and what talks to what? | A component added, a dependency introduced, a service split |
| **Sequence** | What happens at run time, in what order? | A retry added, an ordering fixed, a signal now handled |

A PR that fixes terminal restoration on `SIGTERM` touches two files and draws three boxes structurally, while its sequence — signal → flag set → loop exits → guard dropped → terminal restored — *is* the explanation of the fix. So lgtmaybe now draws both.

## What changed

- `DiagramResult` gains typed `steps` (`source`, `target`, `label`, `reply`), returned by the **same single** structured diagram call — no second model call, no second PR comment.
- `engine/diagram.py` renders the steps as a Mermaid `sequenceDiagram` beneath the flowchart, each view with its own text version and full-screen link, under `Structure` / `Sequence` headings.
- The sequence section — headings included — is **omitted entirely** when the model returns no steps, so a docs or config PR keeps exactly the body it has today (byte-identical; existing tests unchanged).
- Bounds and safety carried over from the flowchart path: steps referencing unknown components are dropped, the flow is capped at eight steps, participants reuse the six-component budget, and the model still never writes Mermaid — lgtmaybe renders the syntax from typed data.
- Sequence labels are escaped with Mermaid's own entity codes (`#`, `;`, `<`, `>`, `"`), because participant aliases and message text both run to end of line. Verified against `mermaid-cli`: `<b>"now"</b>; go` renders as literal text, not markup.

## Testing

- Six new tests in `tests/engine/test_diagram.py` (written first, red → green): sequence rendering beside the flowchart, self-calls, dashed replies, numbered text version, cap/validation/escaping, its own full-screen link, the omitted-when-no-steps case, and the prompt contract.
- Full suite: 1705 passed, 3 skipped. `ruff`, `mypy`, `openspec validate --specs`, and the anchor/docs-freshness gates all green.
- Rendered output checked end-to-end through `@mermaid-js/mermaid-cli` for both fences.

## Docs

`docs/how-to/generate-a-change-diagram.md` gains a worked sequence example and a "Structure and sequence" section explaining which view answers which question; homepage, README, tutorial, Action input table, `action.yml`, data-and-privacy, `ARCHITECTURE.md` and `CLAUDE.md` updated; `llms.txt` / `llms-full.txt` regenerated. New living-spec requirement **"Change diagrams show structure and sequence"** in `openspec/specs/cli-and-local/spec.md`, anchored to `_sequence_views`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_