### PR TITLE
ci: stop Dependabot updating lgtmaybe examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,5 +31,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "MattJColes/lgtmaybe"
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## What changed

- Ignore `MattJColes/lgtmaybe` in the GitHub Actions Dependabot configuration.
- Keep Dependabot updates enabled for every other action in `/` and `/examples/workflows`.

## Why

The example workflows intentionally use the floating `MattJColes/lgtmaybe@v1` tag. Because Dependabot scans `/examples/workflows`, it treated the repository's own action as an external dependency and opened #346 to replace `@v1` with the exact `@v1.9.1` tag. The release workflow already moves `v1` to each compatible v1.x release, so that self-update is unwanted noise.

## Impact

Dependabot will stop opening self-referential lgtmaybe update PRs. Updates for `actions/checkout` and other GitHub Actions remain unchanged.

## Validation

- Parsed `.github/dependabot.yml` and asserted the ignore rule is present.
- `pytest tests/specs -q` — 17 passed.
- `openspec validate --specs` — 10 passed.