### PR TITLE
refactor(engine): reuse parse_structured for triage and thin the profiler API

### DIFF
--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -56,11 +56,11 @@ stack.
 - **THEN** typed nodes and edges are rendered into Mermaid and text views with
   stable ids, escaped labels, compact cards, and change markers on nodes
 
-#### Scenario: provider returns legacy C4
-- **WHEN** the diagram provider ignores the graph contract and returns C4
-  source together with an ASCII rendering
-- **THEN** the C4 source is not posted as Mermaid and the ASCII rendering is
-  shown instead
+#### Scenario: provider returns diagram syntax instead of graph data
+- **WHEN** the diagram provider ignores the graph contract and returns diagram
+  source (C4, a Mermaid fence) with no nodes
+- **THEN** that source is not posted as Mermaid and the comment explains that no
+  valid diagram was produced
 
 ### Requirement: Change diagrams show structure and sequence
 

--- a/src/lgtmaybe/cli/slash.py
+++ b/src/lgtmaybe/cli/slash.py
@@ -17,9 +17,8 @@ from enum import StrEnum
 
 from lgtmaybe.core.models import AnswerResult, ReviewConfig
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
-from lgtmaybe.engine.describe import parse_structured
 from lgtmaybe.engine.injection import wrap_diff, wrap_reply
-from lgtmaybe.engine.parse import iter_json_values
+from lgtmaybe.engine.parse import iter_json_values, parse_structured
 from lgtmaybe.engine.redact import redact
 
 

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -501,15 +501,13 @@ class DiagramResult(_Strict):
     The model returns presentation-agnostic nodes, edges, and ordered steps.
     lgtmaybe renders Mermaid (a flowchart of the structure, a sequence diagram
     of the flow) and text locally so model-authored syntax never reaches a
-    Mermaid fence. ``ascii`` remains only as a compatibility fallback for weak
-    models that return the legacy C4-plus-text shape.
+    Mermaid fence.
     """
 
     title: str = ""
     nodes: list[DiagramNode] = Field(default_factory=list)
     edges: list[DiagramEdge] = Field(default_factory=list)
     steps: list[DiagramStep] = Field(default_factory=list)
-    ascii: str = ""
     notes: str = ""
 
 

--- a/src/lgtmaybe/engine/describe.py
+++ b/src/lgtmaybe/engine/describe.py
@@ -26,7 +26,7 @@ from lgtmaybe.core.ports import ProviderClient
 from .compress import count_tokens
 from .engine import _intent_text  # same package; the one canonical intent extractor
 from .injection import DIFF_END, DIFF_START, neutralise, wrap_intent
-from .parse import iter_json_values
+from .parse import parse_structured
 from .redact import redact
 
 _M = TypeVar("_M", bound=BaseModel)
@@ -165,22 +165,6 @@ def _fit_diff(diff: str, max_tokens: int) -> str:
         kept.append(line)
         used += t
     return "\n".join([*kept, _MAX_DIFF_LINES_OVER_BUDGET_MARKER])
-
-
-def parse_structured(
-    raw: str, result_model: type[_M], wanted: Callable[[dict[str, Any]], bool]
-) -> _M | None:
-    """Leniently extract the first *wanted* JSON object from *raw*; None when absent."""
-    for data in iter_json_values(raw):
-        if not isinstance(data, dict) or not wanted(data):
-            continue
-        try:
-            return result_model.model_validate(
-                {k: v for k, v in data.items() if k in result_model.model_fields}
-            )
-        except Exception:  # noqa: BLE001 — fall through to the raw-text fallback
-            continue
-    return None
 
 
 def _render(desc: DescribeResult, *, has_intent: bool) -> str:

--- a/src/lgtmaybe/engine/diagram.py
+++ b/src/lgtmaybe/engine/diagram.py
@@ -135,11 +135,9 @@ def build_diagram(ctx: PRContext, cfg: ReviewConfig, provider: ProviderClient) -
 
 
 def _has_diagram(data: dict[str, Any]) -> bool:
-    """Whether a parsed object carries graph nodes or a legacy ASCII fallback."""
+    """Whether a parsed object carries graph nodes to render."""
     nodes = data.get("nodes")
-    return (isinstance(nodes, list) and bool(nodes)) or (
-        isinstance(data.get("ascii"), str) and bool(data["ascii"].strip())
-    )
+    return isinstance(nodes, list) and bool(nodes)
 
 
 def _single_line(value: str) -> str:
@@ -283,7 +281,7 @@ def _view(mermaid: str, text: str) -> list[str]:
 
 
 def _render(diagram: DiagramResult) -> str:
-    """Render a validated graph, or a legacy ASCII-only response."""
+    """Render a validated graph; the invalid-diagram notice when there is none."""
     title = _single_line(diagram.title) or "Architecture of this change"
     lines = [f"## {title}", ""]
     nodes, node_ids = _prepare_nodes(diagram)
@@ -297,8 +295,6 @@ def _render(diagram: DiagramResult) -> str:
         lines += _view(mermaid, ascii_art)
         if sequence:
             lines += ["", "### Sequence", "", *_view(sequence, sequence_text)]
-    elif diagram.ascii.strip():
-        lines += _fenced(diagram.ascii.strip())
     else:
         return _invalid_diagram("")
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -28,7 +28,6 @@ from lgtmaybe.core.models import (
     ReviewResult,
     StaticAnalysisTool,
     ToolMode,
-    attempts_of,
 )
 from lgtmaybe.core.ports import (
     Message,
@@ -1235,20 +1234,7 @@ class LLMReviewEngine(ReviewEngine):
             result = self._provider.complete(messages, model=model, **opts)
         except Exception as exc:
             reason = _error_reason(exc)
-            profiler.record_call(
-                label=lens.id,
-                batch=batch_num,
-                elapsed=time.perf_counter() - started,
-                # What the adapter stamped on the exception: a failure that burned
-                # its retry budget must not read as one that was never retried.
-                # 0 only when the failure never reached the retry loop.
-                attempts=attempts_of(exc),
-                input_tokens=0,
-                output_tokens=0,
-                cache_read_tokens=0,
-                cache_creation_tokens=0,
-                error=reason,
-            )
+            profiler.record_error(lens.id, batch_num, time.perf_counter() - started, exc, reason)
             _log.warning(
                 "review call failed",
                 extra={"lens": lens.id, "reason": reason},
@@ -1267,17 +1253,7 @@ class LLMReviewEngine(ReviewEngine):
                 findings, split_reason = on_oversized(reason)
                 return completed + findings, split_reason
             return [], reason
-        profiler.record_call(
-            label=lens.id,
-            batch=batch_num,
-            elapsed=time.perf_counter() - started,
-            attempts=result.attempts,
-            input_tokens=result.input_tokens,
-            output_tokens=result.output_tokens,
-            cache_read_tokens=result.cache_read_tokens,
-            cache_creation_tokens=result.cache_creation_tokens,
-            reasoning_tokens=result.reasoning_tokens,
-        )
+        profiler.record_result(lens.id, batch_num, time.perf_counter() - started, result)
         salvaged = 0
         try:
             findings = parse_findings(result.text)

--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -23,10 +23,14 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Callable, Iterator
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
 
 from lgtmaybe.core.models import ReviewFinding
+
+_M = TypeVar("_M", bound=BaseModel)
 
 
 class ParseError(Exception):
@@ -310,3 +314,19 @@ def parse_findings(raw: str) -> list[ReviewFinding]:
     if last_error is not None:
         raise ParseError(f"Finding validation failed: {last_error}") from last_error
     raise ParseError("Cannot parse JSON findings from response")
+
+
+def parse_structured(
+    raw: str, result_model: type[_M], wanted: Callable[[dict[str, Any]], bool]
+) -> _M | None:
+    """Leniently extract the first *wanted* JSON object from *raw*; None when absent."""
+    for data in iter_json_values(raw):
+        if not isinstance(data, dict) or not wanted(data):
+            continue
+        try:
+            return result_model.model_validate(
+                {k: v for k, v in data.items() if k in result_model.model_fields}
+            )
+        except Exception:  # noqa: BLE001 — fall through to the raw-text fallback
+            continue
+    return None

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -19,7 +19,7 @@ import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from lgtmaybe.core.logging import get_logger
@@ -100,22 +100,47 @@ class Profiler:
         )
         with self._lock:
             self.calls.append(record)
-        _log.info(
-            "provider call",
-            extra={
-                "label": label,
-                "batch": batch,
-                "elapsed_s": round(elapsed, 3),
-                "attempts": attempts,
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "cache_read_tokens": cache_read_tokens,
-                "cache_creation_tokens": cache_creation_tokens,
-                # Only when reported: a 0 on every line would read as a claim
-                # that the model did no thinking, which is not what it means.
-                **({"reasoning_tokens": reasoning_tokens} if reasoning_tokens else {}),
-                **({"error": error} if error else {}),
-            },
+        extra = asdict(record)
+        extra["elapsed_s"] = round(extra.pop("elapsed"), 3)
+        # Only when reported: a 0 on every line would read as a claim that the
+        # model did no thinking, which is not what it means.
+        if not reasoning_tokens:
+            del extra["reasoning_tokens"]
+        if not error:
+            del extra["error"]
+        _log.info("provider call", extra=extra)
+
+    def record_result(self, label: str, batch: int, elapsed: float, result: ProviderResult) -> None:
+        """Record a successful call: usage counters straight off *result*."""
+        self.record_call(
+            label=label,
+            batch=batch,
+            elapsed=elapsed,
+            attempts=result.attempts,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            cache_read_tokens=result.cache_read_tokens,
+            cache_creation_tokens=result.cache_creation_tokens,
+            reasoning_tokens=result.reasoning_tokens,
+        )
+
+    def record_error(
+        self, label: str, batch: int, elapsed: float, exc: BaseException, reason: str | None = None
+    ) -> None:
+        """Record a failed call: no usage to report, so every counter is zero."""
+        self.record_call(
+            label=label,
+            batch=batch,
+            elapsed=elapsed,
+            # What the adapter stamped on the exception: a failure that burned its
+            # retry budget must not read as one that was never retried. 0 only when
+            # the failure never reached the retry loop.
+            attempts=attempts_of(exc),
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            error=reason or type(exc).__name__,
         )
 
     def total_tokens(self) -> int:
@@ -244,27 +269,7 @@ def timed_complete(
     try:
         result = provider.complete(messages, model=model, **opts)
     except Exception as exc:
-        profiler.record_call(
-            label=label,
-            batch=batch,
-            elapsed=time.perf_counter() - started,
-            attempts=attempts_of(exc),  # 0 only if it never reached the retry loop
-            input_tokens=0,
-            output_tokens=0,
-            cache_read_tokens=0,
-            cache_creation_tokens=0,
-            error=f"{type(exc).__name__}",
-        )
+        profiler.record_error(label, batch, time.perf_counter() - started, exc)
         raise
-    profiler.record_call(
-        label=label,
-        batch=batch,
-        elapsed=time.perf_counter() - started,
-        attempts=result.attempts,
-        input_tokens=result.input_tokens,
-        output_tokens=result.output_tokens,
-        cache_read_tokens=result.cache_read_tokens,
-        cache_creation_tokens=result.cache_creation_tokens,
-        reasoning_tokens=result.reasoning_tokens,
-    )
+    profiler.record_result(label, batch, time.perf_counter() - started, result)
     return result

--- a/src/lgtmaybe/engine/triage.py
+++ b/src/lgtmaybe/engine/triage.py
@@ -25,7 +25,7 @@ from lgtmaybe.core.models import ReviewConfig, TriageResult
 from lgtmaybe.core.ports import ProviderClient
 
 from .injection import neutralise
-from .parse import iter_json_values
+from .parse import parse_structured
 from .profiling import timed_complete
 from .static_analysis import ToolFinding
 
@@ -180,24 +180,12 @@ def _ask_triage(
 
 
 def _parse_triage(raw: str) -> dict[str, tuple[bool, int]] | None:
-    """Leniently parse the triage verdict; None when no usable shape is found."""
-    for data in iter_json_values(raw):
-        if not isinstance(data, dict) or not isinstance(data.get("files"), list):
-            continue
-        out: dict[str, tuple[bool, int]] = {}
-        for item in data["files"]:
-            if not isinstance(item, dict) or "path" not in item:
-                continue
-            out[str(item["path"])] = (
-                bool(item.get("review", True)),
-                _coerce_risk(item.get("risk")),
-            )
-        return out
-    return None
+    """Leniently parse the triage verdict; None when no usable shape is found.
 
-
-def _coerce_risk(value: object) -> int:
-    """Clamp a verdict's risk to 0-10; anything non-numeric means mid-scale."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return 5
-    return max(0, min(10, int(value)))
+    :class:`TriageResult` already declares the defaults and the 0–10 risk range,
+    so validation is the whole parser. A verdict pydantic rejects (a risk out of
+    range, a file entry without a path) yields None — which routes to "review
+    everything", the safe direction triage may never depart from.
+    """
+    parsed = parse_structured(raw, TriageResult, lambda d: isinstance(d.get("files"), list))
+    return None if parsed is None else {v.path: (v.review, v.risk) for v in parsed.files}

--- a/tests/engine/test_diagram.py
+++ b/tests/engine/test_diagram.py
@@ -5,9 +5,8 @@ plus an ASCII view locally. Contracts:
 
 - structured JSON renders the title, a ``mermaid`` fence, the ASCII in a
   collapsed ``<details>``, and the notes;
-- model-authored Mermaid never enters a ``mermaid`` fence;
-- legacy C4 output also drops to the ASCII fallback rather than rendering an
-  overlap-prone graph;
+- model-authored Mermaid never enters a ``mermaid`` fence — the prompt asks for
+  graph data only, so a response carrying syntax but no nodes is invalid;
 - unparseable model output becomes a safe explanatory comment;
 - a valid Mermaid fence is followed by an "Open full screen" mermaid.live link
   whose pako fragment round-trips to the exact fenced source;
@@ -179,6 +178,8 @@ def test_response_format_is_the_diagram_schema() -> None:
 
 
 def test_model_authored_mermaid_is_never_rendered() -> None:
+    """Syntax the model wrote is not a diagram: with no nodes it is invalid
+    output, not something to render."""
     body = build_diagram(
         _CTX,
         _CFG,
@@ -186,46 +187,22 @@ def test_model_authored_mermaid_is_never_rendered() -> None:
             nodes=[],
             edges=[],
             mermaid='```mermaid\nflowchart LR\n    a["A"]\n```',
-            ascii="[A]",
         ),
     )
 
     assert "```mermaid" not in body
-    assert "\n[A]\n" in body
+    assert "couldn't produce a valid change diagram" in body
 
 
-def test_reported_invalid_mermaid_falls_back_to_ascii_only() -> None:
+def test_legacy_c4_without_nodes_is_invalid() -> None:
     body = build_diagram(
         _CTX,
         _CFG,
-        _structured_provider(
-            nodes=[],
-            edges=[],
-            mermaid=_BROKEN_MERMAID,
-            ascii="[Bundled step reference] (changed)",
-        ),
+        _structured_provider(nodes=[], edges=[], mermaid=_LEGACY_C4),
     )
 
     assert "```mermaid" not in body
-    assert "<details>" not in body
-    assert "[Bundled step reference] (changed)" in body
-
-
-def test_legacy_c4_falls_back_to_ascii_only() -> None:
-    body = build_diagram(
-        _CTX,
-        _CFG,
-        _structured_provider(
-            nodes=[],
-            edges=[],
-            mermaid=_LEGACY_C4,
-            ascii="[Client] --> [App] (changed)",
-        ),
-    )
-
-    assert "```mermaid" not in body
-    assert "<details>" not in body
-    assert "[Client] --> [App] (changed)" in body
+    assert "couldn't produce a valid change diagram" in body
 
 
 def test_mermaid_gets_a_full_screen_link() -> None:
@@ -245,7 +222,7 @@ def test_no_full_screen_link_without_mermaid() -> None:
     body = build_diagram(
         _CTX,
         _CFG,
-        _structured_provider(nodes=[], edges=[], mermaid=_BROKEN_MERMAID, ascii="[Fallback]"),
+        _structured_provider(nodes=[], edges=[], mermaid=_BROKEN_MERMAID),
     )
 
     assert "mermaid.live" not in body

--- a/tests/engine/test_triage.py
+++ b/tests/engine/test_triage.py
@@ -179,6 +179,18 @@ def test_unparseable_triage_reviews_everything() -> None:
     assert skipped == []
 
 
+def test_out_of_range_risk_reviews_everything() -> None:
+    """The verdict schema declares risk as 0-10, so a value outside it is a
+    verdict lgtmaybe cannot trust — and an untrusted verdict means review, never
+    a guessed-down score that could skip a file."""
+    provider = _verdict_provider([{"path": BORING[0], "review": False, "risk": 99}])
+
+    kept, skipped = triage_files([BORING, PLAIN], [], _cfg(triage_model="tiny"), provider)
+
+    assert [p for p, _ in kept] == [BORING[0], PLAIN[0]]
+    assert skipped == []
+
+
 def test_provider_failure_reviews_everything() -> None:
     class _Boom(FakeProvider):
         def complete(self, messages, model, **opts):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Ponytail cleanups from #339, items 1–3. Item 4 (`resolve_needs` wave-slicing) is deliberately untouched — determinism under budget is guaranteed and tested.

## 1. `triage` stops re-implementing a parser the package already has

`_parse_triage` hand-walked `iter_json_values`, re-checked `isinstance(item, dict)`, re-coerced `path`, re-defaulted `review` and re-clamped `risk` — all of which `TriageResult`/`TriageFileVerdict` already declare (`risk: int = Field(default=5, ge=0, le=10)`), and which `_ask_triage` already passes as `response_format`. It now validates through `parse_structured`, and `_coerce_risk` is gone.

`parse_structured` **moved from `engine/describe.py` to `engine/parse.py`** — its natural home next to `iter_json_values`, and necessary here: `describe` imports `engine`, `engine` imports `triage`, so importing it from `describe` would have closed an import cycle. `describe.py` and `cli/slash.py` now import it from `parse`; the function body is unchanged.

**Behaviour change, stated plainly:** an out-of-range `risk` (e.g. `99`) now **fails validation and returns `None`** instead of being clamped to `10`. `None` routes to "review everything" — the module's own documented safe direction, and the same degradation every other triage failure path already takes. A verdict the schema rejects is a verdict lgtmaybe cannot trust, and an untrusted verdict must never be the thing that lets a file be skipped. Pinned by `test_out_of_range_risk_reviews_everything`.

## 2. Two thin recorders over `record_call`

`Profiler.record_result(label, batch, elapsed, result)` and `record_error(label, batch, elapsed, exc, reason=None)` replace four ten-keyword `record_call` spellings (two in `profiling.timed_complete`, two in the engine's fan-out, which needed its own copy only because it holds the exception object). `record_call` **stays** as the underlying primitive — `tests/engine/test_profiling.py` and `tests/cli/test_token_footer.py` call it directly.

The log `extra` is now built from `dataclasses.asdict(record)` with `elapsed` renamed to `elapsed_s`. **The emitted field set is unchanged**, verified against the old shape: `reasoning_tokens` and `error` are still omitted when absent — a `reasoning_tokens: 0` on every line would read as a claim the model did no thinking, which is not what it means, so that conditional earned its two lines and was kept.

## 3. The `ascii` diagram fallback: cut

Confirmed by reading `_DIAGRAM_SYSTEM` end to end — it lists exactly five keys (`title`, `nodes`, `edges`, `steps`, `notes`), never names `ascii`, and explicitly says *"Return graph data only. lgtmaybe owns Mermaid and ASCII syntax; do not return flowchart source, code fences, styling, or positioning directives."* No other caller in `src/` populates the field: the only references were its own declaration, its branch in `_has_diagram`, and its `elif` in `_render`.

Judged the regression not real enough to keep the field for:

- with `structured_output` on, the JSON schema itself was the only thing advertising `ascii` — removing it removes the invitation, and the model fills `nodes` instead;
- with it off, the model has no way to learn the key name, since the prompt never mentions it;
- `_invalid_diagram` already covers the junk case, and the response that would have hit this branch is one carrying zero nodes — i.e. no graph at all.

The locally-rendered text view (`_graph_views`' `ascii_art`, the `<details>` "Text version") is **untouched** — that is what `docs/how-to/generate-a-change-diagram.md` means by "what the ASCII is for". Three tests that reached the branch now assert the stronger contract they were really about: model-authored Mermaid never reaches a fence, and a nodeless response is invalid output.

`openspec/specs/cli-and-local/spec.md`'s "provider returns legacy C4" scenario was made stale by the cut and is updated in place.

## Net

11 files, **-155 / +110**, ~45 net lines out of `src/`. Gate green: `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (1806 passed, 3 skipped), plus `tests/specs` and `openspec validate --specs`.

Closes #339

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuQejxPXg376HDcUb69g7)_