### PR TITLE
test(diagram): cover the unlabelled sequence step

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -87,6 +87,11 @@ jobs:
           # more credits, or fewer max_tokens") — every lens fails and the review
           # posts nothing.
           model: deepseek/deepseek-v4-flash-0731
+          # This model tops out at a 16k output ceiling, and the default 100k
+          # input budget hands one call more diff than it can answer for: the
+          # response is cut off mid-JSON and the lens is lost (three of four on
+          # #309). Smaller batches keep each answer inside the ceiling.
+          max_input_tokens: 40000
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}
           github_identity: lgtmaybe

--- a/tests/engine/test_diagram.py
+++ b/tests/engine/test_diagram.py
@@ -348,6 +348,20 @@ def test_sequence_steps_are_capped_validated_and_escaped() -> None:
     assert "dangling" not in body
 
 
+def test_step_without_a_label_renders_an_em_dash_and_no_text_suffix() -> None:
+    """Mermaid needs a message after the colon, so an unlabelled step gets an
+    em-dash; the text view drops the suffix instead."""
+    body = build_diagram(
+        _CTX,
+        _CFG,
+        _sequence_provider(steps=[{"source": "client", "target": "app", "label": "   "}]),
+    )
+
+    assert "    n0->>n1: —" in body
+    assert "1. [Client] -> [App (changed)]" in body
+    assert "1. [Client] -> [App (changed)]:" not in body
+
+
 def test_sequence_diagram_gets_its_own_full_screen_link() -> None:
     body = build_diagram(_CTX, _CFG, _sequence_provider())
 


### PR DESCRIPTION
Follow-up to #309, addressing lgtmaybe's own review comment on that PR plus the truncation warning it posted alongside it.

## Test — unlabelled sequence step

`_sequence_views` has two branches for a step whose label is empty: the Mermaid line substitutes an em-dash (Mermaid needs a message after the colon, so `n0->>n1:` alone would be malformed) and the text view drops the `: label` suffix. Neither was covered, so a regression to a bare trailing colon would have shipped silently.

`test_step_without_a_label_renders_an_em_dash_and_no_text_suffix` drives a whitespace-only label — which also exercises `_single_line` stripping *into* the fallback rather than only the empty-string case.

## Dogfood workflow — cap the input budget

The dogfood review of #309 posted "⚠️ 3 of 4 review calls failed (ProviderTruncated: response truncated at the model's output limit after 16384 tokens)". `deepseek-v4-flash` tops out at a 16k output ceiling while the workflow was running the default 100k input budget, so a single call was handed more diff than it could answer for and the response was cut off mid-JSON — losing three lenses entirely.

`max_input_tokens: 40000` keeps each answer inside the ceiling. That is a mitigation, not the fix: the engine already knows how to halve an oversized batch and retry (`_review_split`), but that path is wired only to a wall-clock timeout — a blown output ceiling discards the lens instead. Automating it is a separate PR.

## Testing

`uv run pytest tests/engine/test_diagram.py -q` → 29 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_