### PR TITLE
refactor: use stdlib for record attrs, severity order and path counts

### DIFF
--- a/src/lgtmaybe/core/logging.py
+++ b/src/lgtmaybe/core/logging.py
@@ -15,32 +15,11 @@ from typing import Any
 _secrets: set[str] = set()
 
 # Standard LogRecord attributes; anything else is treated as a structured extra.
-_STD_ATTRS = frozenset(
-    {
-        "name",
-        "msg",
-        "args",
-        "levelname",
-        "levelno",
-        "pathname",
-        "filename",
-        "module",
-        "exc_info",
-        "exc_text",
-        "stack_info",
-        "lineno",
-        "funcName",
-        "created",
-        "msecs",
-        "relativeCreated",
-        "thread",
-        "threadName",
-        "processName",
-        "process",
-        "taskName",
-        "message",
-    }
-)
+# Read off an empty record rather than hand-listed, so an attribute CPython adds
+# (3.12's ``taskName``) is filtered out on the version that has it instead of
+# leaking into every log line's payload. ``message`` is the one manual entry:
+# ``Formatter.format`` sets it, ``LogRecord.__init__`` doesn't.
+_STD_ATTRS = frozenset(logging.makeLogRecord({}).__dict__) | {"message"}
 
 
 def register_secret(value: str | None) -> None:

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -36,7 +36,9 @@ class Severity(StrEnum):
 
     @property
     def rank(self) -> int:
-        return _SEVERITY_ORDER.index(self)
+        # Enum iteration order IS declaration order, so the members above are the
+        # single source of the ordering — no second list to keep in step.
+        return list(Severity).index(self)
 
     # All four order comparisons rank by severity. Defined explicitly (not via
     # functools.total_ordering, which skips operators str already defines) so
@@ -60,15 +62,6 @@ class Severity(StrEnum):
         if isinstance(other, Severity):
             return self.rank >= other.rank
         return NotImplemented
-
-
-_SEVERITY_ORDER: list[Severity] = [
-    Severity.info,
-    Severity.low,
-    Severity.medium,
-    Severity.high,
-    Severity.critical,
-]
 
 
 class ReviewCategory(StrEnum):

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -8,6 +8,7 @@ review calls are, with a lenient parser + keep-all safe default as fallback.
 from __future__ import annotations
 
 import json
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
@@ -368,16 +369,11 @@ def _grounding_block(
     if budget_tokens < _MIN_GROUNDING_TOKENS or not ctx.file_contents:
         return "", set()
 
-    counts: dict[str, int] = {}
-    for f in findings:
-        counts[f.path] = counts.get(f.path, 0) + 1
+    counts = Counter(f.path for f in findings)
     # Most-flagged first; stable on ties by first appearance order of the path.
-    order = sorted(counts, key=lambda p: counts[p], reverse=True)
+    order = [p for p, _ in counts.most_common()]
     # Then the deferral-fetched files (not a finding's own path), de-duplicated.
-    for path in extra_paths:
-        if path not in counts:
-            order.append(path)
-            counts[path] = 0
+    order += [p for p in dict.fromkeys(extra_paths) if p not in counts]
 
     remaining = budget_tokens
     blocks: list[str] = []

--- a/src/lgtmaybe/providers/constants.py
+++ b/src/lgtmaybe/providers/constants.py
@@ -7,6 +7,14 @@ from __future__ import annotations
 # litellm client) so the two never drift.
 DEFAULT_OLLAMA_BASE = "http://localhost:11434"
 
+# Per-request timeout (seconds) for a direct cloud provider — the factory's
+# shortest provider default, and the adapter's last-resort fallback when a caller
+# builds it outside the factory or passes no timeout at all. One definition so the
+# fallback can't drift below the default: a fallback that silently undercuts the
+# configured budget is how a reasoning model's review turns into "1 of 8 review
+# calls failed" with zero findings.
+CLOUD_TIMEOUT = 600
+
 # Sent as the api_key for an `openai-compatible` endpoint when the user supplies
 # none. Local servers (llama.cpp / LM Studio / vLLM) need no auth, but the OpenAI
 # client litellm uses rejects an empty key — so we pass this harmless placeholder.

--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -35,6 +35,15 @@ class AuthConfig:
 # Data-plane scope for Azure OpenAI / Cognitive Services AD tokens.
 _AZURE_OPENAI_SCOPE = "https://cognitiveservices.azure.com/.default"
 
+# Env var carrying the key, for the plain API-key providers. Looked up (not
+# .get) on purpose: a provider missing here is a bug, and a KeyError names it
+# rather than resolving to a keyless AuthConfig that fails at the API.
+_ENV_VAR: dict[Provider, str] = {
+    Provider.openai: "OPENAI_API_KEY",
+    Provider.anthropic: "ANTHROPIC_API_KEY",
+    Provider.openrouter: "OPENROUTER_API_KEY",
+}
+
 
 def _default_aws_probe() -> bool:
     """Detect ambient AWS credentials.
@@ -221,11 +230,6 @@ def resolve_credentials(
         return AuthConfig(api_key=key, api_base=base)
 
     # API-key providers: openai, anthropic, openrouter
-    _ENV_VAR: dict[Provider, str] = {
-        Provider.openai: "OPENAI_API_KEY",
-        Provider.anthropic: "ANTHROPIC_API_KEY",
-        Provider.openrouter: "OPENROUTER_API_KEY",
-    }
     env_var = _ENV_VAR[provider]
 
     # An explicit --api-base (e.g. an OpenAI-format proxy) rides along with the

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lgtmaybe.core.models import Provider
-from lgtmaybe.providers.constants import DEFAULT_OLLAMA_BASE
+from lgtmaybe.providers.constants import CLOUD_TIMEOUT, DEFAULT_OLLAMA_BASE
 
 if TYPE_CHECKING:
     from lgtmaybe.providers.litellm_provider import LiteLLMProvider
@@ -49,9 +49,9 @@ _PREFIXES: dict[Provider, str] = {
 # Both are sized for the failure that matters: a timed-out lens call posts
 # "results may be incomplete" with no findings, which a human reads as a clean
 # review. Waiting longer for an answer beats reporting a confident nothing, so
-# these are deliberately far above what a healthy call needs.
+# these are deliberately far above what a healthy call needs. The cloud one is
+# shared with the adapter's fallback (providers.constants.CLOUD_TIMEOUT).
 _SLOW_TIMEOUT = 1800
-_CLOUD_TIMEOUT = 600
 
 # Providers whose endpoint may be a slow model (local server or open gateway).
 _SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider.openrouter})
@@ -65,7 +65,7 @@ _OLLAMA_NUM_CTX = 32768
 
 def default_timeout_for(provider: Provider) -> int:
     """The auto timeout (seconds) for a provider when none is given explicitly."""
-    return _SLOW_TIMEOUT if provider in _SLOW_CAPABLE else _CLOUD_TIMEOUT
+    return _SLOW_TIMEOUT if provider in _SLOW_CAPABLE else CLOUD_TIMEOUT
 
 
 def cheaper_reflect_sibling(provider: Provider, model: str) -> str | None:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -43,15 +43,10 @@ from lgtmaybe.core.ports import (
     ProviderTruncated,
     ProviderWallTimeout,
 )
+from lgtmaybe.providers.constants import CLOUD_TIMEOUT
 
 _log = get_logger(__name__)
 
-# Last-resort per-request timeout (seconds), used only when a caller builds this
-# adapter outside the factory or passes no timeout at all. Kept at the factory's
-# shortest provider default (see providers.factory) rather than something tighter:
-# a fallback that silently undercuts the configured budget is how a reasoning
-# model's review turns into "1 of 8 review calls failed" with zero findings.
-_DEFAULT_TIMEOUT = 600  # seconds
 _MAX_ATTEMPTS = 4
 
 # All attempts for one completion share a total wall-clock budget of this many
@@ -156,22 +151,10 @@ _EXPIRED_CREDENTIAL_MARKERS = (
 )
 
 
-def _is_quota_rate_limit(exc: BaseException) -> bool:
-    """True for a quota/billing 429 (permanent), False for a capacity 429."""
+def _mentions(exc: BaseException, markers: tuple[str, ...]) -> bool:
+    """True when *exc*'s message mentions any of *markers* (case-insensitively)."""
     msg = str(exc).lower()
-    return any(marker in msg for marker in _QUOTA_MARKERS)
-
-
-def _is_insufficient_credit(exc: BaseException) -> bool:
-    """True when *exc* is a prepaid-balance refusal (permanent until topped up)."""
-    msg = str(exc).lower()
-    return any(marker in msg for marker in _INSUFFICIENT_CREDIT_MARKERS)
-
-
-def _is_expired_credential(exc: BaseException) -> bool:
-    """True when *exc* is an expired/invalid ambient cloud credential (permanent)."""
-    msg = str(exc).lower()
-    return any(marker in msg for marker in _EXPIRED_CREDENTIAL_MARKERS)
+    return any(marker in msg for marker in markers)
 
 
 def _is_permanent(exc: BaseException) -> bool:
@@ -197,9 +180,12 @@ def _is_permanent(exc: BaseException) -> bool:
     # attempt worth refusing.
     if isinstance(exc, ProviderTruncated):
         return True
+    # A 429 is permanent only when it's a quota/billing one; a capacity 429 retries.
     if isinstance(exc, RateLimitError):
-        return _is_quota_rate_limit(exc)
-    return _is_expired_credential(exc) or _is_insufficient_credit(exc)
+        return _mentions(exc, _QUOTA_MARKERS)
+    return _mentions(exc, _EXPIRED_CREDENTIAL_MARKERS) or _mentions(
+        exc, _INSUFFICIENT_CREDIT_MARKERS
+    )
 
 
 def _rejects_response_format(exc: Exception) -> bool:
@@ -294,7 +280,7 @@ class LiteLLMProvider(ProviderClient):
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
-        merged.setdefault("timeout", _DEFAULT_TIMEOUT)
+        merged.setdefault("timeout", CLOUD_TIMEOUT)
         # We own retries (tenacity, below). Disable litellm's own retry loop so a
         # failure isn't ground through two stacked backoff layers — the doubling
         # that helped a quota error run ~13 min before it surfaced.
@@ -348,7 +334,7 @@ class LiteLLMProvider(ProviderClient):
         # Attempts share one deadline derived from the per-request timeout (the
         # fallback model, when configured, gets its own fresh budget — it is a
         # separate recovery path, not another attempt).
-        timeout = float(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
+        timeout = float(kwargs.get("timeout") or CLOUD_TIMEOUT)
 
         @retry(
             retry=retry_if_exception(lambda exc: not _is_permanent(exc)),
@@ -599,7 +585,7 @@ def _completion_with_wall_timeout(
     replace its real error (a quota 429, a bad key) with a bare timeout, hiding the
     one thing that tells the user what to fix.
     """
-    timeout = float(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
+    timeout = float(kwargs.get("timeout") or CLOUD_TIMEOUT)
     future: Future[Any] = Future()
 
     def complete() -> None:

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -217,10 +217,11 @@ class TestDefaultTimeout:
         """The adapter's last-resort timeout applies whenever a caller builds a
         provider outside the factory (or passes timeout=None through), so it must
         not silently reimpose a budget shorter than the factory would have."""
+        from lgtmaybe.providers.constants import CLOUD_TIMEOUT
         from lgtmaybe.providers.factory import default_timeout_for
-        from lgtmaybe.providers.litellm_provider import _DEFAULT_TIMEOUT
 
-        assert _DEFAULT_TIMEOUT >= min(default_timeout_for(p) for p in Provider)
+        # One definition, shared: >= would let the two 600s drift apart silently.
+        assert CLOUD_TIMEOUT == min(default_timeout_for(p) for p in Provider)
 
     def test_build_provider_threads_temperature_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", temperature=0.0)


### PR DESCRIPTION
Six rung-3 simplifications from the ponytail audit in #333: hand-maintained tables and duplicated helpers that the stdlib — or an existing constant — already provides. No behaviour change anywhere; net **-81 / +48**, so **33 lines removed** across 7 source files plus one test.

## What changed

**1. `core/logging.py` — `_STD_ATTRS` read off a real record instead of hand-listed**

```python
_STD_ATTRS = frozenset(logging.makeLogRecord({}).__dict__) | {"message"}
```

replaces a 26-line literal. `"message"` stays manual because `Formatter.format` sets it, `LogRecord.__init__` doesn't.

**2. `core/models.py` — `_SEVERITY_ORDER` deleted**

`Severity.rank` is now `list(Severity).index(self)`. Enum iteration order *is* declaration order, so the members declared 30 lines above are the single source of the ordering rather than the second one.

**3. `engine/reflect.py` — `Counter` for the grounding-block path frequency**

```python
counts = Counter(f.path for f in findings)
order = [p for p, _ in counts.most_common()]
order += [p for p in dict.fromkeys(extra_paths) if p not in counts]
```

`dict.fromkeys` does the order-preserving de-dupe the old `counts[path] = 0` sentinel write was faking. `counts` is not read after `order` is built, so dropping the sentinel is safe.

**4. `providers/litellm_provider.py` — three byte-identical predicates → one `_mentions(exc, markers)`**

`_is_quota_rate_limit`, `_is_insufficient_credit` and `_is_expired_credential` had identical bodies differing only in the tuple they closed over. All three marker tuples and their comments are kept verbatim — that's the actual knowledge — and `_is_permanent` calls `_mentions` with the same tuples in the same order, so the permanent-vs-transient classification is byte-for-byte the same decision.

**5. The 600s timeout had two definitions → `providers/constants.CLOUD_TIMEOUT`**

`litellm_provider._DEFAULT_TIMEOUT` and `factory._CLOUD_TIMEOUT` were both `600`, with the invariant stated only in prose. Both now read the shared constant (no import cycle — both modules already import `DEFAULT_OLLAMA_BASE` from there). `tests/providers/test_factory.py` tightened from `>=` to `==`, since with one definition drift is no longer expressible.

**6. `providers/credentials.py` — `_ENV_VAR` hoisted to module scope**

It was rebuilt inside `resolve_credentials` on every call, after five early-return branches. The `KeyError`-on-unknown-provider lookup is deliberately kept (and now documented) — a `.get` there would silently produce a keyless `AuthConfig` that fails later at the API instead of naming the bug.

## Equivalence evidence (items 1–3)

Run in the repo's own venv, Python 3.11.15:

| Check | Result |
|---|---|
| **1.** `OLD - NEW` | `['taskName']` |
| **1.** `NEW - OLD` | `[]` |
| **2.** `[s.rank for s in Severity]` | `[0, 1, 2, 3, 4]` for `info, low, medium, high, critical` |
| **3.** old vs new ordering, 20,000 randomised cases | `0` mismatches |

- **Item 1:** the only delta is `taskName`, which does not exist on 3.11 (the repo's floor) and *is* auto-included by `makeLogRecord` on 3.12+ — identical behaviour today, self-correcting tomorrow. Nothing asserts the literal's contents.
- **Item 2:** ordering and all four comparison operators unchanged (`critical > info`, `low < medium` spot-checked alongside the ranks).
- **Item 3:** the tie ordering was checked, not assumed. 20k randomised `(paths, extra_paths)` pairs over a small alphabet — including heavy ties, empty inputs, and extras that duplicate both each other and flagged paths — produced zero differences from the old `sorted(..., reverse=True)` + sentinel version. Both `sorted(reverse=True)` and `Counter.most_common()` are stable, so equal counts keep first-appearance order either way.

## Gate

`uv sync --dev && uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest -q` — all green: 1801 passed, 3 skipped.

Out of scope by design, left to their own issues: `compress.py`'s bisect sentinel (#332), `github/diff.py` path splitting (#327), `astgrep.py`'s `_SOURCE_EXTS` (#334). The litellm retry/fallback loop is untouched.

Closes #333

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_