### PR TITLE
refactor(cli): share option declarations across commands

### DIFF
--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import click
 
@@ -33,7 +34,9 @@ from lgtmaybe.cli import (
 )
 from lgtmaybe.config import store
 from lgtmaybe.config.loader import load_config
-from lgtmaybe.core.models import ReviewConfig
+from lgtmaybe.core.models import Provider, ReviewConfig, ReviewPreset, Severity
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 def _apply_static_analysis_flag(cfg: ReviewConfig, flag: bool | None) -> ReviewConfig:
@@ -77,18 +80,131 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
         raise click.ClickException(str(exc)) from exc
 
 
-@main.command()
-@click.option(
-    "--provider",
-    default=None,
-    help="LLM provider (openai, anthropic, bedrock, vertex, azure, ollama, "
-    "openrouter, zai, openai-compatible)",
+def _check_diff_mode(working: bool, uncommitted: bool) -> None:
+    """Reject --working with --uncommitted, once, for both local commands.
+
+    ``local_pr_context`` enforces the same invariant for library callers; the
+    CLI checks it up front so the user gets a usage error (exit 2) before any
+    provider work, rather than a runtime failure after it.
+    """
+    if working and uncommitted:
+        raise click.UsageError("--working and --uncommitted are mutually exclusive")
+
+
+def _runtime(
+    api_key: str | None, api_base: str | None, fallback_model: str | None, profile: bool = False
+) -> RuntimeOptions:
+    """The RuntimeOptions every ``model_options`` command builds from its flags."""
+    return RuntimeOptions(
+        api_key=api_key, api_base=api_base, fallback_model=fallback_model, profile=profile
+    )
+
+
+def _stack(*options: Callable[..., Any]) -> Callable[[F], F]:
+    """Bundle click options into one reusable decorator, applied bottom-up.
+
+    A shared group then reads on the command exactly as the inline decorators
+    did — and can only document itself one way across the commands that take it.
+    """
+
+    def wrap(func: F) -> F:
+        for option in reversed(options):
+            func = option(func)
+        return func
+
+    return wrap
+
+
+#: The provider/model/credential flags every model-invoking command takes.
+model_options = _stack(
+    click.option(
+        "--provider",
+        default=None,
+        # NOT `click.Choice(Provider)`: click matches an Enum by member NAME, so
+        # that would accept `openai_compatible` and reject the documented
+        # `openai-compatible`. The values keep the wire spelling, still derived.
+        type=click.Choice([p.value for p in Provider]),
+        # The nine names review used to spell out in prose are the metavar now,
+        # so --help still shows them all — from the enum, not a second copy.
+        help="LLM backend to review with (overrides the configured provider)",
+    ),
+    click.option("--model", default=None, help="Model name understood by the chosen provider"),
+    click.option(
+        "--fallback-model",
+        default=None,
+        help="Model to retry with if the primary model fails",
+    ),
+    click.option(
+        "--api-key",
+        default=None,
+        envvar="LGTMAYBE_API_KEY",
+        help="API key (not needed for bedrock/vertex/keyless-azure ambient creds, or ollama)",
+    ),
+    click.option(
+        "--api-base",
+        default=None,
+        help="API base URL (ollama: http://localhost:11434; "
+        "azure: https://<resource>.openai.azure.com; "
+        "openai-compatible: any OpenAI /v1 endpoint, e.g. https://api.deepseek.com/v1 "
+        "or http://localhost:8000/v1; "
+        "zai: optional override for the China / coding-plan GLM endpoint, "
+        "e.g. https://open.bigmodel.cn/api/paas/v4)",
+    ),
+    click.option(
+        "--config",
+        "config_path",
+        default=None,
+        help="Path to a per-repo config file (must exist when given) "
+        "[default: .lgtmaybe.yml, absent is fine]",
+    ),
 )
-@click.option("--model", default=None, help="Model name understood by the chosen provider")
+
+#: The flags the two local (no-GitHub) commands share: what to diff, and the
+#: model-call knobs a slow local model needs.
+local_diff_options = _stack(
+    click.option(
+        "--base",
+        default=None,
+        help="Base ref to diff against (default: the remote's primary branch — "
+        "origin/HEAD, else origin/main / origin/master, else a local main/master)",
+    ),
+    click.option(
+        "--working",
+        is_flag=True,
+        default=False,
+        help="Use the whole worktree — branch commits plus uncommitted edits — "
+        "against the base, instead of only the committed branch changes",
+    ),
+    click.option(
+        "--uncommitted",
+        is_flag=True,
+        default=False,
+        help="Use only the uncommitted working-tree edits (vs HEAD); "
+        "mutually exclusive with --working",
+    ),
+    click.option(
+        "--timeout",
+        default=None,
+        type=int,
+        help="Per-request timeout in seconds for each model call (raise for slow local models)",
+    ),
+    click.option(
+        "--num-ctx",
+        default=None,
+        type=int,
+        help="ollama context window (ollama only; ignored for hosted providers). "
+        "Raise it so a large multi-file diff isn't truncated; default 32768",
+    ),
+)
+
+
+@main.command()
+@model_options
+@local_diff_options
 @click.option(
     "--preset",
     default=None,
-    type=click.Choice(["fast", "full"]),
+    type=click.Choice(ReviewPreset),
     help="Review preset: fast (default) covers all nine categories in four "
     "calls, one per concern — security, correctness (stated intent folds in), "
     "code health, artefacts (tests/documentation) — the same four on every "
@@ -100,11 +216,6 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     is_flag=True,
     default=False,
     help="Shorthand for --preset full",
-)
-@click.option(
-    "--fallback-model",
-    default=None,
-    help="Model to retry with if the primary model fails",
 )
 @click.option(
     "--reflect-model",
@@ -127,31 +238,15 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "Security-relevant files always escalate past triage. Unset = no triage",
 )
 @click.option(
-    "--api-key",
-    default=None,
-    envvar="LGTMAYBE_API_KEY",
-    help="API key (not needed for bedrock/vertex/keyless-azure ambient creds, or ollama)",
-)
-@click.option(
-    "--api-base",
-    default=None,
-    help="API base URL (ollama: http://localhost:11434; "
-    "azure: https://<resource>.openai.azure.com; "
-    "openai-compatible: any OpenAI /v1 endpoint, e.g. https://api.deepseek.com/v1 "
-    "or http://localhost:8000/v1; "
-    "zai: optional override for the China / coding-plan GLM endpoint, "
-    "e.g. https://open.bigmodel.cn/api/paas/v4)",
-)
-@click.option(
     "--min-severity",
     default=None,
-    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    type=click.Choice(Severity),
     help="Minimum severity to report",
 )
 @click.option(
     "--fail-on",
     default=None,
-    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    type=click.Choice(Severity),
     help="Merge-gate threshold: on the GitHub Action, create a Check Run that "
     "fails when any finding is at or above this severity (make it a required "
     "check in branch protection). Default off",
@@ -159,7 +254,7 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
 @click.option(
     "--unanchored-min-severity",
     default=None,
-    type=click.Choice(["info", "low", "medium", "high", "critical"]),
+    type=click.Choice(Severity),
     help="Minimum severity for a finding the engine could not anchor to a changed "
     "line (default high; raise/lower to control how many low-confidence guesses surface)",
 )
@@ -190,33 +285,6 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "thinking first, so raising the cap grows the reasoning instead of the answer",
 )
 @click.option(
-    "--num-ctx",
-    default=None,
-    type=int,
-    help="ollama context window (ollama only; ignored for hosted providers). "
-    "Raise it so a large multi-file diff isn't truncated; default 32768",
-)
-@click.option(
-    "--base",
-    default=None,
-    help="Base ref to diff against (default: the remote's primary branch — "
-    "origin/HEAD, else origin/main / origin/master, else a local main/master)",
-)
-@click.option(
-    "--working",
-    is_flag=True,
-    default=False,
-    help="Review the whole worktree — branch commits plus uncommitted edits — "
-    "against the base, instead of only the committed branch changes",
-)
-@click.option(
-    "--uncommitted",
-    is_flag=True,
-    default=False,
-    help="Review only the uncommitted working-tree edits (vs HEAD); "
-    "mutually exclusive with --working",
-)
-@click.option(
     "--format",
     "output_format",
     type=click.Choice(["human", "json", "agent"]),
@@ -245,12 +313,6 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     "lenses share one pool). Default: 8 for cloud providers, 1 for ollama, and "
     "1 for openai-compatible — a llama.cpp/LM Studio single-slot server wants 1, "
     "while a vLLM server batches happily at 8; raise it there explicitly",
-)
-@click.option(
-    "--timeout",
-    default=None,
-    type=int,
-    help="Per-request timeout in seconds for each model call (raise for slow local models)",
 )
 @click.option(
     "--max-review-seconds",
@@ -348,17 +410,10 @@ def _load_cfg(config_path: str | None, **inputs: Any) -> ReviewConfig:
     help="Print a timing profile at the end of the run: total wall time, "
     "per-stage and per-call tables, and prompt-cache hit totals",
 )
-@click.option(
-    "--config",
-    "config_path",
-    default=None,
-    help="Path to a per-repo config file (must exist when given) "
-    "[default: .lgtmaybe.yml, absent is fine]",
-)
 def review(
     provider: str | None,
     model: str | None,
-    preset: str | None,
+    preset: ReviewPreset | None,
     full_preset: bool,
     fallback_model: str | None,
     reflect_model: str | None,
@@ -366,9 +421,9 @@ def review(
     triage_model: str | None,
     api_key: str | None,
     api_base: str | None,
-    min_severity: str | None,
-    fail_on: str | None,
-    unanchored_min_severity: str | None,
+    min_severity: Severity | None,
+    fail_on: Severity | None,
+    unanchored_min_severity: Severity | None,
     max_files: int | None,
     max_input_tokens: int | None,
     max_tokens: int | None,
@@ -398,16 +453,15 @@ def review(
     config_path: str | None,
 ) -> None:
     """Review local git changes and print findings — no GitHub needed."""
-    if working and uncommitted:
-        raise click.UsageError("--working and --uncommitted are mutually exclusive")
-    if full_preset and preset == "fast":
+    _check_diff_mode(working, uncommitted)
+    if full_preset and preset is ReviewPreset.fast:
         raise click.UsageError("--full contradicts --preset fast")
     cfg = _load_cfg(
         config_path,
         user_config_path=store.user_config_path(),
         provider=provider,
         model=model,
-        preset="full" if full_preset else preset,
+        preset=ReviewPreset.full if full_preset else preset,
         reflect_model=reflect_model,
         language=language,
         triage_model=triage_model,
@@ -436,61 +490,14 @@ def review(
     )
     cfg = _apply_static_analysis_flag(cfg, static_analysis)
 
-    runtime = RuntimeOptions(
-        api_key=api_key, api_base=api_base, fallback_model=fallback_model, profile=profile
-    )
+    runtime = _runtime(api_key, api_base, fallback_model, profile=profile)
     fmt = output_format or ("json" if as_json else "human")
     execute_local_review(cfg, runtime, base=base, working=working, uncommitted=uncommitted, fmt=fmt)
 
 
 @main.command()
-@click.option("--provider", default=None, help="LLM provider override")
-@click.option("--model", default=None, help="Model name understood by the chosen provider")
-@click.option("--fallback-model", default=None, help="Model to retry with if the primary fails")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="LGTMAYBE_API_KEY",
-    help="API key (not needed for bedrock/vertex/keyless-azure ambient creds, or ollama)",
-)
-@click.option("--api-base", default=None, help="API base URL (e.g. ollama)")
-@click.option(
-    "--base",
-    default=None,
-    help="Base ref to diff against (default: the remote's primary branch)",
-)
-@click.option(
-    "--working",
-    is_flag=True,
-    default=False,
-    help="Diagram the whole worktree — branch commits plus uncommitted edits — vs the base",
-)
-@click.option(
-    "--uncommitted",
-    is_flag=True,
-    default=False,
-    help="Diagram only the uncommitted working-tree edits (vs HEAD); "
-    "mutually exclusive with --working",
-)
-@click.option(
-    "--timeout",
-    default=None,
-    type=int,
-    help="Per-request timeout in seconds for the model call (raise for slow local models)",
-)
-@click.option(
-    "--num-ctx",
-    default=None,
-    type=int,
-    help="ollama context window (ollama only; raise it for a large multi-file diff)",
-)
-@click.option(
-    "--config",
-    "config_path",
-    default=None,
-    help="Path to a per-repo config file (must exist when given) "
-    "[default: .lgtmaybe.yml, absent is fine]",
-)
+@model_options
+@local_diff_options
 def diagram(
     provider: str | None,
     model: str | None,
@@ -510,8 +517,7 @@ def diagram(
     source — paste that into a GitHub comment, mermaid.live, or a Markdown file
     to render it.
     """
-    if working and uncommitted:
-        raise click.UsageError("--working and --uncommitted are mutually exclusive")
+    _check_diff_mode(working, uncommitted)
     cfg = _load_cfg(
         config_path,
         user_config_path=store.user_config_path(),
@@ -520,7 +526,7 @@ def diagram(
         timeout=timeout,
         num_ctx=num_ctx,
     )
-    runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
+    runtime = _runtime(api_key, api_base, fallback_model)
     execute_local_diagram(cfg, runtime, base=base, working=working, uncommitted=uncommitted)
 
 
@@ -531,18 +537,7 @@ def diagram(
     required=True,
     help="Path to the issue_comment event payload (GitHub sets GITHUB_EVENT_PATH).",
 )
-@click.option("--provider", default=None, help="LLM provider override")
-@click.option("--model", default=None, help="Model name override")
-@click.option("--fallback-model", default=None, help="Model to retry with if the primary fails")
-@click.option("--api-key", default=None, envvar="LGTMAYBE_API_KEY", help="API key")
-@click.option("--api-base", default=None, help="API base URL (e.g. ollama)")
-@click.option(
-    "--config",
-    "config_path",
-    default=None,
-    help="Path to a per-repo config file (must exist when given) "
-    "[default: .lgtmaybe.yml, absent is fine]",
-)
+@model_options
 def comment(
     event_path: str,
     provider: str | None,
@@ -555,7 +550,7 @@ def comment(
     """Handle an issue_comment event: route a /slash command to the engine."""
     event = json.loads(Path(event_path).read_text(encoding="utf-8"))
     cfg = _load_cfg(config_path, provider=provider, model=model)
-    runtime = RuntimeOptions(api_key=api_key, api_base=api_base, fallback_model=fallback_model)
+    runtime = _runtime(api_key, api_base, fallback_model)
     execute_comment(event, cfg, runtime)
 
 

--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -285,5 +285,4 @@ def _repo_name(cwd: Path | None) -> str:
     if url:
         parts = re.split(r"[:/]", url.removesuffix(".git"))
         return "/".join(parts[-2:])
-    toplevel = _git(cwd, "rev-parse", "--show-toplevel").strip()
-    return Path(toplevel).name
+    return _repo_root(cwd).name

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -159,7 +159,9 @@ class TestReviewCommandLocal:
             ["review", "--provider", "ollama", "--model", "llama3", "--working", "--uncommitted"],
         )
 
-        assert result.exit_code != 0
+        # Exit 2: a usage error, not a runtime failure — the shared
+        # command-level check must keep raising UsageError, not ClickException.
+        assert result.exit_code == 2, result.output
         assert "mutually exclusive" in result.output
 
     def test_uncommitted_flag_is_threaded_through(self, monkeypatch):
@@ -251,7 +253,9 @@ class TestDiagramCommand:
             ["diagram", "--provider", "ollama", "--model", "llama3", "--working", "--uncommitted"],
         )
 
-        assert result.exit_code != 0
+        # Exit 2: a usage error, not a runtime failure — the shared
+        # command-level check must keep raising UsageError, not ClickException.
+        assert result.exit_code == 2, result.output
         assert "mutually exclusive" in result.output
 
 

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import re
-
+import click
 from click.testing import CliRunner
 
 from lgtmaybe.cli import main
+from lgtmaybe.core.models import Provider, ReviewPreset, Severity
 
 
 def test_help_lists_commands_and_examples() -> None:
@@ -79,8 +79,64 @@ def test_bare_invocation_shows_enriched_help() -> None:
 def test_comment_options_all_have_help_text() -> None:
     result = CliRunner().invoke(main, ["comment", "--help"])
     assert result.exit_code == 0
-    for line in result.output.splitlines():
-        match = re.match(r"^\s+(--[a-z-]+)(?: \S+)?\s*(.*)$", line)
-        if match and match.group(1) != "--help":
-            assert match.group(2), f"option {match.group(1)} has no help text"
+    for flag, option in _options("comment").items():
+        assert option.help, f"option {flag} has no help text"
     assert "config file" in result.output
+
+
+def _options(command_name: str) -> dict[str, click.Option]:
+    """The named command's options, keyed by their primary flag."""
+    command = main.get_command(click.Context(main), command_name)
+    assert command is not None
+    return {p.opts[0]: p for p in command.params if isinstance(p, click.Option)}
+
+
+def test_shared_options_have_identical_help_across_commands() -> None:
+    """`review`, `diagram` and `comment` declare their common flags once, so the
+    same flag can never document itself differently depending on the command —
+    which is exactly how `--provider` and `--api-base` drifted."""
+    review, diagram, comment = (_options(name) for name in ("review", "diagram", "comment"))
+    shared = set(review) & set(diagram) & set(comment)
+    assert {"--provider", "--model", "--fallback-model", "--api-key", "--api-base"} <= shared
+    for flag in shared:
+        assert review[flag].help == diagram[flag].help == comment[flag].help, flag
+    # --config is spelled the same way but is not part of the model group above.
+    assert review["--config"].help == diagram["--config"].help == comment["--config"].help
+
+
+def test_local_diff_options_have_identical_help_across_commands() -> None:
+    """The flags `review` and `diagram` share are declared once too."""
+    review, diagram = (_options(name) for name in ("review", "diagram"))
+    for flag in ("--base", "--working", "--uncommitted", "--timeout", "--num-ctx"):
+        assert review[flag].help == diagram[flag].help, flag
+
+
+def test_choice_options_are_derived_from_the_enums() -> None:
+    """The severity/preset/provider choices come from the enums themselves, so a
+    new member can't be missed in one of the three severity lists."""
+    review = _options("review")
+    severities = [s.value for s in Severity]
+    for flag in ("--min-severity", "--fail-on", "--unanchored-min-severity"):
+        choice = review[flag].type
+        assert isinstance(choice, click.Choice)
+        assert [str(c) for c in choice.choices] == severities, flag
+    preset = review["--preset"].type
+    assert isinstance(preset, click.Choice)
+    assert [str(c) for c in preset.choices] == [p.value for p in ReviewPreset]
+    provider = review["--provider"].type
+    assert isinstance(provider, click.Choice)
+    assert list(provider.choices) == [p.value for p in Provider]
+
+
+def test_provider_choice_accepts_the_hyphenated_wire_value() -> None:
+    """`openai-compatible` is the documented spelling — click.Choice over the
+    Enum itself would only accept the member NAME (`openai_compatible`)."""
+    result = CliRunner().invoke(main, ["comment", "--provider", "openai-compatible", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_unknown_provider_fails_with_a_usage_error() -> None:
+    result = CliRunner().invoke(main, ["review", "--provider", "bogus"])
+    assert result.exit_code == 2
+    assert "bogus" in result.output
+    assert "openai-compatible" in result.output

--- a/tests/local/test_git_context.py
+++ b/tests/local/test_git_context.py
@@ -433,3 +433,11 @@ def test_explicit_file_reader_root_is_used_verbatim(tmp_path: Path) -> None:
     read = local_file_reader(corpus)
 
     assert read("migrations/ledger.py") == "def pending():\n    return []\n"
+
+
+def test_repo_name_falls_back_to_the_directory_name_outside_a_repo(tmp_path: Path) -> None:
+    """`_repo_name` reuses `_repo_root`, whose fallback makes it answer for a
+    directory git knows nothing about instead of raising."""
+    from lgtmaybe.local import _repo_name
+
+    assert _repo_name(tmp_path) == tmp_path.name


### PR DESCRIPTION
Addresses the drift items in #330 that are strictly inside `cli/commands.py`, `cli/__init__.py`, `local/__init__.py` and their tests.

## What changed

**1. Two module-level Click decorator stacks.** `--provider`, `--model`, `--fallback-model`, `--api-key`, `--api-base` and `--config` were declared once each on `review`, `diagram` and `comment`. They are now `model_options`, applied to all three. `--base`, `--working`, `--uncommitted`, `--timeout` and `--num-ctx` were declared twice; they are now `local_diff_options`, applied to `review` and `diagram`. A tiny `_stack(*options)` applies them bottom-up, so a command reads exactly as it did with the decorators written out.

**2. `click.Choice` derived from the enums.** `["info", "low", "medium", "high", "critical"]` was written out three times and `["fast", "full"]` once — hand copies of `Severity` and `ReviewPreset`. Now `click.Choice(Severity)` (×3) and `click.Choice(ReviewPreset)`, which on click 8.4.2 convert to the enum member that pydantic already accepts. `--provider` gains a `Choice` too, so a typo is a usage error with click's suggestion instead of a downstream pydantic error.

> ⚠️ One real trap found while doing this: **`click.Choice(Provider)` matches an Enum by member NAME**, so it accepts `openai_compatible` and *rejects* the documented `openai-compatible`. The provider choice is therefore built from `[p.value for p in Provider]` — still derived from the enum, but keeping the wire spelling. There is a comment on the line and a test (`test_provider_choice_accepts_the_hyphenated_wire_value`) so nobody "tidies" it into the enum class later.

**3. One `--working`/`--uncommitted` guard.** Written three times before. The command-level copies are now one `_check_diff_mode` helper, which **still raises `UsageError`** — the two conflict tests were tightened from `exit_code != 0` to `exit_code == 2` so the exit code is pinned, not incidental. `local_pr_context`'s `ValueError` stays: it is the invariant for library callers, and the CLI check exists so the user fails before any provider work rather than after it.

**4. `_runtime` helper.** The three identical `RuntimeOptions(api_key=…, api_base=…, fallback_model=…)` constructions are one call.

**5. `_repo_name` reuses `_repo_root`.** It re-ran `git rev-parse --show-toplevel` itself, without `_repo_root`'s fallback — so it could raise on a path `_repo_root` answers for. Now `return _repo_root(cwd).name`, with a test for the no-repo path.

## Which help text won

| Option | Winner |
|---|---|
| `--model`, `--fallback-model`, `--api-key`, `--api-base`, `--base`, `--timeout`, `--num-ctx` | `review`'s (the longer, more complete text in every case) |
| `--config` | already identical everywhere |
| `--working`, `--uncommitted` | `review`'s wording, with the leading verb made neutral ("Use the whole worktree…") since the same text now serves `diagram` |
| `--provider` | **neither, deliberately.** The nine-provider list `review` spelled out in prose is now the `Choice` metavar, so `--help` still shows all nine — rendered from the enum rather than a second hand-maintained copy. Repeating them in the help string next to the metavar would have re-created exactly the duplication this PR removes. The help text now says what the flag *does*. |

## Left deliberately

- **`--full` was not removed** (#330 item 4). It is documented at `docs/how-to/configure-lgtmaybe-yml.md:168` and user-visible, so cutting it needs a deprecation/changelog cycle rather than a silent removal inside a refactor.
- **`should_auto_describe` / `should_auto_diagram` were not merged** (#330 item 5). The spec anchor `cli.starter-workflow-diagrams` (`openspec/specs/cli-and-local/anchors.yml:76-80`) matches a `function_definition` named exactly `should_auto_diagram`; merging them would dangle the anchor and require moving the rule and its spec section in the same change. Against 8 lines of duplication, leaving it is the better trade.
- `action_inputs()` and the `action()` command are untouched — they belong to #331.

## Tests

Red-first: `tests/cli/test_help.py` gained assertions that the shared flags carry *identical* help across `review`/`diagram`/`comment`, that the three severity choices plus the preset and provider choices are derived from the enums, and that `--provider openai-compatible` is accepted while `--provider bogus` exits 2. `tests/local/test_git_context.py` gained the `_repo_name` no-repo fallback case. The existing per-command option-help scrape was rewritten to inspect the declared `Option.help` rather than regex the rendered output — the long provider metavar wraps help onto a second line, which the old regex could not see.

Full gate green: `uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest -q` — 1807 passed, 3 skipped.

Closes #330

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_