### PR TITLE
ci: regenerate uv.lock on release so the lockfile never lags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,6 +37,31 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please bumps `version` in pyproject.toml, which invalidates the
+      # `[[package]] name = "lgtmaybe"` entry in uv.lock — and `uv lock --check`
+      # in ci.yml then fails on main after every release. Regenerate the lockfile
+      # on the Release PR branch so both land in the same merge. Running the real
+      # `uv lock` is the only correct fix: uv.lock holds a `version` key per
+      # dependency, so a text/TOML updater aimed at it could rewrite the wrong
+      # one — and silently no-ops if its path stops matching.
+      - uses: actions/checkout@v7
+        if: ${{ steps.rp.outputs.pr }}
+        with:
+          ref: ${{ fromJSON(steps.rp.outputs.pr).headBranchName }}
+      - uses: astral-sh/setup-uv@v7
+        if: ${{ steps.rp.outputs.pr }}
+        with:
+          python-version: "3.12"
+      - name: Sync uv.lock with the bumped version
+        if: ${{ steps.rp.outputs.pr }}
+        run: |
+          uv lock
+          git diff --quiet -- uv.lock && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync uv.lock with the version bump" -- uv.lock
+          git push
+
   # PyPI publish — inline (top-level) so OIDC trusted publishing matches the
   # `release-please.yml` publisher. Runs on a fresh release or a manual dispatch.
   pypi:

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -29,6 +29,7 @@ import pytest
 import lgtmaybe
 
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_UV_LOCK = Path(__file__).resolve().parent.parent / "uv.lock"
 
 
 def _all_module_names() -> list[str]:
@@ -57,6 +58,36 @@ def test_deprecation_gate_is_configured() -> None:
     assert "error::DeprecationWarning" in filters
     assert "error::PendingDeprecationWarning" in filters
     assert "error::EncodingWarning" in filters
+
+
+def test_uv_lock_records_the_current_project_version() -> None:
+    """`uv.lock` must record the version `pyproject.toml` declares.
+
+    The lockfile pins the workspace package's own version, so every release bump
+    invalidates it and `uv lock --check` fails on main. This asserts the same
+    thing locally and names the fix, instead of the failure only showing up in CI.
+    """
+    project_version = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+    locked = next(
+        pkg
+        for pkg in tomllib.loads(_UV_LOCK.read_text(encoding="utf-8"))["package"]
+        if pkg["name"] == "lgtmaybe"
+    )
+    assert locked["version"] == project_version, (
+        f"uv.lock pins lgtmaybe {locked['version']} but pyproject.toml declares "
+        f"{project_version} — run `uv lock` and commit the result"
+    )
+
+
+def test_release_workflow_regenerates_the_lockfile() -> None:
+    """The release path must re-lock itself, or the drift above returns each release."""
+    workflow = (_UV_LOCK.parent / ".github" / "workflows" / "release-please.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "uv lock" in workflow, (
+        "release-please.yml must run `uv lock` on the Release PR branch so the "
+        "version bump and the lockfile land together"
+    )
 
 
 def test_no_default_encoding_io() -> None:


### PR DESCRIPTION
## The recurrence

`.github/workflows/ci.yml:35` runs `uv lock --check`. release-please bumps `version` in `pyproject.toml`; nothing regenerates `uv.lock`, whose `[[package]] name = "lgtmaybe"` entry therefore stays a release behind and breaks `main`.

This has now happened three consecutive releases:

| release commit | `pyproject.toml` | `uv.lock` lgtmaybe entry |
|---|---|---|
| 1.11.0 | 1.11.0 | 1.10.0 |
| 1.11.1 | 1.11.1 | 1.10.0 |
| `08e6480` — 1.12.0 | 1.12.0 | 1.11.0 |

`main` is green today only because #340 hand-synced it. Without a fix to the release path, 1.12.1 drifts again.

## Approach — (a): run the real `uv lock` on the Release PR branch

After `googleapis/release-please-action@v5` opens or updates the Release PR, the workflow checks out that branch (`fromJSON(steps.rp.outputs.pr).headBranchName`), runs `uv lock`, and commits the result onto the same branch — so the version bump and the lockfile land in one merge. If `uv lock` produces no diff the step exits 0 without a commit. release-please force-pushes the branch on each subsequent update, and this step runs immediately after every one, so it self-heals rather than needing to survive the force-push.

Verified against the action source before wiring it: `pr` is set only when a release PR exists (`core.setOutput('pr', prs[0])` in `release-please-action/src/index.ts`, guarded by `prs.length > 0`), and `headBranchName` is a real field of release-please's `PullRequest` interface (`src/pull-request.ts:16`).

### Why the alternatives lose

**(b) register `uv.lock` as a versioned `extra-file`** — the trap the issue hints at. `uv.lock` contains **158** `version = ` keys, one per locked dependency; only line 1296 belongs to lgtmaybe.

- The **`generic`** updater keys off an `x-release-please-version` comment in the file. `uv lock` regenerates `uv.lock` wholesale and does not preserve hand-added comments, so the annotation would not survive the first re-lock — and without it the updater has no way to distinguish our `version` from the other 157.
- The **`toml`** updater (`release-please/src/updaters/generic-toml.ts`) resolves a jsonpath with `jsonpath-plus` and rewrites the matched pointers. A filter expression could in principle target only our entry — but its miss behaviour is the disqualifier:
  ```ts
  if (!paths || paths.length === 0) {
    logger.warn(`No entries modified in ${this.jsonpath}`);
    return content;      // silently unchanged
  }
  ```
  A jsonpath that stops matching (uv changes the lock schema, renames the table, reorders) **warns and no-ops** — reintroducing exactly this bug, silently, in the one place nobody reads the logs.
- Even a correct version rewrite only guarantees that one string is right. `uv lock --check` validates the whole lockfile against `pyproject.toml`; only running `uv lock` guarantees it passes.

**Scheduled / manual re-sync** — a workaround, not a fix. `main` would still be red between the release and the next scheduled run.

## Proof it cannot rewrite dependency versions

The fix performs no text surgery on `uv.lock` at all. It runs `uv lock`, uv's own resolver, and commits whatever uv writes. There is no pattern, jsonpath, or `sed` that could match the wrong `version = ` key, because there is no pattern. `git diff --quiet -- uv.lock` gates the commit and the commit is path-scoped to `uv.lock`, so nothing else can ride along.

## The guard

`tests/test_code_quality.py` (the deterministic-gate file, alongside the existing lockfile-drift note in CLAUDE.md) gains two tests:

- `test_uv_lock_records_the_current_project_version` — parses both files with `tomllib` and asserts `pyproject.toml`'s `version` equals the `lgtmaybe` entry's version in `uv.lock`, with a message naming the fix. Verified red/green: it **passes** on current `main` (post-#340) and **fails** when `uv.lock` is restored from `08e6480`, the 1.12.0 release commit:
  ```
  FAILED tests/test_code_quality.py::test_uv_lock_records_the_current_project_version
  ```
  Drift now fails locally on `uv run pytest`, not only in CI.
- `test_release_workflow_regenerates_the_lockfile` — pins the `uv lock` step in `release-please.yml`, so deleting it fails the suite. Nothing pinned it before, which is how the bug recurred three times.

Gate green: `uv sync --dev && uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest -q` → 1803 passed, 3 skipped.

Scope is limited to `.github/workflows/release-please.yml` and `tests/` — `release-please-config.json` and `.release-please-manifest.json` need no change, and no other workflow file is touched (#338 owns those).

Closes #337

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_