### PR TITLE
feat(cli): flatten the diagram's collapsible blocks for a terminal

### DIFF
--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -171,9 +171,35 @@ $ lgtmaybe diagram --provider ollama --model llama3
 It diffs your branch against the base (the same base resolution as `lgtmaybe
 review`; `--base` overrides, `--working` includes uncommitted edits,
 `--uncommitted` reviews only the working-tree edits). The output is the same
-Markdown body the `/diagram` comment carries — each diagram's Mermaid source
-first, then its text rendering (which reads fine in a terminal) in a collapsed
-"Text version" block. Paste the Mermaid into a GitHub comment,
+body the `/diagram` comment carries — each diagram's Mermaid source first, then
+its text rendering — with one adaptation: a terminal renders no HTML, so the
+collapsible "Text version" wrapper is flattened into a plain labelled section:
+
+````console
+$ lgtmaybe diagram --provider ollama --model llama3
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant n0 as Order API (changed)
+    participant n1 as Payments
+    n0->>n1: POST /charge
+    n1-->>n0: 503 Unavailable
+    n0->>n0: backs off 200ms
+```
+
+Text version:
+
+```
+1. [Order API (changed)] -> [Payments]: POST /charge
+2. [Payments] --> [Order API (changed)]: 503 Unavailable
+3. [Order API (changed)] -> [Order API (changed)]: backs off 200ms
+```
+````
+
+The Mermaid source stays in the output on purpose: your terminal can't draw it,
+but it is what you paste into a GitHub comment,
 [mermaid.live](https://mermaid.live), or a Markdown file to render it.
 
 ## Why Mermaid (and what the ASCII is for)
@@ -185,11 +211,12 @@ hosting an image would mean committing a file or calling an external service,
 neither of which fits a fork-safe, idempotently-updated comment.
 
 A terminal, though, can't render Mermaid — which is exactly why each diagram
-also comes as **plain text**. Both the CLI output and the GitHub comment show
-the Mermaid with the text tucked in a collapsible "Text version" — the text is
-what you actually read in a terminal, and it doubles as the fallback body, so a
-reviewer never sees a red "unable to render" box if a diagram comes back
-malformed.
+also comes as **plain text**. In the GitHub comment that text sits in a
+collapsible "Text version" block, out of the way of the rendered diagram; in the
+terminal the same block is flattened to a labelled section, because HTML tags
+are noise in a shell. Either way the text is what you actually read without a
+renderer, and it doubles as the fallback body, so a reviewer never sees a red
+"unable to render" box if a diagram comes back malformed.
 
 The model never writes Mermaid. It returns typed graph data — components,
 relationships, ordered steps — and lgtmaybe renders the syntax itself, escaping

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3282,9 +3282,35 @@ $ lgtmaybe diagram --provider ollama --model llama3
 It diffs your branch against the base (the same base resolution as `lgtmaybe
 review`; `--base` overrides, `--working` includes uncommitted edits,
 `--uncommitted` reviews only the working-tree edits). The output is the same
-Markdown body the `/diagram` comment carries — each diagram's Mermaid source
-first, then its text rendering (which reads fine in a terminal) in a collapsed
-"Text version" block. Paste the Mermaid into a GitHub comment,
+body the `/diagram` comment carries — each diagram's Mermaid source first, then
+its text rendering — with one adaptation: a terminal renders no HTML, so the
+collapsible "Text version" wrapper is flattened into a plain labelled section:
+
+````console
+$ lgtmaybe diagram --provider ollama --model llama3
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant n0 as Order API (changed)
+    participant n1 as Payments
+    n0->>n1: POST /charge
+    n1-->>n0: 503 Unavailable
+    n0->>n0: backs off 200ms
+```
+
+Text version:
+
+```
+1. [Order API (changed)] -> [Payments]: POST /charge
+2. [Payments] --> [Order API (changed)]: 503 Unavailable
+3. [Order API (changed)] -> [Order API (changed)]: backs off 200ms
+```
+````
+
+The Mermaid source stays in the output on purpose: your terminal can't draw it,
+but it is what you paste into a GitHub comment,
 [mermaid.live](https://mermaid.live), or a Markdown file to render it.
 
 ## Why Mermaid (and what the ASCII is for)
@@ -3296,11 +3322,12 @@ hosting an image would mean committing a file or calling an external service,
 neither of which fits a fork-safe, idempotently-updated comment.
 
 A terminal, though, can't render Mermaid — which is exactly why each diagram
-also comes as **plain text**. Both the CLI output and the GitHub comment show
-the Mermaid with the text tucked in a collapsible "Text version" — the text is
-what you actually read in a terminal, and it doubles as the fallback body, so a
-reviewer never sees a red "unable to render" box if a diagram comes back
-malformed.
+also comes as **plain text**. In the GitHub comment that text sits in a
+collapsible "Text version" block, out of the way of the rendered diagram; in the
+terminal the same block is flattened to a labelled section, because HTML tags
+are noise in a shell. Either way the text is what you actually read without a
+renderer, and it doubles as the fallback body, so a reviewer never sees a red
+"unable to render" box if a diagram comes back malformed.
 
 The model never writes Mermaid. It returns typed graph data — components,
 relationships, ordered steps — and lgtmaybe renders the syntax itself, escaping

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -83,6 +83,11 @@ when the model reports no run-time flow.
 - **THEN** the comment carries the flowchart alone, with no sequence section
   and no headings
 
+#### Scenario: the same diagram printed in a terminal
+- **WHEN** `lgtmaybe diagram` prints the body locally
+- **THEN** each collapsible text version becomes a labelled section with its
+  HTML wrapper removed, and the Mermaid source stays intact to paste elsewhere
+
 ### Requirement: Finding-thread replies are answered in-thread
 
 A `pull_request_review_comment` reply in a finding thread lgtmaybe opened SHALL

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import click
 
-from lgtmaybe.cli.render import render_findings
+from lgtmaybe.cli.render import flatten_details, render_findings
 from lgtmaybe.cli.runtime import RuntimeOptions
 from lgtmaybe.core.diffparse import FILE_HEADER_RE, hunk_for_line
 from lgtmaybe.core.logging import get_logger
@@ -564,8 +564,9 @@ def execute_local_diagram(
 
     Builds the provider straight from config/runtime (no token, no gateway) and
     echoes the same Markdown body the ``/diagram`` comment would carry: the
-    Mermaid source (paste it into GitHub to render) plus the ASCII rendering,
-    which is what actually shows in a terminal.
+    Mermaid source (paste it into GitHub to render) plus the text rendering,
+    which is what actually shows in a terminal — with the comment's collapsible
+    wrappers flattened, since a terminal renders no HTML.
     """
     from lgtmaybe.engine.diagram import build_diagram
 
@@ -576,7 +577,7 @@ def execute_local_diagram(
     except Exception as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(body)
+    click.echo(flatten_details(body))
 
 
 def _post_extras(

--- a/src/lgtmaybe/cli/render.py
+++ b/src/lgtmaybe/cli/render.py
@@ -1,8 +1,11 @@
-"""Output formatting for the local ``review`` command.
+"""Output formatting for the local commands.
 
-Turns engine findings into one of three text shapes: ``human`` (a readable
-listing), ``json`` (a machine-readable array), or ``agent`` (correction
-instructions an AI coding agent can read and apply).
+``render_findings`` turns engine findings into one of three text shapes:
+``human`` (a readable listing), ``json`` (a machine-readable array), or
+``agent`` (correction instructions an AI coding agent can read and apply).
+
+``flatten_details`` adapts a body written for a GitHub comment — the change
+diagram — to a terminal, which renders no HTML.
 """
 
 from __future__ import annotations
@@ -16,6 +19,33 @@ from lgtmaybe.core.models import ReviewFinding
 # (the incomplete-run flag). They mean nothing to a terminal — strip them rather
 # than print raw HTML at the end of a local review.
 _HIDDEN_MARKER_RE = re.compile(r"[ \t]*<!--.*?-->")
+
+# The diagram body tucks each text rendering in a <details> block, which GitHub
+# collapses and a terminal prints as raw tags. The summary is the block's label,
+# so it becomes the section heading the tags were standing in for.
+_DETAILS_OPEN_RE = re.compile(r"^\s*<details><summary>(.*?)</summary>\s*$")
+_DETAILS_CLOSE_RE = re.compile(r"^\s*</details>\s*$")
+
+
+def flatten_details(body: str) -> str:
+    """Turn ``<details>`` blocks into labelled sections for a terminal.
+
+    The Mermaid fences are left alone: a terminal can't draw them, but they are
+    what you paste into a GitHub comment or mermaid.live, so dropping them would
+    cost more than the noise it saved.
+    """
+    lines: list[str] = []
+    for line in body.splitlines():
+        opened = _DETAILS_OPEN_RE.match(line)
+        if opened:
+            lines.append(f"{opened.group(1)}:")
+        elif not _DETAILS_CLOSE_RE.match(line):
+            lines.append(line)
+        elif lines and not lines[-1].strip():
+            # The closing tag's leading blank line separated it from the fence
+            # above; with the tag gone it would double up with the next one.
+            lines.pop()
+    return "\n".join(lines)
 
 
 def render_findings(findings: list[ReviewFinding], summary: str, *, fmt: str = "human") -> str:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -227,6 +227,22 @@ class TestDiagramCommand:
         assert "flowchart LR" in result.output
         assert "[Client] --calls--> [App (changed)]" in result.output
 
+    def test_diagram_output_flattens_the_collapsible_wrapper(self, monkeypatch):
+        """A terminal cannot collapse a <details> block, so the local view shows
+        each text rendering as a plain labelled section rather than raw HTML —
+        while the Mermaid source stays intact to paste into GitHub."""
+        self._patch_diagram_provider(monkeypatch)
+
+        result = CliRunner().invoke(main, ["diagram", "--provider", "ollama", "--model", "llama3"])
+
+        assert result.exit_code == 0, result.output
+        assert "<details>" not in result.output
+        assert "</details>" not in result.output
+        assert "<summary>" not in result.output
+        assert "Text version:" in result.output
+        assert "[Client] --calls--> [App (changed)]" in result.output
+        assert "```mermaid" in result.output
+
     def test_working_and_uncommitted_flags_conflict(self, monkeypatch):
         self._patch_diagram_provider(monkeypatch)
 

--- a/tests/cli/test_render.py
+++ b/tests/cli/test_render.py
@@ -1,10 +1,12 @@
-"""render_findings formats findings for the local CLI (human, json, agent)."""
+"""render_findings formats findings for the local CLI (human, json, agent),
+and flatten_details unwraps the comment-shaped collapsible blocks for a terminal."""
 
 from __future__ import annotations
 
 import json
 
 from lgtmaybe.cli import render_findings
+from lgtmaybe.cli.render import flatten_details
 from lgtmaybe.core.models import ReviewFinding, Severity
 
 _FINDING = ReviewFinding(
@@ -147,3 +149,46 @@ def test_hidden_markers_are_stripped_from_the_terminal_summary() -> None:
     agent = render_findings([], summary, fmt="agent")
     assert "results may be incomplete" in agent
     assert "<!--" not in agent
+
+
+def test_details_blocks_flatten_into_labelled_sections() -> None:
+    """The diagram comment tucks each text rendering in a <details> block GitHub
+    can collapse. A terminal shows the raw tags instead, so the label becomes a
+    heading and the tags go."""
+    body = (
+        "## Retry flow\n\n### Sequence\n\n```mermaid\nsequenceDiagram\n```\n\n"
+        "<details><summary>Text version</summary>\n\n"
+        "```\n1. [A] -> [B]: calls\n```\n\n"
+        "</details>\n\nA note."
+    )
+
+    out = flatten_details(body)
+
+    assert "<details>" not in out
+    assert "</summary>" not in out
+    assert "Text version:" in out
+    assert "1. [A] -> [B]: calls" in out
+    # The Mermaid source survives — it is what you paste into a GitHub comment.
+    assert "```mermaid" in out
+    assert "A note." in out
+
+
+def test_two_details_blocks_both_flatten() -> None:
+    """Structure and sequence each carry one, so a diagram body has two."""
+    body = (
+        "<details><summary>Text version</summary>\n\n```\nfirst\n```\n\n</details>\n\n"
+        "<details><summary>Text version</summary>\n\n```\nsecond\n```\n\n</details>"
+    )
+
+    out = flatten_details(body)
+
+    assert out.count("Text version:") == 2
+    assert "details" not in out
+    assert "first" in out
+    assert "second" in out
+
+
+def test_a_body_without_details_is_returned_unchanged() -> None:
+    body = '## Title\n\n```mermaid\nflowchart LR\n    n0["A"]\n```\n\nNotes.'
+
+    assert flatten_details(body) == body


### PR DESCRIPTION
## Why

`lgtmaybe diagram` echoes the same body the `/diagram` comment carries, and that body tucks each text rendering in a `<details><summary>Text version</summary>` block so GitHub can collapse it behind the rendered diagram.

A terminal renders no HTML. So it printed the raw tags around the very text that exists *for* readers without a renderer:

```
<details><summary>Text version</summary>

```
[Client] --calls--> [App (changed)]
```

</details>
```

Pre-existing, but the sequence view doubled it — two wrappers per diagram instead of one — which is what made it worth fixing.

## What changed

`cli/render.py` gains `flatten_details`, applied in `execute_local_diagram` only:

```
Text version:

```
1. [Order API (changed)] -> [Payments]: POST /charge
2. [Payments] --> [Order API (changed)]: 503 Unavailable
3. [Order API (changed)] -> [Order API (changed)]: backs off 200ms
```
```

The `<summary>` text becomes the heading it was standing in for, rather than being dropped — it is the label that says what the block is. The blank line that separated the closing tag from the fence above is consumed with it, so the sections don't drift apart.

**The Mermaid fences stay.** A terminal can't draw them, but they are what you paste into a GitHub comment or mermaid.live — dropping them would cost more than the noise it saved. Only the HTML goes.

The GitHub comment is untouched: this is a local-output adaptation, not a change to what gets posted.

## Testing

Tests first, red then green:

- `tests/cli/test_render.py` — `test_details_blocks_flatten_into_labelled_sections`, `test_two_details_blocks_both_flatten` (structure + sequence each carry one), `test_a_body_without_details_is_returned_unchanged`.
- `tests/cli/test_cli.py` — `test_diagram_output_flattens_the_collapsible_wrapper`, driving the real `diagram` command and asserting no `<details>`/`<summary>` reaches the output while the Mermaid source and the text rendering both survive.

Full gate: 1755 passed, 3 skipped. `ruff format`/`check`, `mypy`, `pytest tests/specs`, `openspec validate --specs` (10/10) all green.

## Docs

`docs/how-to/generate-a-change-diagram.md` gains a worked terminal example and states the difference plainly in "Why Mermaid (and what the ASCII is for)": collapsible on GitHub, flattened in a shell. New scenario on the existing "Change diagrams show structure and sequence" requirement in `openspec/specs/cli-and-local/spec.md`. `docs/llms-full.txt` regenerated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_