### PR TITLE
chore: ignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,7 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Claude Code agent worktrees — transient checkouts created under a tracked
+# directory, so without this a `git add .` stages nested copies of the repo.
+.claude/worktrees/


### PR DESCRIPTION
## What

One line in `.gitignore`:

```
.claude/worktrees/
```

## Why

Claude Code agent worktrees are created under `.claude/worktrees/`. That path sits inside an **already tracked** directory — `.claude/commands/opsx/*.md` are checked in — so the worktrees show up as a single innocuous-looking untracked entry with nothing indicating what's inside.

Running the audit agents in parallel put **13 worktrees totalling 2.0 GB** there. A `git add .` at that moment would have staged thirteen nested copies of this repository.

```
$ du -sh .claude/worktrees
2.0G    .claude/worktrees
$ git status --porcelain
?? .claude/worktrees/
```

Nothing else in the repo guards against it: `.gitignore` covers the usual Python/tooling paths but has no `.claude/` entry, because until agents started running there was nothing under it but tracked files.

## Testing

`git status --porcelain` is clean afterwards apart from the `.gitignore` edit itself. `tests/test_code_quality.py` passes (47).

Not itself an audit finding — spotted while running the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_