### PR TITLE
fix(deps): sync uv.lock with the 1.12.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1293,7 +1293,7 @@ wheels = [
 
 [[package]]
 name = "lgtmaybe"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },


### PR DESCRIPTION
## What

Regenerates `uv.lock` so the workspace package's own entry matches `pyproject.toml`.

```diff
 [[package]]
 name = "lgtmaybe"
-version = "1.11.0"
+version = "1.12.0"
```

## Why

`.github/workflows/ci.yml:35` runs `uv lock --check`. release-please bumps `version` in `pyproject.toml` but never regenerates the lockfile, whose own `lgtmaybe` entry therefore lags a release behind.

**This has now recurred across three consecutive releases.** The PR originally targeted 1.10.0 → 1.11.0; while it was open, `main` shipped 1.11.1 and 1.12.0 and drifted again. Rebased onto `08e6480` and regenerated, so it now closes the current gap.

Credit where due: lgtmaybe's own review bot caught the staleness on this PR — its `/diagram` comment flagged that the diff no longer matched the stated intent. Dogfooding worked.

## Note

This is the symptom, not the cause. Until the release workflow regenerates `uv.lock` (or carries it as a release-please versioned extra file), 1.12.1 will drift too. Tracked in #337.

## Testing

`uv lock --check` passes with this change and fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7