### PR TITLE
feat(engine): skip oversized files and more generated artefacts

### DIFF
--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -28,6 +28,10 @@ Before the diff reaches the model it is cleaned:
 - **Non-reviewable files are skipped** — lockfiles, minified/bundled assets,
   vendored directories, generated LLM-index corpora (`llms.txt` / `llms-full.txt`),
   and binaries. Reviewing them is noise and wastes tokens.
+- **Oversized files are skipped** — a single file whose diff runs past
+  `max_file_diff_lines` (default 2000, `0` disables) is dropped and named in the
+  summary. Name matching can only catch generated files that admit it in their
+  name; a hand-named 154,000-line data blob is caught on size alone.
 - **Secrets are redacted** — anything that looks like a key or token is stripped
   from the diff before it leaves your environment for the provider.
 
@@ -248,9 +252,10 @@ Where the stated intent comes from:
 ### The lens is told what it was not shown
 
 An intent lens judging "did the author keep their promise?" against a *filtered*
-diff will call a kept promise broken. Files go missing for six different
+diff will call a kept promise broken. Files go missing for seven different
 reasons — the generated/binary/vendored skip, your `include_paths` /
-`exclude_paths` globs, the `max_files` cap, a triage skip, an incremental
+`exclude_paths` globs, the `max_file_diff_lines` size cap, the `max_files` cap,
+a triage skip, an incremental
 scope, and simply being in another batch (the lens runs once **per batch**, so
 on a large PR each call sees only part of the change).
 
@@ -299,6 +304,7 @@ configurable in `.lgtmaybe.yml` (see
 |---|---|---|
 | `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
+| `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3972,6 +3972,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `language` | string / null | No | `null` | Language |
 | `learn_feedback` | boolean | No | `True` | Learn Feedback |
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
+| `max_file_diff_lines` | integer | No | `2000` | Max File Diff Lines |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
@@ -4691,6 +4692,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": null,
       "title": "Max Concurrency"
     },
+    "max_file_diff_lines": {
+      "default": 2000,
+      "minimum": 0,
+      "title": "Max File Diff Lines",
+      "type": "integer"
+    },
     "max_files": {
       "default": 50,
       "title": "Max Files",
@@ -5219,6 +5226,10 @@ Before the diff reaches the model it is cleaned:
 - **Non-reviewable files are skipped** — lockfiles, minified/bundled assets,
   vendored directories, generated LLM-index corpora (`llms.txt` / `llms-full.txt`),
   and binaries. Reviewing them is noise and wastes tokens.
+- **Oversized files are skipped** — a single file whose diff runs past
+  `max_file_diff_lines` (default 2000, `0` disables) is dropped and named in the
+  summary. Name matching can only catch generated files that admit it in their
+  name; a hand-named 154,000-line data blob is caught on size alone.
 - **Secrets are redacted** — anything that looks like a key or token is stripped
   from the diff before it leaves your environment for the provider.
 
@@ -5439,9 +5450,10 @@ Where the stated intent comes from:
 ### The lens is told what it was not shown
 
 An intent lens judging "did the author keep their promise?" against a *filtered*
-diff will call a kept promise broken. Files go missing for six different
+diff will call a kept promise broken. Files go missing for seven different
 reasons — the generated/binary/vendored skip, your `include_paths` /
-`exclude_paths` globs, the `max_files` cap, a triage skip, an incremental
+`exclude_paths` globs, the `max_file_diff_lines` size cap, the `max_files` cap,
+a triage skip, an incremental
 scope, and simply being in another batch (the lens runs once **per batch**, so
 on a large PR each call sees only part of the change).
 
@@ -5490,6 +5502,7 @@ configurable in `.lgtmaybe.yml` (see
 |---|---|---|
 | `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens. |
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
+| `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
 | `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -34,6 +34,7 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `language` | string / null | No | `null` | Language |
 | `learn_feedback` | boolean | No | `True` | Learn Feedback |
 | `max_concurrency` | integer / null | No | `null` | Max Concurrency |
+| `max_file_diff_lines` | integer | No | `2000` | Max File Diff Lines |
 | `max_files` | integer | No | `50` | Max Files |
 | `max_input_tokens` | integer | No | `100000` | Max Input Tokens |
 | `max_review_seconds` | integer | No | `3600` | Max Review Seconds |
@@ -752,6 +753,12 @@ The canonical machine-readable schemas. These are the source of truth for provid
       ],
       "default": null,
       "title": "Max Concurrency"
+    },
+    "max_file_diff_lines": {
+      "default": 2000,
+      "minimum": 0,
+      "title": "Max File Diff Lines",
+      "type": "integer"
     },
     "max_files": {
       "default": 50,

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -172,8 +172,9 @@ and the same reply the resolve-on-fix path uses.
 
 ### Requirement: Generated and binary files are skipped
 
-Lockfiles, minified bundles, vendored trees, binary files, and generated LLM-index corpora (`llms.txt` / `llms-full.txt`) SHALL be excluded from review
-before any path filter or cap applies.
+Lockfiles, minified bundles, vendored trees, binary files, code-generator output (protobuf, Dart `build_runner`), snapshot corpora, and generated LLM-index corpora (`llms.txt` / `llms-full.txt`) SHALL be excluded from review
+before any path filter or cap applies. Lockfiles SHALL stay scannable, so a new
+lockfile joins the lockfile set rather than the generated-path patterns.
 <!-- anchor: github.reviewable -->
 
 #### Scenario: lockfile in the diff

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -38,6 +38,12 @@ engine.path-filters:
     has: { field: name, regex: '^passes_path_filters$' }
   files: [src/lgtmaybe/engine/**/*.py]
 
+engine.size-cap:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^passes_size_cap$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
 engine.recursive-walk:
   - rule:
       kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -107,6 +107,25 @@ on every host.
   only by letter case
 - **THEN** the path does not match on Windows or POSIX hosts
 
+### Requirement: Oversized single files are skipped and named
+
+A file whose own patch exceeds `max_file_diff_lines` SHALL be dropped in the
+same stage as the skip and path filters — before batching, so no model call and
+no recursive walk ever sees it — and every dropped path SHALL be named in the
+summary notice, because a silent drop reads as "everything was covered". The
+skip SHALL NOT count towards `max_files`, exactly like a lockfile skip. `0`
+disables the cap. This is the deterministic backstop for generated content the
+name-based filter cannot recognise.
+<!-- anchor: engine.size-cap -->
+
+#### Scenario: a hand-named generated data blob
+- **WHEN** the PR changes a 154,000-line `clause_index.json` and one source file
+- **THEN** only the source file is reviewed and the summary names the skipped blob
+
+#### Scenario: the cap is disabled
+- **WHEN** `max_file_diff_lines` is `0`
+- **THEN** no file is skipped for size and no size notice is posted
+
 ### Requirement: Over-budget files walk hunk-by-hunk
 
 When one file's diff exceeds `max_input_tokens`, the engine SHALL decompose it

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -261,6 +261,14 @@ local_diff_options = _stack(
 )
 @click.option("--max-files", default=None, type=int, help="Maximum number of files to review")
 @click.option(
+    "--max-file-diff-lines",
+    default=None,
+    type=click.IntRange(min=0),
+    help="Skip any single file whose diff is longer than this many lines "
+    "(default 2000; 0 disables). Catches generated data blobs no name-based "
+    "filter can recognise; every skip is named in the summary",
+)
+@click.option(
     "--max-input-tokens",
     default=None,
     type=int,
@@ -426,6 +434,7 @@ def review(
     fail_on: Severity | None,
     unanchored_min_severity: Severity | None,
     max_files: int | None,
+    max_file_diff_lines: int | None,
     max_input_tokens: int | None,
     max_tokens: int | None,
     reasoning_effort: str | None,
@@ -470,6 +479,7 @@ def review(
         fail_on=fail_on,
         unanchored_min_severity=unanchored_min_severity,
         max_files=max_files,
+        max_file_diff_lines=max_file_diff_lines,
         max_input_tokens=max_input_tokens,
         max_tokens=max_tokens,
         reasoning_effort=reasoning_effort,

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -650,6 +650,22 @@ class ReviewConfig(_Strict):
     include_paths: list[str] = Field(default_factory=list)
     exclude_paths: list[str] = Field(default_factory=list)
     max_files: int = 50
+    # Per-file diff-size cap: a single file whose patch is longer than this many
+    # lines is dropped before any model call, and named in the summary notice.
+    #
+    # The name-based skip filter (`is_reviewable`) can only catch generated files
+    # that ADMIT it in their name. It cannot catch a hand-named data blob — a
+    # 154,000-line `clause_index.json`, an 18,000-line snapshot corpus — and those
+    # are exactly the files that dominate a review's token bill while yielding
+    # nothing worth commenting on. Size is the deterministic signal left, and
+    # spending it here costs nothing: the file never reaches the provider, and the
+    # recursive walk never splits it into hundreds of per-hunk calls.
+    #
+    # 2000 sits well above a real hand-written file change (a 2000-line single-file
+    # patch is already past what any human reviews in one sitting) and far below
+    # the generated artefacts above, so the default catches blobs without ever
+    # silently dropping honest work. 0 disables the cap.
+    max_file_diff_lines: int = Field(default=2000, ge=0)
     max_input_tokens: int = 100_000
     # RLM-style recursive walk: when a single file's diff exceeds
     # max_input_tokens, split it into per-hunk review calls instead of sending it

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -497,6 +497,21 @@ class LLMReviewEngine(ReviewEngine):
                 and passes_path_filters(path, include=cfg.include_paths, exclude=cfg.exclude_paths)
             ]
 
+            # 2b. Per-file size cap: a patch longer than max_file_diff_lines is a
+            #     data blob or a generated file the name-based filter could not
+            #     recognise. Drop it here — before batching, so the recursive walk
+            #     never decomposes it into hundreds of per-hunk calls — and record
+            #     the names, because a silent drop reads as "everything was
+            #     covered". Like a lockfile skip, it never counts against max_files.
+            oversized: list[str] = []
+            kept: list[tuple[str, str]] = []
+            for path, patch in file_patches:
+                if passes_size_cap(patch, cfg.max_file_diff_lines):
+                    kept.append((path, patch))
+                else:
+                    oversized.append(path)
+            file_patches = kept
+
             # 3. File cap: review only the first N reviewable files, note the rest.
             total_files = len(file_patches)
             capped_files = total_files > cfg.max_files
@@ -831,6 +846,16 @@ class LLMReviewEngine(ReviewEngine):
             notices.append(
                 f"⚠️ Reviewed the top {cfg.max_files} of {total_files} changed files "
                 f"(file cap {cfg.max_files}). Raise max_files to review them all."
+            )
+        if oversized:
+            # Transparency, same rule as the file cap: a skip must be visible.
+            plural_big = _plural(len(oversized))
+            listed_big = ", ".join(f"`{p}`" for p in oversized[:10])
+            more_big = ", …" if len(oversized) > 10 else ""
+            notices.append(
+                f"📄 Skipped {len(oversized)} oversized file{plural_big} "
+                f"(over {cfg.max_file_diff_lines} diff lines): {listed_big}{more_big}. "
+                "Raise `max_file_diff_lines` (0 disables) to review them."
             )
         if skipped_by_triage:
             # Transparency: a triage skip must be visible, never silent.
@@ -1368,6 +1393,20 @@ def passes_path_filters(path: str, *, include: list[str], exclude: list[str]) ->
     return not any(_matches_glob(path, pattern) for pattern in exclude)
 
 
+def passes_size_cap(patch: str, max_lines: int) -> bool:
+    """Whether one file's *patch* is small enough to be worth reviewing.
+
+    The companion to the name-based skip filter, which can only recognise a
+    generated file that ADMITS it in its name. A hand-named data blob — a
+    154,000-line index, an 18,000-line snapshot corpus — has no such tell, so
+    size is the deterministic signal left. Counting the patch's own lines (not
+    the file's) keeps the judgement about what this PR actually changed.
+
+    ``max_lines`` of 0 disables the cap.
+    """
+    return not max_lines or patch.count("\n") <= max_lines
+
+
 def _matches_glob(path: str, pattern: str) -> bool:
     if fnmatchcase(path, pattern):
         return True
@@ -1379,14 +1418,15 @@ def files_not_visible(changed_files: Sequence[str], batch_paths: set[str]) -> li
 
     Derived, not captured. One subtraction covers every way a file goes missing
     before a lens sees it — the hardcoded generated/binary/vendored skip, the
-    include/exclude globs, the ``max_files`` cap, a triage skip, an incremental
-    scope, and simply being in another batch — because it asks what is left of
-    the PR after this batch rather than which filter removed what.
+    include/exclude globs, the ``max_file_diff_lines`` size cap, the
+    ``max_files`` cap, a triage skip, an incremental scope, and simply being in
+    another batch — because it asks what is left of the PR after this batch
+    rather than which filter removed what.
 
-    Capturing at each filter instead would mean five call sites kept in sync,
-    three of which have no pattern list to report (the skip filter is hardcoded
-    rules, the cap is a count, triage is a per-file model verdict) — and it
-    would still miss batching, which has the widest reach of the six: the intent
+    Capturing at each filter instead would mean six call sites kept in sync,
+    four of which have no pattern list to report (the skip filter is hardcoded
+    rules, the caps are counts, triage is a per-file model verdict) — and it
+    would still miss batching, which has the widest reach of the seven: the intent
     lens runs once PER BATCH, so on a multi-batch PR every call is judging the
     whole PR's promise against a fraction of the change.
 

--- a/src/lgtmaybe/github/diff.py
+++ b/src/lgtmaybe/github/diff.py
@@ -81,6 +81,9 @@ _LOCKFILES = frozenset(
         "mix.lock",
         "Package.resolved",
         "gradle.lockfile",
+        "pubspec.lock",
+        "Podfile.lock",
+        "packages.lock.json",
     }
 )
 
@@ -128,9 +131,22 @@ _SKIP_DIR_PREFIXES = (
 _SKIP_GLOB_PATTERNS = (
     "*.min.js",
     "*.min.css",
+    # Snapshot corpora: jest writes `.snap`, syrupy (Python) writes `.ambr`.
     "*.snap",
+    "*.ambr",
     "*.pb.go",
     "*.pb.py",
+    # protoc output for Python (`_pb2`) and C++ (`.pb.cc` / `.pb.h`). The `.proto`
+    # source they are generated from stays reviewable.
+    "*_pb2.py",
+    "*_pb2.pyi",
+    "*.pb.cc",
+    "*.pb.h",
+    # Dart/Flutter build_runner output: json_serializable/built_value (`.g.dart`),
+    # freezed, and mockito's generated test doubles.
+    "*.g.dart",
+    "*.freezed.dart",
+    "*.mocks.dart",
     "*.generated.*",
     "*.d.ts",
     # Sourcemaps are compiler output, never hand-written.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -185,6 +185,33 @@ class TestReviewCommandLocal:
         assert seen.get("uncommitted") is True
         assert seen.get("working") is False
 
+    def test_max_file_diff_lines_flag_reaches_the_config(self, monkeypatch):
+        """`--max-file-diff-lines` overrides the per-file size cap, like --max-files."""
+        seen: dict[str, object] = {}
+
+        class _CapturingEngine(FakeEngine):
+            def review(self, ctx, cfg):
+                seen["max_file_diff_lines"] = cfg.max_file_diff_lines
+                return super().review(ctx, cfg)
+
+        _patch_local(monkeypatch, engine=_CapturingEngine(FakeProvider()))
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "review",
+                "--provider",
+                "ollama",
+                "--model",
+                "llama3",
+                "--max-file-diff-lines",
+                "500",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen == {"max_file_diff_lines": 500}
+
 
 class TestDiagramCommand:
     def _patch_diagram_provider(self, monkeypatch):

--- a/tests/engine/test_caps.py
+++ b/tests/engine/test_caps.py
@@ -114,6 +114,83 @@ def test_file_cap_reviews_top_n_with_notice() -> None:
     assert "added line in f3.py" not in sent
 
 
+def _big_diff(path: str, added_lines: int) -> str:
+    """A single-file diff adding *added_lines* lines to *path*."""
+    body = "".join(f"+line {i} in {path}\n" for i in range(added_lines))
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 0000001..0000002 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -1,1 +1,{added_lines + 1} @@\n"
+        f" first\n" + body
+    )
+
+
+def _ctx_from(diff: str, paths: list[str]) -> PRContext:
+    return PRContext(
+        diff=diff,
+        changed_files=paths,
+        base_sha="abc",
+        head_sha="def",
+        repo="org/repo",
+        pr_number=1,
+    )
+
+
+def test_oversized_file_is_skipped_with_a_notice() -> None:
+    """A hand-named data blob no pattern can catch is skipped on size alone.
+
+    The motivating case is a generated 154k-line `clause_index.json`: nothing in
+    `is_reviewable` can know that name is machine-written, so the line cap is the
+    only deterministic defence — and, like the file cap, the skip must be named in
+    the summary rather than read as "everything was covered".
+    """
+    provider = _Provider([_A_FINDING])
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", max_file_diff_lines=10)
+
+    paths = ["data/clause_index.json", "src/app.py"]
+    diff = _big_diff("data/clause_index.json", 50) + _diff_for(["src/app.py"])
+    _findings, summary = engine.review(_ctx_from(diff, paths), cfg)
+
+    sent = " ".join(msg.get("content", "") for call in provider.calls for msg in call["messages"])
+    assert "line 0 in data/clause_index.json" not in sent
+    assert "added line in src/app.py" in sent
+    assert "clause_index.json" in summary
+    assert "max_file_diff_lines" in summary
+
+
+def test_oversized_skip_does_not_consume_the_file_cap() -> None:
+    """A size-skipped file is out of the review entirely, exactly like a lockfile
+    — so it must not count towards `max_files` and trigger a spurious cap notice."""
+    provider = _Provider([])
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(
+        provider=Provider.ollama, model="llama3", max_files=2, max_file_diff_lines=10
+    )
+
+    diff = _big_diff("blob.json", 50) + _diff_for(["a.py", "b.py"])
+    _findings, summary = engine.review(_ctx_from(diff, ["blob.json", "a.py", "b.py"]), cfg)
+
+    assert "file cap" not in summary
+    sent = " ".join(msg.get("content", "") for call in provider.calls for msg in call["messages"])
+    assert "added line in a.py" in sent
+    assert "added line in b.py" in sent
+
+
+def test_zero_disables_the_file_size_cap() -> None:
+    provider = _Provider([])
+    engine = LLMReviewEngine(provider)
+    cfg = ReviewConfig(provider=Provider.ollama, model="llama3", max_file_diff_lines=0)
+
+    _findings, summary = engine.review(_ctx_from(_big_diff("blob.json", 50), ["blob.json"]), cfg)
+
+    sent = " ".join(msg.get("content", "") for call in provider.calls for msg in call["messages"])
+    assert "line 0 in blob.json" in sent
+    assert "max_file_diff_lines" not in summary
+
+
 def test_generated_and_lockfiles_are_skipped() -> None:
     provider = _Provider([_A_FINDING])
     engine = LLMReviewEngine(provider)

--- a/tests/github/test_diff.py
+++ b/tests/github/test_diff.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from lgtmaybe.github import build_commentable_lines, is_reviewable
+from lgtmaybe.github.diff import is_scannable_manifest
 
 # ---------------------------------------------------------------------------
 # Commentable-line index
@@ -301,3 +302,45 @@ def test_is_reviewable_accepts_a_dotfile_named_like_an_extension() -> None:
 def test_is_reviewable_rejects_sourcemaps() -> None:
     assert not is_reviewable("assets/app.js.map")
     assert not is_reviewable("assets/styles.css.map")
+
+
+def test_is_reviewable_rejects_mobile_ecosystem_lockfiles() -> None:
+    """Lockfiles from the mobile / .NET ecosystems, all generated resolvers.
+
+    They join `_LOCKFILES` rather than the glob list so they are also fetched
+    for vulnerability scanning — `osv-scanner` reads all three.
+    """
+    for path in (
+        "pubspec.lock",
+        "Podfile.lock",
+        "packages.lock.json",
+        "ios/Podfile.lock",
+        "app/pubspec.lock",
+    ):
+        assert not is_reviewable(path), path
+        assert is_scannable_manifest(path), path
+
+
+def test_is_reviewable_rejects_dart_codegen() -> None:
+    """build_runner output: json_serializable (`.g.dart`), freezed, mockito."""
+    assert not is_reviewable("lib/models/user.g.dart")
+    assert not is_reviewable("lib/models/user.freezed.dart")
+    assert not is_reviewable("test/repo_test.mocks.dart")
+    # Control: the hand-written source these are generated FROM stays reviewable.
+    assert is_reviewable("lib/models/user.dart")
+
+
+def test_is_reviewable_rejects_syrupy_snapshots() -> None:
+    """`.ambr` is syrupy's snapshot format — the Python analogue of jest's
+    `.snap`, which was already covered."""
+    assert not is_reviewable("tests/__snapshots__/test_api.ambr")
+
+
+def test_is_reviewable_rejects_protobuf_outputs() -> None:
+    """protoc output for Python and C++, alongside the Go rule already present."""
+    assert not is_reviewable("proto/service_pb2.py")
+    assert not is_reviewable("proto/service_pb2.pyi")
+    assert not is_reviewable("proto/service.pb.cc")
+    assert not is_reviewable("proto/service.pb.h")
+    # Control: the .proto source is hand-written.
+    assert is_reviewable("proto/service.proto")

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -602,6 +602,12 @@
       "default": null,
       "title": "Max Concurrency"
     },
+    "max_file_diff_lines": {
+      "default": 2000,
+      "minimum": 0,
+      "title": "Max File Diff Lines",
+      "type": "integer"
+    },
     "max_files": {
       "default": 50,
       "title": "Max Files",


### PR DESCRIPTION
## Why

A downstream monorepo had to hand-write a long `exclude_paths` list in its `.lgtmaybe.yml` because lgtmaybe was sending generated artefacts to the model. What it had to exclude by hand:

- 89 generated Dart files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`)
- a 154,003-line `clause_index.json`
- an 18,587-line syrupy snapshot (`.ambr` — we covered jest's `.snap`, not syrupy's)
- `pubspec.lock`

Every one of those should have been skipped deterministically, at zero token cost, before any model call. Deterministic work costs no tokens; making the user pay a model to read a lockfile is the opposite of that. `is_reviewable` was purely name-based and missed all four.

## What

Two changes.

### 1. The patterns the name filter was missing

- `pubspec.lock` (Dart/Flutter), `Podfile.lock` (CocoaPods), `packages.lock.json` (NuGet) join **`_LOCKFILES`**, not the glob list — so they get both behaviours the module docstring describes: skipped from review, still fetched for vulnerability scanning via `is_scannable_manifest` (osv-scanner reads all three).
- New generated-path globs: `*.g.dart`, `*.freezed.dart`, `*.mocks.dart` (build_runner / freezed / mockito output), `*.ambr` (syrupy snapshots), and `*_pb2.py`, `*_pb2.pyi`, `*.pb.cc`, `*.pb.h` (protoc, completing the `*.pb.go` rule that was already there).

### 2. The real gap — a size guard

`is_reviewable` takes only a path, so no amount of pattern-matching catches a hand-named 154k-line data file. `ReviewConfig.max_file_diff_lines` (default **2000**, `0` disables) drops any single file whose own patch runs longer.

- Applied in the **same stage** as `is_reviewable` / `passes_path_filters` — before batching, so the recursive walk never decomposes a data blob into hundreds of per-hunk calls, and no model call ever sees it.
- **Every skip is named in the summary notice**, following the existing "reviewed top N of M" file-cap pattern. A silently truncated review reads as "everything was covered" when it wasn't.
- A size skip **does not count towards `max_files`**, exactly like a lockfile skip — otherwise one blob would trigger a spurious cap notice.
- 2000 sits well above a real hand-written single-file change and far below the artefacts above, so the default catches blobs without ever quietly dropping honest work.

Surfaced as a CLI flag (`--max-file-diff-lines`) and a YAML key, matching its sibling `max_files`. **No `action.yml` input** — also matching `max_files`: which blobs a repo generates is a repo-level property, so it belongs in the `.lgtmaybe.yml` the Action already reads, and adding an input for every cap grows the Action surface without buying anything.

## Deliberately not done

- **No machine-shape heuristic** (long lines / low whitespace ratio). A line cap covers every observed case; the heuristic is unmeasured and would misfire on minified-but-hand-edited files.
- **`*_pb2_grpc.py` left out.** It is genuinely protoc output and arguably belongs, but it was outside the reported cases — worth its own line if anyone hits it.

## Tests (red first, then green)

`tests/github/test_diff.py`
- `test_is_reviewable_rejects_mobile_ecosystem_lockfiles` — asserts both halves: not reviewable **and** still scannable
- `test_is_reviewable_rejects_dart_codegen` (control: `user.dart` stays reviewable)
- `test_is_reviewable_rejects_syrupy_snapshots`
- `test_is_reviewable_rejects_protobuf_outputs` (control: `.proto` stays reviewable)

`tests/engine/test_caps.py`
- `test_oversized_file_is_skipped_with_a_notice` — the motivating case: the blob never reaches the provider, the sibling source file does, and the summary names the skip and the knob
- `test_oversized_skip_does_not_consume_the_file_cap`
- `test_zero_disables_the_file_size_cap`

`tests/cli/test_cli.py`
- `test_max_file_diff_lines_flag_reaches_the_config`

## Specs & generated docs

- New anchored requirement `engine.size-cap` in `openspec/specs/review-pipeline/spec.md` (+ its `anchors.yml` rule, bound to the new `passes_size_cap` helper).
- Targeted edit to `github.reviewable` in `openspec/specs/github-posting/spec.md`: names codegen output and snapshot corpora, and records why a new lockfile joins the lockfile set rather than the glob patterns.
- `tests/specs` green; `openspec validate --specs` green.
- Regenerated `docs/reference/config.md`, `tests/snapshots/ReviewConfig.json`, `docs/llms*.txt`; `docs/explanation/what-gets-reviewed.md` updated by hand (the skip list, the knobs table, and the "files go missing for N reasons" count the intent lens depends on).

## Gate

`ruff check` · `ruff format --check` · `mypy` · `pytest -q` — all pass (1835 passed, 3 skipped).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1zKeXbpsNjxkBW6N7oV9P)_