### PR TITLE
perf(ci): start no job for a comment with no slash command

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -34,11 +34,31 @@ jobs:
     # review — automatically on their PRs, or via a slash command. This keeps a
     # drive-by /ask or /review from a stranger from spending the provider
     # budget, and skips comments that aren't on a pull request.
+    #
+    # The issue_comment arm also requires the body to carry one of our slash
+    # commands. issue_comment fires on EVERY comment on every PR, and without
+    # this a plain "lgtm, merging" claims a runner, pulls the container and boots
+    # Python only for the CLI to find no command and exit. Free of provider
+    # spend, but a whole job — and on a contended runner pool that queueing is
+    # what delays the reviews that do have work to do. The check is deliberately
+    # looser than `parse_command`, which additionally requires the command at the
+    # START of the body: `contains` is case-insensitive (so /REVIEW passes) and
+    # substring-based (so `/review full` passes). A guard tighter than the parser
+    # would silently disable a command that used to work.
+    #
+    # The pull_request_review_comment arm is NOT gated this way: that is the
+    # answer_replies path, where a PR author's reply inside a finding thread is
+    # plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     # Two independent guards against cancelling our own review. The job scope

--- a/README.md
+++ b/README.md
@@ -228,7 +228,16 @@ permissions:
 
 jobs:
   review:
-    if: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request }}
+    # A comment only starts a job when it carries one of lgtmaybe's slash
+    # commands — issue_comment fires on every comment on every PR.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -70,21 +70,38 @@ if: >-
   (github.event_name == 'pull_request_target' &&
    contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
   (github.event.issue.pull_request &&
-   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+   (contains(github.event.comment.body, '/review') ||
+    contains(github.event.comment.body, '/improve') ||
+    contains(github.event.comment.body, '/ask') ||
+    contains(github.event.comment.body, '/describe') ||
+    contains(github.event.comment.body, '/diagram')))
 ```
 
 A maintainer can still review an outside contributor's PR any time by commenting
 `/review` on it — their own association passes the gate. To change the policy,
 edit the list:
 
-- **Open it up to everyone** — drop the `if:` so any PR or `/review` comment runs
-  a review.
+- **Open it up to everyone** — drop the author-association checks so any PR or
+  `/review` comment runs a review.
 - **Welcome returning contributors** — add `CONTRIBUTOR` to auto-review anyone
   whose PR has merged before.
 - **Tighten to admins** — keep just `OWNER` (and `MEMBER` for your org).
 
 Because the gate lives in the workflow YAML, not in the action's code, the policy
 is entirely yours.
+
+The second half of the comment arm is a different kind of thrift. `issue_comment`
+fires on every comment on every pull request, and lgtmaybe's answer to one that
+holds no slash command is to exit — correct, and free of tokens, but only after a
+runner has been claimed, a container pulled and Python booted. Deciding that in
+the `if:` costs nothing at all, and on a busy runner pool it is the difference
+between a review starting now and a review queueing behind comment threads. The
+clause is deliberately looser than the parser it stands in for — substring, not
+prefix, and case-insensitive — because a guard tighter than the parser would
+silently disable a command that used to work. Replies inside a finding thread
+arrive on the separate `pull_request_review_comment` event and are never gated
+this way; they are ordinary prose, and gating them would switch the feature off.
 
 ## If you want extra guardrails
 

--- a/docs/how-to/review-with-azure.md
+++ b/docs/how-to/review-with-azure.md
@@ -77,7 +77,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -94,7 +94,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/how-to/review-with-vertex-wif.md
+++ b/docs/how-to/review-with-vertex-wif.md
@@ -66,7 +66,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -86,11 +86,22 @@ and default to **trusted contributors** — `OWNER`, `MEMBER`, and `COLLABORATOR
 A maintainer can also review an outside contributor's PR any time by commenting
 `/review` on it (their own association passes the gate).
 
+The same `if:` also requires a comment to actually carry a slash command before
+any job starts. `issue_comment` fires on every comment on every pull request, so
+without that clause an ordinary "lgtm, merging" would claim a runner, pull the
+container and boot Python only to find no command and exit — no tokens spent, but
+a job queued ahead of the reviews that do have work to do. The check is
+substring-based and case-insensitive, so `/REVIEW` and `/review full` both pass.
+It is not applied to the `pull_request_review_comment` arm: replies in a finding
+thread are ordinary prose and carry no command.
+
 To change the policy, edit the `if:` on the `review` job:
 
-- **Everyone** — drop the `if:` so any PR or `/ask` / `/review` comment runs a
-  review. A friendly choice for an open project — just remember that on a
-  hosted provider it means anyone can start a paid run, so pick it deliberately.
+- **Everyone** — drop the author-association checks so any PR or `/ask` /
+  `/review` comment runs a review (keep the slash-command clause, or every
+  comment starts a job). A friendly choice for an open project — just remember
+  that on a hosted provider it means anyone can start a paid run, so pick it
+  deliberately.
 - **Returning contributors too** — add `CONTRIBUTOR` to auto-review anyone whose
   PR has merged before.
 - **Admins only** — keep just `OWNER` (plus `MEMBER` for your org).
@@ -119,12 +130,18 @@ permissions:
 
 jobs:
   review:
-    # Only trusted authors (owner / member / collaborator) can trigger a review.
+    # Only trusted authors (owner / member / collaborator) can trigger a review,
+    # and a comment only starts a job when it carries a slash command.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -448,11 +448,22 @@ and default to **trusted contributors** — `OWNER`, `MEMBER`, and `COLLABORATOR
 A maintainer can also review an outside contributor's PR any time by commenting
 `/review` on it (their own association passes the gate).
 
+The same `if:` also requires a comment to actually carry a slash command before
+any job starts. `issue_comment` fires on every comment on every pull request, so
+without that clause an ordinary "lgtm, merging" would claim a runner, pull the
+container and boot Python only to find no command and exit — no tokens spent, but
+a job queued ahead of the reviews that do have work to do. The check is
+substring-based and case-insensitive, so `/REVIEW` and `/review full` both pass.
+It is not applied to the `pull_request_review_comment` arm: replies in a finding
+thread are ordinary prose and carry no command.
+
 To change the policy, edit the `if:` on the `review` job:
 
-- **Everyone** — drop the `if:` so any PR or `/ask` / `/review` comment runs a
-  review. A friendly choice for an open project — just remember that on a
-  hosted provider it means anyone can start a paid run, so pick it deliberately.
+- **Everyone** — drop the author-association checks so any PR or `/ask` /
+  `/review` comment runs a review (keep the slash-command clause, or every
+  comment starts a job). A friendly choice for an open project — just remember
+  that on a hosted provider it means anyone can start a paid run, so pick it
+  deliberately.
 - **Returning contributors too** — add `CONTRIBUTOR` to auto-review anyone whose
   PR has merged before.
 - **Admins only** — keep just `OWNER` (plus `MEMBER` for your org).
@@ -481,12 +492,18 @@ permissions:
 
 jobs:
   review:
-    # Only trusted authors (owner / member / collaborator) can trigger a review.
+    # Only trusted authors (owner / member / collaborator) can trigger a review,
+    # and a comment only starts a job when it carries a slash command.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
@@ -1246,7 +1263,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -1400,7 +1422,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -1544,7 +1571,12 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -6282,21 +6314,38 @@ if: >-
   (github.event_name == 'pull_request_target' &&
    contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
   (github.event.issue.pull_request &&
-   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+   contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+   (contains(github.event.comment.body, '/review') ||
+    contains(github.event.comment.body, '/improve') ||
+    contains(github.event.comment.body, '/ask') ||
+    contains(github.event.comment.body, '/describe') ||
+    contains(github.event.comment.body, '/diagram')))
 ```
 
 A maintainer can still review an outside contributor's PR any time by commenting
 `/review` on it — their own association passes the gate. To change the policy,
 edit the list:
 
-- **Open it up to everyone** — drop the `if:` so any PR or `/review` comment runs
-  a review.
+- **Open it up to everyone** — drop the author-association checks so any PR or
+  `/review` comment runs a review.
 - **Welcome returning contributors** — add `CONTRIBUTOR` to auto-review anyone
   whose PR has merged before.
 - **Tighten to admins** — keep just `OWNER` (and `MEMBER` for your org).
 
 Because the gate lives in the workflow YAML, not in the action's code, the policy
 is entirely yours.
+
+The second half of the comment arm is a different kind of thrift. `issue_comment`
+fires on every comment on every pull request, and lgtmaybe's answer to one that
+holds no slash command is to exit — correct, and free of tokens, but only after a
+runner has been claimed, a container pulled and Python booted. Deciding that in
+the `if:` costs nothing at all, and on a busy runner pool it is the difference
+between a review starting now and a review queueing behind comment threads. The
+clause is deliberately looser than the parser it stands in for — substring, not
+prefix, and case-insensitive — because a guard tighter than the parser would
+silently disable a command that used to work. Replies inside a finding thread
+arrive on the separate `pull_request_review_comment` event and are never gated
+this way; they are ordinary prose, and gating them would switch the feature off.
 
 ## If you want extra guardrails
 

--- a/examples/workflows/review-anthropic.yml
+++ b/examples/workflows/review-anthropic.yml
@@ -30,11 +30,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -41,11 +41,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -34,11 +34,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -31,11 +31,26 @@ concurrency:
 
 jobs:
   review:
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -35,11 +35,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-openai.yml
+++ b/examples/workflows/review-openai.yml
@@ -32,11 +32,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-openrouter.yml
+++ b/examples/workflows/review-openrouter.yml
@@ -30,11 +30,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-self-managed-github-app.yml
+++ b/examples/workflows/review-self-managed-github-app.yml
@@ -18,11 +18,26 @@ permissions:
 
 jobs:
   review:
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-vertex.yml
+++ b/examples/workflows/review-vertex.yml
@@ -34,11 +34,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -30,11 +30,26 @@ jobs:
     # review, so fork PRs and drive-by /ask or /review comments from strangers
     # cannot spend your provider budget. A maintainer can still opt-in to an
     # external PR by commenting /review on it. (Comments not on a PR are skipped.)
+    # The issue_comment arm also requires a slash command in the body. That event
+    # fires on EVERY comment on every PR, so without it an ordinary "lgtm,
+    # merging" starts a job that claims a runner, pulls the container and boots
+    # Python only to find no command and exit — no provider spend, but a runner
+    # held ahead of the reviews that do have work to do. `contains` is
+    # case-insensitive and substring-based, so the guard stays looser than the
+    # parser (which additionally wants the command at the START of the body):
+    # /REVIEW and `/review full` both pass. The pull_request_review_comment arm
+    # is NOT gated this way — that is lgtmaybe answering a reply inside a finding
+    # thread, and a reply is plain prose with no command in it.
     if: >-
       (github.event_name == 'pull_request_target' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event.issue.pull_request &&
-       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram'))) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -49,6 +49,31 @@ def _concurrency_blocks(workflow: dict) -> list[tuple[str, dict]]:
     return blocks
 
 
+def _top_level_arms(condition: str) -> list[str]:
+    """The `||`-separated arms of a job condition, split at paren depth zero.
+
+    Substring and index checks over the whole condition cannot tell which arm a
+    clause landed in — a guard hoisted into its own `||` branch reads exactly
+    like one ANDed inside the arm it belongs to, and sits at the same offset.
+    Splitting first is what lets an assertion name the arm it means.
+    """
+    arms: list[str] = []
+    depth = start = index = 0
+    while index < len(condition):
+        if condition[index] == "(":
+            depth += 1
+        elif condition[index] == ")":
+            depth -= 1
+        elif depth == 0 and condition.startswith("||", index):
+            arms.append(condition[start:index])
+            index += 2
+            start = index
+            continue
+        index += 1
+    arms.append(condition[start:])
+    return [arm.strip() for arm in arms]
+
+
 def test_supplied_workflows_rely_on_the_auto_diagram_default() -> None:
     # auto_diagram defaults to on in ReviewConfig, so a workflow that sets it
     # explicitly is redundant config that would mask a default regression.
@@ -173,33 +198,48 @@ def test_comment_arm_starts_no_job_without_a_slash_command() -> None:
     for path in _workflows():
         condition = yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]["review"]["if"]
         flat = " ".join(condition.split())
+        arms = _top_level_arms(flat)
 
         for command in SlashCommand:
             assert f"github.event.comment.body, '/{command.value}'" in flat, (
                 f"{path.name} does not admit /{command.value}; its `if:` guard is tighter "
                 "than parse_command and would silently disable the command"
             )
-        # The command group must be ANDed onto the trusted-author check, with
-        # nothing but `&&` between them. Hoisted into its own `||` branch it
-        # would let ANY commenter — a stranger included — start a job, defeating
-        # the author-association gate whose whole job is to stop a drive-by
-        # /review spending the provider budget. Matched on the whitespace-
-        # normalised string and blind to the order of the commands inside the
-        # group, so a reflow or a reorder does not fail this.
+        # `github.event.issue.pull_request` is what confines this arm to comments
+        # on a pull request. Without it a `/review` on a plain issue starts a job,
+        # and the arm also begins matching pull_request_review_comment events.
+        comment_arms = [arm for arm in arms if "github.event.issue.pull_request" in arm]
+        assert len(comment_arms) == 1, (
+            f"{path.name} has no single issue_comment arm keyed on "
+            "github.event.issue.pull_request — a comment on a plain issue would start a job"
+        )
+        # The command group must be ANDed onto the trusted-author check *inside*
+        # that arm, with nothing but `&&` between them. As its own `||` branch —
+        # or negated — it lets ANY commenter, a stranger included, start a job,
+        # defeating the author-association gate whose whole purpose is to stop a
+        # drive-by /review spending the provider budget. Matched on the
+        # whitespace-normalised arm and blind to the order of the commands inside
+        # the group, so a reflow or a reorder does not fail this.
         assert re.search(
             r"comment\.author_association\)\s*&&\s*\(\s*contains\(github\.event\.comment\.body",
-            flat,
+            comment_arms[0],
         ), (
             f"{path.name} does not AND the slash-command group onto the trusted-author "
-            "check — as a separate `||` branch (or negated) it lets any commenter "
-            "start a job"
+            "check inside the issue_comment arm — as a separate `||` branch (or "
+            "negated) it lets any commenter start a job"
         )
         # The pull_request_review_comment arm is the answer_replies path, whose
         # replies are plain prose. Gating it on a command would disable the
         # feature outright, so it must inspect no comment body at all.
-        reply_arm = flat[flat.index("'pull_request_review_comment'") :]
+        [reply_arm] = [arm for arm in arms if "'pull_request_review_comment'" in arm]
         assert "github.event.comment.body" not in reply_arm, (
             f"{path.name} gates the reply arm on a slash command; replies carry none"
+        )
+        # One reference per command and nowhere else. With all five living in the
+        # issue_comment arm checked above, this is what pins that no other arm —
+        # pull_request_target included — gates on the comment body.
+        assert flat.count("github.event.comment.body") == len(SlashCommand), (
+            f"{path.name} references the comment body outside the issue_comment arm"
         )
 
 

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -157,7 +157,7 @@ def test_self_triggered_workflows_discriminate_concurrency_by_event() -> None:
 
 
 def test_comment_arm_starts_no_job_without_a_slash_command() -> None:
-    """A comment carrying no slash command must not start a job at all.
+    """A comment carrying no slash command must not start the issue_comment job.
 
     `issue_comment` fires on every comment on every PR. Without this guard the
     runner is claimed, the container pulled and Python booted, only for
@@ -172,23 +172,33 @@ def test_comment_arm_starts_no_job_without_a_slash_command() -> None:
     """
     for path in _workflows():
         condition = yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]["review"]["if"]
+        flat = " ".join(condition.split())
 
         for command in SlashCommand:
-            assert f"github.event.comment.body, '/{command.value}'" in condition, (
+            assert f"github.event.comment.body, '/{command.value}'" in flat, (
                 f"{path.name} does not admit /{command.value}; its `if:` guard is tighter "
                 "than parse_command and would silently disable the command"
             )
-        # One guard per command and no more: the pull_request_review_comment arm
-        # is the answer_replies path, whose replies are plain prose. Gating it on
-        # a slash command would disable that feature outright.
-        assert condition.count("github.event.comment.body") == len(SlashCommand), (
-            f"{path.name} inspects the comment body outside the issue_comment arm"
+        # The command group must be ANDed onto the trusted-author check, with
+        # nothing but `&&` between them. Hoisted into its own `||` branch it
+        # would let ANY commenter — a stranger included — start a job, defeating
+        # the author-association gate whose whole job is to stop a drive-by
+        # /review spending the provider budget. Matched on the whitespace-
+        # normalised string and blind to the order of the commands inside the
+        # group, so a reflow or a reorder does not fail this.
+        assert re.search(
+            r"comment\.author_association\)\s*&&\s*\(\s*contains\(github\.event\.comment\.body",
+            flat,
+        ), (
+            f"{path.name} does not AND the slash-command group onto the trusted-author "
+            "check — as a separate `||` branch (or negated) it lets any commenter "
+            "start a job"
         )
-        guard_at = condition.index("github.event.comment.body")
-        assert condition.index("github.event.issue.pull_request") < guard_at, (
-            f"{path.name} does not place the slash-command guard in the issue_comment arm"
-        )
-        assert guard_at < condition.index("'pull_request_review_comment'"), (
+        # The pull_request_review_comment arm is the answer_replies path, whose
+        # replies are plain prose. Gating it on a command would disable the
+        # feature outright, so it must inspect no comment body at all.
+        reply_arm = flat[flat.index("'pull_request_review_comment'") :]
+        assert "github.event.comment.body" not in reply_arm, (
             f"{path.name} gates the reply arm on a slash command; replies carry none"
         )
 

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import yaml
 
+from lgtmaybe.cli.slash import SlashCommand
+
 _REPO_ROOT = Path(__file__).parent.parent
 _DOGFOOD_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "lgtmaybe.yml"
 _PROJECT_VERSION = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
@@ -152,6 +154,43 @@ def test_self_triggered_workflows_discriminate_concurrency_by_event() -> None:
                 f"but its {scope} concurrency group is not discriminated by event: "
                 f"{block.get('group')!r} — lgtmaybe's own comments will cancel its reviews"
             )
+
+
+def test_comment_arm_starts_no_job_without_a_slash_command() -> None:
+    """A comment carrying no slash command must not start a job at all.
+
+    `issue_comment` fires on every comment on every PR. Without this guard the
+    runner is claimed, the container pulled and Python booted, only for
+    `execute_comment` to find no command and exit — correct, free of provider
+    spend, and still a whole job. On a contended self-hosted pool that queueing
+    delays the reviews that do have work to do.
+
+    The guard is keyed on the command names the parser accepts, and is
+    deliberately looser than `parse_command` (which additionally requires the
+    command at the *start* of the body): a guard tighter than the parser would
+    silently disable a command that used to work.
+    """
+    for path in _workflows():
+        condition = yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]["review"]["if"]
+
+        for command in SlashCommand:
+            assert f"github.event.comment.body, '/{command.value}'" in condition, (
+                f"{path.name} does not admit /{command.value}; its `if:` guard is tighter "
+                "than parse_command and would silently disable the command"
+            )
+        # One guard per command and no more: the pull_request_review_comment arm
+        # is the answer_replies path, whose replies are plain prose. Gating it on
+        # a slash command would disable that feature outright.
+        assert condition.count("github.event.comment.body") == len(SlashCommand), (
+            f"{path.name} inspects the comment body outside the issue_comment arm"
+        )
+        guard_at = condition.index("github.event.comment.body")
+        assert condition.index("github.event.issue.pull_request") < guard_at, (
+            f"{path.name} does not place the slash-command guard in the issue_comment arm"
+        )
+        assert guard_at < condition.index("'pull_request_review_comment'"), (
+            f"{path.name} gates the reply arm on a slash command; replies carry none"
+        )
 
 
 def test_dogfood_workflow_uses_the_public_app_identity() -> None:


### PR DESCRIPTION
## What

`issue_comment` fires on **every** comment on every pull request. Today each one
starts a job: a runner is claimed, the container pulled, Python booted, and
`execute_comment` calls `parse_command`, gets `None`, prints "No lgtmaybe slash
command found; ignoring." and exits. Correct behaviour and zero provider spend —
but a whole job. On a contended self-hosted pool that queueing is what delays the
reviews that do have work to do; on GitHub-hosted runners it is wasted minutes
and a confusing no-op check on every comment thread.

That decision is deterministic, so it belongs in the job `if:`, where it costs
nothing.

## The guard

Added to the **`issue_comment` arm only**:

```yaml
      (github.event.issue.pull_request &&
       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       (contains(github.event.comment.body, '/review') ||
        contains(github.event.comment.body, '/improve') ||
        contains(github.event.comment.body, '/ask') ||
        contains(github.event.comment.body, '/describe') ||
        contains(github.event.comment.body, '/diagram'))) ||
```

**Not** gated:

- the `pull_request_review_comment` arm — that is `answer_replies`, where a PR
  author's reply inside a finding thread is plain prose with no command in it.
  Gating it would silently switch the feature off.
- the `pull_request_target` arm — the automatic review on open/sync.

## Why it is looser than the parser, on purpose

`src/lgtmaybe/cli/slash.py::parse_command` strips the body, requires it to
**start** with `/`, splits on any whitespace, and lower-cases the first token
before matching `SlashCommand`. The guard is a superset of that:

| Parser rule | Guard |
|---|---|
| command must be at the start of the body | not required — `contains` is substring-based |
| `parts[0].lower()` — case-insensitive | `contains()` is documented "not case sensitive", so `/REVIEW` passes |
| `/review full`, `/review\nfull`, leading whitespace all parse | all pass |
| exact token match (`/reviewer` is rejected) | `/reviewer` passes the guard, then the CLI rejects it |

A guard *tighter* than the parser would silently break a command that used to
work; being looser only costs the occasional harmless job.

## Verification

- **New test** (written failing-first): `tests/test_workflow_examples.py::test_comment_arm_starts_no_job_without_a_slash_command`
  — iterates the dogfood workflow and all ten starters, asserts one
  `github.event.comment.body` clause **per `SlashCommand` member** (so adding a
  command to the enum breaks the workflows until they admit it), asserts the
  count is exactly `len(SlashCommand)` and that the clause sits between the
  `issue_comment` arm and the `pull_request_review_comment` arm — i.e. the reply
  arm stays ungated.
- **Expression simulation** (throwaway script, not committed): translated each of
  the 11 workflow `if:` strings into Python under Actions semantics
  (case-insensitive `contains`, null cast to `""`, property access on null yields
  null) and evaluated 16 scenarios each — PR opened by member/stranger, each of
  the five commands, `/review full`, `/REVIEW`, leading whitespace, `/review\nfull`,
  a plain comment, `/deploy`, `/review` from a stranger, a comment on a non-PR
  issue, and a finding-thread reply. 176/176 as expected, and parentheses balance
  in every file. In particular `pull_request_target` (where `github.event.comment`
  is null) is unaffected, and the reply arm still fires on plain prose.
- **Differential check** against the real parser: 990 generated comment bodies run
  through both `parse_command` and the evaluated expression — **zero** bodies the
  parser accepts but the guard rejects.
- `contains()`'s case-insensitivity confirmed against the GitHub docs source, not
  from memory: *"This function is not case sensitive. Casts values to a string."*
  The docs do not state `&&`/`||` precedence, so every arm and the OR group are
  fully parenthesised — precedence is not load-bearing here.
- Gate: `uv run ruff check .` ✅ · `uv run ruff format --check .` ✅ ·
  `uv run mypy` ✅ · `uv run pytest -q` ✅ (1828 passed, 3 skipped) ·
  `uv run pytest tests/specs -q` ✅ (17 passed).

## Files

- `.github/workflows/lgtmaybe.yml` — the dogfood workflow. The existing
  author-association reasoning and both concurrency guards are preserved verbatim;
  the new clause is appended to the comment arm with its own comment paragraph.
- `examples/workflows/*.yml` — all ten starters, identically.
- Docs: `docs/how-to/use-as-github-action.md` and the three cloud how-tos
  (`review-with-{azure,bedrock-oidc,vertex-wif}.md`) carry copy-paste snippets, so
  those got the guard too; `docs/explanation/trust-and-cost.md` gains a paragraph
  explaining the thrift and why the reply arm is exempt; `README.md`'s minimal
  snippet too. The "open it up to everyone" advice used to say *drop the `if:`* —
  which would now also drop this guard — so it says *drop the author-association
  checks* instead. `docs/llms-full.txt` regenerated via
  `uv run python docs/generate_llms_txt.py`.
- `tests/test_workflow_examples.py` — the new test.

## Spec anchors

No spec section went stale: `parse_command` and the slash router
(`cli.slash`) are untouched — this changes only which comments ever reach them.
`uv run pytest tests/specs -q` is green.

## Note on coverage

This is a config/YAML change. The repo does have a workflow-file harness
(`tests/test_workflow_examples.py`), so it was extended failing-first rather than
left uncovered — but note that what is asserted is the **shape of the `if:`
string**. GitHub's expression evaluator itself is not exercised by pytest; the
simulation and differential checks above were run by hand and are not committed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1zKeXbpsNjxkBW6N7oV9P)_