### PR TITLE
feat(cli): post partial results when the process is signalled

### DIFF
--- a/.github/workflows/lgtmaybe.yml
+++ b/.github/workflows/lgtmaybe.yml
@@ -58,8 +58,9 @@ jobs:
     # model call can't sit on the runner for GitHub's 6-hour default. Fail-fast on
     # permanent provider errors (quota/auth) means this only ever trips on a real
     # hang, not on an out-of-credit key. Kept above the review's own
-    # `max_review_seconds` ceiling (60 min) so the soft deadline — which posts
-    # partial findings — always fires first; a killed job posts nothing at all.
+    # `max_review_seconds` ceiling (60 min) so the soft deadline fires first and
+    # posts partial findings calmly; if the runner does cut the job short, the
+    # CLI's SIGINT/SIGTERM wind-down posts what it has as the backstop.
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7 # base repo only — for action.yml + .lgtmaybe.yml config

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -240,8 +240,9 @@ run; generated/binary files are skipped automatically.
 
 **Reliability** — provider retries with fallback (all attempts for one call
 share a 2.5×-timeout budget), provider-aware timeouts, a soft whole-review
-deadline (`max_review_seconds`, default 1800s) that degrades an overrunning run
-to partial results with an explicit notice, a self-reflection pass to cut
+deadline (`max_review_seconds`) that degrades an overrunning run to partial
+results with an explicit notice (a SIGINT/SIGTERM from a cancelled or
+timed-out CI job winds the run down the same way), a self-reflection pass to cut
 false positives (toggle with `--no-reflect`; its verdicts carry a 0–10
 confidence score, filtered by `min_confidence`), and loud failure surfacing (a
 "review failed" comment + non-zero exit) rather than silent passes. Every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,9 +285,15 @@ pattern, event bus, plugin framework.
      `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 8
      cloud, 1 ollama/openai-compatible), then the findings are **merged and
      de-duped** (`engine._dedupe`, keyed on path/line/side) before reflection.
-     A soft whole-review deadline (`max_review_seconds`, default 1800s, 0 = off)
+     A soft whole-review deadline (`max_review_seconds`, default 3600s, 0 = off)
      skips still-queued calls once passed — partial results with a notice,
-     never a silent LGTM. Every stage and call is timed
+     never a silent LGTM. A **termination signal** (SIGINT/SIGTERM from a
+     cancelled or timed-out CI job) sets that same state via
+     `engine.request_interrupt`, so an interrupted run posts what it has
+     instead of nothing; the handler is installed by the CLI entrypoint only
+     (`cli.graceful_interrupt` — never at library import), restores the
+     previous handler as it fires (a second signal still kills), and is a
+     no-op off the main thread. Every stage and call is timed
      (`engine/profiling.py`); `--profile` / Action input `profile` prints the
      breakdown.
    - **Custom lenses (BYO):** beyond the built-in `ReviewCategory` set, users add

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: ""
   max_review_seconds:
-    description: "Soft wall-clock ceiling for the whole review, in seconds (default 3600). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with the incomplete-results notice every failed or skipped call raises. Set 0 to disable."
+    description: "Soft wall-clock ceiling for the whole review, in seconds (default 3600). Once it passes, no further model calls are dispatched — in-flight calls finish and the review posts partial results with the incomplete-results notice every failed or skipped call raises. A job cancelled or timed out by the runner does the same: the CLI winds the review down on SIGINT/SIGTERM and posts what it already has. Set 0 to disable."
     required: false
     default: ""
   max_review_tokens:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -232,13 +232,23 @@ network recovers but a dead-end failure surfaces fast:
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
   run can't hold a runner for GitHub's six-hour default — set above
   `max_review_seconds`, so the soft deadline (which still posts partial
-  findings) always fires before the runner is killed.
+  findings) fires before the runner is killed. If the runner does cut the job
+  short — a blown `timeout-minutes`, or `cancel-in-progress` on a new push — the
+  CLI's signal handler is the backstop (below).
 
 - **A whole-review deadline.** `max_review_seconds` (default 3600, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a
   run where every call failed or was skipped still fails loud.
+
+- **A termination signal does the same thing.** The CLI installs a
+  SIGINT/SIGTERM handler that sets the deadline's state, so a job the runner
+  cancels or times out stops dispatching model calls and posts what it already
+  has, with a notice naming the interruption, instead of dying with nothing on
+  the PR. The handler is installed by the CLI entrypoint only (importing
+  lgtmaybe as a library never touches your signal handlers), and it restores the
+  previous handler as it fires — a second signal still kills the process.
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -214,7 +214,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -576,7 +576,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `preset` | `fast` | `fast` uses four calls — security, correctness, code health, artefacts — on every provider; `full` runs one call per lens |
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
-| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice. `0` disables |
+| `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
 | `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
@@ -5895,13 +5895,23 @@ network recovers but a dead-end failure surfaces fast:
   posting workflows additionally set a job-level `timeout-minutes` so a wedged
   run can't hold a runner for GitHub's six-hour default — set above
   `max_review_seconds`, so the soft deadline (which still posts partial
-  findings) always fires before the runner is killed.
+  findings) fires before the runner is killed. If the runner does cut the job
+  short — a blown `timeout-minutes`, or `cancel-in-progress` on a new push — the
+  CLI's signal handler is the backstop (below).
 
 - **A whole-review deadline.** `max_review_seconds` (default 3600, `0` disables)
   is a soft ceiling on the run: once it passes, queued model calls are skipped
   — in-flight ones finish and their findings post — and the summary carries an
   explicit incomplete-results notice. It can never produce a silent LGTM: a
   run where every call failed or was skipped still fails loud.
+
+- **A termination signal does the same thing.** The CLI installs a
+  SIGINT/SIGTERM handler that sets the deadline's state, so a job the runner
+  cancels or times out stops dispatching model calls and posts what it already
+  has, with a notice naming the interruption, instead of dying with nothing on
+  the PR. The handler is installed by the CLI entrypoint only (importing
+  lgtmaybe as a library never touches your signal handlers), and it restores the
+  previous handler as it fires — a second signal still kills the process.
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -12,6 +12,12 @@ cli.run-review:
     has: { field: name, regex: '^run_review$' }
   files: [src/lgtmaybe/cli/**/*.py]
 
+cli.graceful-interrupt:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^graceful_interrupt$' }
+  files: [src/lgtmaybe/cli/**/*.py]
+
 cli.slash:
   - rule:
       kind: function_definition

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -29,6 +29,28 @@ vs full decision, optional auto-describe, engine call, posting — so `review`,
 - **WHEN** the Action runs on `synchronize` with `incremental` unset
 - **THEN** the same orchestrator picks incremental review automatically
 
+### Requirement: A termination signal posts partial results
+
+The CLI SHALL turn the first SIGINT/SIGTERM into a graceful wind-down that
+posts what the review already produced. The handler sets the same state the
+`max_review_seconds` deadline sets, so queued model calls are skipped, in-flight
+ones finish, and the summary carries the partial-results notice — naming the
+interruption rather than a ceiling nobody hit. It is installed by the CLI
+entrypoint only (importing lgtmaybe as a library never touches a host's
+handlers), is a no-op off the main thread or where the platform lacks the
+signal, and restores the previous handler as it fires.
+<!-- anchor: cli.graceful-interrupt -->
+
+#### Scenario: the CI job is cancelled or exceeds timeout-minutes
+- **WHEN** the runner signals the process mid-review
+- **THEN** no further model calls are dispatched and the findings already
+  produced post with a notice, instead of the run dying with nothing on the PR
+
+#### Scenario: a second signal arrives
+- **WHEN** the wind-down is under way and another signal is delivered
+- **THEN** the previous handler is already back in place, so the process is
+  still killable
+
 ### Requirement: Slash commands route to the same engine
 
 `issue_comment` events SHALL parse into commands — `/review` (with `full`

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import sys
 from collections import Counter
-from collections.abc import Callable
-from contextlib import suppress
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,7 @@ from lgtmaybe.engine import (
     LLMReviewEngine,
     SymbolResolver,
     build_symbol_resolver,
+    request_interrupt,
 )
 from lgtmaybe.engine.profiling import profiler
 from lgtmaybe.github import RestGitHubGateway
@@ -890,10 +892,64 @@ def _utf8_stdio() -> None:
                 reconfigure(encoding="utf-8", errors="replace")
 
 
+@contextmanager
+def graceful_interrupt() -> Iterator[None]:
+    """Turn the FIRST SIGINT/SIGTERM into the engine's partial-results wind-down.
+
+    A CI job that blows its `timeout-minutes`, or a run cancelled by
+    `cancel-in-progress`, is signalled before it is killed. Ignoring that signal
+    is why an over-running review posts *nothing* — no findings, no failure
+    comment. The handler sets the same state the `max_review_seconds` deadline
+    sets, so queued model calls are skipped and the review posts what it already
+    has (see `engine.request_interrupt`).
+
+    Installed here, in the CLI entrypoint, and never at import time: importing
+    lgtmaybe as a library must not hijack a host application's handlers. The
+    previous handler is restored on the way out *and* on the first signal — so a
+    second signal takes its normal course and the process is still killable if
+    the wind-down itself hangs. Off the main thread (where `signal.signal`
+    raises) and on a platform missing a signal, this is a no-op.
+    """
+    previous: dict[int, Any] = {}
+
+    def _restore() -> None:
+        for sig in list(previous):
+            handler = previous.pop(sig, None)
+            if handler is not None:
+                with suppress(ValueError, OSError):
+                    signal.signal(sig, handler)
+
+    def _on_signal(signum: int, _frame: Any) -> None:
+        _restore()
+        _log.warning(
+            "interrupted — winding down and posting partial results",
+            extra={"signal": signum},
+        )
+        request_interrupt()
+
+    try:
+        for name in ("SIGINT", "SIGTERM"):
+            sig = getattr(signal, name, None)
+            if sig is not None:
+                previous[sig] = signal.signal(sig, _on_signal)
+    except (ValueError, OSError):
+        # Not the main thread, or the platform won't take this handler: degrade
+        # to the process's normal termination behaviour rather than fail.
+        _restore()
+    try:
+        yield
+    finally:
+        _restore()
+
+
 @click.group(epilog=_EPILOG)
-def main() -> None:
+@click.pass_context
+def main(ctx: click.Context) -> None:
     """lgtmaybe — provider-agnostic PR reviewer."""
     _utf8_stdio()
+    # Held open for the subcommand: click closes the context (and this resource)
+    # once the command it dispatches to has returned.
+    ctx.with_resource(graceful_interrupt())
 
 
 @main.group(name="config")
@@ -915,6 +971,7 @@ __all__ = [
     "execute_local_review",
     "execute_review",
     "execute_review_reply",
+    "graceful_interrupt",
     "main",
     "parse_pr_url",
     "pr_url_from_event",

--- a/src/lgtmaybe/engine/__init__.py
+++ b/src/lgtmaybe/engine/__init__.py
@@ -1,13 +1,23 @@
 """lgtmaybe.engine — the review pipeline (Track C)."""
 
 from .astgrep import SymbolResolver, build_symbol_resolver
-from .engine import INCOMPLETE_MARKER, LLMReviewEngine, ReviewIncompleteError
+from .engine import (
+    INCOMPLETE_MARKER,
+    LLMReviewEngine,
+    ReviewIncompleteError,
+    clear_interrupt,
+    interrupt_requested,
+    request_interrupt,
+)
 from .retrieve import FileFetcher
 
 __all__ = [
     "INCOMPLETE_MARKER",
     "LLMReviewEngine",
     "ReviewIncompleteError",
+    "clear_interrupt",
+    "interrupt_requested",
+    "request_interrupt",
     "FileFetcher",
     "SymbolResolver",
     "build_symbol_resolver",

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -8,6 +8,7 @@ Pipeline: redact → compress/batch → (per batch) fan out one call per review
 
 from __future__ import annotations
 
+import threading
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
@@ -138,6 +139,36 @@ INCOMPLETE_MARKER = "<!-- lgtmaybe-incomplete -->"
 # summary step, which counts these to tell a budget stop (spend the user chose)
 # apart from the provider failures the generic incomplete notice covers.
 _BUDGET_SKIP_REASON = "token budget (max_review_tokens) reached — call skipped"
+
+# The reason string a call skipped by an interruption reports. Worded to name
+# the cause, because the remedy differs from the deadline's: nobody should go
+# hunting for a `max_review_seconds` they never hit.
+_INTERRUPT_SKIP_REASON = "review interrupted (termination signal) — call skipped"
+
+# A wind-down asked for from OUTSIDE the pipeline — in practice the CLI's
+# SIGTERM/SIGINT handler, when the CI job blows its `timeout-minutes` or a push
+# cancels the run. Deliberately the same state the elapsed deadline sets: queued
+# model calls are skipped, in-flight ones finish, and the review posts partial
+# results with a notice instead of dying with nothing on the PR. Process-global
+# and never cleared by `review()` — a signal means stop, not stop-for-one-review
+# — so the CLI's other steps wind down too. `Event` because the fan-out reads it
+# from every worker thread.
+_interrupted = threading.Event()
+
+
+def request_interrupt() -> None:
+    """Stop starting new model calls; post what the review already has."""
+    _interrupted.set()
+
+
+def interrupt_requested() -> bool:
+    """Whether a wind-down has been asked for."""
+    return _interrupted.is_set()
+
+
+def clear_interrupt() -> None:
+    """Forget a requested wind-down (tests, and a long-lived host process)."""
+    _interrupted.clear()
 
 
 def _plural(n: int, one: str = "", many: str = "s") -> str:
@@ -333,11 +364,14 @@ def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
 def _skip_reason(deadline_at: float | None, budget_at: int | None, lens: _Lens) -> str | None:
     """Why this model call must not be made, or None to go ahead.
 
-    Both ceilings are checked at EXECUTION time (tasks queue in the pool long
+    Every ceiling is checked at EXECUTION time (tasks queue in the pool long
     before a worker picks them up, and a deferral is decided later still), so the
     figures include everything that landed in the meantime. One function, so the
     first call and a deferral's re-run can never drift apart on when to stop.
     """
+    if interrupt_requested():
+        _log.warning("review interrupted — skipping call", extra={"lens": lens.id})
+        return _INTERRUPT_SKIP_REASON
     if deadline_at is not None and time.perf_counter() >= deadline_at:
         _log.warning("review deadline reached — skipping call", extra={"lens": lens.id})
         return "review deadline (max_review_seconds) reached — call skipped"
@@ -775,17 +809,27 @@ class LLMReviewEngine(ReviewEngine):
         scanned = [f for f in all_findings if _is_scan_finding(f)]
         all_findings = [f for f in all_findings if not _is_scan_finding(f)]
         if cfg.reflect and all_findings:
-            if deadline_at is not None and time.perf_counter() >= deadline_at:
+            if interrupt_requested():
+                # The process is being torn down: audit nothing, post what we
+                # have. Same trade as the deadline below, on someone else's clock.
+                reflection_skipped = "Review interrupted (termination signal)"
+                _log.warning(
+                    "review interrupted — skipping reflection",
+                    extra={"findings": len(all_findings)},
+                )
+            elif deadline_at is not None and time.perf_counter() >= deadline_at:
                 # Better unaudited findings with an honest notice than more
                 # minutes past the ceiling — and never a silent quality drop.
-                reflection_skipped = f"Review deadline ({cfg.max_review_seconds}s)"
+                reflection_skipped = f"Review deadline ({cfg.max_review_seconds}s) reached"
                 _log.warning(
                     "review deadline reached — skipping reflection",
                     extra={"findings": len(all_findings)},
                 )
             elif budget_at is not None and profiler.total_tokens() >= budget_at:
                 # Same trade, spend instead of time.
-                reflection_skipped = f"Token budget (max_review_tokens = {cfg.max_review_tokens})"
+                reflection_skipped = (
+                    f"Token budget (max_review_tokens = {cfg.max_review_tokens}) reached"
+                )
                 _log.warning(
                     "review token budget reached — skipping reflection",
                     extra={"findings": len(all_findings)},
@@ -880,7 +924,7 @@ class LLMReviewEngine(ReviewEngine):
             )
         if reflection_skipped:
             notices.append(
-                f"⚠️ {reflection_skipped} reached — the self-reflection audit was "
+                f"⚠️ {reflection_skipped} — the self-reflection audit was "
                 "skipped, so findings may include false positives."
             )
         # Findings the model DID raise and the run then hid: an ignore

--- a/tests/cli/test_signal.py
+++ b/tests/cli/test_signal.py
@@ -1,0 +1,104 @@
+"""The CLI's graceful wind-down on SIGTERM/SIGINT.
+
+A GitHub Action job that blows its `timeout-minutes`, or a run cancelled by
+`cancel-in-progress`, gets a termination signal before it is killed. The CLI
+turns the first one into the engine's existing partial-results wind-down;
+everything about *installing* that handler is tested here.
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from click.testing import CliRunner
+
+from lgtmaybe.cli import graceful_interrupt, main
+from lgtmaybe.engine import clear_interrupt, interrupt_requested
+
+_SIGNALS = [getattr(signal, name) for name in ("SIGINT", "SIGTERM") if hasattr(signal, name)]
+
+
+@pytest.fixture(autouse=True)
+def _clean_flag() -> Iterator[None]:
+    clear_interrupt()
+    yield
+    clear_interrupt()
+
+
+class TestGracefulInterrupt:
+    @pytest.mark.parametrize("sig", _SIGNALS)
+    def test_installs_and_restores_the_previous_handler(self, sig: signal.Signals) -> None:
+        before = signal.getsignal(sig)
+        with graceful_interrupt():
+            assert signal.getsignal(sig) is not before, "handler not installed"
+        assert signal.getsignal(sig) is before, "previous handler not restored"
+
+    @pytest.mark.parametrize("sig", _SIGNALS)
+    def test_first_signal_requests_the_wind_down(self, sig: signal.Signals) -> None:
+        before = signal.getsignal(sig)
+        with graceful_interrupt():
+            handler = signal.getsignal(sig)
+            assert callable(handler)
+            handler(sig, None)  # what the interpreter does on delivery
+            assert interrupt_requested(), "the engine was not asked to wind down"
+            # A SECOND signal must still kill the process: we only ever
+            # intercept one, so the previous handler is back immediately.
+            assert signal.getsignal(sig) is before
+
+    def test_off_the_main_thread_is_a_no_op(self) -> None:
+        """signal.signal() raises off the main thread — degrade, never crash."""
+        errors: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                with graceful_interrupt():
+                    pass
+            except BaseException as exc:  # pragma: no cover - only on failure
+                errors.append(exc)
+
+        thread = threading.Thread(target=run)
+        thread.start()
+        thread.join(timeout=10)
+        assert not errors, f"raised off the main thread: {errors}"
+
+    def test_main_wraps_the_command_in_the_wind_down(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """Installed by the CLI entrypoint, and held open for the subcommand."""
+        events: list[str] = []
+
+        @contextmanager
+        def _recording() -> Iterator[None]:
+            events.append("enter")
+            try:
+                yield
+            finally:
+                events.append("exit")
+
+        def _command_ran() -> str:
+            events.append("command")
+            return "/tmp/lgtmaybe.yml"
+
+        monkeypatch.setattr("lgtmaybe.cli.graceful_interrupt", _recording)
+        monkeypatch.setattr("lgtmaybe.config.store.user_config_path", _command_ran)
+        result = CliRunner().invoke(main, ["config", "path"])
+        assert result.exit_code == 0, result.output
+        assert events == ["enter", "command", "exit"]
+
+
+def test_importing_the_library_installs_no_handler() -> None:
+    """Importing lgtmaybe must never hijack a host application's signals."""
+    check = (
+        "import signal, sys;"
+        "before = signal.getsignal(signal.SIGINT);"
+        "import lgtmaybe, lgtmaybe.cli, lgtmaybe.engine;"
+        "sys.exit(0 if signal.getsignal(signal.SIGINT) is before else 1)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", check], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, f"import-time signal handler installed\nstderr: {proc.stderr}"

--- a/tests/cli/test_signal.py
+++ b/tests/cli/test_signal.py
@@ -14,6 +14,7 @@ import sys
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 from click.testing import CliRunner
@@ -65,7 +66,38 @@ class TestGracefulInterrupt:
         thread = threading.Thread(target=run)
         thread.start()
         thread.join(timeout=10)
+        # A hang leaves `errors` empty too — assert the thread actually finished,
+        # or a wedged wind-down would read as success.
+        assert not thread.is_alive(), "graceful_interrupt hung off the main thread"
         assert not errors, f"raised off the main thread: {errors}"
+
+    @pytest.mark.skipif(
+        not (hasattr(signal, "SIGINT") and hasattr(signal, "SIGTERM")),
+        reason="needs both signals to install one and fail the other",
+    )
+    def test_a_partial_install_restores_what_it_managed_to_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SIGINT installs, then SIGTERM refuses: the SIGINT handler installed a
+        moment earlier must not be left behind for the rest of the process."""
+        real_signal = signal.signal
+        attempts: list[int] = []
+
+        def fake_signal(sig: Any, handler: Any) -> Any:
+            attempts.append(sig)
+            if len(attempts) == 2:  # the SIGTERM install
+                raise ValueError("signal only works in main thread")
+            return real_signal(sig, handler)
+
+        monkeypatch.setattr(signal, "signal", fake_signal)
+        before = signal.getsignal(signal.SIGINT)
+        with graceful_interrupt():
+            # A partial install is no install: the previous handler is already
+            # back, so the process keeps its normal termination behaviour.
+            assert signal.getsignal(signal.SIGINT) is before
+        assert attempts == [signal.SIGINT, signal.SIGTERM, signal.SIGINT], (
+            f"expected install SIGINT, fail on SIGTERM, then restore SIGINT — got {attempts}"
+        )
 
     def test_main_wraps_the_command_in_the_wind_down(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
         """Installed by the CLI entrypoint, and held open for the subcommand."""

--- a/tests/engine/test_interrupt.py
+++ b/tests/engine/test_interrupt.py
@@ -1,0 +1,123 @@
+"""Tests for the wind-down flag a termination signal raises.
+
+The engine already degrades an over-running review to partial-results-with-a-
+notice when ``max_review_seconds`` passes. An interruption (SIGTERM from a job
+timeout or a cancelled workflow) sets the SAME state, so everything downstream
+— skipped calls, the failed-call notice, the hidden incomplete marker, the
+skipped reflection — is shared; only the reason wording differs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.engine import (
+    INCOMPLETE_MARKER,
+    LLMReviewEngine,
+    ReviewIncompleteError,
+    clear_interrupt,
+    interrupt_requested,
+    request_interrupt,
+)
+from tests.fakes import FakeProvider
+
+_CTX = PRContext(
+    diff="@@ -1,3 +1,4 @@\n context\n+new line\n context\n",
+    changed_files=["a.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="org/repo",
+    pr_number=1,
+)
+
+_FINDING_JSON = (
+    '[{"path": "a.py", "line": 1, "severity": "high", "title": "bug", "body": "broken",'
+    ' "failure_scenario": "When the changed line runs, the operation fails."}]'
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_flag() -> Iterator[None]:
+    """The flag is process-global: never let one test leak into the next."""
+    clear_interrupt()
+    yield
+    clear_interrupt()
+
+
+class _InterruptingProvider(FakeProvider):
+    """Raises the wind-down flag from inside its first completion."""
+
+    def __init__(self, text: str = _FINDING_JSON) -> None:
+        super().__init__()
+        self._text = text
+
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        request_interrupt()
+        return ProviderResult(text=self._text, input_tokens=1, output_tokens=1)
+
+
+def _cfg(**overrides: object) -> ReviewConfig:
+    defaults: dict[str, object] = {
+        "provider": Provider.ollama,  # serial: calls execute one at a time
+        "model": "m",
+        "categories": [
+            ReviewCategory.security,
+            ReviewCategory.correctness,
+            ReviewCategory.performance,
+        ],
+        "reflect": False,
+    }
+    defaults.update(overrides)
+    return ReviewConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestInterrupt:
+    def test_flag_starts_clear_and_round_trips(self) -> None:
+        assert interrupt_requested() is False
+        request_interrupt()
+        assert interrupt_requested() is True
+        clear_interrupt()
+        assert interrupt_requested() is False
+
+    def test_queued_calls_are_skipped_and_partial_findings_still_post(self) -> None:
+        """The in-flight call finishes and its findings survive; the queued rest
+        are skipped, exactly as when the deadline passes."""
+        provider = _InterruptingProvider()
+        findings, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+        assert len(provider.calls) == 1
+        assert findings, "the completed call's findings still post"
+        assert "review calls failed" in summary
+        assert INCOMPLETE_MARKER in summary
+        assert "LGTM" not in summary
+
+    def test_notice_names_the_interruption_not_the_deadline(self) -> None:
+        """Same machinery, distinguishable cause: a user reading the notice must
+        not be sent hunting for a `max_review_seconds` they never hit."""
+        _, summary = LLMReviewEngine(_InterruptingProvider()).review(_CTX, _cfg())
+        assert "interrupted" in summary
+        assert "max_review_seconds" not in summary
+
+    def test_reflection_is_skipped_with_an_honest_notice(self) -> None:
+        cfg = _cfg(categories=[ReviewCategory.security], reflect=True)
+        provider = _InterruptingProvider()
+        findings, summary = LLMReviewEngine(provider).review(_CTX, cfg)
+        # One review call, then reflection would start after the interruption.
+        assert len(provider.calls) == 1
+        assert findings, "kept unaudited rather than dropped"
+        assert "self-reflection audit was skipped" in summary
+        assert "interrupted" in summary.lower()
+
+    def test_every_call_skipped_still_fails_loud(self) -> None:
+        """An interruption must never turn a total failure into a silent LGTM."""
+        with pytest.raises(ReviewIncompleteError):
+            LLMReviewEngine(_InterruptingProvider(text="no json")).review(_CTX, _cfg())


### PR DESCRIPTION
## What

On `SIGINT`/`SIGTERM`, lgtmaybe stops dispatching new model calls and posts whatever the review has already produced, with a notice naming the interruption — instead of dying with nothing on the PR.

## Why

Two routine ways a review currently posts **nothing at all** — no findings, no failure comment:

1. The job exceeds its `timeout-minutes`. `max_review_seconds` defaults to 3600s, so a workflow with `timeout-minutes: 25` gets killed long before the soft deadline can fire and post partial findings. The workaround has been hand-tuning `max_review_seconds` under the job timeout — fragile config discipline every user has to rediscover (our own `.github/workflows/lgtmaybe.yml` carries a comment explaining the layering).
2. `concurrency: cancel-in-progress: true` cancels an in-flight review when a new push lands.

In both cases the runner signals the process before killing it. We ignored the signal.

## How

**Reuses the deadline mechanism rather than building a parallel one.** The engine already degrades an over-running review to partial-results-with-a-notice when `max_review_seconds` passes. A signal now sets the *same* state:

- `engine.request_interrupt()` sets a process-global flag that `_skip_reason` checks alongside the deadline and the token budget, so queued lens calls are skipped at execution time exactly as they are past the deadline. In-flight calls finish and their findings post.
- Everything downstream is shared and unchanged: the "N of M review calls failed" notice, the hidden incomplete marker (so the notice also posts as its own PR comment), the skipped-reflection notice, and the `ReviewIncompleteError` path when *every* call was skipped — an interruption can never become a silent 👍 LGTM.
- Only the reason wording differs (`review interrupted (termination signal)` vs the deadline's), so nobody goes hunting for a `max_review_seconds` they never hit.

**Handler installation** (`cli.graceful_interrupt`), against the constraints:

- Installed by the **CLI entrypoint only**, held open for the subcommand via the click context — importing lgtmaybe as a library never touches a host application's handlers (guarded by a fresh-interpreter test).
- `signal.signal()` only works on the main thread; off it (and on a platform missing a signal) the context manager degrades to a no-op rather than raising — the engine runs a `ThreadPoolExecutor`, so this matters.
- The previous handler is restored on the way out **and** as the handler fires, so a **second signal still kills the process** if the wind-down itself hangs. lgtmaybe never becomes unkillable, and it never permanently steals the signal.
- Windows-safe: signals are looked up with `getattr` and `signal.signal` failures are tolerated, and the tests parametrise over whichever signals the platform actually has.

## Tests

TDD, red first (both files failed to import before the implementation existed).

`tests/engine/test_interrupt.py`
- `test_flag_starts_clear_and_round_trips`
- `test_queued_calls_are_skipped_and_partial_findings_still_post`
- `test_notice_names_the_interruption_not_the_deadline`
- `test_reflection_is_skipped_with_an_honest_notice`
- `test_every_call_skipped_still_fails_loud`

`tests/cli/test_signal.py`
- `test_installs_and_restores_the_previous_handler` (per available signal)
- `test_first_signal_requests_the_wind_down` (per available signal — also asserts the previous handler is already back)
- `test_off_the_main_thread_is_a_no_op`
- `test_main_wraps_the_command_in_the_wind_down`
- `test_importing_the_library_installs_no_handler`

## Also

- Spec: new `cli.graceful-interrupt` requirement + anchor in `openspec/specs/cli-and-local/` (the review-pipeline section it would otherwise extend is already at the 40-line cap). `uv run pytest tests/specs -q` and `openspec validate --specs` green.
- Docs: `action.yml`'s `max_review_seconds` description, the Action input table, `docs/explanation/architecture.md`, `ARCHITECTURE.md`, `CLAUDE.md`, regenerated `docs/llms*.txt`.
- `.github/workflows/lgtmaybe.yml`: the timeout-layering comment now names the wind-down as the backstop. Timeout layering is still the calm path — the signal handler can only skip *queued* calls, so a job cut short mid-call is still racing the runner's grace period. No workflow `if:` conditions touched.

Gate: `ruff check` / `ruff format --check` / `mypy` / `pytest -q` (1839 passed, 3 skipped) all green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1zKeXbpsNjxkBW6N7oV9P)_