### PR TITLE
refactor: remove unreachable members

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,6 @@ static-analysis = [
     # the odd one out: a Go binary with no wheel, fetched in the Dockerfile.
     "zizmor>=1.5",
 ]
-# Hosted identity broker only; not installed by CLI or Action users.
-identity-broker = [
-    "aws-lambda-powertools>=3.23",
-    "httpx>=0.28.1",
-    "pyjwt[crypto]>=2.10",
-]
 
 [project.scripts]
 lgtmaybe = "lgtmaybe.cli:main"

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -286,14 +286,6 @@ def build_review_context(
     return github, engine, provider
 
 
-def build_adapters(
-    cfg: ReviewConfig, runtime: RuntimeOptions
-) -> tuple[GitHubGateway, ReviewEngine]:
-    """Construct the real GitHub gateway and review engine from config + runtime."""
-    github, engine, _provider = build_review_context(cfg, runtime)
-    return github, engine
-
-
 def _apply_learned_feedback(github: GitHubGateway, ctx: PRContext, cfg: ReviewConfig) -> PRContext:
     """Attach 👎-downvoted finding fingerprints to ``ctx.feedback_downvotes``.
 
@@ -527,34 +519,6 @@ def execute_local_review(
         # than only under --profile (whose table already ends with this line —
         # hence the elif). stderr keeps --json / --agent output pipeable.
         click.echo(profiler.render_total(), err=True)
-
-
-def _execute_auxiliary(
-    cfg: ReviewConfig,
-    runtime: RuntimeOptions,
-    run: Callable[[GitHubGateway, ProviderClient, ReviewConfig], None],
-    name: str,
-) -> None:
-    """Build a fresh context and run one auxiliary post. Best-effort.
-
-    The extras are auxiliary: any failure is logged and swallowed so they can
-    never block a review.
-    """
-    try:
-        github, _engine, provider = build_review_context(cfg, runtime)
-        run(github, provider, cfg)
-    except Exception:
-        _log.warning("auto-%s failed — continuing without it", name, exc_info=True)
-
-
-def execute_describe(cfg: ReviewConfig, runtime: RuntimeOptions) -> None:
-    """Post the structured PR description (standalone path). Best-effort."""
-    _execute_auxiliary(cfg, runtime, run_describe, "describe")
-
-
-def execute_diagram(cfg: ReviewConfig, runtime: RuntimeOptions) -> None:
-    """Post the change diagram (standalone path). Best-effort."""
-    _execute_auxiliary(cfg, runtime, run_diagram, "diagram")
 
 
 def execute_local_diagram(
@@ -935,12 +899,10 @@ from lgtmaybe.cli import commands as _commands  # noqa: E402,F401
 __all__ = [
     "RuntimeOptions",
     "action_inputs",
-    "build_adapters",
     "build_provider_engine",
     "build_review_context",
     "config_cmd",
     "execute_comment",
-    "execute_describe",
     "execute_local_review",
     "execute_review",
     "execute_review_reply",

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -171,9 +171,6 @@ def batch_files(
     Returns:
         A list of batches; each batch is a list of (path, patch) pairs.
     """
-    if not files:
-        return []
-
     # RLM walk: decompose any over-budget file into per-hunk units up front, so a
     # large file becomes several small calls that each fit instead of one
     # oversized call. Files within budget pass through whole (context preserved).
@@ -347,7 +344,6 @@ class _Hunk:
     """One parsed hunk: its header positions plus its verbatim body lines."""
 
     old_start: int
-    old_len: int
     new_start: int
     new_len: int
     section: str
@@ -369,7 +365,6 @@ def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
             hunks.append(
                 _Hunk(
                     old_start=header.old_start,
-                    old_len=header.old_len,
                     new_start=header.new_start,
                     new_len=header.new_len,
                     section=header.section,

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -173,9 +173,6 @@ class _Lens:
     # and falls back to the lens id otherwise; None (a focused lens) means the
     # lens id is always stamped — the model's value is ignored, as before.
     allowed_categories: frozenset[str] | None = None
-    # A split task can keep a distinct profiler label while attributing its
-    # findings to an existing public category.
-    finding_category: str | None = None
 
 
 def _build_lenses(cfg: ReviewConfig, *, has_intent: bool, retrieval: bool = False) -> list[_Lens]:
@@ -1356,14 +1353,11 @@ def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[Review
     like any other.
     """
     allowed = lens.allowed_categories
-    fallback_category = lens.finding_category or lens.id
     return [
         f.model_copy(
             update={
                 "category": (
-                    f.category
-                    if allowed is not None and f.category in allowed
-                    else fallback_category
+                    f.category if allowed is not None and f.category in allowed else lens.id
                 )
             }
         )

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -70,10 +70,6 @@ def _strip_think_blocks(text: str) -> str:
     return _THINK_RE.sub("", text)
 
 
-def _repair_trailing_commas(text: str) -> str:
-    return _TRAILING_COMMA_RE.sub(r"\1", text)
-
-
 def _balanced_span(text: str, start: int) -> str | None:
     """Return the balanced ``{...}`` / ``[...]`` span beginning at *start*.
 
@@ -123,7 +119,7 @@ def iter_json_values(raw: str) -> Iterator[Any]:
     seen: set[str] = set()
 
     def _try(candidate: str) -> Iterator[Any]:
-        repaired = _repair_trailing_commas(candidate)
+        repaired = _TRAILING_COMMA_RE.sub(r"\1", candidate)
         if repaired in seen:
             return
         seen.add(repaired)

--- a/src/lgtmaybe/engine/retrieve.py
+++ b/src/lgtmaybe/engine/retrieve.py
@@ -33,12 +33,6 @@ FileFetcher = Callable[[str], "str | None"]
 MAX_HOPS = 2
 MAX_FETCH_FILES = 5
 
-# Concurrent read-only fetches per wave. The deferral fetch sits on the review's
-# serial tail — reflection cannot begin until every lens has returned — so these
-# round-trips are pure added wall clock, and they are independent of each other.
-# Bounded so a long `needs` list can't open a connection per entry.
-_FETCH_WORKERS = 8
-
 
 def resolve_needs(
     needs: list[str],
@@ -77,12 +71,16 @@ def resolve_needs(
         order, so the token budget and file cap allocate exactly as they did
         when each fetch blocked — the same `needs` list must always resolve to
         the same files, whatever order the responses happen to land in.
+
+        The pool is as wide as the wave, which ``take_in_waves`` already slices
+        to the remaining ``max_files`` headroom — so a long `needs` list can
+        never open a connection per entry.
         """
         todo = [p for p in dict.fromkeys(paths) if p not in seen and p not in already]
         if not todo:
             return
         seen.update(todo)
-        with ThreadPoolExecutor(max_workers=min(_FETCH_WORKERS, len(todo))) as pool:
+        with ThreadPoolExecutor(max_workers=len(todo)) as pool:
             fetched.update(zip(todo, pool.map(fetch_file, todo), strict=True))
 
     def accept(path: str) -> bool:

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -355,7 +355,9 @@ class RestGitHubGateway(GitHubGateway):
         files_url = (
             f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/files?per_page=100"
         )
-        changed_files = self._fetch_all_files(files_url)
+        changed_files = [
+            item["filename"] for resp in self._paginate(files_url) for item in resp.json()
+        ]
 
         # Fetch head-revision text of reviewable files so the engine can pad hunks
         # with surrounding context. Read-only API fetch — never a checkout — and
@@ -440,14 +442,14 @@ class RestGitHubGateway(GitHubGateway):
             # replacing the body it clears any stale stamp, so the next run
             # safely falls back to a full review).
             body += f"\n<!-- lgtmaybe-reviewed:{self._reviewed_sha} -->"
-        existing_id = self._find_existing_review()
+        existing = self._find_existing_review_entry()
 
         reviews_url = f"https://api.github.com/repos/{self._repo}/pulls/{self._pr_number}/reviews"
 
-        if existing_id is not None:
+        if existing is not None:
             # Update the existing review body (inline comments cannot be changed
             # through this endpoint, but the summary is updated).
-            update_url = f"{reviews_url}/{existing_id}"
+            update_url = f"{reviews_url}/{existing[0]}"
             resp = self._client.put(
                 update_url,
                 headers={**self._headers, "Accept": "application/vnd.github+json"},
@@ -925,14 +927,6 @@ class RestGitHubGateway(GitHubGateway):
             return []
         return subjects
 
-    def _fetch_all_files(self, first_url: str) -> list[str]:
-        """Follow Link rel=next pagination and collect all filenames."""
-        files: list[str] = []
-        for resp in self._paginate(first_url):
-            for item in resp.json():
-                files.append(item["filename"])
-        return files
-
     def _paginate(self, url: str) -> Iterator[httpx.Response]:
         next_url: str | None = url
         while next_url is not None:
@@ -945,11 +939,6 @@ class RestGitHubGateway(GitHubGateway):
             yield resp
             # httpx parses the Link header for us.
             next_url = resp.links.get("next", {}).get("url")
-
-    def _find_existing_review(self) -> int | None:
-        """Return the ID of the first review whose body contains the marker, or None."""
-        entry = self._find_existing_review_entry()
-        return entry[0] if entry is not None else None
 
     def _find_existing_review_entry(self) -> tuple[int, str] | None:
         """Return ``(id, body)`` of the first review carrying our marker, or None.

--- a/src/lgtmaybe/providers/__init__.py
+++ b/src/lgtmaybe/providers/__init__.py
@@ -1,24 +1,10 @@
 """providers — public surface for the provider track."""
 
-from typing import Any
-
 from lgtmaybe.providers.credentials import AuthConfig, resolve_credentials
 from lgtmaybe.providers.factory import build_provider
 
 __all__ = [
     "AuthConfig",
-    "LiteLLMProvider",
     "build_provider",
     "resolve_credentials",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    # LiteLLMProvider is resolved lazily (PEP 562): importing it pulls in
-    # litellm, whose multi-second import would otherwise be paid by every CLI
-    # command — including ones that never talk to a model.
-    if name == "LiteLLMProvider":
-        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
-
-        return LiteLLMProvider
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ import json
 import pytest
 from click.testing import CliRunner
 
-from lgtmaybe.cli import RuntimeOptions, build_adapters, main, run_review
+from lgtmaybe.cli import RuntimeOptions, build_review_context, main, run_review
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
 from lgtmaybe.core.ports import ReviewEngine
 from tests.fakes import FakeEngine, FakeGitHub, FakeProvider
@@ -440,9 +440,9 @@ class TestParsePrUrl:
             parse_pr_url("https://github.com/org/my-repo/issues/42")
 
 
-class TestBuildAdapters:
+class TestBuildReviewContext:
     def test_builds_real_adapters_for_ollama(self, monkeypatch):
-        """build_adapters returns a RestGitHubGateway + LLMReviewEngine wired from config."""
+        """build_review_context returns a RestGitHubGateway + LLMReviewEngine wired from config."""
         from lgtmaybe.engine import LLMReviewEngine
         from lgtmaybe.github import RestGitHubGateway
 
@@ -450,7 +450,7 @@ class TestBuildAdapters:
         cfg = _default_cfg(provider="ollama", model="llama3")
         runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
-        github, engine = build_adapters(cfg, runtime)
+        github, engine = build_review_context(cfg, runtime)[:2]
 
         assert isinstance(github, RestGitHubGateway)
         assert isinstance(engine, LLMReviewEngine)
@@ -461,7 +461,7 @@ class TestBuildAdapters:
         runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
         with pytest.raises(ValueError, match="GITHUB_TOKEN"):
-            build_adapters(cfg, runtime)
+            build_review_context(cfg, runtime)[:2]
 
     def test_surfaces_missing_provider_credentials(self, monkeypatch):
         """An API-key provider with no key raises the resolver's clear error."""
@@ -471,12 +471,10 @@ class TestBuildAdapters:
         runtime = RuntimeOptions(pr_url="https://github.com/org/repo/pull/7")
 
         with pytest.raises(ValueError, match="OPENAI_API_KEY"):
-            build_adapters(cfg, runtime)
+            build_review_context(cfg, runtime)[:2]
 
     def test_fallback_model_threads_to_provider(self, monkeypatch):
         """A runtime fallback_model reaches the built LiteLLMProvider."""
-        from lgtmaybe.cli import build_review_context
-
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
         cfg = _default_cfg(provider="ollama", model="llama3")
         runtime = RuntimeOptions(
@@ -489,8 +487,6 @@ class TestBuildAdapters:
 
     def test_azure_keyless_ad_token_threads_to_provider(self, monkeypatch):
         """Keyless azure resolves an ambient AD token and threads it to litellm."""
-        from lgtmaybe.cli import build_review_context
-
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
         monkeypatch.delenv("AZURE_API_KEY", raising=False)
         monkeypatch.setattr(

--- a/tests/cli/test_lazy_imports.py
+++ b/tests/cli/test_lazy_imports.py
@@ -36,10 +36,3 @@ def test_build_provider_still_returns_litellm_provider() -> None:
 
     provider = build_provider(Provider.openai, "gpt-4o", api_key="k")
     assert isinstance(provider, LiteLLMProvider)
-
-
-def test_providers_package_still_exports_litellm_provider() -> None:
-    """`from lgtmaybe.providers import LiteLLMProvider` keeps working lazily."""
-    import lgtmaybe.providers as providers
-
-    assert providers.LiteLLMProvider.__name__ == "LiteLLMProvider"

--- a/uv.lock
+++ b/uv.lock
@@ -1293,7 +1293,7 @@ wheels = [
 
 [[package]]
 name = "lgtmaybe"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },
@@ -1311,11 +1311,6 @@ azure = [
 ]
 bedrock = [
     { name = "boto3" },
-]
-identity-broker = [
-    { name = "aws-lambda-powertools" },
-    { name = "httpx" },
-    { name = "pyjwt", extra = ["crypto"] },
 ]
 static-analysis = [
     { name = "bandit" },
@@ -1353,26 +1348,23 @@ packaging = [
 [package.metadata]
 requires-dist = [
     { name = "ast-grep-cli", specifier = ">=0.44.0" },
-    { name = "aws-lambda-powertools", marker = "extra == 'identity-broker'", specifier = ">=3.23" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.19" },
     { name = "bandit", marker = "extra == 'static-analysis'", specifier = ">=1.7" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.4.1" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx", marker = "extra == 'identity-broker'", specifier = ">=0.28.1" },
     { name = "litellm", marker = "python_full_version < '3.14'", specifier = ">=1.87.1" },
     { name = "litellm", marker = "python_full_version >= '3.14'", specifier = ">=1.87.1,<1.94" },
     { name = "mypy", marker = "extra == 'static-analysis'", specifier = ">=1.11" },
     { name = "pydantic", specifier = ">=2.7" },
-    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'identity-broker'", specifier = ">=2.10" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'static-analysis'", specifier = ">=0.5" },
     { name = "semgrep", marker = "extra == 'static-analysis'", specifier = ">=1.60" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "zizmor", marker = "extra == 'static-analysis'", specifier = ">=1.5" },
 ]
-provides-extras = ["azure", "bedrock", "vertex", "static-analysis", "identity-broker"]
+provides-extras = ["azure", "bedrock", "vertex", "static-analysis"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Dead code sweep from #325. Every item was re-verified with a repo-wide `rg` across `src/`, `tests/`, `docs/`, `evals/`, `openspec/`, `.github/`, `action.yml` and `scripts/` immediately before deletion.

**Net: 126 lines removed, 21 added** (105 net, of which ~90 are `src/`).

## Removed outright

| Member | Why it was dead |
|---|---|
| `execute_describe` / `execute_diagram` / `_execute_auxiliary` + the `"execute_describe"` `__all__` entry (`cli/__init__.py`) | Zero callers. `/describe` and `/diagram` go `dispatch` → `run_describe`/`run_diagram`; auto-extras go through `_post_extras`. |
| `build_adapters` (`cli/__init__.py`, and its `__all__` entry) | A wrapper that called `build_review_context` and discarded the provider. Only callers were three tests, now on `build_review_context(...)[:2]`. |
| `_Lens.finding_category` (`engine/engine.py`) | Never set by any of the five `_Lens(...)` sites, so `lens.finding_category or lens.id` was unconditionally `lens.id`. Folded into the expression. |
| `_Hunk.old_len` (`engine/compress.py`) | Written from the parsed header, never read. (The `old_len` in `_render_group` is an unrelated local.) |
| `batch_files` empty-input guard (`engine/compress.py`) | With `files == []` the loop body never runs and the function already returns `[]`. |
| PEP 562 lazy-export shim (`providers/__init__.py`) + its test | Nothing imported `LiteLLMProvider` through the package; `factory.build_provider`'s function-local import is what actually delivers the lazy-import win. The two remaining tests in `test_lazy_imports.py` still guard that (`import lgtmaybe.cli` must not pull in litellm, and the factory still returns a `LiteLLMProvider`). |
| `_FETCH_WORKERS` (`engine/retrieve.py`) | `take_in_waves` already slices each wave to the remaining `max_files` headroom, so `min(_FETCH_WORKERS, len(todo))` never engaged. The bound is preserved and now documented on `prefetch` — the pool is as wide as the wave, and the wave is capped by `max_files`. |
| `identity-broker` extra (`pyproject.toml`) | **Changes published PyPI metadata:** this optional-dependency group disappears from the `lgtmaybe` distribution. Nothing installs it — the Lambda is bundled by CDK from `services/github_app_identity/pyproject.toml`, which has its own lockfile — and it was stale besides (no `boto3`, no `tenacity`, both of which the real service manifest declares), so it could not have built the Lambda anyway. Unrelated to the `identity_broker_url` Action input, which is live and untouched. `uv.lock` regenerated accordingly. |

## Inlined at their single call sites

- `rest_gateway._fetch_all_files` → the same comprehension `apply_pr_labels` already writes inline.
- `rest_gateway._find_existing_review` → the call site already branched on `is not None`, so it now uses `_find_existing_review_entry()` directly and indexes `[0]` for the update URL.
- `parse._repair_trailing_commas` → a one-line `_TRAILING_COMMA_RE.sub` at its only caller; the regex constant already carries the explanatory comment.

## Partially skipped

**The `max_files` parameter of `retrieve.resolve_needs`** — the issue also proposed collapsing this "single-value indirection". Skipped: it is genuinely multi-valued in practice, exercised at `1`, `2` and `5` across seven cap tests in `tests/engine/test_retrieve.py`. Hardcoding `MAX_FETCH_FILES` would trade one line of `src/` indirection for `monkeypatch.setattr` indirection in every one of those tests, and it would remove the caller-side bound on a fetch driven by model-supplied `needs`. The dead half of the item — `_FETCH_WORKERS` — is removed as described above.

Nothing else was skipped; every other checklist item was confirmed still-dead and deleted.

## Verification

- Re-ran `rg` per item before each deletion; also checked `openspec/`, `docs/`, `.github/`, `action.yml` and `scripts/` for references to every removed name — none. No `anchors.yml` rule names any of these members (they bind the enclosing functions, which are untouched), so no anchor dangles and no spec section went stale.
- Full gate green: `uv sync --dev`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` (53 files, clean), `uv run pytest -q` → **1800 passed, 3 skipped**. `uv lock --check` resolves clean.

Closes #325

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_