### PR TITLE
refactor(engine): share one ast-grep language table and scan only present languages

### DIFF
--- a/src/lgtmaybe/engine/astgrep.py
+++ b/src/lgtmaybe/engine/astgrep.py
@@ -25,9 +25,9 @@ import json
 import re
 import shutil
 import subprocess
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from lgtmaybe.core.logging import get_logger
 
@@ -53,12 +53,96 @@ _MAX_CANDIDATES = 3
 # (handled by the path fetcher) and keeps the symbol safe to drop into the rule's
 # ``regex: ^<name>$`` — an identifier carries no regex or YAML metacharacters.
 _IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-# Source-file extensions (no dot). A `need` like ``models.py`` is a filename the
-# path fetcher handles — not a ``module.symbol`` reference — so it must not be
-# mistaken for a symbol whose name is ``py``.
-_SOURCE_EXTS = frozenset(
-    {"py", "js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts", "go", "java", "rs", "rb"}
-)
+
+
+class _LangSpec(NamedTuple):
+    """One ast-grep language: the files it owns and its definition node kinds.
+
+    ``block`` kinds OPEN a body worth padding a hunk back to (functions, methods,
+    classes) — ``engine/boundaries.py`` scans those alone, since a
+    ``variable_declarator`` boundary would be noise. Symbol resolution scans
+    :attr:`kinds`, the block kinds plus the rest. One table, one blockness flag —
+    so adding a language can no longer land in half of it.
+    """
+
+    exts: tuple[str, ...]
+    block: tuple[str, ...]
+    other: tuple[str, ...] = ()
+
+    @property
+    def kinds(self) -> tuple[str, ...]:
+        return self.block + self.other
+
+
+# ast-grep language name -> its file extensions and the tree-sitter definition
+# node kinds whose ``name`` field we match. Validated against ast-grep 0.44. C/C++
+# are intentionally omitted: their function names nest inside declarators that
+# ``has: {field: name}`` can't bind, and a broken matcher is worse than none.
+# ``.jsx`` maps to ``javascript`` and ``.tsx`` to ``tsx`` by ast-grep's own
+# extension table — we just supply the matching language name so its file
+# selection lines up.
+_LANGS: dict[str, _LangSpec] = {
+    "python": _LangSpec((".py",), ("function_definition", "class_definition")),
+    "javascript": _LangSpec(
+        (".js", ".jsx", ".mjs", ".cjs"),
+        ("function_declaration", "method_definition", "class_declaration"),
+        ("variable_declarator",),
+    ),
+    "typescript": _LangSpec(
+        (".ts", ".mts", ".cts"),
+        ("function_declaration", "method_definition", "class_declaration"),
+        (
+            "variable_declarator",
+            "interface_declaration",
+            "type_alias_declaration",
+            "enum_declaration",
+        ),
+    ),
+    "tsx": _LangSpec(
+        (".tsx",),
+        ("function_declaration", "method_definition", "class_declaration"),
+        (
+            "variable_declarator",
+            "interface_declaration",
+            "type_alias_declaration",
+            "enum_declaration",
+        ),
+    ),
+    "go": _LangSpec(
+        (".go",),
+        ("function_declaration", "method_declaration"),
+        ("type_spec", "const_spec"),
+    ),
+    "java": _LangSpec(
+        (".java",),
+        ("method_declaration", "class_declaration"),
+        ("interface_declaration", "enum_declaration", "record_declaration"),
+    ),
+    "rust": _LangSpec(
+        (".rs",),
+        ("function_item", "impl_item", "trait_item"),
+        (
+            "struct_item",
+            "enum_item",
+            "const_item",
+            "static_item",
+            "type_item",
+            "mod_item",
+            "macro_definition",
+        ),
+    ),
+    "ruby": _LangSpec((".rb",), ("method", "singleton_method", "class", "module")),
+}
+
+# Extension -> (language, block kinds), the lookup boundary detection needs.
+_BY_EXT: dict[str, tuple[str, tuple[str, ...]]] = {
+    ext: (language, spec.block) for language, spec in _LANGS.items() for ext in spec.exts
+}
+
+
+def block_kinds_for_path(path: str) -> tuple[str, tuple[str, ...]] | None:
+    """``(ast-grep language, body-opening kinds)`` for *path*, or None if unsupported."""
+    return _BY_EXT.get(Path(path).suffix.lower())
 
 
 def _symbol_name(raw: str) -> str | None:
@@ -69,68 +153,10 @@ def _symbol_name(raw: str) -> str | None:
     `self.method`) by taking its final segment, the name ast-grep can match.
     """
     s = raw.strip()
-    if not s or "/" in s or "\\" in s:
+    if not s or "/" in s or "\\" in s or Path(s).suffix.lower() in _BY_EXT:
         return None
     name = s.rsplit(".", 1)[-1]
-    if name in _SOURCE_EXTS:
-        return None
     return name if _IDENT.match(name) else None
-
-
-# ast-grep language name -> the tree-sitter definition node kinds whose ``name``
-# field we match. Validated against ast-grep 0.44. C/C++ are intentionally omitted:
-# their function names nest inside declarators that ``has: {field: name}`` can't
-# bind, and a broken matcher is worse than none. ``.jsx`` maps to ``javascript``
-# and ``.tsx`` to ``tsx`` by ast-grep's own extension table — we just supply the
-# matching language name so its file selection lines up.
-_LANG_KINDS: dict[str, tuple[str, ...]] = {
-    "python": ("function_definition", "class_definition"),
-    "javascript": (
-        "function_declaration",
-        "class_declaration",
-        "method_definition",
-        "variable_declarator",
-    ),
-    "typescript": (
-        "function_declaration",
-        "class_declaration",
-        "method_definition",
-        "variable_declarator",
-        "interface_declaration",
-        "type_alias_declaration",
-        "enum_declaration",
-    ),
-    "tsx": (
-        "function_declaration",
-        "class_declaration",
-        "method_definition",
-        "variable_declarator",
-        "interface_declaration",
-        "type_alias_declaration",
-        "enum_declaration",
-    ),
-    "go": ("function_declaration", "method_declaration", "type_spec", "const_spec"),
-    "java": (
-        "method_declaration",
-        "class_declaration",
-        "interface_declaration",
-        "enum_declaration",
-        "record_declaration",
-    ),
-    "rust": (
-        "function_item",
-        "struct_item",
-        "enum_item",
-        "trait_item",
-        "impl_item",
-        "const_item",
-        "static_item",
-        "type_item",
-        "mod_item",
-        "macro_definition",
-    ),
-    "ruby": ("method", "singleton_method", "class", "module"),
-}
 
 
 def _find_binary() -> str | None:
@@ -138,14 +164,18 @@ def _find_binary() -> str | None:
     return shutil.which("ast-grep")
 
 
-def _rule_yaml(language: str, kinds: tuple[str, ...], symbol: str) -> str:
-    """An inline ast-grep rule: a definition node of *language* named *symbol*.
+def rule_yaml(language: str, kinds: Sequence[str], symbol: str | None = None) -> str:
+    """An inline ast-grep rule matching any of *kinds* in *language*.
 
-    Matches any of *kinds* whose ``name`` field equals *symbol* (searched through
-    nested declarators via ``stopBy: end``). *symbol* is identifier-validated by
-    the caller, so it is safe inside the ``^...$`` regex with no escaping.
+    With *symbol*, the match is narrowed to a definition whose ``name`` field
+    equals it (searched through nested declarators via ``stopBy: end``) — symbol
+    resolution's rule. *symbol* is identifier-validated by the caller, so it is
+    safe inside the ``^...$`` regex with no escaping. Without it, the bare
+    ``any:`` rule boundary detection uses.
     """
     kinds_flow = ", ".join(f"{{kind: {k}}}" for k in kinds)
+    if symbol is None:
+        return f"id: lgtmaybe-boundaries\nlanguage: {language}\nrule: {{any: [{kinds_flow}]}}\n"
     return (
         "id: lgtmaybe-find-def\n"
         f"language: {language}\n"
@@ -154,6 +184,20 @@ def _rule_yaml(language: str, kinds: tuple[str, ...], symbol: str) -> str:
         f"    - any: [{kinds_flow}]\n"
         f"    - has: {{field: name, regex: ^{symbol}$, stopBy: end}}\n"
     )
+
+
+def _present_languages(root: Path) -> tuple[str, ...]:
+    """The languages actually present under *root*, by file extension.
+
+    Scanning a pure-Python tree for a Ruby ``singleton_method`` is guaranteed-zero
+    work; one filesystem walk (cached with the corpus root) replaces up to eight
+    repo-wide ``ast-grep scan`` subprocesses per unresolved symbol.
+    """
+    try:
+        exts = {path.suffix.lower() for path in root.rglob("*")}
+    except OSError:  # unreadable corpus — best-effort, scan nothing
+        return ()
+    return tuple(name for name, spec in _LANGS.items() if not exts.isdisjoint(spec.exts))
 
 
 def _default_runner(binary: str, rule_yaml: str, target: Path) -> str:
@@ -228,7 +272,9 @@ def build_symbol_resolver(
     Otherwise returns a callable that, given a symbol the auditor deferred on,
     structurally searches the corpus (``get_root()``, resolved and cached on first
     use) for its definition and returns up to :data:`_MAX_CANDIDATES`
-    repo-relative paths.
+    repo-relative paths. Only the languages the corpus actually contains are
+    scanned, so an unresolved symbol costs one subprocess per present language
+    rather than one per supported language.
 
     Best-effort throughout: a non-identifier symbol, an absent corpus, an
     unsupported language, or any ast-grep failure yields [] so the deferral falls
@@ -241,23 +287,28 @@ def build_symbol_resolver(
     run = runner or _default_runner
 
     @functools.cache
-    def _root() -> Path | None:
+    def _corpus() -> tuple[Path, tuple[str, ...]] | None:
+        """The resolved corpus root and the languages present in it, or None."""
         root = get_root()
-        return root.resolve() if root is not None else None
+        if root is None:
+            return None
+        root = root.resolve()
+        return root, _present_languages(root)
 
     def resolve(symbol: str) -> list[str]:
         name = _symbol_name(symbol)
         if name is None:
             return []
-        root = _root()
-        if root is None:
+        corpus = _corpus()
+        if corpus is None:
             return []
+        root, languages = corpus
         found: list[str] = []
         seen: set[str] = set()
-        for language, kinds in _LANG_KINDS.items():
+        for language in languages:
             if len(found) >= _MAX_CANDIDATES:
                 break
-            stdout = run(binary, _rule_yaml(language, kinds, name), root)
+            stdout = run(binary, rule_yaml(language, _LANGS[language].kinds, name), root)
             for rel in _parse_paths(stdout, root):
                 if rel in seen:
                     continue

--- a/src/lgtmaybe/engine/boundaries.py
+++ b/src/lgtmaybe/engine/boundaries.py
@@ -7,6 +7,11 @@ stack) parses the head file text and reports where function/class definitions
 START, so ``compress.expand_hunks`` can pad the leading context up to the
 enclosing signature when it sits above the fixed window.
 
+The language table is astgrep.py's single one: this module asks it for the
+``block`` kinds — the ones that OPEN a body worth padding to (functions, methods,
+classes), never a ``variable_declarator`` — and an extension it doesn't list
+simply keeps the fixed-line pad.
+
 Parsing, not executing: the text is written to a throwaway temp file and
 structurally scanned, the same fork-safety posture as symbol resolution and
 static analysis. Best-effort throughout — an unsupported language, a missing
@@ -22,32 +27,13 @@ from pathlib import Path
 
 from lgtmaybe.core.logging import get_logger
 
-from .astgrep import _default_runner, _find_binary, iter_matches
+from .astgrep import _default_runner, _find_binary, block_kinds_for_path, iter_matches, rule_yaml
 
 _log = get_logger(__name__)
 
 # Abstracts the ast-grep subprocess: (binary, rule_yaml, file) -> stdout ("" on
 # failure). Injected so tests don't have to shell out.
 BoundaryRunner = Callable[[str, str, Path], str]
-
-# Extension -> (ast-grep language, block-level definition kinds). Deliberately a
-# narrower table than symbol resolution's: only kinds that OPEN a body worth
-# padding to (functions/methods/classes) — a variable_declarator boundary would
-# be noise. An extension not listed simply keeps the fixed-line pad.
-_LANG_DEFS: dict[str, tuple[str, tuple[str, ...]]] = {
-    ".py": ("python", ("function_definition", "class_definition")),
-    ".js": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
-    ".jsx": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
-    ".ts": (
-        "typescript",
-        ("function_declaration", "method_definition", "class_declaration"),
-    ),
-    ".tsx": ("tsx", ("function_declaration", "method_definition", "class_declaration")),
-    ".go": ("go", ("function_declaration", "method_declaration")),
-    ".rs": ("rust", ("function_item", "impl_item", "trait_item")),
-    ".java": ("java", ("method_declaration", "class_declaration")),
-    ".rb": ("ruby", ("method", "singleton_method", "class", "module")),
-}
 
 
 def definition_spans(
@@ -68,15 +54,13 @@ def definition_spans(
     extension, no ast-grep binary, or any scan/parse failure — the caller then
     pads by fixed line count exactly as before.
     """
-    lang_defs = _LANG_DEFS.get(Path(path).suffix.lower())
+    lang_defs = block_kinds_for_path(path)
     if lang_defs is None:
         return []
     binary = find_binary()
     if binary is None:
         return []
-    language, kinds = lang_defs
-    kinds_flow = ", ".join(f"{{kind: {k}}}" for k in kinds)
-    rule = f"id: lgtmaybe-boundaries\nlanguage: {language}\nrule: {{any: [{kinds_flow}]}}\n"
+    rule = rule_yaml(*lang_defs)
     run = runner if runner is not None else _default_runner
     with tempfile.TemporaryDirectory(prefix="lgtmaybe-bounds-", ignore_cleanup_errors=True) as tmp:
         target = Path(tmp) / f"file{Path(path).suffix.lower()}"

--- a/tests/engine/test_astgrep.py
+++ b/tests/engine/test_astgrep.py
@@ -8,20 +8,142 @@ shapes and JSON parsing are verified end to end.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
 
 import pytest
 
 from lgtmaybe.engine.astgrep import (
+    _LANGS,
     _parse_paths,
+    block_kinds_for_path,
     build_symbol_resolver,
-)
-from lgtmaybe.engine.astgrep import (
-    _rule_yaml as rule_yaml,
+    rule_yaml,
 )
 
 _HAVE_BINARY = "ast-grep"  # any non-None string stands in for "binary present"
+
+# The two pre-refactor tables, frozen verbatim (astgrep._LANG_KINDS and
+# boundaries._LANG_DEFS). The shared table + shared builder must keep emitting the
+# same rule for every language — same id, same language, same kind set.
+_OLD_LANG_KINDS: dict[str, tuple[str, ...]] = {
+    "python": ("function_definition", "class_definition"),
+    "javascript": (
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "variable_declarator",
+    ),
+    "typescript": (
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "variable_declarator",
+        "interface_declaration",
+        "type_alias_declaration",
+        "enum_declaration",
+    ),
+    "tsx": (
+        "function_declaration",
+        "class_declaration",
+        "method_definition",
+        "variable_declarator",
+        "interface_declaration",
+        "type_alias_declaration",
+        "enum_declaration",
+    ),
+    "go": ("function_declaration", "method_declaration", "type_spec", "const_spec"),
+    "java": (
+        "method_declaration",
+        "class_declaration",
+        "interface_declaration",
+        "enum_declaration",
+        "record_declaration",
+    ),
+    "rust": (
+        "function_item",
+        "struct_item",
+        "enum_item",
+        "trait_item",
+        "impl_item",
+        "const_item",
+        "static_item",
+        "type_item",
+        "mod_item",
+        "macro_definition",
+    ),
+    "ruby": ("method", "singleton_method", "class", "module"),
+}
+
+_OLD_LANG_DEFS: dict[str, tuple[str, tuple[str, ...]]] = {
+    ".py": ("python", ("function_definition", "class_definition")),
+    ".js": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
+    ".jsx": ("javascript", ("function_declaration", "method_definition", "class_declaration")),
+    ".ts": ("typescript", ("function_declaration", "method_definition", "class_declaration")),
+    ".tsx": ("tsx", ("function_declaration", "method_definition", "class_declaration")),
+    ".go": ("go", ("function_declaration", "method_declaration")),
+    ".rs": ("rust", ("function_item", "impl_item", "trait_item")),
+    ".java": ("java", ("method_declaration", "class_declaration")),
+    ".rb": ("ruby", ("method", "singleton_method", "class", "module")),
+}
+
+
+def _old_kinds_flow(kinds: tuple[str, ...]) -> str:
+    # The line that was character-for-character identical in both modules.
+    return ", ".join(f"{{kind: {k}}}" for k in kinds)
+
+
+def _old_symbol_rule(language: str, kinds: tuple[str, ...], symbol: str) -> str:
+    return (
+        "id: lgtmaybe-find-def\n"
+        f"language: {language}\n"
+        "rule:\n"
+        "  all:\n"
+        f"    - any: [{_old_kinds_flow(kinds)}]\n"
+        f"    - has: {{field: name, regex: ^{symbol}$, stopBy: end}}\n"
+    )
+
+
+def _old_boundary_rule(language: str, kinds: tuple[str, ...]) -> str:
+    return (
+        f"id: lgtmaybe-boundaries\nlanguage: {language}\n"
+        f"rule: {{any: [{_old_kinds_flow(kinds)}]}}\n"
+    )
+
+
+def _sorted_kinds(rule: str) -> str:
+    """The rule with its ``any: [...]`` list sorted — that list is order-insensitive."""
+    return re.sub(
+        r"\[(\{kind: [^\]]+)\]",
+        lambda m: "[" + ", ".join(sorted(m.group(1).split(", "))) + "]",
+        rule,
+    )
+
+
+def test_symbol_rule_yaml_unchanged_by_the_shared_table() -> None:
+    # Byte-for-byte the pre-refactor rule for all eight languages, modulo the order
+    # of the order-insensitive `any:` list.
+    for language, old_kinds in _OLD_LANG_KINDS.items():
+        assert sorted(_LANGS[language].kinds) == sorted(old_kinds)
+        assert _sorted_kinds(rule_yaml(language, _LANGS[language].kinds, "foo")) == _sorted_kinds(
+            _old_symbol_rule(language, old_kinds, "foo")
+        )
+
+
+def test_boundary_rule_yaml_unchanged_by_the_shared_table() -> None:
+    for ext, (language, old_kinds) in _OLD_LANG_DEFS.items():
+        lang_defs = block_kinds_for_path(f"src/sample{ext}")
+        assert lang_defs is not None
+        assert lang_defs[0] == language
+        assert sorted(lang_defs[1]) == sorted(old_kinds)
+        assert _sorted_kinds(rule_yaml(*lang_defs)) == _sorted_kinds(
+            _old_boundary_rule(language, old_kinds)
+        )
+
+
+def test_unsupported_extension_has_no_block_kinds() -> None:
+    assert block_kinds_for_path("notes.txt") is None
 
 
 def test_build_returns_none_without_binary() -> None:
@@ -79,7 +201,26 @@ def test_parse_paths_emits_posix_separators(tmp_path: Path) -> None:
     assert _parse_paths(output, tmp_path.resolve()) == ["src/app.py"]
 
 
+def test_only_languages_present_in_the_tree_are_scanned(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("x = 1\n")
+    scanned: list[str] = []
+
+    def runner(binary: str, rule: str, root: Path) -> str:
+        scanned.append(rule.split("language: ", 1)[1].split("\n", 1)[0])
+        return "[]"
+
+    resolve = build_symbol_resolver(
+        lambda: tmp_path, runner=runner, find_binary=lambda: _HAVE_BINARY
+    )
+    assert resolve is not None
+    # Defined nowhere — the common case, since this runs only after the fetch failed.
+    assert resolve("defined_nowhere") == []
+    # One subprocess for the one language present, not one per supported language.
+    assert scanned == ["python"]
+
+
 def test_resolver_uses_last_dotted_segment(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("x = 1\n")
     seen: list[str] = []
 
     def runner(binary: str, rule: str, root: Path) -> str:
@@ -91,7 +232,7 @@ def test_resolver_uses_last_dotted_segment(tmp_path: Path) -> None:
     )
     assert resolve is not None
     resolve("ledger.already_applied")
-    assert all("regex: ^already_applied$" in rule for rule in seen)
+    assert seen and all("regex: ^already_applied$" in rule for rule in seen)
 
 
 def test_resolver_caps_candidates(tmp_path: Path) -> None:
@@ -134,6 +275,7 @@ def test_corpus_root_resolved_at_most_once(tmp_path: Path) -> None:
 
 
 def test_malformed_runner_output_is_tolerated(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("x = 1\n")
     resolve = build_symbol_resolver(
         lambda: tmp_path, runner=lambda *_: "not json", find_binary=lambda: _HAVE_BINARY
     )


### PR DESCRIPTION
Ponytail audit follow-up for #334 — the two forked ast-grep language tables and the eight-scans-per-unresolved-symbol loop.

## What changed

**1. One table, one rule builder.** `astgrep.py` now holds a single `_LANGS` map (`_LangSpec(exts, block, other)`), where `block` names the kinds that OPEN a body — the narrower set `boundaries.py` wants — and `kinds` is `block + other`, what symbol resolution scans. `boundaries.py`'s `_LANG_DEFS` and its inline rule string are gone; it calls the exported `rule_yaml(language, kinds, symbol=None)` (no symbol → the bare `any:` rule) via `block_kinds_for_path(path)`. The duplicated `kinds_flow = ", ".join(...)` line now exists once. Adding a language can no longer land in one table only.

**2. Only present languages are scanned.** `build_symbol_resolver` computed candidates from all eight languages, breaking early only after 3 hits — so a symbol defined nowhere (the common case, since this path runs only after the file fetch already failed) cost **eight full-repo `ast-grep scan` subprocesses**, each with a 60s ceiling, on the review's serial tail. The resolver now derives the candidate languages from the extensions actually present under the corpus root, via one `rglob` cached alongside the root (`_corpus()`). A pure-Python repo: **1 subprocess instead of 8**; a Python+TS repo: 2. An unreadable tree scans nothing and resolution returns `[]`, unchanged.

**3. Micro.** `_SOURCE_EXTS` is gone — `_symbol_name` now tests `Path(s).suffix.lower() in _BY_EXT`, the same extension set spelled once, derived from the table.

## YAML equality evidence

Two new tests freeze the pre-refactor `_LANG_KINDS` and `_LANG_DEFS` tables plus their two rule builders verbatim, and assert for **all eight languages** (and all nine boundary extensions) that:

- the kind **set** emitted is identical to the old table's, and
- the emitted rule is **byte-for-byte identical** to the old one once the `any: [...]` list is sorted in both.

That list is the one place ordering moved (a single shared ordering can't reproduce both modules' orders), and `any:` is order-insensitive in ast-grep — `id`, `language`, the `has: {field: name, regex: ^…$, stopBy: end}` clause and every byte of layout are unchanged. The real-binary tests in `test_astgrep.py` and `test_boundaries.py` still pass against the live ast-grep.

Plus `test_only_languages_present_in_the_tree_are_scanned`: a Python-only tree resolving a symbol defined nowhere records exactly `["python"]`, not one scan per supported language.

## Gate

`uv run ruff check .` / `ruff format --check .` / `mypy` / `pytest -q` → 1810 passed, 3 skipped. Net −74 lines in `src/`; changes stay strictly inside `engine/astgrep.py`, `engine/boundaries.py` and their tests. Resolution remains best-effort on every path — a scan failure still can't fail the review.

Closes #334

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_