### PR TITLE
fix(config): stop the dogfood cap starving a reasoning model

### DIFF
--- a/.lgtmaybe.yml
+++ b/.lgtmaybe.yml
@@ -14,9 +14,16 @@ exclude_paths:
 # The truncation is legible now (it names itself, and the findings it finished
 # emitting survive), but nothing bounded the cost of getting there.
 #
-# 16k is ~7x the largest output a healthy lens has produced here (2,261 tokens),
-# so an ordinary review — including a reasoning model's thinking tokens, which
-# come out of this same budget — never reaches it, while a runaway stops in
-# about a quarter of the time. It also shrinks the pre-flight reservation
-# OpenRouter charges against max_tokens before generating anything.
-max_tokens: 16384
+# 16k was ~7x the largest output a healthy lens had produced here (2,261 tokens),
+# and that turned out to be the wrong measure. Under a reasoning model the cap
+# also pays for thinking tokens, and this model spends most of it there: on #309
+# it truncated 3 of 4 lenses, and on #311 — a fifteen-line diff — it still
+# truncated 1 of 4 at the same 16,384. That is the starvation this comment
+# already warned about, observed: a cap sized to a plain model's findings
+# payload truncates every lens rather than only a runaway.
+#
+# 32k restores the thinking headroom while still bounding the runaway at half
+# the model's own 65,536 ceiling, so a lens that goes away still stops in half
+# the time instead of 21 minutes. It also keeps the pre-flight reservation
+# OpenRouter charges against max_tokens well under the full ceiling.
+max_tokens: 32768

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -169,12 +169,15 @@ def test_dogfood_workflow_uses_the_public_app_identity() -> None:
     assert "app_private_key" not in inputs
 
 
+# The cap that was observed to STARVE the reviewer rather than bound it: at
+# 16,384 a reasoning model spent the budget on thinking and truncated 3 of 4
+# lenses on one PR, and 1 of 4 on a fifteen-line diff — where input size cannot
+# be the cause. The floor is set from that failure, not from the findings
+# payload of a plain model, because `max_tokens` pays for thinking too.
+_STARVED_CAP = 16_384
 # The largest output any healthy lens has been observed to generate on the
 # dogfood review (artefacts, 2,261 tokens; security and code-health were under
-# 1,800). The floor below is several times this, because `max_tokens` also pays
-# for a reasoning model's thinking tokens — a cap sized to a plain model's
-# findings payload would starve one that thinks first, and every lens would
-# truncate instead of the runaway this guards against.
+# 1,800) — kept as the reason the floor is a multiple of it, not a sibling of it.
 _OBSERVED_HEALTHY_OUTPUT = 2_261
 # The ceiling deepseek-v4-pro ran to when a lens went away: 65,536 tokens and
 # 21 minutes for a single call, against ~5.5k for the other three combined.
@@ -182,22 +185,28 @@ _RUNAWAY_OUTPUT = 65_536
 
 
 def test_dogfood_config_caps_what_one_call_may_generate() -> None:
-    """A runaway generation is bounded, not just reported.
+    """A runaway generation is bounded, without starving an ordinary one.
 
-    Truncation is now legible (it names itself and its salvaged findings survive),
+    Truncation is legible (it names itself and its salvaged findings survive),
     but nothing stopped a lens burning a full output ceiling to get there. The cap
     is what makes that cost seconds instead of minutes — and on a prepaid route
     like OpenRouter it also shrinks the pre-flight reservation, which is charged
     against `max_tokens` before a single token is generated.
+
+    The floor is the other half of the bargain, and it is set from an observed
+    failure: at 16,384 this reasoning model truncated lenses on a fifteen-line
+    diff, spending the budget on thinking before it wrote findings. A cap that
+    low reports a problem it created.
     """
     config = yaml.safe_load((_REPO_ROOT / ".lgtmaybe.yml").read_text(encoding="utf-8"))
     cap = config.get("max_tokens")
 
     assert cap is not None, ".lgtmaybe.yml must cap max_tokens — see the reasoning above"
-    assert cap >= _OBSERVED_HEALTHY_OUTPUT * 3, (
-        f"max_tokens={cap} leaves too little headroom over the largest healthy lens "
-        f"({_OBSERVED_HEALTHY_OUTPUT} tokens) — a reasoning model spends this budget on "
-        "thinking too, and a starved cap truncates every lens rather than only a runaway"
+    assert cap > _STARVED_CAP, (
+        f"max_tokens={cap} is at or below the cap observed to starve a reasoning model "
+        f"({_STARVED_CAP} tokens truncated lenses on a fifteen-line diff) — this budget "
+        f"pays for thinking as well as the ~{_OBSERVED_HEALTHY_OUTPUT}-token findings "
+        "payload, so a starved cap truncates every lens rather than only a runaway"
     )
     assert cap < _RUNAWAY_OUTPUT, (
         f"max_tokens={cap} does not bound the runaway it exists to bound "


### PR DESCRIPTION
## The diagnosis was wrong, and the evidence says so

The truncation notices on #309 and #311 read "response truncated at the model's output limit after 16384 tokens". That number is **not** the model's limit — it is our own `.lgtmaybe.yml` `max_tokens: 16384`, set in #307 to bound a runaway lens, against `deepseek-v4-flash`'s real 65,536 ceiling.

My first response (#311) capped `max_input_tokens` in the dogfood workflow, on the theory that a call was being handed more diff than it could answer for. Then #311's own review — a **fifteen-line diff** — truncated 1 of 4 lenses at the same 16,384. Input size cannot explain that.

What explains it is in the config comment #307 already wrote:

> a cap sized to a plain model's findings payload would starve one that thinks first — truncating every lens instead of only the runaway

That is exactly what happened. `max_tokens` pays for a reasoning model's thinking tokens as well as its findings, and this model spends most of the budget there before it writes any JSON. 16k was sized from the largest healthy *payload* (2,261 tokens); it was never sized for the thinking in front of it.

Observed: #309 lost 3 of 4 lenses, #311 lost 1 of 4.

## The change

- `max_tokens: 16384` → `32768`. Still bounds the runaway this cap exists for — at half the model's own ceiling, a lens that goes away costs half the time rather than the 21 minutes that prompted #307 — and the OpenRouter pre-flight reservation stays well under the full ceiling.
- The guard in `tests/test_workflow_examples.py` now derives its floor from the **observed failure** (`_STARVED_CAP = 16_384`) instead of from a plain model's payload, so the next retune has to argue with the evidence rather than redo the arithmetic that produced the starvation.

`max_input_tokens: 40000` from #311 stays. Smaller batches genuinely mean less to think about as well as less to write about — it just was not the binding constraint.

## What this does not fix

The engine already knows how to halve an oversized batch and retry (`_review_split`), but that path is wired only to a wall-clock timeout — a blown output ceiling discards the lens instead of splitting it. A separate PR automates that, and it matters more now that we know a truncation can be reasoning-bound rather than input-bound: splitting reduces the demand but cannot be assumed to clear it, so the terminal message has to name `max_tokens` as the lever.

## Testing

`uv run pytest -q` → 1706 passed, 3 skipped. `ruff check` / `ruff format --check` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_