### PR TITLE
feat(github): show the lens and confidence on posted findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,12 @@ autocrlf before checkout.
   bedrock, vertex, azure, ollama to one `completion()` call. A thin wrapper on
   top adds retries / fallback.
 - **License:** MIT (already in `LICENSE`).
-- **Posting:** REST review API — batched inline comments + one summary.
+- **Posting:** REST review API — batched inline comments + one summary. Every
+  posted finding's title line carries its provenance inside the severity
+  brackets — `**[HIGH · security · 8/10] Title**`, the originating lens and the
+  reflection auditor's confidence (`rest_gateway._finding_badge`, each half
+  omitted when absent; inline, demoted, and broad render it identically). It is
+  visible prose only — never part of the hidden ids below.
   Idempotent updates via a hidden marker comment (which also carries the
   last-reviewed-SHA watermark driving incremental review). Each inline comment also carries
   **two** hidden per-finding ids: `finding_fingerprint(path, title)` — which keys

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -347,6 +347,33 @@ can commit straight from the PR:
 The summary carries a hidden marker (`<!-- lgtmaybe -->`), so re-running on the
 same PR **updates** the existing review instead of creating duplicates.
 
+#### Reading the title line
+
+A comment's title line carries the finding's provenance in its brackets:
+
+```
+**[HIGH · security · 8/10] User input is concatenated into the SQL string**
+```
+
+- **`HIGH`** — the severity.
+- **`security`** — the lens that raised it. One of the nine review categories
+  (or your own id if you added a [custom lens](../how-to/add-a-custom-lens.md)),
+  and the same value you match on in `finding_rules` — so a badge you keep seeing
+  and don't want tells you exactly what rule to write.
+- **`8/10`** — the self-reflection auditor's confidence that the finding is real,
+  reached by actively trying to disprove it. Set the `min_confidence` floor to
+  drop everything below a score you choose.
+
+Each half drops away when it isn't there: with `reflect: false` there is no score
+and the badge is just the lens.
+
+One asymmetry worth knowing: GitHub's review API can't edit an inline comment
+once it's posted, so an inline comment's score is **frozen at first post** — a
+later run that judges the same finding differently won't change it. Findings in
+the summary body (the "Additional findings" and "Broader observations" sections)
+are rewritten on every run, so those badges do track. That's how severity and
+title have always behaved too; the badge just makes it visible.
+
 ### Resolving conversations once they're fixed
 
 Each inline comment also carries a hidden per-finding fingerprint. When you push

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -335,9 +335,12 @@ During reflection the auditor also scores each kept finding's confidence from
 0 (certainly a false positive) to 10 (certain it is real), reached by actively
 trying to disprove the finding against the diff and the file text. Findings
 scored **below** `min_confidence` are dropped before posting; the surviving
-score is shown in the CLI output and the JSON export. A finding the auditor
-keeps but doesn't score always survives the threshold — a missing score never
-drops a real finding. CLI: `--min-confidence`.
+score is shown in the CLI output, the JSON export, and on the posted GitHub
+comment itself — `**[HIGH · security · 8/10] Title**`, alongside the lens that
+raised it. A finding the auditor keeps but doesn't score always survives the
+threshold — a missing score never drops a real finding, and the comment simply
+omits that half of the badge (as it does for every finding when `reflect:
+false`). CLI: `--min-confidence`.
 
 ```yaml
 min_confidence: 5   # drop findings the auditor scores 0-4

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2425,9 +2425,12 @@ During reflection the auditor also scores each kept finding's confidence from
 0 (certainly a false positive) to 10 (certain it is real), reached by actively
 trying to disprove the finding against the diff and the file text. Findings
 scored **below** `min_confidence` are dropped before posting; the surviving
-score is shown in the CLI output and the JSON export. A finding the auditor
-keeps but doesn't score always survives the threshold — a missing score never
-drops a real finding. CLI: `--min-confidence`.
+score is shown in the CLI output, the JSON export, and on the posted GitHub
+comment itself — `**[HIGH · security · 8/10] Title**`, alongside the lens that
+raised it. A finding the auditor keeps but doesn't score always survives the
+threshold — a missing score never drops a real finding, and the comment simply
+omits that half of the badge (as it does for every finding when `reflect:
+false`). CLI: `--min-confidence`.
 
 ```yaml
 min_confidence: 5   # drop findings the auditor scores 0-4
@@ -5135,6 +5138,33 @@ can commit straight from the PR:
 
 The summary carries a hidden marker (`<!-- lgtmaybe -->`), so re-running on the
 same PR **updates** the existing review instead of creating duplicates.
+
+#### Reading the title line
+
+A comment's title line carries the finding's provenance in its brackets:
+
+```
+**[HIGH · security · 8/10] User input is concatenated into the SQL string**
+```
+
+- **`HIGH`** — the severity.
+- **`security`** — the lens that raised it. One of the nine review categories
+  (or your own id if you added a [custom lens](../how-to/add-a-custom-lens.md)),
+  and the same value you match on in `finding_rules` — so a badge you keep seeing
+  and don't want tells you exactly what rule to write.
+- **`8/10`** — the self-reflection auditor's confidence that the finding is real,
+  reached by actively trying to disprove it. Set the `min_confidence` floor to
+  drop everything below a score you choose.
+
+Each half drops away when it isn't there: with `reflect: false` there is no score
+and the badge is just the lens.
+
+One asymmetry worth knowing: GitHub's review API can't edit an inline comment
+once it's posted, so an inline comment's score is **frozen at first post** — a
+later run that judges the same finding differently won't change it. Findings in
+the summary body (the "Additional findings" and "Broader observations" sections)
+are rewritten on every run, so those badges do track. That's how severity and
+title have always behaved too; the badge just makes it visible.
 
 ### Resolving conversations once they're fixed
 

--- a/openspec/changes/show-finding-lens-and-confidence/.openspec.yaml
+++ b/openspec/changes/show-finding-lens-and-confidence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/show-finding-lens-and-confidence/README.md
+++ b/openspec/changes/show-finding-lens-and-confidence/README.md
@@ -1,0 +1,5 @@
+# show-finding-lens-and-confidence
+
+Show the lens that raised a finding and the reflection auditor's confidence on
+every posted GitHub comment — values the engine already computes and only the
+CLI ever displayed.

--- a/openspec/changes/show-finding-lens-and-confidence/design.md
+++ b/openspec/changes/show-finding-lens-and-confidence/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`ReviewFinding` reaches the GitHub adapter carrying two engine-derived signals
+the adapter ignores:
+
+- `category` — the id of the lens whose call produced the finding, overwritten
+  by `engine._stamp_categories` so the model cannot claim it. Already drives the
+  `possible-security-issue` label and category-matched `finding_rules`.
+- `confidence` — the reflection auditor's 0-10 score for "is this real", never
+  self-reported by the reviewing model. Already gates `min_confidence` and
+  already prints in `lgtmaybe review` output.
+
+The GitHub title line is `**[SEVERITY] Title**` and has been since the adapter
+was written. The hidden ids that make re-runs idempotent live *below* the visible
+prose: `finding_fingerprint(path, title)` and `finding_identity(finding)` are
+both computed from the finding's fields, and `_finding_keys` recovers them by
+regexing the marker comments out of a posted body. Nothing in that machinery
+reads the title line.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Show the originating lens and the auditor's confidence on every posted
+  finding, on all three surfaces, so the three read the same.
+- Change nothing about dedupe, resolve-on-fix, or idempotent updates — including
+  for comments posted before this change.
+- Render nothing empty when a value is absent.
+
+**Non-Goals:**
+
+- A config knob to turn the badge off (see the proposal — `reflect: false` is
+  already the opt-out for the noisy half).
+- A PR-level confidence score in the summary line.
+- Changing the frozen `confidence` scale to Greptile's `n/5`.
+- Backfilling badges onto comments already posted (see the asymmetry below).
+
+## Decisions
+
+**Inside the severity brackets, separated by `·`.** The title line already opens
+with a bracketed metadata group, so `**[HIGH · security · 8/10] Title**` extends
+a shape the reader has already parsed rather than adding a second one. The
+alternatives were a trailing suffix (`**[HIGH] Title** · security · 8/10`),
+which competes with the title for the eye and wraps awkwardly on a narrow diff
+view, and Markdown badge images, which are an external fetch a CSP-ish corporate
+proxy may not serve and which look like ornament. A middle dot rather than a
+pipe or slash: it separates without reading as a delimiter, and it survives
+GitHub's Markdown untouched.
+
+**Ordering: severity, lens, confidence.** Severity is what a reader triages on
+and stays leftmost, unmoved. The lens explains *why this was looked for*, the
+score *how much to trust it* — so provenance precedes credence, and the two
+optional fields fall off the right end as they become absent, keeping the
+line's left edge stable.
+
+**A badge requires a category.** Confidence without a category cannot occur in
+the pipeline (every lens stamps one), and a lone `· 8/10` would read as a score
+attached to nothing. Requiring the category keeps the helper's output to three
+shapes and makes "no badge at all" exactly the legacy rendering.
+
+**`0` renders.** `confidence` is `int | None`; the check is `is None`, not
+truthiness. A 0/10 verdict on a finding that survived `min_confidence: 0` is a
+real and useful warning, and the falsy-vs-None trap is the obvious bug here, so
+it has its own test.
+
+**The category is defanged.** It is trusted config (a built-in `ReviewCategory`
+value, a `scan:<tool>` id, or a `CustomLens.id` from `.lgtmaybe.yml`), not model
+prose — but it now reaches rendered Markdown, and running it through the same
+`_defang_fences` as the title costs one call and removes the question.
+
+## Risks / Trade-offs
+
+**A badged title line could break dedupe.** It cannot: both ids are computed
+from fields, and `_finding_keys` reads only the marker comments. The risk worth
+guarding is the *upgrade* case — a comment posted by an older version has an
+unbadged title, and if matching read the visible prose the first post-upgrade
+run would re-post every finding on every open PR. A test pins that a pre-badge
+body still suppresses its re-post.
+
+**Confidence on an inline comment is frozen at first post.** The review-update
+endpoint cannot edit inline comments, so a comment posted at 8/10 keeps that
+badge even if a later run scores the same finding differently. Demoted and broad
+findings live in the review body, which *is* rewritten in place, so their badges
+do track. This asymmetry is pre-existing — it applies to the title and severity
+today — so it is documented rather than fixed here.
+
+## Migration Plan
+
+None. The change is additive to rendered prose; findings without a category are
+unchanged, and existing comments keep working.
+
+## Open Questions
+
+None.

--- a/openspec/changes/show-finding-lens-and-confidence/proposal.md
+++ b/openspec/changes/show-finding-lens-and-confidence/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+A reader of a posted lgtmaybe comment cannot tell which lens raised it or how
+sure the reviewer was. Both answers already exist on the finding by the time it
+is posted — `category` is stamped by `engine._stamp_categories` (the originating
+lens) and `confidence` is the reflection auditor's 0-10 score — and both already
+render in the local CLI (`cli/render.py`). Only the GitHub surface drops them,
+so the one place most reviews are actually read is the least informative.
+
+Competing reviewers surface exactly these two signals: Greptile puts a `3/5`
+confidence on each comment, CodeRabbit a category badge. Neither costs us a new
+model call or a new field; the values are computed today and thrown away at the
+boundary.
+
+## What Changes
+
+- Add `_finding_badge(f)` in `github/rest_gateway.py`, returning the provenance
+  suffix for a finding's title line: `""`, `" · security"`, or
+  `" · security · 8/10"`.
+- Render it inside the existing severity brackets on all three posting surfaces
+  — the inline comment title, `_render_demoted`, and `_render_broad` — so the
+  three agree.
+- Omit each half when its value is absent, so a `--no-reflect` run or a
+  deterministic static-analysis finding never renders an empty field, and an
+  uncategorised (legacy) finding renders byte-for-byte as it does today.
+
+Explicitly **not** in scope:
+
+- **No config knob.** `reflect: false` already suppresses the confidence half,
+  and `category` is one word that also keys `finding_rules` — surfacing it
+  teaches users what to write rules against. A flag would cost a model field, a
+  CLI option, an Action input, env plumbing, and a generated-reference
+  regeneration for a nine-character suffix.
+- **No PR-level confidence score.** `summary_template` is user-customisable; a
+  new placeholder would silently change templates teams already wrote.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-posting`: A posted finding names the lens that raised it and the
+  auditor's confidence in its title line, on every posting surface, without
+  touching the hidden ids that key dedupe.
+
+## Impact
+
+Every inline comment, demoted finding, and broad observation gains up to nine
+characters in its title line. Nothing else moves: the hidden fingerprint and
+identity markers are computed from the finding's fields, not its rendering, so
+re-run dedupe, resolve-on-fix marker rewriting, and idempotent updates are
+unaffected — including for comments posted before this change, which continue
+to suppress their re-post on the first run after upgrade.

--- a/openspec/changes/show-finding-lens-and-confidence/specs/github-posting/spec.md
+++ b/openspec/changes/show-finding-lens-and-confidence/specs/github-posting/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: A posted finding names its lens and confidence
+
+Every posted finding SHALL carry the lens that raised it and the reflection
+auditor's confidence in its title line, so a GitHub reader can weigh it without
+leaving the PR. Both halves are omitted when absent — no category renders no
+badge at all, and no score renders the lens alone — and the badge is visible
+prose only, never part of the hidden fingerprint/identity markers that key
+re-run dedupe and resolve-on-fix. Inline, demoted, and broad findings SHALL
+render it identically.
+
+#### Scenario: a scored finding from a lens
+- **WHEN** a finding carries a category and a confidence score
+- **THEN** its title line reads `**[HIGH · security · 8/10] Title**`
+
+#### Scenario: reflection is off
+- **WHEN** a finding has a category but no score
+- **THEN** the confidence half is omitted rather than rendered empty
+
+#### Scenario: a comment posted before badges existed
+- **WHEN** a re-run reports a finding already posted with an unbadged title
+- **THEN** it is still recognised and not posted again

--- a/openspec/changes/show-finding-lens-and-confidence/tasks.md
+++ b/openspec/changes/show-finding-lens-and-confidence/tasks.md
@@ -1,0 +1,35 @@
+## 1. Acceptance Tests
+
+- [x] 1.1 Add a failing test that an inline comment's title line renders
+  `**[MEDIUM · security · 8/10] Title**`.
+- [x] 1.2 Add failing tests that the confidence half is omitted when unscored,
+  and that `0` still renders (the falsy-vs-None trap).
+- [x] 1.3 Add a test that an uncategorised finding's body is byte-identical to
+  the pre-badge rendering.
+- [x] 1.4 Add failing tests that demoted and broad findings carry the same badge.
+- [x] 1.5 Add tests that the hidden fingerprint/identity markers are byte-identical
+  with and without a badge, and that a comment posted before badges existed still
+  dedupes (no re-post storm on the first run after upgrade).
+
+## 2. Rendering
+
+- [x] 2.1 Add `_finding_badge(f)` returning `""` / `" · <lens>"` /
+  `" · <lens> · <n>/10"`, defanging the lens id.
+- [x] 2.2 Render it inside the severity brackets on the inline comment title,
+  `_render_demoted`, and `_render_broad`.
+
+## 3. Specs & Docs
+
+- [x] 3.1 Add the `github.finding-badge` requirement to
+  `openspec/specs/github-posting/spec.md` and its ast-grep rule to `anchors.yml`.
+- [x] 3.2 Document what a posted comment looks like in
+  `docs/explanation/what-gets-reviewed.md`, including that an inline comment's
+  badge is frozen at first post while the body's is rewritten each run.
+- [x] 3.3 Note the badge beside `min_confidence` in
+  `docs/how-to/configure-lgtmaybe-yml.md`, then regenerate `llms.txt`.
+
+## 4. Verification
+
+- [x] 4.1 Run the gateway posting suite.
+- [x] 4.2 Run the full gate: pytest, ruff format/check, mypy, spec tests, and
+  `openspec validate --specs`.

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -36,6 +36,12 @@ github.demote:
     has: { field: name, regex: '^_render_demoted$' }
   files: [src/lgtmaybe/github/**/*.py]
 
+github.finding-badge:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_finding_badge$' }
+  files: [src/lgtmaybe/github/**/*.py]
+
 github.incremental:
   - rule:
       kind: function_definition

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -74,6 +74,29 @@ floors what is worth demoting.
 - **WHEN** a finding's line is a guess
 - **THEN** it appears in the review body, not as an inline comment
 
+### Requirement: A posted finding names its lens and confidence
+
+Every posted finding SHALL carry the lens that raised it and the reflection
+auditor's confidence in its title line, so a GitHub reader can weigh it without
+leaving the PR. Both halves are omitted when absent — no category renders no
+badge at all, and no score renders the lens alone — and the badge is visible
+prose only, never part of the hidden fingerprint/identity markers that key
+re-run dedupe and resolve-on-fix. Inline, demoted, and broad findings SHALL
+render it identically.
+<!-- anchor: github.finding-badge -->
+
+#### Scenario: a scored finding from a lens
+- **WHEN** a finding carries a category and a confidence score
+- **THEN** its title line reads `**[HIGH · security · 8/10] Title**`
+
+#### Scenario: reflection is off
+- **WHEN** a finding has a category but no score
+- **THEN** the confidence half is omitted rather than rendered empty
+
+#### Scenario: a comment posted before badges existed
+- **WHEN** a re-run reports a finding already posted with an unbadged title
+- **THEN** it is still recognised and not posted again
+
 ### Requirement: Incremental review is commit-scoped and safe
 
 A re-run with a watermark SHALL review only the compare-API diff since the

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -172,6 +172,30 @@ def _defang_fences(text: str) -> str:
     return text.replace("```", f"`{_ZWSP}`{_ZWSP}`")
 
 
+def _finding_badge(f: ReviewFinding) -> str:
+    """The provenance suffix for a finding's title line: lens, then confidence.
+
+    Both values are already computed and already shown by the local CLI — the
+    lens the engine stamped (``category``) and the 0-10 score the reflection
+    auditor gave it (``confidence``) — but a GitHub reader could never see them.
+    They answer the two questions a reviewer asks of a bot comment: which pass
+    raised this, and how sure was it. Rendered inside the existing severity
+    brackets (``**[HIGH · security · 8/10] Title**``) so the title line gains no
+    new visual furniture, and appended by the caller so it can never displace the
+    hidden fingerprint/identity markers that key re-run dedupe.
+
+    Each half is omitted when absent, so nothing renders empty: no category (a
+    legacy finding) means no badge at all — byte-identical to the pre-badge
+    rendering — and no score (``--no-reflect``, or a deterministic
+    static-analysis finding) means just the lens. A ``0`` is a real verdict, not
+    a missing one, so it renders.
+    """
+    if not f.category:
+        return ""
+    badge = f" · {_defang_fences(f.category)}"
+    return badge if f.confidence is None else f"{badge} · {f.confidence}/10"
+
+
 def _render_demoted(demoted: list[ReviewFinding]) -> str:
     """Render findings that couldn't be confidently placed inline as a body section.
 
@@ -191,7 +215,7 @@ def _render_demoted(demoted: list[ReviewFinding]) -> str:
     ]
     for f in demoted:
         lines.append(
-            f"- **[{f.severity.upper()}] {_defang_fences(f.title)}** "
+            f"- **[{f.severity.upper()}{_finding_badge(f)}] {_defang_fences(f.title)}** "
             f"(`{f.path}`) — {_defang_fences(f.body)}"
         )
     return "\n".join(lines)
@@ -219,7 +243,7 @@ def _render_broad(broad: list[ReviewFinding]) -> str:
     ]
     for f in broad:
         lines.append(
-            f"- **[{f.severity.upper()}] {_defang_fences(f.title)}** "
+            f"- **[{f.severity.upper()}{_finding_badge(f)}] {_defang_fences(f.title)}** "
             f"(`{f.path}`) — {_defang_fences(f.body)}"
         )
     lines += ["", "</details>"]
@@ -1358,7 +1382,8 @@ class RestGitHubGateway(GitHubGateway):
                 "path": f.path,
                 "line": f.line,
                 "side": f.side,
-                "body": f"**[{f.severity.upper()}] {_defang_fences(f.title)}**"
+                "body": f"**[{f.severity.upper()}{_finding_badge(f)}] "
+                f"{_defang_fences(f.title)}**"
                 f"\n\n{_defang_fences(f.body)}",
             }
             if f.suggestion is not None:

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -10,7 +10,12 @@ import respx
 
 from lgtmaybe.core.models import ReviewFinding, Severity
 from lgtmaybe.github import RestGitHubGateway
-from lgtmaybe.github.rest_gateway import _RESOLVE_WORKERS, finding_fingerprint
+from lgtmaybe.github.rest_gateway import (
+    _RESOLVE_WORKERS,
+    _finding_keys,
+    finding_fingerprint,
+    finding_identity,
+)
 
 REPO = "owner/repo"
 PR_NUMBER = 42
@@ -1359,3 +1364,183 @@ def test_open_finding_threads_follows_pagination() -> None:
 
     assert gw.count_open_finding_threads() == 3  # 2 on page one, 1 on page two
     assert seen_cursors == [None, "page-2"], "the endCursor was not carried into page two"
+
+
+# ---------------------------------------------------------------------------
+# Finding badge: the originating lens + the auditor's confidence
+# ---------------------------------------------------------------------------
+
+
+def _capture_created_review() -> list[dict[object, object]]:
+    """Route a first-run review POST and collect the payloads it is called with."""
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=[]))
+    created: list[dict[object, object]] = []
+
+    def capture_create(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        created.append(body)
+        return httpx.Response(201, json={"id": 1, "body": body.get("body", "")})
+
+    respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+    return created
+
+
+def _badged(**overrides: object) -> ReviewFinding:
+    """The FINDINGS entry, plus the two values a badge renders."""
+    fields: dict[str, object] = {
+        "path": "src/app.py",
+        "line": 2,
+        "side": "RIGHT",
+        "severity": Severity.medium,
+        "title": "Import order",
+        "body": "sys should be before os",
+        "category": "security",
+        "confidence": 8,
+    }
+    fields.update(overrides)
+    return ReviewFinding.model_validate(fields)
+
+
+@respx.mock
+def test_inline_comment_title_carries_lens_and_confidence() -> None:
+    """The inline comment's title line names the lens that raised the finding and
+    the auditor's confidence, so a reader can weigh it without leaving GitHub."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([_badged()], "Summary text", diff=SAMPLE_DIFF)
+
+    body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+    assert body.startswith("**[MEDIUM · security · 8/10] Import order**")
+
+
+@respx.mock
+def test_inline_comment_badge_omits_confidence_when_unscored() -> None:
+    """With reflection off (or the auditor silent) there is no score, so the
+    confidence half is omitted rather than rendered empty."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([_badged(confidence=None)], "Summary text", diff=SAMPLE_DIFF)
+
+    body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+    assert body.startswith("**[MEDIUM · security] Import order**")
+    assert "/10" not in body
+
+
+@respx.mock
+def test_inline_comment_badge_renders_a_zero_score() -> None:
+    """0/10 is a real verdict, not a missing one — it must still render (the
+    falsy-vs-None trap)."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([_badged(confidence=0)], "Summary text", diff=SAMPLE_DIFF)
+
+    body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+    assert body.startswith("**[MEDIUM · security · 0/10] Import order**")
+
+
+@respx.mock
+def test_inline_comment_has_no_badge_without_a_category() -> None:
+    """An uncategorised finding renders byte-for-byte as it did before badges."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "Summary text", diff=SAMPLE_DIFF)
+
+    fp = finding_fingerprint("src/app.py", "Import order")
+    identity = finding_identity(FINDINGS[0])
+    body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+    assert body == (
+        "**[MEDIUM] Import order**\n\nsys should be before os\n\n"
+        f"<!-- lgtmaybe-finding:{fp} -->\n<!-- lgtmaybe-identity:{identity} -->"
+    )
+
+
+@respx.mock
+def test_demoted_finding_carries_the_badge() -> None:
+    """A finding demoted to the review body shows the same badge as an inline one,
+    so the two surfaces agree."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([_badged(anchored=False)], "Summary text", diff=SAMPLE_DIFF)
+
+    rendered = str(created[0].get("body", ""))
+    assert "### Additional findings" in rendered
+    assert "**[MEDIUM · security · 8/10] Import order**" in rendered
+
+
+@respx.mock
+def test_broad_finding_carries_the_badge() -> None:
+    """A broad finding collapsed into "Broader observations" carries it too."""
+    created = _capture_created_review()
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([_badged(broad=True)], "Summary text", diff=SAMPLE_DIFF)
+
+    rendered = str(created[0].get("body", ""))
+    assert "Broader observations" in rendered
+    assert "**[MEDIUM · security · 8/10] Import order**" in rendered
+
+
+@respx.mock
+def test_badge_leaves_the_hidden_markers_byte_identical() -> None:
+    """The badge lives in the visible title line only. The hidden fingerprint and
+    identity markers — which key re-run dedupe and resolve-on-fix — are computed
+    from the finding's fields, so a score appearing (or not) never moves them."""
+    created = _capture_created_review()
+
+    scored, unscored = _badged(), _badged(confidence=None)
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review([scored], "Summary text", diff=SAMPLE_DIFF)
+    scored_body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+
+    created.clear()
+    gw.post_review([unscored], "Summary text", diff=SAMPLE_DIFF)
+    unscored_body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
+
+    assert "· security · 8/10" in scored_body
+    assert "8/10" not in unscored_body
+    marker_tail = scored_body[scored_body.index("\n\n<!-- lgtmaybe-finding:") :]
+    assert marker_tail == unscored_body[unscored_body.index("\n\n<!-- lgtmaybe-finding:") :]
+    # And they are exactly the ids derived from the finding — no badge text leaks in.
+    assert _finding_keys(scored_body) == {
+        finding_fingerprint(scored.path, scored.title),
+        finding_identity(scored),
+    }
+
+
+@respx.mock
+def test_pre_badge_comment_still_dedupes_against_a_badged_finding() -> None:
+    """A comment posted before badges existed (an unbadged title line) is still
+    recognised on the next run, so upgrading causes no re-post storm."""
+    _mark_existing_review()
+    respx.route(method="POST", url=GRAPHQL_URL).mock(
+        side_effect=_GraphQL([])  # no prior threads to resolve
+    )
+
+    finding = _badged()
+    # Exactly the body run 1 posted before this change: no badge in the title.
+    legacy_body = (
+        "**[MEDIUM] Import order**\n\nsys should be before os\n\n"
+        f"<!-- lgtmaybe-finding:{finding_fingerprint(finding.path, finding.title)} -->\n"
+        f"<!-- lgtmaybe-identity:{finding_identity(finding)} -->"
+    )
+    respx.route(method="GET", url__startswith=f"{PR_URL}/comments").mock(
+        return_value=httpx.Response(200, json=[{"id": 1, "body": legacy_body}])
+    )
+    posted: list[httpx.Request] = []
+
+    def capture_post(request: httpx.Request) -> httpx.Response:
+        posted.append(request)
+        return httpx.Response(201, json={"id": 2})
+
+    respx.route(method="POST", url=f"{PR_URL}/comments").mock(side_effect=capture_post)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.mark_reviewed("deadbee")
+    gw.post_review([finding], "New summary", diff=SAMPLE_DIFF)
+
+    assert posted == [], "a pre-badge comment must still suppress its re-post"


### PR DESCRIPTION
## Why

Two signals already exist on every finding by the time it's posted, and both are already computed — they just never reach GitHub:

- `ReviewFinding.category` — the originating lens, stamped by `engine._stamp_categories`.
- `ReviewFinding.confidence` — the reflection auditor's 0–10 score.

Both render in the local CLI (`cli/render.py`). The GitHub comment — the one place most reviews are actually read — showed only `**[SEVERITY] Title**`. Greptile puts a `3/5` on each comment and CodeRabbit a category badge; this is parity with values we already have, at zero extra model cost.

## The rendered format

Inside the existing severity brackets, middle-dot separated:

```
**[HIGH · security · 8/10] User input is concatenated into the SQL string**
```

Why this shape:

- **Inside the brackets, not trailing.** The title line already opens with a bracketed metadata group, so this extends a shape the reader has parsed rather than adding a second one. A trailing suffix (`**[HIGH] Title** · security · 8/10`) competes with the title for the eye and wraps badly in a narrow diff view. Markdown badge images were rejected too — an external fetch, and they read as ornament.
- **Severity, then lens, then confidence.** Severity is what you triage on and stays leftmost, unmoved. The lens says *why this was looked for*, the score *how much to trust it* — provenance before credence. The two optional fields fall off the right end as they become absent, so the line's left edge is stable.
- **`·` rather than `|` or `/`.** Separates without reading as a delimiter, and survives GitHub's Markdown untouched.

One new private helper, `_finding_badge(f) -> str`, returning `""` / `" · security"` / `" · security · 8/10"`, used on all three posting surfaces (inline title, `_render_demoted`, `_render_broad`) so they agree.

## Correctness

- **Dedupe is untouched.** `finding_fingerprint` and `finding_identity` are computed from the finding's *fields*; `_finding_keys` recovers them by regexing the marker comments. Nothing reads the title line. The case worth guarding is the *upgrade*: a comment posted by an older version has an unbadged title, and if matching read visible prose, the first post-upgrade run would re-post every finding on every open PR. Pinned by test.
- **Each half omits when absent.** No category → no badge at all, byte-identical to today (asserted against the full expected body, markers included). No score (`--no-reflect`, or a deterministic static-analysis finding) → just the lens.
- **`0` renders.** `confidence` is `int | None` and the check is `is None`, not truthiness — 0/10 is a real verdict. Own test, because that's the obvious bug here.
- **The lens id is defanged.** It's trusted config, but it now reaches rendered Markdown, so it goes through the same `_defang_fences` as the title.

## Deliberately not included

- **No config knob.** `reflect: false` is already the opt-out for the noisy half, and `category` is one word that also keys `finding_rules` — surfacing it teaches users what to write rules against. A flag would cost a model field, a CLI option, an Action input, env plumbing, and a generated-reference regen, for a nine-character suffix.
- **No PR-level confidence score.** `summary_template` is user-customisable; a new placeholder would silently change templates teams already wrote.

## Known asymmetry (documented, not fixed)

GitHub's review API can't edit an inline comment once posted, so an inline badge is **frozen at first post**. Demoted and broad findings live in the review body, which *is* rewritten each run, so those badges track. This is pre-existing — severity and title behave the same way — so it's written up in `docs/explanation/what-gets-reviewed.md` rather than addressed here.

## Tests (red first)

Added to `tests/github/test_post_review.py`:

| Test | Pins |
|---|---|
| `test_inline_comment_title_carries_lens_and_confidence` | `**[MEDIUM · security · 8/10] …` |
| `test_inline_comment_badge_omits_confidence_when_unscored` | lens alone, no `/10` |
| `test_inline_comment_badge_renders_a_zero_score` | `0/10` renders (falsy-vs-None) |
| `test_inline_comment_has_no_badge_without_a_category` | body byte-identical to pre-badge |
| `test_demoted_finding_carries_the_badge` | "Additional findings" agrees |
| `test_broad_finding_carries_the_badge` | "Broader observations" agrees |
| `test_badge_leaves_the_hidden_markers_byte_identical` | marker tail unchanged by a score; ids are the field-derived ones |
| `test_pre_badge_comment_still_dedupes_against_a_badged_finding` | no re-post storm on upgrade |

Six failed before the change; the two regression guards (`…no_badge_without_a_category`, `…pre_badge_comment_still_dedupes…`) passed before and after, which is the point of them.

## Gate

`uv run pytest -q` (1713 passed, 3 skipped) · `ruff format --check` · `ruff check` · `mypy src` · `pytest tests/specs -q` · `openspec validate --specs` · `scripts/check_spec_drift.py` (no drift) — all green.

## Also in this PR

- OpenSpec change `openspec/changes/show-finding-lens-and-confidence/` (proposal, design, tasks, delta spec).
- Living spec: new `github.finding-badge` requirement in `openspec/specs/github-posting/spec.md`, placed after the demote requirement, with its ast-grep rule in `anchors.yml` (exactly one match).
- Docs: a "Reading the title line" section in `docs/explanation/what-gets-reviewed.md`, a note beside `min_confidence` in `docs/how-to/configure-lgtmaybe-yml.md`, and a regenerated `llms.txt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_