### PR TITLE
refactor(engine): carry run-wide review settings in one object

### DIFF
--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -6,13 +6,13 @@ Provides a dynamic context-line calculator for the remaining budget.
 
 from __future__ import annotations
 
-import sys
 from bisect import bisect_right
 from dataclasses import dataclass
 from functools import lru_cache
+from operator import itemgetter
 from typing import Any
 
-from lgtmaybe.core.diffparse import parse_hunk_header
+from lgtmaybe.core.diffparse import HunkHeader, parse_hunk_header
 
 _MAX_CONTEXT_LINES = 20
 
@@ -247,7 +247,7 @@ def _enclosing_boundary(boundaries: list[tuple[int, int]], new_start: int) -> in
     None when nothing encloses it, or when the enclosing definition begins more
     than :data:`_MAX_BOUNDARY_REACH` lines above (padding would drown the diff).
     """
-    idx = bisect_right(boundaries, (new_start, _UNBOUNDED_END)) - 1
+    idx = bisect_right(boundaries, new_start, key=itemgetter(0)) - 1
     while idx >= 0:
         start, end = boundaries[idx]
         if new_start - start > _MAX_BOUNDARY_REACH:
@@ -257,12 +257,6 @@ def _enclosing_boundary(boundaries: list[tuple[int, int]], new_start: int) -> in
             return start
         idx -= 1
     return None
-
-
-# Sentinel upper bound for the bisect probe: pairs compare element-wise, so this
-# has to sort above any real end line for the probe to find every span whose
-# start is at or below the hunk.
-_UNBOUNDED_END = sys.maxsize
 
 
 def trailing_context_lines(before: int) -> int:
@@ -344,19 +338,15 @@ def expand_hunks(
 
 @dataclass(frozen=True)
 class _Hunk:
-    """One parsed hunk: its header positions plus its verbatim body lines."""
+    """One parsed hunk: its parsed header plus its verbatim body lines."""
 
-    old_start: int
-    old_len: int
-    new_start: int
-    new_len: int
-    section: str
+    header: HunkHeader
     body: list[str]
 
     @property
     def last_new(self) -> int:
         """The hunk's final new-file line number."""
-        return self.new_start + self.new_len - 1
+        return self.header.new_start + self.header.new_len - 1
 
 
 def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
@@ -366,16 +356,7 @@ def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
     for line in patch.splitlines():
         header = parse_hunk_header(line)
         if header is not None:
-            hunks.append(
-                _Hunk(
-                    old_start=header.old_start,
-                    old_len=header.old_len,
-                    new_start=header.new_start,
-                    new_len=header.new_len,
-                    section=header.section,
-                    body=[],
-                )
-            )
+            hunks.append(_Hunk(header, []))
         elif hunks:
             hunks[-1].body.append(line)
         else:
@@ -385,9 +366,9 @@ def _parse_hunks(patch: str) -> tuple[list[str], list[_Hunk]]:
 
 def _lead_start(hunk: _Hunk, n: int, boundaries: list[tuple[int, int]] | None) -> int:
     """The first new-file line *hunk*'s leading pad should reach back to."""
-    lead_start = max(1, hunk.new_start - n)
+    lead_start = max(1, hunk.header.new_start - n)
     if boundaries:
-        enclosing = _enclosing_boundary(boundaries, hunk.new_start)
+        enclosing = _enclosing_boundary(boundaries, hunk.header.new_start)
         if enclosing is not None and enclosing < lead_start:
             # The enclosing definition starts above the fixed window and
             # within reach — widen the pad up to its signature line.
@@ -397,7 +378,7 @@ def _lead_start(hunk: _Hunk, n: int, boundaries: list[tuple[int, int]] | None) -
     # unclamped pad drives it negative — an invalid header that
     # parse_hunk_header rejects, mis-numbering every line downstream. Clamp the
     # pad (after any boundary widening) so the old start stays >= 1.
-    return max(lead_start, hunk.new_start - (hunk.old_start - 1))
+    return max(lead_start, hunk.header.new_start - (hunk.header.old_start - 1))
 
 
 @dataclass
@@ -434,7 +415,7 @@ def _group_hunks(
             previous = groups[-1].hunks[-1]
             trail_end = min(len(content_lines), previous.last_new + n_after)
             reaches = lead_start <= trail_end + 1
-            fillable = hunk.new_start - 1 <= len(content_lines)
+            fillable = hunk.header.new_start - 1 <= len(content_lines)
             if reaches and fillable:
                 groups[-1].hunks.append(hunk)
                 continue
@@ -455,7 +436,7 @@ def _render_group(group: _Group, content_lines: list[str], n_after: int) -> list
     # Clamp reads to the file's real bounds: redaction or stale head text can
     # leave the file shorter than the hunk positions — degrade to less padding,
     # never an IndexError.
-    lead_end = min(first.new_start, len(content_lines) + 1)
+    lead_end = min(first.header.new_start, len(content_lines) + 1)
     leading = content_lines[min(group.lead_start, lead_end) - 1 : lead_end - 1]
 
     body: list[str] = []
@@ -464,7 +445,9 @@ def _render_group(group: _Group, content_lines: list[str], n_after: int) -> list
             # Fill the gap between the previous hunk's last line and this one
             # with the head text, as ordinary context.
             previous_end = group.hunks[index - 1].last_new
-            body.extend(f" {text}" for text in content_lines[previous_end : hunk.new_start - 1])
+            body.extend(
+                f" {text}" for text in content_lines[previous_end : hunk.header.new_start - 1]
+            )
         body.extend(hunk.body)
 
     trailing = content_lines[last.last_new : min(len(content_lines), last.last_new + n_after)]
@@ -474,6 +457,6 @@ def _render_group(group: _Group, content_lines: list[str], n_after: int) -> list
     # counts on both sides; "\ No newline at end of file" counts on neither.
     old_len = sum(1 for line in lines if line[:1] in {" ", "-", ""})
     new_len = sum(1 for line in lines if line[:1] in {" ", "+", ""})
-    old_start = first.old_start - len(leading)
-    new_start = first.new_start - len(leading)
-    return [f"@@ -{old_start},{old_len} +{new_start},{new_len} @@{first.section}", *lines]
+    old_start = first.header.old_start - len(leading)
+    new_start = first.header.new_start - len(leading)
+    return [f"@@ -{old_start},{old_len} +{new_start},{new_len} @@{first.header.section}", *lines]

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -141,6 +141,11 @@ INCOMPLETE_MARKER = "<!-- lgtmaybe-incomplete -->"
 _BUDGET_SKIP_REASON = "token budget (max_review_tokens) reached — call skipped"
 
 
+def _plural(n: int, one: str = "", many: str = "s") -> str:
+    """The word (or suffix) for a count of *n*: *one* when it is exactly 1, else *many*."""
+    return one if n == 1 else many
+
+
 def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
     """The fan-out pool size: the explicit cap, else the provider-aware default."""
     if cfg.max_concurrency is not None:
@@ -280,6 +285,30 @@ _LensOutcome = tuple[list[ReviewFinding], str | None]
 _ReviewTask = partial[_LensOutcome]
 
 
+@dataclass(frozen=True)
+class _Run:
+    """The settings that are fixed for a whole review, resolved once in ``review()``.
+
+    Every model call in the fan-out — the first one, an oversized batch's split
+    pieces, a deferral's re-run — reads exactly the same values, so they travel
+    as one object rather than as seven parameters re-declared at each hop.
+    """
+
+    model: str
+    # Constrains output to the findings schema (provider-native JSON mode) on
+    # review calls only — the reflection call keeps its own format.
+    response_format: type[ReviewResult] | None
+    # The message shape: True (prompt_cache on, the default) splits the prompt
+    # into a cacheable shared prefix plus the lens block; False is the legacy
+    # lens-in-system layout.
+    split_prompt: bool
+    language: str | None
+    deadline_at: float | None
+    budget_at: int | None
+    # Mid-review retrieval budget in tokens, or None when a lens may not defer.
+    retrieval_budget: int | None
+
+
 def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
     """Split a timed-out batch into smaller review units.
 
@@ -323,15 +352,13 @@ def _skip_reason(deadline_at: float | None, budget_at: int | None, lens: _Lens) 
 
 
 def _lens_messages(
+    run: _Run,
     wrapped: str,
     intent_block: str | None,
     hint_block: str | None,
     dir_block: str | None,
-    split_prompt: bool,
-    language: str | None,
     lens: _Lens,
     *,
-    retrieval: bool,
     context: str | None = None,
 ) -> list[Message]:
     """The messages for one lens call, in whichever prompt shape is configured.
@@ -343,29 +370,30 @@ def _lens_messages(
     ahead of the lens checklist for the same reason the diff does, so the trusted
     instructions stay closest to the answer.
     """
-    if split_prompt:
+    # Only the intent lens pays the intent-block tokens (and its injection
+    # surface); the other lenses never see PR-authored prose. In the split shape
+    # it rides the lens block — NOT the shared prefix — so their cached prefix
+    # stays identical.
+    intent = intent_block if lens.carries_intent else None
+    retrieval = run.retrieval_budget is not None
+    if run.split_prompt:
         # The directory block joins the ONE prefix string rather than adding
         # a fourth message: the adapter puts its cache breakpoint on the last
         # prefix block, and it varies per batch exactly like the hints do, so
         # it is warmed once by the primer and read by lenses 2..N.
         prefix = "\n\n".join(part for part in (dir_block, hint_block, wrapped) if part is not None)
         suffix = lens.user_block if context is None else f"{context}\n\n{lens.user_block}"
-        if lens.carries_intent and intent_block is not None:
-            # Only the intent lens pays the intent-block tokens (and its
-            # injection surface). It rides the lens block — NOT the shared
-            # prefix — so the other lenses' cached prefix stays identical.
-            suffix = f"{intent_block}\n\n{suffix}"
+        if intent is not None:
+            suffix = f"{intent}\n\n{suffix}"
         return [
-            {"role": "system", "content": build_shared_preamble(language, retrieval)},
+            {"role": "system", "content": build_shared_preamble(run.language, retrieval)},
             {"role": "user", "content": prefix},
             {"role": "user", "content": suffix},
         ]
 
     user_content = wrapped
-    if lens.carries_intent and intent_block is not None:
-        # Only the intent lens pays the intent-block tokens (and its
-        # injection surface); the other lenses never see PR-authored prose.
-        user_content = f"{intent_block}\n\n{user_content}"
+    if intent is not None:
+        user_content = f"{intent}\n\n{user_content}"
     if hint_block is not None:
         # Static-analysis grounding: every lens sees the hints (each judges
         # relevance to its own concern) ahead of the diff they refer to.
@@ -586,9 +614,20 @@ class LLMReviewEngine(ReviewEngine):
         #    waves; flattened, it is `ceil(batches × lenses / workers)`. Each
         #    lens gets a focused prompt; findings are merged afterwards.
         #    Concurrency is provider-aware (see _resolve_workers).
-        # Constrain output to the findings schema (provider-native JSON mode) per
-        # review call — NOT globally, so the reflection call keeps its own format.
-        response_format = ReviewResult if cfg.structured_output else None
+        # Everything a model call needs that does not vary across the run, in one
+        # object: resolved here, then carried unchanged through the fan-out, the
+        # oversized-batch split, and a deferral's re-run.
+        run = _Run(
+            model=cfg.model,
+            # Constrain output to the findings schema (provider-native JSON mode) per
+            # review call — NOT globally, so the reflection call keeps its own format.
+            response_format=ReviewResult if cfg.structured_output else None,
+            split_prompt=cfg.prompt_cache,
+            language=cfg.language,
+            deadline_at=deadline_at,
+            budget_at=budget_at,
+            retrieval_budget=retrieval_budget,
+        )
         workers = _resolve_workers(cfg, len(batches) * len(lenses))
         per_batch: list[tuple[bool, list[_ReviewTask]]] = []
         for batch_num, batch in enumerate(batches, start=1):
@@ -632,18 +671,12 @@ class LLMReviewEngine(ReviewEngine):
             batch_tasks = [
                 partial(
                     self._review_lens,
+                    run,
                     wrapped,
                     intent_block,
                     hint_block,
                     dir_block,
-                    cfg.model,
-                    response_format,
                     batch_num,
-                    cfg.prompt_cache,
-                    cfg.language,
-                    deadline_at,
-                    budget_at,
-                    retrieval_budget,
                     lens,
                     batch,
                 )
@@ -805,7 +838,7 @@ class LLMReviewEngine(ReviewEngine):
             )
         if skipped_by_triage:
             # Transparency: a triage skip must be visible, never silent.
-            plural_files = "s" if len(skipped_by_triage) != 1 else ""
+            plural_files = _plural(len(skipped_by_triage))
             listed = ", ".join(f"`{p}`" for p in skipped_by_triage[:10])
             more = ", …" if len(skipped_by_triage) > 10 else ""
             notices.append(
@@ -818,7 +851,7 @@ class LLMReviewEngine(ReviewEngine):
         # partial and that must never be softened into a clean bill of health).
         budget_skips = sum(1 for e in errors if e == _BUDGET_SKIP_REASON)
         if budget_skips:
-            plural = "s were" if budget_skips != 1 else " was"
+            plural = _plural(budget_skips, " was", "s were")
             notices.append(
                 f"💸 Token budget reached ({cfg.max_review_tokens} billable tokens) — "
                 f"{budget_skips} of {total_calls} review call{plural} skipped, so this "
@@ -841,11 +874,12 @@ class LLMReviewEngine(ReviewEngine):
         # wall clock and a blown output ceiling), because the remedy is the same.
         if self._split_batches:
             count = len(self._split_batches)
-            plural = "es" if count != 1 else ""
+            plural = _plural(count, many="es")
+            was = _plural(count, "was", "were")
             notices.append(
-                f"⏱️ {count} batch{plural} {'were' if count != 1 else 'was'} too big for one "
+                f"⏱️ {count} batch{plural} {was} too big for one "
                 "call (timed out, or ran past the `max_tokens` ceiling) and "
-                f"{'were' if count != 1 else 'was'} reviewed in smaller pieces instead. "
+                f"{was} reviewed in smaller pieces instead. "
                 "Consider a lower `max_input_tokens`, a higher `max_tokens`, or a faster model."
             )
         if reflection_skipped:
@@ -858,7 +892,7 @@ class LLMReviewEngine(ReviewEngine):
         # the remaining count as a clean bill of health would let a suppression
         # quietly convert a real finding into "LGTM".
         if suppressed:
-            plural = "s" if suppressed != 1 else ""
+            plural = _plural(suppressed)
             notices.append(
                 f"🙈 {suppressed} finding{plural} suppressed (ignored fingerprint, "
                 "inline `lgtmaybe: ignore`, or a 👎 from a previous run) — not "
@@ -869,7 +903,7 @@ class LLMReviewEngine(ReviewEngine):
         # them would make a repo with a pre-existing secret look clean, so say
         # the number and where to look.
         if off_diff:
-            plural = "s" if off_diff != 1 else ""
+            plural = _plural(off_diff)
             notices.append(
                 f"🔍 {off_diff} scan finding{plural} skipped — on unchanged lines "
                 "outside this PR's diff. Run the tool over the repository to see them."
@@ -880,7 +914,7 @@ class LLMReviewEngine(ReviewEngine):
         # they were fixed.
         if ctx.open_finding_threads:
             count = ctx.open_finding_threads
-            subject = "conversation is" if count == 1 else "conversations are"
+            subject = _plural(count, "conversation is", "conversations are")
             notices.append(
                 f"💬 {count} earlier lgtmaybe {subject} still unresolved on this PR — "
                 "this run's count covers what it reviewed now, not those."
@@ -940,18 +974,12 @@ class LLMReviewEngine(ReviewEngine):
 
     def _review_lens(
         self,
+        run: _Run,
         wrapped: str,
         intent_block: str | None,
         hint_block: str | None,
         dir_block: str | None,
-        model: str,
-        response_format: type[ReviewResult] | None,
         batch_num: int,
-        split_prompt: bool,
-        language: str | None,
-        deadline_at: float | None,
-        budget_at: int | None,
-        retrieval_budget: int | None,
         lens: _Lens,
         batch: list[tuple[str, str]] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
@@ -968,7 +996,7 @@ class LLMReviewEngine(ReviewEngine):
         :meth:`_review_split`). None means "already a piece" — no further
         splitting.
 
-        ``split_prompt`` selects the message shape. True (``prompt_cache`` on —
+        ``run.split_prompt`` selects the message shape. True (``prompt_cache`` on —
         the default): shared system preamble, then the shared prefix (hints +
         diff) as one user message, then the lens block (intent + checklist +
         example) as a final user message — every lens call shares the same
@@ -977,13 +1005,13 @@ class LLMReviewEngine(ReviewEngine):
         kept as the escape hatch for a model that reviews worse under the
         split layout.
 
-        ``retrieval_budget`` (None = off) opts this call into the one deferral a
-        lens may make: answering with ``needs``, it is re-run once with that code
+        ``run.retrieval_budget`` (None = off) opts this call into the one deferral
+        a lens may make: answering with ``needs``, it is re-run once with that code
         fetched read-only (see :meth:`_review_with_context`). Like the
         oversized-payload split, it is offered only when ``batch`` is supplied —
         so a re-run, which passes none, can never defer again.
         """
-        skip = _skip_reason(deadline_at, budget_at, lens)
+        skip = _skip_reason(run.deadline_at, run.budget_at, lens)
         if skip is not None:
             return [], skip
         on_oversized = (
@@ -991,54 +1019,33 @@ class LLMReviewEngine(ReviewEngine):
             if batch is None
             else partial(
                 self._review_split,
+                run=run,
                 batch=batch,
                 intent_block=intent_block,
                 hint_block=hint_block,
                 dir_block=dir_block,
-                model=model,
-                response_format=response_format,
                 batch_num=batch_num,
-                split_prompt=split_prompt,
-                language=language,
-                deadline_at=deadline_at,
-                budget_at=budget_at,
-                retrieval_budget=retrieval_budget,
                 lens=lens,
             )
         )
         on_needs = (
             None
-            if batch is None or retrieval_budget is None
+            if batch is None or run.retrieval_budget is None
             else partial(
                 self._review_with_context,
+                run=run,
                 wrapped=wrapped,
                 batch=batch,
                 intent_block=intent_block,
                 hint_block=hint_block,
                 dir_block=dir_block,
-                model=model,
-                response_format=response_format,
                 batch_num=batch_num,
-                split_prompt=split_prompt,
-                language=language,
-                deadline_at=deadline_at,
-                budget_at=budget_at,
-                retrieval_budget=retrieval_budget,
                 lens=lens,
             )
         )
-        messages = _lens_messages(
-            wrapped,
-            intent_block,
-            hint_block,
-            dir_block,
-            split_prompt,
-            language,
-            lens,
-            retrieval=retrieval_budget is not None,
-        )
+        messages = _lens_messages(run, wrapped, intent_block, hint_block, dir_block, lens)
         return self._complete_lens(
-            messages, model, response_format, batch_num, lens, on_oversized, on_needs
+            messages, run.model, run.response_format, batch_num, lens, on_oversized, on_needs
         )
 
     def _review_with_context(
@@ -1046,19 +1053,13 @@ class LLMReviewEngine(ReviewEngine):
         needs: list[str],
         findings: list[ReviewFinding],
         *,
+        run: _Run,
         wrapped: str,
         batch: list[tuple[str, str]],
         intent_block: str | None,
         hint_block: str | None,
         dir_block: str | None,
-        model: str,
-        response_format: type[ReviewResult] | None,
         batch_num: int,
-        split_prompt: bool,
-        language: str | None,
-        deadline_at: float | None,
-        budget_at: int | None,
-        retrieval_budget: int,
         lens: _Lens,
     ) -> _LensOutcome:
         """Re-run one lens with the bounded, read-only code it asked to read.
@@ -1072,9 +1073,9 @@ class LLMReviewEngine(ReviewEngine):
 
         Bounded on every axis. One hop (the re-run is issued with ``batch=None``, so
         a second ``needs`` is ignored); at most ``MAX_FETCH_FILES`` files inside
-        ``retrieval_budget`` tokens; and the deadline/budget guards are re-checked
-        first, so a deferral arriving past a ceiling degrades into the existing
-        incomplete-results notice instead of spending past it.
+        ``run.retrieval_budget`` tokens; and the deadline/budget guards are
+        re-checked first, so a deferral arriving past a ceiling degrades into the
+        existing incomplete-results notice instead of spending past it.
 
         Returns ``first + retry`` findings, left for the pipeline's ``_dedupe`` to
         collapse. Replacing the first call's findings wholesale would be simpler and
@@ -1082,19 +1083,20 @@ class LLMReviewEngine(ReviewEngine):
         something else. The cost is a duplicate pair when the re-run repeats itself —
         which dedupe (keyed path/line/side) is exactly what removes.
         """
-        skip = _skip_reason(deadline_at, budget_at, lens)
+        skip = _skip_reason(run.deadline_at, run.budget_at, lens)
         if skip is not None:
             # The lens asked for code we may no longer spend on. Keep what it
             # already found and report the skip: the run IS incomplete, and the
             # existing notice is how that reaches the PR.
             return findings, skip
-        if self._fetch_file is None:  # pragma: no cover — never offered without one
+        # Never offered without both; the guard is here so the types line up.
+        if self._fetch_file is None or run.retrieval_budget is None:  # pragma: no cover
             return findings, None
         fetched = resolve_needs(
             needs,
             self._fetch_file,
             already={path for path, _ in batch},
-            budget_tokens=retrieval_budget,
+            budget_tokens=run.retrieval_budget,
             max_files=MAX_FETCH_FILES,
             resolve_symbol=self._resolve_symbol,
         )
@@ -1112,18 +1114,16 @@ class LLMReviewEngine(ReviewEngine):
             extra={"lens": lens.id, "batch": batch_num, "files": sorted(fetched)},
         )
         messages = _lens_messages(
+            run,
             wrapped,
             intent_block,
             hint_block,
             dir_block,
-            split_prompt,
-            language,
             lens,
-            retrieval=True,
             context=wrap_context(fetched),
         )
         retry, error = self._complete_lens(
-            messages, model, response_format, batch_num, lens, None, None
+            messages, run.model, run.response_format, batch_num, lens, None, None
         )
         return findings + retry, error
 
@@ -1131,18 +1131,12 @@ class LLMReviewEngine(ReviewEngine):
         self,
         reason: str,
         *,
+        run: _Run,
         batch: list[tuple[str, str]],
         intent_block: str | None,
         hint_block: str | None,
         dir_block: str | None,
-        model: str,
-        response_format: type[ReviewResult] | None,
         batch_num: int,
-        split_prompt: bool,
-        language: str | None,
-        deadline_at: float | None,
-        budget_at: int | None,
-        retrieval_budget: int | None,
         lens: _Lens,
     ) -> _LensOutcome:
         """Re-review an oversized batch as smaller pieces, one call each.
@@ -1175,18 +1169,12 @@ class LLMReviewEngine(ReviewEngine):
         errors: list[str] = []
         for piece in pieces:
             piece_findings, piece_error = self._review_lens(
+                run,
                 wrap_diff("\n".join(patch for _, patch in piece)),
                 intent_block,
                 hint_block,
                 dir_block,
-                model,
-                response_format,
                 batch_num,
-                split_prompt,
-                language,
-                deadline_at,
-                budget_at,
-                retrieval_budget,
                 lens,
             )
             findings.extend(piece_findings)
@@ -1296,8 +1284,8 @@ class LLMReviewEngine(ReviewEngine):
             # and "0 recovered" are very different states to be told about.
             findings, salvaged = exc.recovered, len(exc.recovered)
             recovered_note = (
-                f"; {salvaged} finding{'s' if salvaged != 1 else ''} completed before the cut "
-                f"{'are' if salvaged != 1 else 'is'} included"
+                f"; {salvaged} finding{_plural(salvaged)} completed before the cut "
+                f"{_plural(salvaged, 'is', 'are')} included"
                 if salvaged
                 else ""
             )
@@ -1389,7 +1377,7 @@ def _summary_line(count: int, cfg: ReviewConfig) -> str:
                 "summary_template failed to format — using the default",
                 extra={"error": str(exc)},
             )
-    plural = "s" if count != 1 else ""
+    plural = _plural(count)
     return (
         f"{count} finding{plural} · provider {cfg.provider} · model {cfg.model} "
         f"· lgtmaybe {version}"
@@ -1531,21 +1519,14 @@ def _filter_missing_failure_scenarios(
     findings: list[ReviewFinding],
 ) -> list[ReviewFinding]:
     """Drop built-in defect findings that provide no concrete causal evidence."""
-    kept: list[ReviewFinding] = []
-    for finding in findings:
-        scenario = finding.failure_scenario
-        if finding.category in _FAILURE_SCENARIO_CATEGORIES and not (scenario and scenario.strip()):
-            _log.info(
-                "finding missing failure scenario — dropping",
-                extra={
-                    "path": finding.path,
-                    "line": finding.line,
-                    "title": finding.title,
-                    "category": finding.category,
-                },
-            )
-            continue
-        kept.append(finding)
+    kept = [
+        f
+        for f in findings
+        if f.category not in _FAILURE_SCENARIO_CATEGORIES or (f.failure_scenario or "").strip()
+    ]
+    dropped = len(findings) - len(kept)
+    if dropped:
+        _log.info("findings missing a failure scenario dropped", extra={"count": dropped})
     return kept
 
 


### PR DESCRIPTION
Ponytail cleanup of `engine/engine.py` + `engine/compress.py`. No behaviour change.

## Main item — one `_Run` instead of seven hand-threaded parameters

`model`, `response_format`, `split_prompt`, `language`, `deadline_at`, `budget_at` and `retrieval_budget` are resolved once in `review()` and never vary for the rest of the run, yet they were re-declared and re-passed at eight sites: the `partial` in `review()`, `_review_lens`, the `on_oversized` and `on_needs` partials, `_review_with_context`, `_review_split`, `_review_split`'s recursive `_review_lens` call, and `_lens_messages`.

They now travel as one frozen `_Run` dataclass, built once in `review()`:

```python
_review_lens(self, run, wrapped, intent_block, hint_block, dir_block, batch_num, lens, batch=None)
```

Both callbacks collapse from ~20-line `partial(...)` blocks to a handful of lines. Every function **name** is unchanged, so the ast-grep rules in `openspec/specs/review-pipeline/anchors.yml` still resolve (`tests/specs` green). Per the issue, this stops at the run-wide object — the per-batch one (`wrapped`/`intent_block`/`hint_block`/`dir_block`/`batch_num`) is deliberately not added.

The deadline/budget safety path is untouched: `_skip_reason` is still checked at the top of `_review_lens` and again in `_review_with_context`, and a skipped call still returns its reason so the incomplete-results notice reaches the PR. `_review_with_context` gained a `run.retrieval_budget is None` arm on its existing unreachable guard, since the field is now optional on the shared object.

## Smaller items in the same two files

- **`_lens_messages` wrote the intent-block prepend twice** — once per prompt shape, with two near-identical comments. Computed once before the branch as `intent`. **Concatenation order is unchanged**, so the byte-for-byte legacy-shape guarantee holds.
- **`_filter_missing_failure_scenarios`** — a 20-line loop with a per-finding log becomes a filter comprehension plus one aggregate count log, matching the file's own convention for this shape.
- **`_Hunk` re-declared `HunkHeader` field-for-field** (`compress.py` vs `core/diffparse.py`), with `_parse_hunks` copying each field across by hand. Composed as `_Hunk(header, body)`; `last_new` is `header.new_start + header.new_len - 1`, and the 10-line construction is now `hunks.append(_Hunk(header, []))`.
- **`sys.maxsize` sentinel faking a keyed bisect** — replaced with `bisect_right(boundaries, new_start, key=itemgetter(0)) - 1` (the `key=` parameter is available on the 3.11 floor). The sentinel, its four-line comment and the `import sys` are gone.
- **The plural-suffix idiom, eleven times** — `"s" if n != 1 else ""`, `"es"/""`, `"were"/"was"`, `"are"/"is"`, three of them inside one f-string — replaced with a single `_plural(n, one="", many="s")`.

## Notice strings are byte-identical

Confirmed. Every user-facing notice produced by the `_plural` call sites renders exactly the same bytes as before for both the singular and plural branches — including the split-batch notice, where one `was = _plural(count, "was", "were")` now feeds both interpolations that previously each carried their own inline conditional. `tests/test_incomplete_visibility.py`, which asserts these verbatim, passes unchanged; no test was modified in this PR.

## Gate

`uv sync --dev && uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest -q` — all green (1801 passed, 3 skipped). Net **−36 lines** across the two files (117 insertions, 153 deletions).

Closes #332


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_