### PR TITLE
feat(engine): report reasoning tokens on every provider call

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -81,16 +81,23 @@ jobs:
         with:
           image: lgtmaybe:dogfood
           provider: openrouter
-          # deepseek-v4-pro is cheap enough to run on every PR, which is what a
+          # deepseek-v4-flash is cheap enough to run on every PR, which is what a
           # per-PR dogfood needs: a pricier model exhausts the key's monthly
           # limit, and OpenRouter then rejects each call with a 402 ("requires
           # more credits, or fewer max_tokens") — every lens fails and the review
           # posts nothing.
           model: deepseek/deepseek-v4-flash-latest
-          # This model tops out at a 16k output ceiling, and the default 100k
-          # input budget hands one call more diff than it can answer for: the
-          # response is cut off mid-JSON and the lens is lost (three of four on
-          # #309). Smaller batches keep each answer inside the ceiling.
+          # The default 100k input budget hands one call more diff than it can
+          # answer for: the response is cut off mid-JSON and the lens is lost
+          # (three of four on #309). Smaller batches keep each answer inside the
+          # output ceiling.
+          #
+          # That ceiling is lgtmaybe's own `max_tokens` (.lgtmaybe.yml), NOT the
+          # model's — an earlier revision of this comment said the model "tops
+          # out at 16k", which sent the reader to a knob they cannot move. The
+          # 16k was ours, against a model that ran to 65,536 when a lens went
+          # away. Reasoning models spend that same budget on thought before
+          # writing a finding; `--profile` reports the split (`think_tok`).
           max_input_tokens: 40000
           profile: true
           api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -86,7 +86,12 @@ jobs:
           # limit, and OpenRouter then rejects each call with a 402 ("requires
           # more credits, or fewer max_tokens") — every lens fails and the review
           # posts nothing.
-          model: deepseek/deepseek-v4-flash-latest
+          # The bare id is what OpenRouter rejected on #319 — `{"message":
+          # "deepseek/deepseek-v4-flash-latest is not a valid model ID","code":
+          # 400}` on every lens, so the review posted a failure instead of a
+          # review. The `~` prefix is the floating-alias form; quoted because a
+          # bare `~` is YAML's null and leading-`~` scalars are easy to misread.
+          model: "~deepseek/deepseek-v4-flash-latest"
           # The default 100k input budget hands one call more diff than it can
           # answer for: the response is cut off mid-JSON and the lens is lost
           # (three of four on #309). Smaller batches keep each answer inside the

--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -1,4 +1,4 @@
-# Dogfood: lgtmaybe reviews its own PRs via OpenRouter (deepseek/deepseek-v4-pro).
+# Dogfood: lgtmaybe reviews its own PRs via OpenRouter (deepseek-v4-flash).
 # Runs the in-repo action (./) so changes to action.yml are exercised too.
 # Add an OPENROUTER_API_KEY repo secret.
 #
@@ -9,7 +9,7 @@
 # Reviews run automatically on PRs from trusted authors (owner / member /
 # collaborator), and on demand via slash commands (/review, /improve, /ask,
 # /describe, /diagram) — a maintainer can opt an external PR in by commenting
-# /review on it. deepseek-v4-pro is cheap enough to run per-PR; on a
+# /review on it. deepseek-v4-flash is cheap enough to run per-PR; on a
 # `synchronize` push the review is incremental (only the new commits).
 name: lgtmaybe
 

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -48,6 +48,19 @@ the diff, over and over, once per lens per batch. The per-call table above it
 shows exactly which lens and which batch each call belongs to, so you can see
 whether the cost is lens count, batch count, or one enormous file.
 
+On a reasoning model, read the table's `think_tok` column next to `out_tok`.
+That is how much of the output budget went on thought before the model wrote a
+single finding, and a summary line totals it:
+
+```
+reasoning: 41,300 of 47,900 output tokens (86%)
+```
+
+The line appears only when a route reports the breakdown — its absence means
+"not reported", not "no thinking". When the share is high, it explains a lens
+that ran for a minute and returned three findings, and it is the number to
+check before [raising `max_tokens`](#if-a-call-runs-past-max_tokens).
+
 In the GitHub Action, set `profile: true` and the same breakdown lands in the
 job log. Every provider call also emits a structured `provider call` log line
 with its own token counts, so you can total a run without the summary.
@@ -220,6 +233,12 @@ finding, which is how a fifteen-line diff can truncate. The failure names the
 reasoning tokens where the provider reports them — if most of the ceiling went
 on thought, no amount of shrinking the input will help, and the cap is what
 needs raising.
+
+You do not have to wait for a truncation to find that out. `--profile` reports
+the same split on calls that **succeeded** (`think_tok`, and the `reasoning:`
+total), which is the comparison a truncated call cannot give you: a call that
+hit the ceiling spent reasoning + findings ≥ `max_tokens` by definition, so it
+tells you nothing about the healthy calls sitting beside it.
 
 ## What costs more, on purpose
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3509,6 +3509,19 @@ the diff, over and over, once per lens per batch. The per-call table above it
 shows exactly which lens and which batch each call belongs to, so you can see
 whether the cost is lens count, batch count, or one enormous file.
 
+On a reasoning model, read the table's `think_tok` column next to `out_tok`.
+That is how much of the output budget went on thought before the model wrote a
+single finding, and a summary line totals it:
+
+```
+reasoning: 41,300 of 47,900 output tokens (86%)
+```
+
+The line appears only when a route reports the breakdown — its absence means
+"not reported", not "no thinking". When the share is high, it explains a lens
+that ran for a minute and returned three findings, and it is the number to
+check before [raising `max_tokens`](#if-a-call-runs-past-max_tokens).
+
 In the GitHub Action, set `profile: true` and the same breakdown lands in the
 job log. Every provider call also emits a structured `provider call` log line
 with its own token counts, so you can total a run without the summary.
@@ -3681,6 +3694,12 @@ finding, which is how a fifteen-line diff can truncate. The failure names the
 reasoning tokens where the provider reports them — if most of the ceiling went
 on thought, no amount of shrinking the input will help, and the cap is what
 needs raising.
+
+You do not have to wait for a truncation to find that out. `--profile` reports
+the same split on calls that **succeeded** (`think_tok`, and the `reasoning:`
+total), which is the comparison a truncated call cannot give you: a call that
+hit the ceiling spent reasoning + findings ≥ `max_tokens` by definition, so it
+tells you nothing about the healthy calls sitting beside it.
 
 ## What costs more, on purpose
 
@@ -4018,6 +4037,7 @@ The normalised return value of one LLM completion, including token usage.
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `output_tokens` | integer | Yes | — | Output Tokens |
+| `reasoning_tokens` | integer | No | `0` | Reasoning Tokens |
 | `text` | string | Yes | — | Text |
 
 ## PRContext
@@ -5012,6 +5032,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
     },
     "output_tokens": {
       "title": "Output Tokens",
+      "type": "integer"
+    },
+    "reasoning_tokens": {
+      "default": 0,
+      "title": "Reasoning Tokens",
       "type": "integer"
     },
     "text": {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -118,6 +118,7 @@ The normalised return value of one LLM completion, including token usage.
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `output_tokens` | integer | Yes | — | Output Tokens |
+| `reasoning_tokens` | integer | No | `0` | Reasoning Tokens |
 | `text` | string | Yes | — | Text |
 
 ## PRContext
@@ -1112,6 +1113,11 @@ The canonical machine-readable schemas. These are the source of truth for provid
     },
     "output_tokens": {
       "title": "Output Tokens",
+      "type": "integer"
+    },
+    "reasoning_tokens": {
+      "default": 0,
+      "title": "Reasoning Tokens",
       "type": "integer"
     },
     "text": {

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -63,7 +63,9 @@ this provider" message.
 adapter boundary, retry transient failures within its bounded budget, switch to
 `fallback_model` when the primary is exhausted, and place explicit cache
 breakpoints on the shared prefix for supported routes. Cache usage SHALL land
-on `ProviderResult`.
+on `ProviderResult`, as SHALL the reasoning-token count where the route reports
+one — on successful calls, not only on the truncated ones that name it as a
+cause, since a ceiling-hitting call offers no healthy call to compare against.
 <!-- anchor: provider.complete -->
 
 #### Scenario: provider SDK ignores its timeout

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -548,6 +548,16 @@ class ProviderResult(_Strict):
     # providers/models without prompt caching (back-compat default).
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
+    # Tokens the model spent thinking before it wrote a word of the answer, when
+    # the route reports them. A SUBSET of `output_tokens`, never an addition to
+    # it — the two are added nowhere, or the budget double-counts. Zero on routes
+    # that report no breakdown, which means "not reported", NOT "did no thinking".
+    #
+    # It is on the success path for a reason: read only off truncated calls (where
+    # it was first surfaced, to name the cause) the number cannot answer the
+    # question it exists for, because such a call has reasoning + findings >=
+    # max_tokens by definition and so offers no healthy call to compare against.
+    reasoning_tokens: int = 0
     # Completion attempts the adapter made to produce this result (1 = first try).
     # Feeds the timing instrumentation so a call that burned its retry budget is
     # distinguishable from one that was merely slow.

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1269,6 +1269,7 @@ class LLMReviewEngine(ReviewEngine):
             output_tokens=result.output_tokens,
             cache_read_tokens=result.cache_read_tokens,
             cache_creation_tokens=result.cache_creation_tokens,
+            reasoning_tokens=result.reasoning_tokens,
         )
         salvaged = 0
         try:

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -42,6 +42,9 @@ class CallRecord:
     cache_read_tokens: int
     cache_creation_tokens: int
     error: str | None = None  # None on success; the concise failure reason otherwise
+    # Thinking tokens inside `output_tokens` (0 = the route reported no breakdown).
+    # Keyword-defaulted so every existing caller keeps working unchanged.
+    reasoning_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,7 @@ class Profiler:
         output_tokens: int,
         cache_read_tokens: int,
         cache_creation_tokens: int,
+        reasoning_tokens: int = 0,
         error: str | None = None,
     ) -> None:
         """Record one provider call and log it as a structured line."""
@@ -91,6 +95,7 @@ class Profiler:
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
             cache_creation_tokens=cache_creation_tokens,
+            reasoning_tokens=reasoning_tokens,
             error=error,
         )
         with self._lock:
@@ -106,6 +111,9 @@ class Profiler:
                 "output_tokens": output_tokens,
                 "cache_read_tokens": cache_read_tokens,
                 "cache_creation_tokens": cache_creation_tokens,
+                # Only when reported: a 0 on every line would read as a claim
+                # that the model did no thinking, which is not what it means.
+                **({"reasoning_tokens": reasoning_tokens} if reasoning_tokens else {}),
                 **({"error": error} if error else {}),
             },
         )
@@ -152,14 +160,16 @@ class Profiler:
             lines.append(f"{stage.name:<16} {stage.elapsed:>8.2f}s")
         lines.append("")
 
+        # `think_tok` sits next to `out_tok` deliberately: side by side they are
+        # the whole story of a lens that ran for a minute and wrote 50 tokens.
         lines.append(
             f"{'call':<16} {'batch':>5} {'tries':>5} {'elapsed':>9} "
-            f"{'in_tok':>8} {'out_tok':>8} {'cache_rd':>8} {'cache_wr':>8}  error"
+            f"{'in_tok':>8} {'out_tok':>8} {'think_tok':>9} {'cache_rd':>8} {'cache_wr':>8}  error"
         )
         for call in sorted(calls, key=lambda c: c.elapsed, reverse=True):
             lines.append(
                 f"{call.label:<16} {call.batch:>5} {call.attempts:>5} {call.elapsed:>8.2f}s "
-                f"{call.input_tokens:>8} {call.output_tokens:>8} "
+                f"{call.input_tokens:>8} {call.output_tokens:>8} {call.reasoning_tokens:>9} "
                 f"{call.cache_read_tokens:>8} {call.cache_creation_tokens:>8}  "
                 f"{call.error or '-'}"
             )
@@ -168,8 +178,28 @@ class Profiler:
         read = sum(c.cache_read_tokens for c in calls)
         created = sum(c.cache_creation_tokens for c in calls)
         lines.append(f"cache: {read} tokens read / {created} created across {len(calls)} calls")
+        reasoning_line = self._render_reasoning(calls)
+        if reasoning_line:
+            lines.append(reasoning_line)
         lines.append(self.render_total())
         return "\n".join(lines)
+
+    @staticmethod
+    def _render_reasoning(calls: list[CallRecord]) -> str:
+        """How much of the output budget went on thought — "" when unreported.
+
+        Silence, not a zero: a route that reports no breakdown is not a model
+        that did no thinking, and a line reading "0 of 2,000" would say exactly
+        that. The share is computed here rather than left to the reader, because
+        it is the ratio — not either raw count — that says whether the output
+        ceiling is being spent on findings or on reasoning.
+        """
+        reasoning = sum(c.reasoning_tokens for c in calls)
+        if not reasoning:
+            return ""
+        output = sum(c.output_tokens for c in calls)
+        share = round(100 * reasoning / output) if output else 0
+        return f"reasoning: {reasoning:,} of {output:,} output tokens ({share}%)"
 
     def render_total(self) -> str:
         """One line: what this run spent, formatted for a human.
@@ -235,5 +265,6 @@ def timed_complete(
         output_tokens=result.output_tokens,
         cache_read_tokens=result.cache_read_tokens,
         cache_creation_tokens=result.cache_creation_tokens,
+        reasoning_tokens=result.reasoning_tokens,
     )
     return result

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -539,6 +539,10 @@ class LiteLLMProvider(ProviderClient):
             output_tokens=output_tokens,
             cache_read_tokens=cache_read,
             cache_creation_tokens=cache_creation,
+            # Same helper as the truncation message above, so a call that
+            # succeeded and a call that hit the ceiling can never report the
+            # thinking they did by two different readings of the same field.
+            reasoning_tokens=_reasoning_tokens(usage),
         )
 
 

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -67,6 +67,38 @@ class TestProfiler:
         assert (call.label, call.batch, call.attempts) == ("security", 1, 2)
         assert (call.cache_read_tokens, call.cache_creation_tokens) == (90, 10)
 
+    def test_record_call_captures_reasoning_tokens(self) -> None:
+        """A lens that wrote 50 tokens in 40 seconds needs an explanation, and
+        the thinking it did before writing them is that explanation."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.5,
+            attempts=1,
+            input_tokens=100,
+            output_tokens=1200,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=1100,
+        )
+        assert p.calls[0].reasoning_tokens == 1100
+
+    def test_reasoning_tokens_default_to_zero(self) -> None:
+        """Non-reasoning routes report nothing, and callers may omit it."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.5,
+            attempts=1,
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+        assert p.calls[0].reasoning_tokens == 0
+
     def test_reset_clears_prior_records(self) -> None:
         p = Profiler()
         with p.stage("redact"):
@@ -117,6 +149,59 @@ class TestProfiler:
         assert "RateLimitError" in text
         assert "900 tokens read / 200 created across 2 calls" in text
         assert "tokens: 2,100 billable (2,000 in / 100 out) across 2 calls" in text
+
+    def test_render_shows_the_reasoning_column(self) -> None:
+        """The `--profile` table is where the reasoning budget becomes legible:
+        out_tok next to think_tok is the whole comparison."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=2.0,
+            attempts=1,
+            input_tokens=1000,
+            output_tokens=1250,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=1100,
+        )
+        text = p.render()
+        assert "think_tok" in text
+        assert "1100" in text
+
+    def test_render_omits_the_reasoning_line_when_no_route_reported_any(self) -> None:
+        """Zero across the board means "this route does not report it", not "this
+        model did no thinking" — so claim nothing rather than assert a false 0."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=2.0,
+            attempts=1,
+            input_tokens=1000,
+            output_tokens=50,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+        assert "reasoning:" not in p.render()
+
+    def test_render_summarises_the_reasoning_share_of_output(self) -> None:
+        """The share is the number the decision turns on, so compute it here
+        rather than leave every reader to do the division by hand."""
+        p = Profiler()
+        for _ in range(2):
+            p.record_call(
+                label="security",
+                batch=1,
+                elapsed=2.0,
+                attempts=1,
+                input_tokens=1000,
+                output_tokens=1000,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                reasoning_tokens=900,
+            )
+        assert "reasoning: 1,800 of 2,000 output tokens (90%)" in p.render()
 
 
 class TestTotalTokens:
@@ -198,6 +283,20 @@ class TestTimedComplete:
         assert (call.input_tokens, call.cache_read_tokens) == (42, 30)
         assert call.error is None
 
+    def test_success_records_the_reasoning_tokens(self) -> None:
+        """Reflection and triage are model calls too — a reasoning model spends
+        the budget on them the same way, so they report it the same way."""
+        provider = FakeProvider(
+            result=ProviderResult(
+                text="{}",
+                input_tokens=42,
+                output_tokens=700,
+                reasoning_tokens=650,
+            )
+        )
+        timed_complete(provider, [{"role": "user", "content": "hi"}], model="m", label="reflect")
+        assert profiler.calls[-1].reasoning_tokens == 650
+
     def test_failure_records_then_reraises(self) -> None:
         class _Boom(FakeProvider):
             def complete(self, messages, model, **opts):  # type: ignore[override]
@@ -250,6 +349,27 @@ class TestEnginePipelineTiming:
         assert labels == ["performance", "security"]
         assert all(c.batch == 1 for c in profiler.calls)
         assert all(c.error is None for c in profiler.calls)
+
+    def test_per_lens_calls_record_their_reasoning_tokens(self) -> None:
+        """The per-lens fan-out is the measurement that matters: it is the lens
+        calls that truncate, so it is the lens calls that must report the split."""
+        cfg = ReviewConfig(
+            provider=Provider.ollama,
+            model="llama3",
+            categories=[ReviewCategory.security],
+            reflect=False,
+        )
+        provider = FakeProvider(
+            result=ProviderResult(
+                text=json.dumps({"findings": []}),
+                input_tokens=900,
+                output_tokens=1200,
+                reasoning_tokens=1100,
+            )
+        )
+        LLMReviewEngine(provider).review(_CTX, cfg)
+
+        assert [c.reasoning_tokens for c in profiler.calls] == [1100]
 
     def test_failed_lens_call_is_recorded_with_its_reason(self) -> None:
         class _OneBadLens(FakeProvider):

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -62,6 +62,34 @@ class TestLiteLLMProvider:
         assert result.input_tokens == 50
         assert result.output_tokens == 100
 
+    def test_complete_reports_reasoning_tokens_on_the_success_path(self) -> None:
+        """Reasoning tokens must be visible on calls that SUCCEEDED, not only on
+        the ones that blew the ceiling.
+
+        Read only from the failure path, the number can never answer the
+        question it exists to answer: a truncated call has reasoning + findings
+        >= max_tokens by definition, so that sample has no healthy call to
+        compare against. The success path is where the comparison lives.
+        """
+        response = _fake_response(prompt_tokens=900, completion_tokens=1200)
+        response.usage.completion_tokens_details = SimpleNamespace(reasoning_tokens=1100)
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert result.reasoning_tokens == 1100
+        # Reasoning is a SUBSET of the completion count, never an addition to it —
+        # adding it to `output_tokens` would double-count against the budget.
+        assert result.output_tokens == 1200
+
+    def test_a_route_without_reasoning_detail_reports_zero(self) -> None:
+        """No detail is not an error — a non-reasoning route simply reports 0."""
+        with patch("litellm.completion", return_value=_fake_response()):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+        assert result.reasoning_tokens == 0
+
     def test_complete_passes_messages_and_model_to_litellm(self) -> None:
         response = _fake_response()
         messages = [{"role": "user", "content": "review this"}]

--- a/tests/snapshots/ProviderResult.json
+++ b/tests/snapshots/ProviderResult.json
@@ -26,6 +26,11 @@
       "title": "Output Tokens",
       "type": "integer"
     },
+    "reasoning_tokens": {
+      "default": 0,
+      "title": "Reasoning Tokens",
+      "type": "integer"
+    },
     "text": {
       "title": "Text",
       "type": "string"


### PR DESCRIPTION
## Why

`--profile` could show a lens that ran for a minute and wrote 50 tokens, with nothing in the table to explain the gap. On a reasoning model the explanation is thinking — and lgtmaybe already read that count, but only on the **failure** path, where #315 added it to name the cause of a truncation.

Read only there, the number can never answer the question it exists for. A truncated call spent reasoning + findings ≥ `max_tokens` **by definition**, so that sample contains no healthy call to compare against. The success path is where the comparison lives.

This is also the measurement that decides whether lgtmaybe needs a `reasoning_effort` knob at all. Three dogfood reviews have truncated (#309 lost 3 of 4 lenses at a 16k cap, #311 lost 1 of 4 on a *fifteen-line* diff, #315 lost 2 of 4 at 32k). The working theory is that the cap goes on thought before a single finding is written — but that theory is unproven, and I have already been wrong once on this exact question (I first blamed input size and capped `max_input_tokens` in #311). This PR builds the instrument; it does not assume the answer.

## What changed

- **`ProviderResult.reasoning_tokens`** — populated on the success path from the same `_reasoning_tokens` helper the truncation message already uses, so the two paths cannot drift into different readings of one field.
- **A `think_tok` column** beside `out_tok` in the profile table, plus a summary line:
  ```
  reasoning: 13,300 of 14,500 output tokens (92%)
  ```
  Both stay **silent** when no route reported a breakdown. A 0 on every line would read as a claim that the model did no thinking, which is not what an unreported field means.
- **Threaded through both `record_call` sites** — the per-lens fan-out in `engine.py` and `timed_complete` (reflect/triage) — as a defaulted keyword, so every existing caller is unchanged.

Reasoning is a **subset** of `output_tokens`, never an addition to it; totalling the two would double-count against `max_review_tokens`.

## Also in here

Two stale things in the dogfood workflow, both from earlier PRs:

- The comment claiming this model *"tops out at a 16k output ceiling"* was wrong — 16k was lgtmaybe's own `max_tokens`, against a model that ran to 65,536 when a lens went away. Blaming the model sends the reader to a knob they cannot move.
- The model name #318 left behind (`deepseek-v4-pro` in the comment, `deepseek-v4-flash-latest` in the input).

## Testing

TDD, red first — 8 failing tests before any source change:

- `tests/providers/test_litellm_provider.py` — reasoning tokens land on a **successful** result; `output_tokens` is not inflated by them; a route without the detail reports 0.
- `tests/engine/test_profiling.py` — `record_call` captures it and defaults to 0; `render` shows the column; the `reasoning:` line is **omitted** when nothing reported any, and computes the share when it did; `timed_complete` and the per-lens fan-out both pass it through.

Full gate green: `pytest` (1784 passed), `ruff format --check`, `ruff check`, `mypy`, `pytest tests/specs`, `openspec validate --specs`.

Regenerated `docs/reference/config.md`, `tests/snapshots/ProviderResult.json`, and `docs/llms*.txt`. One targeted spec edit to `provider.complete` (`openspec/specs/provider-gateway/spec.md`), which enumerates what lands on `ProviderResult` and was made incomplete by this change.

## Next

Once this is on `main`, a dogfood review's job log carries the split — the workflow builds the reviewer from the **base** branch, so this PR's own review will not show it. Two throwaway PRs (one trivial diff, one few-hundred-line diff) then answer whether reasoning is a floor or scales with input, and `reasoning_effort` gets built or written off on that evidence rather than on a third guess.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEHe6mG3TVPMBvjxhZzF9)_