### PR TITLE
fix(engine): split and retry when a call blows the output ceiling

### DIFF
--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -43,6 +43,17 @@ Two built-in caps also keep any single run modest regardless of who starts it:
 `max_files` (default 50) and `max_input_tokens` (default 100k). See
 [What gets reviewed](what-gets-reviewed.md) for how the diff is bounded.
 
+When a run does bump into a cap, it **degrades rather than fails**. A review call
+that outruns its wall clock, or writes until it hits the `max_tokens` ceiling, is
+not simply lost: the batch was more than one call could cover, so lgtmaybe halves
+it and reviews the pieces, keeping anything the model had already written. That
+costs up to twice the calls for the affected batch, and it is bounded to one
+split — a piece that still runs past the ceiling is reported rather than split
+again. Whatever the outcome, a partial review says so: the summary carries a
+"results may be incomplete" notice, and a lens that was cut short is never
+presented as a clean bill of health. The one thing lgtmaybe will not do is answer
+👍 LGTM for code no model finished reading.
+
 To measure what a run actually spends and bring it down — triage, static
 analysis, prompt caching, and a hard `max_review_tokens` ceiling — see
 [Reduce review cost](../how-to/reduce-review-cost.md).

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -22,6 +22,7 @@ giving up the findings you actually want.
 - [Where the tokens go](#where-the-tokens-go)
 - [The levers, in order of payoff](#the-levers-in-order-of-payoff)
 - [Put a hard ceiling on it](#put-a-hard-ceiling-on-it)
+- [If a call runs past `max_tokens`](#if-a-call-runs-past-max_tokens)
 - [What isn't worth changing](#what-isnt-worth-changing)
 
 ## First, measure
@@ -186,6 +187,36 @@ It is **off by default on purpose**: spend scales with diff size, lens count and
 batch count, so any figure that protects a small repo would silently truncate a
 large one's review. Read a real run's total with `--profile` first, then set the
 ceiling comfortably above it — it is a runaway guard, not a tuning knob.
+
+## If a call runs past `max_tokens`
+
+`max_tokens` caps what one call may *write*. A lens that hits it comes back cut
+off mid-JSON, and lowering it to save money is the usual way to arrive here.
+
+You do not have to do anything. lgtmaybe treats an over-ceiling call the same
+way it treats one that outruns its wall clock: the batch was more than one call
+could cover, so it is **halved and the pieces reviewed separately**, each with a
+fresh ceiling. Whatever the model finished writing before the cut is kept as
+well, so nothing already paid for is thrown away. The summary says a batch was
+shrunk, and — because part of a lens is not a whole lens — the run still reports
+that results may be incomplete.
+
+The cost of that recovery is up to twice the calls for the affected batch. It is
+bounded to one split level: if a piece still runs past the ceiling, it is
+reported rather than split again.
+
+When you see it happening often, the fix is usually **`max_tokens`, not the
+diff**:
+
+```yaml
+max_tokens: 32768
+```
+
+A reasoning model spends the same budget on thinking before it writes a single
+finding, which is how a fifteen-line diff can truncate. The failure names the
+reasoning tokens where the provider reports them — if most of the ceiling went
+on thought, no amount of shrinking the input will help, and the cap is what
+needs raising.
 
 ## What isn't worth changing
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3426,6 +3426,7 @@ giving up the findings you actually want.
 - [Where the tokens go](#where-the-tokens-go)
 - [The levers, in order of payoff](#the-levers-in-order-of-payoff)
 - [Put a hard ceiling on it](#put-a-hard-ceiling-on-it)
+- [If a call runs past `max_tokens`](#if-a-call-runs-past-max_tokens)
 - [What isn't worth changing](#what-isnt-worth-changing)
 
 ## First, measure
@@ -3590,6 +3591,36 @@ It is **off by default on purpose**: spend scales with diff size, lens count and
 batch count, so any figure that protects a small repo would silently truncate a
 large one's review. Read a real run's total with `--profile` first, then set the
 ceiling comfortably above it — it is a runaway guard, not a tuning knob.
+
+## If a call runs past `max_tokens`
+
+`max_tokens` caps what one call may *write*. A lens that hits it comes back cut
+off mid-JSON, and lowering it to save money is the usual way to arrive here.
+
+You do not have to do anything. lgtmaybe treats an over-ceiling call the same
+way it treats one that outruns its wall clock: the batch was more than one call
+could cover, so it is **halved and the pieces reviewed separately**, each with a
+fresh ceiling. Whatever the model finished writing before the cut is kept as
+well, so nothing already paid for is thrown away. The summary says a batch was
+shrunk, and — because part of a lens is not a whole lens — the run still reports
+that results may be incomplete.
+
+The cost of that recovery is up to twice the calls for the affected batch. It is
+bounded to one split level: if a piece still runs past the ceiling, it is
+reported rather than split again.
+
+When you see it happening often, the fix is usually **`max_tokens`, not the
+diff**:
+
+```yaml
+max_tokens: 32768
+```
+
+A reasoning model spends the same budget on thinking before it writes a single
+finding, which is how a fifteen-line diff can truncate. The failure names the
+reasoning tokens where the provider reports them — if most of the ceiling went
+on thought, no amount of shrinking the input will help, and the cap is what
+needs raising.
 
 ## What isn't worth changing
 
@@ -6024,6 +6055,17 @@ want.
 Two built-in caps also keep any single run modest regardless of who starts it:
 `max_files` (default 50) and `max_input_tokens` (default 100k). See
 [What gets reviewed](what-gets-reviewed.md) for how the diff is bounded.
+
+When a run does bump into a cap, it **degrades rather than fails**. A review call
+that outruns its wall clock, or writes until it hits the `max_tokens` ceiling, is
+not simply lost: the batch was more than one call could cover, so lgtmaybe halves
+it and reviews the pieces, keeping anything the model had already written. That
+costs up to twice the calls for the affected batch, and it is bounded to one
+split — a piece that still runs past the ceiling is reported rather than split
+again. Whatever the outcome, a partial review says so: the summary carries a
+"results may be incomplete" notice, and a lens that was cut short is never
+presented as a clean bill of health. The one thing lgtmaybe will not do is answer
+👍 LGTM for code no model finished reading.
 
 To measure what a run actually spends and bring it down — triage, static
 analysis, prompt caching, and a hard `max_review_tokens` ceiling — see

--- a/openspec/changes/split-on-output-ceiling/.openspec.yaml
+++ b/openspec/changes/split-on-output-ceiling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/split-on-output-ceiling/README.md
+++ b/openspec/changes/split-on-output-ceiling/README.md
@@ -1,0 +1,3 @@
+# split-on-output-ceiling
+
+Split and retry an oversized review call instead of losing the whole lens

--- a/openspec/changes/split-on-output-ceiling/design.md
+++ b/openspec/changes/split-on-output-ceiling/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`EngineImpl._review_split` halves an oversized batch and reviews the pieces —
+the one retry a payload-shaped failure can benefit from, since re-sending the
+identical request cannot succeed. `_complete_lens` reached it through a callback
+named `on_wall_timeout`, guarded by `isinstance(exc, ProviderWallTimeout)`.
+
+`ProviderTruncated` (raised in `LiteLLMProvider._map_response` when
+`finish_reason == "length"`) fell past that guard to `return [], reason`, losing
+the whole lens. The inconsistency was visible inside one function: the *parse*
+path for a truncated body already salvaged the findings completed before the cut
+(`ParseError.truncated` / `.recovered`); the *exception* path discarded
+everything.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recover findings from a review call that runs past its output ceiling.
+- Keep the salvage semantics identical on both truncation paths.
+- Point a reader at the knob that will actually move.
+- Keep the retry bounded and the failure visible.
+
+**Non-Goals:**
+
+- Adapter-level retry of a truncated call (it can only re-send the same
+  oversized request).
+- Any new configuration surface, dependency, or cost model.
+- Guaranteeing the split fixes every truncation.
+
+## Decisions
+
+- **One trigger set, one name.** The callback becomes `on_oversized` and fires
+  for `ProviderWallTimeout | ProviderTruncated`. Both mean "one call was asked to
+  cover more than it could finish"; the remedy is the same, so the name is about
+  the payload rather than about one of its symptoms.
+- **The body rides the exception.** `ProviderTruncated` gains a `text` field
+  carrying the cut-off response. The engine feeds it through the existing
+  `parse_findings` / `ParseError.recovered` machinery, so a salvage on the
+  exception path and a salvage on the parse path produce the same result from
+  the same code. Riding the exception (rather than being returned) preserves the
+  property that a caller cannot take the salvage without also seeing the failure.
+- **Salvage plus split, not either/or.** Salvaged findings are prepended to the
+  pieces' findings. They cover the same code, so the existing location-keyed
+  dedupe collapses any overlap; what survives is anything the pieces missed.
+- **Bounded to one level, unchanged.** Pieces are still reviewed with
+  `batch=None`, which leaves `on_oversized` as None — the terminal case returns
+  the salvage and the reason rather than splitting again. This is a reachable
+  state, not a theoretical one (below), so it is covered by its own test.
+- **The ceiling is `max_tokens`, not the model.** In the run that prompted this
+  it was lgtmaybe's own configured 16,384 against a model good for 65,536.
+  Naming "the model's output limit" sent the reader to a limit they cannot move.
+- **Name the reasoning spend.** litellm normalises
+  `completion_tokens_details.reasoning_tokens` on the routes that report it; it
+  is read defensively and named in the message when present. It is the whole
+  explanation for a fifteen-line diff truncating, and it is the difference
+  between "my diff is too big" (wrong) and "my cap is too low for this model"
+  (right). Absent detail simply omits the breakdown — no dependency, no fallback
+  estimate.
+- **`_is_permanent` keeps `ProviderTruncated` permanent.** Not in tension with
+  the engine's new retry: only the engine holds the batch, so only the engine
+  can change the payload. The adapter can only re-send the same oversized one,
+  which is the attempt worth refusing — at a full ceiling-length generation each.
+
+## Risks / Trade-offs
+
+- **The split may not fix a reasoning-bound truncation.** Thinking tokens come
+  out of the same `max_tokens` budget, so a piece can exhaust the cap however
+  small it is. Accepted: a smaller batch is less to think about as well as less
+  to write about, so it often helps, and when it does not the failure terminates
+  naming `max_tokens`.
+- **Up to twice the calls for a truncating batch.** Same trade the wall-timeout
+  split already made, and bounded by the same one split level.
+- **Salvaged findings come from a lens that was cut short.** They are
+  schema-valid and deduped, and the lens still counts as failed, so the summary
+  never presents a partial lens as a complete one.

--- a/openspec/changes/split-on-output-ceiling/proposal.md
+++ b/openspec/changes/split-on-output-ceiling/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The dogfood review of PR #309 posted: "⚠️ 3 of 4 review calls failed
+(ProviderTruncated: response truncated at the model's output limit after 16384
+tokens)". Three of four lenses produced nothing at all. PR #311 lost one of four
+on a fifteen-line diff.
+
+The engine already knows how to recover from a payload one call cannot cover:
+`_review_split` halves the batch and reviews the pieces. But it was reachable
+only from a wall timeout, so a blown output ceiling — which says the same thing
+about the payload — discarded the entire lens instead. The error message even
+told a human to apply the fix by hand ("lower `max_input_tokens` so each call
+has less to say about"); nothing applied it automatically.
+
+Two details the observed runs corrected:
+
+- The 16,384 ceiling was not the model's. It was lgtmaybe's own configured
+  `max_tokens` against a model good for 65,536, so "the model's output limit"
+  pointed the reader at a knob they cannot move.
+- Truncation is not primarily input-size-driven. A reasoning model spends the
+  same `max_tokens` budget on thought, which is how a fifteen-line diff
+  truncates before it emits much JSON at all.
+
+## What Changes
+
+- Fire the batch-splitting retry for `ProviderTruncated` as well as
+  `ProviderWallTimeout`, and rename the callback to the payload-shaped
+  `on_oversized` so its name says what it actually handles.
+- Carry the truncated response body on `ProviderTruncated` and salvage the
+  findings completed before the cut, matching what the parse path already does
+  for a truncation it detects itself. The lens still counts as failed, so the
+  incomplete-results notice keeps firing.
+- Reword the ceiling error to name `max_tokens` (not "the model's output
+  limit") and to report reasoning tokens where the route exposes them.
+- Keep the split bounded to one level: a piece reviewed with `batch=None` that
+  truncates again reports the reason — naming `max_tokens`, the lever that is
+  left once shrinking is spent — and never recurses.
+- Leave `_is_permanent` treating `ProviderTruncated` as permanent: the engine
+  splits, the provider must not re-send the same oversized call.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `review-pipeline`: The split/retry trigger covers both per-request budgets,
+  and salvages a truncated lens's completed findings.
+- `provider-gateway`: The truncation failure names `max_tokens` and reasoning
+  tokens, and carries the cut-off body for the engine to salvage.
+
+## Impact
+
+A review whose calls run past the output ceiling now returns findings instead of
+an empty lens, with the shrink and the failure both disclosed. No new
+configuration, no new dependency, and no change to how many calls a healthy
+review makes. Splitting is not guaranteed to fix a reasoning-bound truncation —
+a piece can exhaust the cap however small it is — so that terminal state stays
+reachable and now names `max_tokens` rather than only the diff size.

--- a/openspec/changes/split-on-output-ceiling/specs/provider-gateway/spec.md
+++ b/openspec/changes/split-on-output-ceiling/specs/provider-gateway/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: A blown output ceiling is named, not retried
+<!-- anchor: provider.truncation -->
+
+A completion that stopped because it ran out of output tokens SHALL be raised
+as its own failure naming `max_tokens` as the ceiling reached — usually a value
+the user set, not the model's own — plus the reasoning-token count where the
+route reports it, and SHALL carry the cut-off body so the engine can salvage the
+findings finished before the cut. It SHALL NOT be retried — at temperature 0 the
+identical request reaches the identical ceiling, and each attempt costs a full
+ceiling-length generation — while a configured fallback model is still tried.
+Detection reads the finish reason only where the route reports it plainly:
+litellm rewrites a reason it does not recognise to `stop`, so a route that
+names a ceiling hit its own way is caught downstream by the parser instead.
+
+#### Scenario: the model generates to its output limit
+- **WHEN** a completion returns with a `length` finish reason
+- **THEN** the call fails naming the token count reached and `max_tokens`, is not
+  retried, and carries the truncated body
+
+#### Scenario: a reasoning model spends the budget on thought
+- **WHEN** the route reports reasoning tokens on a truncated completion
+- **THEN** the failure names them, because that — not diff size — is why a small
+  diff hit the ceiling
+
+#### Scenario: the route misreports why it stopped
+- **WHEN** a provider reports a ceiling hit under a name litellm maps to `stop`
+- **THEN** the response still reaches the parser, which reports the truncation
+  from the unclosed JSON itself

--- a/openspec/changes/split-on-output-ceiling/specs/review-pipeline/spec.md
+++ b/openspec/changes/split-on-output-ceiling/specs/review-pipeline/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: An oversized batch is retried smaller, never repeated
+<!-- anchor: engine.timeout-split -->
+
+A lens call that exhausts a per-request budget SHALL be retried on smaller
+pieces of the same batch rather than re-sent unchanged, bounded to one split
+level, with the shrink disclosed in the summary. Both budgets trigger it: the
+wall clock, and the `max_tokens` ceiling an answer runs into. Findings the model
+completed before a truncation SHALL be kept, and the lens SHALL still count as
+failed.
+
+#### Scenario: a multi-file batch times out
+- **WHEN** a lens call on a batch of several files exceeds its wall-clock budget
+- **THEN** the batch is halved by file and each half reviewed in its own call, and
+  the summary reports that a batch was shrunk
+
+#### Scenario: a single-file batch times out
+- **WHEN** the timed-out batch holds one file
+- **THEN** its hunks are divided into two groups, one review call each, so an
+  oversized lone file still shrinks
+
+#### Scenario: a call runs past its output ceiling
+- **WHEN** a lens call's answer stops at the `max_tokens` ceiling
+- **THEN** the batch is split the same way, and the findings finished before the
+  cut are kept alongside the pieces' findings
+
+#### Scenario: a piece exhausts its budget as well
+- **WHEN** a piece of an already-split batch times out or truncates again
+- **THEN** it fails as an ordinary failed call naming `max_tokens` — no recursion
+
+#### Scenario: one piece answers and another fails
+- **WHEN** part of a split batch is reviewed and part fails
+- **THEN** the findings are kept AND the failure is reported, so the summary never
+  claims a shrunk batch was reviewed when some of it was not
+
+#### Scenario: the failure says nothing about size
+- **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)
+- **THEN** no split happens, because nothing suggests the payload was the problem

--- a/openspec/changes/split-on-output-ceiling/tasks.md
+++ b/openspec/changes/split-on-output-ceiling/tasks.md
@@ -1,0 +1,41 @@
+## 1. Acceptance Coverage
+
+- [x] 1.1 Add `tests/engine/test_truncation_split.py`: a lens whose first call
+  truncates splits and reviews the halves
+- [x] 1.2 Cover the salvage — findings completed before the cut survive the split
+  and are stamped like any other finding
+- [x] 1.3 Cover the terminal case — a piece that truncates again reports
+  `max_tokens` rather than recursing
+- [x] 1.4 Cover the notices — an unsplittable truncation and a failed piece both
+  keep the incomplete-results notice firing
+- [x] 1.5 Extend the provider truncation tests: the ceiling is named as
+  `max_tokens`, reasoning tokens are reported when the route gives them, and the
+  cut-off body travels with the failure
+
+## 2. Engine
+
+- [x] 2.1 Rename `on_wall_timeout` to `on_oversized` and fire it for
+  `ProviderTruncated` as well as `ProviderWallTimeout`
+- [x] 2.2 Salvage the findings completed before the cut, returning them with the
+  failure reason so a partial lens still counts as failed
+- [x] 2.3 Reword the shrink notice for both triggers, naming `max_tokens`
+
+## 3. Provider
+
+- [x] 3.1 Carry the truncated body on `ProviderTruncated`
+- [x] 3.2 Name `max_tokens` as the ceiling and report reasoning tokens where the
+  route exposes them
+- [x] 3.3 Leave `_is_permanent` unchanged, with a comment explaining why the
+  engine's split and the adapter's refusal to retry are not in tension
+
+## 4. Documentation
+
+- [x] 4.1 Update `docs/how-to/reduce-review-cost.md` and
+  `docs/explanation/trust-and-cost.md`
+- [x] 4.2 Regenerate `docs/llms.txt`
+
+## 5. Verification
+
+- [x] 5.1 Run the new truncation and existing timeout split suites
+- [x] 5.2 Run the complete suite, lint, format, and type checks
+- [x] 5.3 Run spec-anchor checks and validate the OpenSpec specs

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -125,9 +125,11 @@ stdout banner SHALL be suppressed, since stdout carries machine-readable output.
 ### Requirement: A blown output ceiling is named, not retried
 
 A completion that stopped because it ran out of output tokens SHALL be raised
-as its own failure naming the ceiling reached and the knob that moves it, never
-passed on as content. It SHALL NOT be retried — at temperature 0 the identical
-request reaches the identical ceiling, and each attempt costs a full
+as its own failure naming `max_tokens` as the ceiling reached — usually a value
+the user set, not the model's own — plus the reasoning-token count where the
+route reports it, and SHALL carry the cut-off body so the engine can salvage the
+findings finished before the cut. It SHALL NOT be retried — at temperature 0 the
+identical request reaches the identical ceiling, and each attempt costs a full
 ceiling-length generation — while a configured fallback model is still tried.
 Detection reads the finish reason only where the route reports it plainly:
 litellm rewrites a reason it does not recognise to `stop`, so a route that
@@ -136,7 +138,13 @@ names a ceiling hit its own way is caught downstream by the parser instead.
 
 #### Scenario: the model generates to its output limit
 - **WHEN** a completion returns with a `length` finish reason
-- **THEN** the call fails naming the token count reached, and is not retried
+- **THEN** the call fails naming the token count reached and `max_tokens`, is not
+  retried, and carries the truncated body
+
+#### Scenario: a reasoning model spends the budget on thought
+- **WHEN** the route reports reasoning tokens on a truncated completion
+- **THEN** the failure names them, because that — not diff size — is why a small
+  diff hit the ceiling
 
 #### Scenario: the route misreports why it stopped
 - **WHEN** a provider reports a ceiling hit under a name litellm maps to `stop`

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -125,11 +125,14 @@ within budget are reviewed whole.
 - **WHEN** the file has no hunk boundary to cut at and is over budget
 - **THEN** the hunk itself is sliced to fit, line numbers still binding
 
-### Requirement: A timed-out batch is retried smaller, never repeated
+### Requirement: An oversized batch is retried smaller, never repeated
 
-A lens call that exhausts its whole per-request budget SHALL be retried on
-smaller pieces of the same batch rather than re-sent unchanged, bounded to one
-split level, with the shrink disclosed in the summary.
+A lens call that exhausts a per-request budget SHALL be retried on smaller
+pieces of the same batch rather than re-sent unchanged, bounded to one split
+level, with the shrink disclosed in the summary. Both budgets trigger it: the
+wall clock, and the `max_tokens` ceiling an answer runs into. Findings the model
+completed before a truncation SHALL be kept, and the lens SHALL still count as
+failed.
 <!-- anchor: engine.timeout-split -->
 
 #### Scenario: a multi-file batch times out
@@ -142,16 +145,21 @@ split level, with the shrink disclosed in the summary.
 - **THEN** its hunks are divided into two groups, one review call each, so an
   oversized lone file still shrinks
 
-#### Scenario: a piece times out as well
-- **WHEN** a piece of an already-split batch also exceeds its budget
-- **THEN** it fails as an ordinary failed call — the split does not recurse
+#### Scenario: a call runs past its output ceiling
+- **WHEN** a lens call's answer stops at the `max_tokens` ceiling
+- **THEN** the batch is split the same way, and the findings finished before the
+  cut are kept alongside the pieces' findings
+
+#### Scenario: a piece exhausts its budget as well
+- **WHEN** a piece of an already-split batch times out or truncates again
+- **THEN** it fails as an ordinary failed call naming `max_tokens` — no recursion
 
 #### Scenario: one piece answers and another fails
 - **WHEN** part of a split batch is reviewed and part fails
 - **THEN** the findings are kept AND the failure is reported, so the summary never
   claims a shrunk batch was reviewed when some of it was not
 
-#### Scenario: the failure is not a timeout
+#### Scenario: the failure says nothing about size
 - **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)
 - **THEN** no split happens, because nothing suggests the payload was the problem
 

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -36,7 +36,22 @@ class ProviderTruncated(Exception):
     and the two send a maintainer to different fixes. Reported as its own
     failure so the notice on the PR names the ceiling and the knob that moves
     it, rather than "unparseable model output".
+
+    Like a wall timeout, this says something about the *payload*: one call was
+    asked to cover more than it could finish saying. The engine therefore reacts
+    the same way — split the batch and review the pieces — rather than failing
+    the whole lens.
+
+    ``text`` carries the cut-off body. It is not usable as an answer, but the
+    findings the model completed before the cut are real work, and the engine
+    salvages them from it exactly as the parser does for a truncation it detects
+    itself. It rides on the error rather than being returned, so a caller cannot
+    take the salvage without also seeing that the lens was cut short.
     """
+
+    def __init__(self, message: str, *, text: str = "") -> None:
+        super().__init__(message)
+        self.text = text
 
 
 class ProviderClient(ABC):

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -30,7 +30,13 @@ from lgtmaybe.core.models import (
     ToolMode,
     attempts_of,
 )
-from lgtmaybe.core.ports import Message, ProviderClient, ProviderWallTimeout, ReviewEngine
+from lgtmaybe.core.ports import (
+    Message,
+    ProviderClient,
+    ProviderTruncated,
+    ProviderWallTimeout,
+    ReviewEngine,
+)
 from lgtmaybe.core.version import package_version
 from lgtmaybe.github import is_reviewable
 
@@ -331,7 +337,8 @@ class LLMReviewEngine(ReviewEngine):
         budget_at = (
             profiler.total_tokens() + cfg.max_review_tokens if cfg.max_review_tokens else None
         )
-        # Batches a wall-clock timeout forced us to review in smaller pieces.
+        # Batches an oversized-payload failure (wall timeout or output ceiling)
+        # forced us to review in smaller pieces.
         # Per-review state (reset here, not in __init__, so a reused engine starts
         # clean); a set's add is atomic, which is all the fan-out threads need.
         self._split_batches: set[int] = set()
@@ -715,15 +722,17 @@ class LLMReviewEngine(ReviewEngine):
                 f"({detail}); results may be incomplete.\n{INCOMPLETE_MARKER}"
             )
         # A batch that had to be shrunk is a standing signal that the diff is at
-        # the edge of what this model finishes in its budget — say it, or the next
-        # run's timeout looks like the first.
+        # the edge of what this model finishes in one call — say it, or the next
+        # run's failure looks like the first. Worded for both triggers (a blown
+        # wall clock and a blown output ceiling), because the remedy is the same.
         if self._split_batches:
             count = len(self._split_batches)
             plural = "es" if count != 1 else ""
             notices.append(
-                f"⏱️ {count} batch{plural} timed out and {'were' if count != 1 else 'was'} "
-                "reviewed in smaller pieces instead. Consider a lower `max_input_tokens` "
-                "or a faster model."
+                f"⏱️ {count} batch{plural} {'were' if count != 1 else 'was'} too big for one "
+                "call (timed out, or ran past the `max_tokens` ceiling) and "
+                f"{'were' if count != 1 else 'was'} reviewed in smaller pieces instead. "
+                "Consider a lower `max_input_tokens`, a higher `max_tokens`, or a faster model."
             )
         if reflection_skipped:
             notices.append(
@@ -839,7 +848,7 @@ class LLMReviewEngine(ReviewEngine):
         of a generic "timeout". A failing lens never aborts the others.
 
         ``batch`` is the file patches ``wrapped`` was built from. Supplying it opts
-        this call into the one retry a wall-clock timeout can actually benefit
+        this call into the one retry an oversized payload can actually benefit
         from: the payload is split and the pieces reviewed (see
         :meth:`_review_split`). None means "already a piece" — no further
         splitting.
@@ -865,7 +874,7 @@ class LLMReviewEngine(ReviewEngine):
         if budget_at is not None and profiler.total_tokens() >= budget_at:
             _log.warning("review token budget reached — skipping call", extra={"lens": lens.id})
             return [], _BUDGET_SKIP_REASON
-        on_wall_timeout = (
+        on_oversized = (
             None
             if batch is None
             else partial(
@@ -904,7 +913,7 @@ class LLMReviewEngine(ReviewEngine):
                 {"role": "user", "content": suffix},
             ]
             return self._complete_lens(
-                messages, model, response_format, batch_num, lens, on_wall_timeout
+                messages, model, response_format, batch_num, lens, on_oversized
             )
 
         user_content = wrapped
@@ -924,9 +933,7 @@ class LLMReviewEngine(ReviewEngine):
             {"role": "system", "content": lens.system_prompt},
             {"role": "user", "content": user_content},
         ]
-        return self._complete_lens(
-            messages, model, response_format, batch_num, lens, on_wall_timeout
-        )
+        return self._complete_lens(messages, model, response_format, batch_num, lens, on_oversized)
 
     def _review_split(
         self,
@@ -945,17 +952,21 @@ class LLMReviewEngine(ReviewEngine):
         budget_at: int | None,
         lens: _Lens,
     ) -> _LensOutcome:
-        """Re-review a timed-out batch as smaller pieces, one call each.
+        """Re-review an oversized batch as smaller pieces, one call each.
 
-        The only retry a wall-clock timeout can benefit from. Repeating the same
-        request is pointless — same payload, same model, same budget — but the
-        payload is the one thing we can change, and a smaller one both fits the
-        budget better and gets a fresh one. Failing the lens outright instead
-        would discard the whole batch's review over a size problem.
+        The only retry a payload-sized failure can benefit from — whether the call
+        ran out of *time* (a wall timeout) or ran out of *room to answer* (the
+        model's output ceiling). Repeating the same request is pointless — same
+        payload, same model, same budget, same ceiling — but the payload is the one
+        thing we can change, and a smaller one both fits the budgets better and gets
+        fresh ones. Failing the lens outright instead would discard the whole
+        batch's review over a size problem, which is what a real run did: three of
+        four lenses produced nothing because each had more to say than one response
+        could hold.
 
         Bounded on purpose: exactly ONE level (the pieces are reviewed with
-        ``batch=None``, so a piece that times out again just fails), and the
-        pieces are re-wrapped from the same redacted patches, so nothing
+        ``batch=None``, so a piece that fails the same way again just fails), and
+        the pieces are re-wrapped from the same redacted patches, so nothing
         unredacted or unwrapped reaches the model. Returns the original *reason*
         unchanged when the batch cannot be split — a single-hunk file has no
         smaller unit to fall back to.
@@ -964,7 +975,7 @@ class LLMReviewEngine(ReviewEngine):
         if len(pieces) < 2:
             return [], reason
         _log.warning(
-            "review call timed out — retrying on smaller pieces",
+            "review call was too big for one response — retrying on smaller pieces",
             extra={"lens": lens.id, "batch": batch_num, "pieces": len(pieces)},
         )
         findings: list[ReviewFinding] = []
@@ -1005,13 +1016,16 @@ class LLMReviewEngine(ReviewEngine):
         response_format: type[ReviewResult] | None,
         batch_num: int,
         lens: _Lens,
-        on_wall_timeout: Callable[[str], _LensOutcome] | None = None,
+        on_oversized: Callable[[str], _LensOutcome] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
         """The provider call + parse + stamp shared by both prompt shapes.
 
-        ``on_wall_timeout`` handles the one failure that says something about the
-        *payload* rather than the provider: the call outlived its entire budget.
-        It is given the failure reason and returns the outcome to use instead.
+        ``on_oversized`` handles the failures that say something about the
+        *payload* rather than the provider: the call outlived its entire budget,
+        or its answer hit the model's output ceiling. Both mean one call was
+        asked to cover more than it could finish, and both are fixed by covering
+        less. It is given the failure reason and returns the outcome to use
+        instead. None when there is nothing left to split.
         """
         opts = {"response_format": response_format} if response_format is not None else {}
         # Heartbeat: log the call going out and coming back so the Action shows
@@ -1041,8 +1055,18 @@ class LLMReviewEngine(ReviewEngine):
                 extra={"lens": lens.id, "reason": reason},
                 exc_info=True,
             )
-            if isinstance(exc, ProviderWallTimeout) and on_wall_timeout is not None:
-                return on_wall_timeout(reason)
+            if isinstance(exc, ProviderWallTimeout | ProviderTruncated):
+                # Whatever the model finished before the ceiling cut it off is real,
+                # schema-valid work — kept, exactly as the parse path keeps it, so
+                # the exception path is not the one place a partial answer is binned.
+                completed = _salvage_truncated(exc, lens)
+                if on_oversized is None:
+                    # Already a piece: nothing smaller to try. Report the reason
+                    # rather than recurse — an unbounded cascade would spend the
+                    # whole review on a model that cannot answer at any size.
+                    return completed, reason
+                findings, split_reason = on_oversized(reason)
+                return completed + findings, split_reason
             return [], reason
         profiler.record_call(
             label=lens.id,
@@ -1074,10 +1098,13 @@ class LLMReviewEngine(ReviewEngine):
                 if salvaged
                 else ""
             )
+            # Worded like the adapter's own ceiling error (see
+            # litellm_provider._map_response): the ceiling is `max_tokens`, which
+            # is usually a value the user set, not the model's own limit.
             reason = (
-                f"response truncated at the model's output limit after "
-                f"{result.output_tokens} tokens — lower `max_input_tokens`, or raise "
-                f"`max_tokens` if the model supports a higher ceiling{recovered_note}"
+                f"response truncated at the {result.output_tokens}-token `max_tokens` "
+                f"ceiling — raise `max_tokens`, or lower `max_input_tokens` so each "
+                f"call covers less{recovered_note}"
             )
             _log.warning(reason, extra={"lens": lens.id, "recovered": salvaged})
             # The findings fall through to be stamped like any others, but the
@@ -1089,6 +1116,25 @@ class LLMReviewEngine(ReviewEngine):
         findings = _stamp_categories(findings, lens)
         _log.info("lens reviewed", extra={"lens": lens.id, "findings": len(findings)})
         return findings, None
+
+
+def _salvage_truncated(exc: BaseException, lens: _Lens) -> list[ReviewFinding]:
+    """Findings the model completed before the output ceiling cut it off.
+
+    The adapter raises the ceiling as its own failure and carries the cut-off body
+    with it, so the salvage the parser already performs on a truncation it detects
+    itself is available here too. Anything else (a wall timeout has no body at all)
+    salvages nothing, and an unparseable remnant is simply empty — never a guess.
+    """
+    if not isinstance(exc, ProviderTruncated) or not exc.text:
+        return []
+    try:
+        findings = parse_findings(exc.text)
+    except ParseError as parse_exc:
+        findings = parse_exc.recovered
+    if findings:
+        _log.info("salvaged findings from truncated response", extra={"lens": lens.id})
+    return _stamp_categories(findings, lens)
 
 
 def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[ReviewFinding]:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -190,6 +190,11 @@ def _is_permanent(exc: BaseException) -> bool:
     # to the identical ceiling, and each attempt costs a full ceiling-length
     # generation — 65,536 output tokens and 21 minutes, in the run that prompted
     # this. Same bargain as above: one attempt, then say so, fallback still tried.
+    # This stays permanent even though the ENGINE now retries a truncated call by
+    # splitting the batch: the two are not in tension, they are the division of
+    # labour. Only the engine holds the batch, so only the engine can change the
+    # payload; the adapter can only re-send the same oversized one, which is the
+    # attempt worth refusing.
     if isinstance(exc, ProviderTruncated):
         return True
     if isinstance(exc, RateLimitError):
@@ -495,12 +500,25 @@ class LiteLLMProvider(ProviderClient):
         # A generation that stopped because it ran out of output tokens is cut off
         # mid-token: it can never parse, and passing it on gets it reported as
         # "unparseable model output", which points at the prompt rather than at
-        # the ceiling actually hit. Raised here so the failure names itself.
+        # the ceiling actually hit. Raised here so the failure names itself. The
+        # body travels with it: unusable as an answer, but the findings finished
+        # before the cut are real, and the engine salvages them from it.
+        #
+        # The ceiling is named as `max_tokens`, NOT as "the model's limit": in the
+        # run that prompted this it was lgtmaybe's own configured 16,384 against a
+        # model good for 65,536, so blaming the model sends the reader to a knob
+        # they cannot move. The reasoning count is named when the route reports it,
+        # because it is the whole explanation for a fifteen-line diff truncating —
+        # a reasoning model spends this same budget on thought before it writes a
+        # single finding, so the cap, not the diff, is what needs raising.
         if _finish_reason(response) == "length":
+            reasoning = _reasoning_tokens(usage)
+            detail = f" ({reasoning} reasoning)" if reasoning else ""
             raise ProviderTruncated(
-                f"response truncated at the model's output limit after {output_tokens} tokens — "
-                "lower `max_input_tokens` so each call has less to say about, or raise "
-                "`max_tokens` if the model supports a higher ceiling"
+                f"response hit the {output_tokens}-token `max_tokens` ceiling{detail} before "
+                "finishing — raise `max_tokens`, or lower `max_input_tokens` so each call "
+                "covers less",
+                text=text,
             )
         cache_read, cache_creation = _cache_usage(usage)
         if cache_read or cache_creation:
@@ -649,6 +667,19 @@ def _supports_cache_control(model: str) -> bool:
         return bool(supports_prompt_caching(model=model))
     except Exception:
         return False
+
+
+def _reasoning_tokens(usage: Any) -> int:
+    """Output tokens the model spent thinking, or 0 when the route doesn't say.
+
+    litellm normalises this onto ``completion_tokens_details.reasoning_tokens``
+    for the routes that report it. Read defensively — a route that omits the
+    wrapper, or fills it with a non-number, must not turn a truncation report
+    into a crash — and 0 simply means "no breakdown to show".
+    """
+    details = getattr(usage, "completion_tokens_details", None)
+    value = getattr(details, "reasoning_tokens", None)
+    return value if isinstance(value, int) and value > 0 else 0
 
 
 def _cache_usage(usage: Any) -> tuple[int, int]:

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -1,0 +1,256 @@
+"""A lens call that blows its OUTPUT ceiling is retried SMALLER too.
+
+Sibling of ``test_timeout_split``. A wall timeout and a blown `max_tokens`
+ceiling say the same thing about the payload — one call was asked to cover more
+than it could finish — so they earn the same remedy: split the batch and review
+the pieces. Before this, a ceiling hit failed the whole lens, and a real dogfood
+run lost three of four lenses to it.
+
+Two wrinkles the timeout does not have:
+
+- A truncated response is a *partial answer*, so the findings the model completed
+  before the cut travel with the failure and are kept.
+- The split is not guaranteed to fix it. A reasoning model spends the same
+  `max_tokens` budget on thought, so a fifteen-line diff can truncate too. A
+  piece that truncates again is a reachable state, not a theoretical one, and it
+  must terminate naming the lever that can actually move — never recurse.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.core.ports import Message, ProviderTruncated
+from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine.engine import ReviewIncompleteError
+from tests.fakes import FakeProvider
+
+_TWO_FILE_DIFF = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,2 +1,4 @@
+ import os
++first_change = os.getcwd()
++early_change = os.sep
+ print(os.name)
+diff --git a/two.py b/two.py
+--- a/two.py
++++ b/two.py
+@@ -1,2 +1,3 @@
+ import sys
++second_change = sys.maxsize
+ print(sys.argv)
+"""
+
+_ONE_FILE_ONE_HUNK = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,2 +1,3 @@
+ import os
++first_change = os.getcwd()
+ print(os.name)
+"""
+
+# The adapter's real wording (litellm_provider._map_response): the ceiling named
+# is `max_tokens` — in the run that prompted this it was lgtmaybe's own
+# configured 16,384 against a model good for 65,536 — and the reasoning count is
+# what explains a small diff truncating at all.
+_CEILING = (
+    "response hit the 16384-token `max_tokens` ceiling (16200 reasoning) before "
+    "finishing — raise `max_tokens`, or lower `max_input_tokens` so each call covers less"
+)
+
+
+def _ctx(diff: str, files: list[str]) -> PRContext:
+    return PRContext(
+        diff=diff,
+        changed_files=files,
+        base_sha="b",
+        head_sha="h",
+        repo="o/r",
+        pr_number=1,
+    )
+
+
+def _cfg(**overrides: Any) -> ReviewConfig:
+    return ReviewConfig(
+        provider=Provider.openrouter,
+        model="deepseek/deepseek-v4-pro",
+        categories=[ReviewCategory.security],
+        reflect=False,
+        prompt_cache=False,
+        **overrides,
+    )
+
+
+def _finding(path: str, anchor: str, title: str) -> dict[str, Any]:
+    return {
+        "path": path,
+        "line": 2,
+        "severity": "medium",
+        "title": title,
+        "body": "the new binding is never validated",
+        "anchor": anchor,
+        "failure_scenario": "A caller reads the new binding before it is set.",
+    }
+
+
+def _finding_json(path: str, anchor: str, title: str | None = None) -> str:
+    return json.dumps({"findings": [_finding(path, anchor, title or f"unchecked value in {path}")]})
+
+
+def _cut_off_json(path: str, anchor: str, title: str) -> str:
+    """One complete finding, then a second the ceiling chopped mid-object."""
+    return '{"findings": [' + json.dumps(_finding(path, anchor, title)) + ', {"path": "one.py", "li'
+
+
+class _TruncatesUntilSmaller(FakeProvider):
+    """Blows the output ceiling while both files ride one call; answers a half.
+
+    The real shape of the failure: the payload, not the provider, asked for more
+    output than one generation could hold.
+    """
+
+    def __init__(self, partial: str = "") -> None:
+        super().__init__()
+        self.diffs: list[str] = []
+        self._partial = partial
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        self.diffs.append(diff)
+        if "one.py" in diff and "two.py" in diff:
+            raise ProviderTruncated(_CEILING, text=self._partial)
+        path = "one.py" if "one.py" in diff else "two.py"
+        anchor = "first_change = os.getcwd()" if path == "one.py" else "second_change = sys.maxsize"
+        return ProviderResult(text=_finding_json(path, anchor), input_tokens=5, output_tokens=5)
+
+
+def test_an_over_ceiling_batch_is_split_and_its_halves_reviewed() -> None:
+    """The remedy the error message tells a human to apply by hand, automated."""
+    provider = _TruncatesUntilSmaller()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    # The oversized call, then one per half — never the same oversized payload twice.
+    assert len(provider.diffs) == 3
+    assert sum("one.py" in d and "two.py" in d for d in provider.diffs) == 1
+
+
+def test_findings_completed_before_the_cut_survive_the_split() -> None:
+    """A truncated response is a partial answer, not a non-answer.
+
+    The findings the model finished emitting are real, schema-valid, already-paid-for
+    work. The parse path already salvages them; the exception path threw them away.
+    """
+    partial = _cut_off_json("one.py", "early_change = os.sep", "sep is never validated")
+    findings, _summary = LLMReviewEngine(_TruncatesUntilSmaller(partial)).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    titles = sorted(f.title for f in findings)
+    assert "sep is never validated" in titles  # salvaged from the cut-off response
+    assert "unchecked value in two.py" in titles  # produced by the split
+    # Salvage is stamped like any other finding — it is posted like any other.
+    salvaged = next(f for f in findings if f.title == "sep is never validated")
+    assert salvaged.category == ReviewCategory.security.value
+    assert salvaged.anchored
+
+
+def test_a_piece_that_truncates_again_is_not_split_further() -> None:
+    """One split level, then the failure stands.
+
+    A reachable state, not a theoretical one: a reasoning model spends the same
+    `max_tokens` budget on thought, so a piece can exhaust the cap however small
+    it is. An unbounded cascade would then spend the whole review chasing a size
+    that does not exist — so it stops, and says which lever is left.
+    """
+
+    class _AlwaysTruncates(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+            raise ProviderTruncated(_CEILING, text="")
+
+    provider = _AlwaysTruncates()
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
+
+    assert len(provider.diffs) == 3  # the batch, then its two halves — and stop
+    assert "`max_tokens`" in str(exc_info.value)
+
+
+def test_an_unsplittable_batch_reports_the_ceiling_with_its_salvage() -> None:
+    """A single-hunk file has nothing smaller to try.
+
+    It must report the ceiling rather than loop — and still keep what the model
+    completed, exactly as the parse path does for a truncated body.
+    """
+
+    class _TruncatesOnce(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+            raise ProviderTruncated(
+                _CEILING,
+                text=_cut_off_json(
+                    "one.py", "first_change = os.getcwd()", "cwd is never validated"
+                ),
+            )
+
+    provider = _TruncatesOnce()
+    findings, summary = LLMReviewEngine(provider).review(
+        _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg()
+    )
+
+    assert len(provider.diffs) == 1  # nothing smaller to try — no recursion
+    assert [f.title for f in findings] == ["cwd is never validated"]
+    # A partial lens is still a failed lens: the notice fires, so a half-answer is
+    # never read as a clean bill of health.
+    assert "results may be incomplete" in summary
+    # And it names the lever that can still move. Shrinking is spent, so pointing
+    # only at `max_input_tokens` would be advice the reader has already taken.
+    assert "`max_tokens`" in summary
+
+
+def test_a_piece_that_fails_is_still_reported() -> None:
+    """Half a batch reviewed is not a reviewed batch — the notice still fires."""
+
+    class _OneHalfRefuses(FakeProvider):
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            if "one.py" in diff and "two.py" in diff:
+                raise ProviderTruncated(_CEILING, text="")
+            if "two.py" in diff:
+                raise RuntimeError("insufficient_quota")
+            return ProviderResult(
+                text=_finding_json("one.py", "first_change = os.getcwd()"),
+                input_tokens=5,
+                output_tokens=5,
+            )
+
+    findings, summary = LLMReviewEngine(_OneHalfRefuses()).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert [f.path for f in findings] == ["one.py"]  # the half that answered
+    assert "results may be incomplete" in summary
+    assert "insufficient_quota" in summary  # naming the piece's real failure

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -404,6 +404,69 @@ class TestOutputCeilingTruncation:
 
         assert calls == 1
 
+    def test_the_ceiling_is_named_as_max_tokens_not_as_the_model_s_limit(self) -> None:
+        """The ceiling hit is almost always `max_tokens`, not the model's own.
+
+        In the run that prompted this it was lgtmaybe's own configured 16,384
+        against a model that would have gone to 65,536 — so calling it "the
+        model's output limit" points the reader at the wrong knob, and at one
+        they cannot move.
+        """
+        with patch("litellm.completion", return_value=self._truncated()):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        message = str(exc_info.value)
+        assert "max_tokens" in message
+        assert "model's output limit" not in message
+
+    def test_the_truncated_body_travels_with_the_failure(self) -> None:
+        """The engine salvages the findings finished before the cut from it."""
+        with patch("litellm.completion", return_value=self._truncated()):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert exc_info.value.text == '{"findings": [{"path": "a.py"'
+
+    def test_reasoning_tokens_are_named_when_the_route_reports_them(self) -> None:
+        """A reasoning model spends the same `max_tokens` budget on thinking.
+
+        That is how a fifteen-line diff truncates: the cap went on thought, not
+        on findings. Saying so is the difference between "my diff is too big"
+        (wrong) and "my cap is too low for this model" (right).
+        """
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=""),
+                    finish_reason="length",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=900,
+                completion_tokens=16384,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=16200),
+            ),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert "16200 reasoning" in str(exc_info.value)
+
+    def test_a_route_without_reasoning_detail_still_reports_the_ceiling(self) -> None:
+        """No detail is not zero detail — the message simply omits the breakdown."""
+        with patch("litellm.completion", return_value=self._truncated()):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert "reasoning" not in str(exc_info.value)
+        assert "65536" in str(exc_info.value)
+
     def test_truncation_still_falls_back_to_the_secondary_model(self) -> None:
         """Permanent stops the *retry*, not the fallback — a different model is a
         genuinely different request and may well fit its answer in budget."""


### PR DESCRIPTION
## Why

The dogfood review of #309 posted:

> ⚠️ 3 of 4 review calls failed (ProviderTruncated: response truncated at the model's output limit after 16384 tokens)

Three of four lenses produced nothing at all. #311 lost one of four on a **fifteen-line** diff.

The engine already knew the remedy. `EngineImpl._review_split` halves a batch that is too big for one call and reviews the pieces — but it was reachable only from a `ProviderWallTimeout`. A `ProviderTruncated` fell through to `return [], reason`, discarding the whole lens. The error message even told a human to apply the fix by hand ("lower `max_input_tokens` so each call has less to say about"); nothing applied it automatically.

There was an inconsistency inside one function, too: the **parse** path for a truncated body already salvaged the findings completed before the cut (`ParseError.truncated` / `.recovered`). The **exception** path threw them away.

## What changed

**Engine**

- `on_wall_timeout` → `on_oversized`, fired for `ProviderWallTimeout | ProviderTruncated`. Both mean "one call was asked to cover more than it could finish"; the remedy is the same, so the name is about the payload rather than one of its symptoms.
- The findings the model completed before the cut are salvaged from the exception and returned **with** the failure reason. The lens still counts as failed, so the incomplete-results notice keeps firing — never a silent half-answer.
- Still bounded to one split level. Pieces are reviewed with `batch=None`, which leaves `on_oversized` as `None`: the terminal case returns the salvage and the reason rather than splitting again.
- The shrink notice is worded for both triggers and names `max_tokens`.

**Provider**

- `ProviderTruncated` carries the cut-off body, so the engine can run it through the same `parse_findings` / `ParseError.recovered` machinery the parse path uses.
- The ceiling is named as **`max_tokens`**, not "the model's output limit". The 16,384 hit was lgtmaybe's own configured cap against a model good for 65,536 — blaming the model pointed the reader at a knob they cannot move.
- **Reasoning tokens are reported** where the route exposes them (`completion_tokens_details.reasoning_tokens`, read defensively). A reasoning model spends the same `max_tokens` budget on thought before it writes a single finding, which is how a fifteen-line diff truncates. It is the difference between "my diff is too big" (wrong) and "my cap is too low for this model" (right).
- `_is_permanent` still treats `ProviderTruncated` as permanent — deliberately, with a comment saying why. Only the engine holds the batch, so only the engine can change the payload; the adapter can only re-send the same oversized call, at a full ceiling-length generation each. The two are a division of labour, not a contradiction.

## The split is not a guarantee

Because thinking tokens come out of the same budget, a piece can exhaust the cap however small it is. That terminal state is reachable, not theoretical — so it terminates naming `max_tokens` (the lever left once shrinking is spent) and never recurses. Covered by its own test.

## Tests (written first)

`tests/engine/test_truncation_split.py`, mirroring `test_timeout_split.py`:

- `test_an_over_ceiling_batch_is_split_and_its_halves_reviewed`
- `test_findings_completed_before_the_cut_survive_the_split`
- `test_a_piece_that_truncates_again_is_not_split_further`
- `test_an_unsplittable_batch_reports_the_ceiling_with_its_salvage`
- `test_a_piece_that_fails_is_still_reported`

`tests/providers/test_retry.py` (`TestOutputCeilingTruncation`):

- `test_the_ceiling_is_named_as_max_tokens_not_as_the_model_s_limit`
- `test_the_truncated_body_travels_with_the_failure`
- `test_reasoning_tokens_are_named_when_the_route_reports_them`
- `test_a_route_without_reasoning_detail_still_reports_the_ceiling`

## Specs and docs

- Living specs: `review-pipeline` (the split requirement now names both per-request budgets and the salvage) and `provider-gateway` (the truncation failure names `max_tokens` + reasoning tokens and carries the body) — targeted edits to those sections.
- OpenSpec change: `openspec/changes/split-on-output-ceiling/`.
- `docs/how-to/reduce-review-cost.md` gains "If a call runs past `max_tokens`"; `docs/explanation/trust-and-cost.md` gains the degradation note. `docs/llms*.txt` regenerated.

## Gate

`uv run pytest -q` (1751 passed), `ruff format --check`, `ruff check`, `mypy src`, `pytest tests/specs -q`, `openspec validate --specs` — all green. Rebased on `main` after #312/#313/#314; `.lgtmaybe.yml` and `tests/test_workflow_examples.py` deliberately untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_