### PR TITLE
perf(engine): stop splitting a truncation the thinking budget caused

### DIFF
--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -217,9 +217,10 @@ well, so nothing already paid for is thrown away. The summary says a batch was
 shrunk, and — because part of a lens is not a whole lens — the run still reports
 that results may be incomplete.
 
-The cost of that recovery is up to twice the calls for the affected batch. It is
-bounded to one split level: if a piece still runs past the ceiling, it is
-reported rather than split again.
+The cost of that recovery is up to twice the calls for the affected batch,
+though the pieces are reviewed **concurrently**, so on the clock it costs about
+one extra call. It is bounded to one split level: if a piece still runs past the
+ceiling, it is reported rather than split again.
 
 When you see it happening often, the fix is usually **`max_tokens`, not the
 diff**:
@@ -230,9 +231,11 @@ max_tokens: 32768
 
 A reasoning model spends the same budget on thinking before it writes a single
 finding, which is how a fifteen-line diff can truncate. The failure names the
-reasoning tokens where the provider reports them — if most of the ceiling went
-on thought, no amount of shrinking the input will help, and the cap is what
-needs raising.
+reasoning tokens where the provider reports them — and when they account for
+essentially the whole ceiling, lgtmaybe **does not split the batch at all**:
+smaller pieces would each re-spend the same ceiling on thought and truncate the
+same way, so it says so and names `reasoning_effort` instead of costing you the
+extra calls.
 
 You do not have to wait for a truncation to find that out. `--profile` reports
 the same split on calls that **succeeded** (`think_tok`, and the `reasoning:`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3678,9 +3678,10 @@ well, so nothing already paid for is thrown away. The summary says a batch was
 shrunk, and — because part of a lens is not a whole lens — the run still reports
 that results may be incomplete.
 
-The cost of that recovery is up to twice the calls for the affected batch. It is
-bounded to one split level: if a piece still runs past the ceiling, it is
-reported rather than split again.
+The cost of that recovery is up to twice the calls for the affected batch,
+though the pieces are reviewed **concurrently**, so on the clock it costs about
+one extra call. It is bounded to one split level: if a piece still runs past the
+ceiling, it is reported rather than split again.
 
 When you see it happening often, the fix is usually **`max_tokens`, not the
 diff**:
@@ -3691,9 +3692,11 @@ max_tokens: 32768
 
 A reasoning model spends the same budget on thinking before it writes a single
 finding, which is how a fifteen-line diff can truncate. The failure names the
-reasoning tokens where the provider reports them — if most of the ceiling went
-on thought, no amount of shrinking the input will help, and the cap is what
-needs raising.
+reasoning tokens where the provider reports them — and when they account for
+essentially the whole ceiling, lgtmaybe **does not split the batch at all**:
+smaller pieces would each re-spend the same ceiling on thought and truncate the
+same way, so it says so and names `reasoning_effort` instead of costing you the
+extra calls.
 
 You do not have to wait for a truncation to find that out. `--profile` reports
 the same split on calls that **succeeded** (`think_tok`, and the `reasoning:`

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -130,7 +130,9 @@ A completion that stopped because it ran out of output tokens SHALL be raised
 as its own failure naming `max_tokens` as the ceiling reached — usually a value
 the user set, not the model's own — plus the reasoning-token count where the
 route reports it, and SHALL carry the cut-off body so the engine can salvage the
-findings finished before the cut. It SHALL NOT be retried — at temperature 0 the
+findings finished before the cut, and both counts as data so a caller can tell a
+long answer from exhausted thinking without reading the message. It SHALL NOT be
+retried — at temperature 0 the
 identical request reaches the identical ceiling, and each attempt costs a full
 ceiling-length generation — while a configured fallback model is still tried.
 Detection reads the finish reason only where the route reports it plainly:
@@ -145,8 +147,13 @@ names a ceiling hit its own way is caught downstream by the parser instead.
 
 #### Scenario: a reasoning model spends the budget on thought
 - **WHEN** the route reports reasoning tokens on a truncated completion
-- **THEN** the failure names them, because that — not diff size — is why a small
-  diff hit the ceiling
+- **THEN** the failure names them and carries them beside the ceiling as numbers,
+  because that — not diff size — is why a small diff hit the ceiling
+
+#### Scenario: the route reports no reasoning breakdown
+- **WHEN** a truncated completion carries no reasoning count
+- **THEN** the failure carries none either, never zero — "it never said" must not
+  read as "it thought nothing"
 
 #### Scenario: the route misreports why it stopped
 - **WHEN** a provider reports a ceiling hit under a name litellm maps to `stop`

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -62,6 +62,12 @@ engine.timeout-split:
       has: { field: name, regex: '^_split_batch$' }
     files: [src/lgtmaybe/engine/**/*.py]
 
+engine.reasoning-ceiling:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_reasoning_exhausted_reason$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
 engine.mid-review-retrieval:
   rule:
     kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -129,10 +129,10 @@ within budget are reviewed whole.
 
 A lens call that exhausts a per-request budget SHALL be retried on smaller
 pieces of the same batch rather than re-sent unchanged, bounded to one split
-level, with the shrink disclosed in the summary. Both budgets trigger it: the
-wall clock, and the `max_tokens` ceiling an answer runs into. Findings the model
-completed before a truncation SHALL be kept, and the lens SHALL still count as
-failed.
+level, the pieces reviewed concurrently, with the shrink disclosed in the
+summary. Both budgets trigger it: the wall clock, and the `max_tokens` ceiling
+an answer runs into. Findings the model completed before a truncation SHALL be
+kept, and the lens SHALL still count as failed.
 <!-- anchor: engine.timeout-split -->
 
 #### Scenario: a multi-file batch times out
@@ -158,6 +158,36 @@ failed.
 - **WHEN** part of a split batch is reviewed and part fails
 - **THEN** the findings are kept AND the failure is reported, so the summary never
   claims a shrunk batch was reviewed when some of it was not
+
+#### Scenario: the pieces are reviewed
+- **WHEN** a batch is split
+- **THEN** its pieces run together in an executor of their own, bounded by the
+  backend's concurrency — never resubmitted into the pool this call occupies
+
+### Requirement: A split is only attempted when covering less can help
+
+A truncation that spent essentially the whole ceiling reasoning SHALL NOT be
+split, and SHALL name `reasoning_effort` as the lever instead: a smaller payload
+does not shrink a thinking budget, so the split would re-spend the whole
+`max_tokens` ceiling on every piece and fail identically. The
+decision reads the counts the failure carries, never its message. Findings
+completed before the cut are kept on this path too, and a failure that says
+nothing about size is not split at all.
+<!-- anchor: engine.reasoning-ceiling -->
+
+#### Scenario: the ceiling went on thinking
+- **WHEN** a lens call truncates having spent nearly the whole ceiling reasoning
+- **THEN** no pieces are reviewed, the salvage is kept, and the notice names
+  `reasoning_effort` rather than `max_tokens`
+
+#### Scenario: the ceiling went on the answer
+- **WHEN** a truncated call spent only a small share of the ceiling reasoning
+- **THEN** the batch is split as usual — that call really did have more to say
+  than one response could hold
+
+#### Scenario: the route reports no reasoning count
+- **WHEN** a truncation carries no reasoning breakdown at all
+- **THEN** the batch is split as usual, because silence is not evidence of thinking
 
 #### Scenario: the failure says nothing about size
 - **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -37,21 +37,38 @@ class ProviderTruncated(Exception):
     failure so the notice on the PR names the ceiling and the knob that moves
     it, rather than "unparseable model output".
 
-    Like a wall timeout, this says something about the *payload*: one call was
-    asked to cover more than it could finish saying. The engine therefore reacts
-    the same way — split the batch and review the pieces — rather than failing
-    the whole lens.
+    Usually this says something about the *payload*: one call was asked to cover
+    more than it could finish saying. The engine then reacts as it does to a wall
+    timeout — split the batch and review the pieces — rather than failing the
+    whole lens. But not always, which is what the counts below are for.
 
     ``text`` carries the cut-off body. It is not usable as an answer, but the
     findings the model completed before the cut are real work, and the engine
     salvages them from it exactly as the parser does for a truncation it detects
     itself. It rides on the error rather than being returned, so a caller cannot
     take the salvage without also seeing that the lens was cut short.
+
+    ``reasoning_tokens`` (None when the route reports no breakdown — which is not
+    the same as zero) and ``output_tokens`` (the ceiling actually reached) carry
+    the *diagnosis* as data rather than as prose. A reasoning model spends this
+    same budget on thought, so a truncation where the thinking accounts for
+    essentially the whole ceiling is not a payload problem at all: covering less
+    does not shrink a thinking budget, and only `reasoning_effort` moves it. The
+    caller must be able to tell the two apart without re-reading our own message.
     """
 
-    def __init__(self, message: str, *, text: str = "") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        text: str = "",
+        reasoning_tokens: int | None = None,
+        output_tokens: int | None = None,
+    ) -> None:
         super().__init__(message)
         self.text = text
+        self.reasoning_tokens = reasoning_tokens
+        self.output_tokens = output_tokens
 
 
 class ProviderClient(ABC):

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -139,19 +139,51 @@ INCOMPLETE_MARKER = "<!-- lgtmaybe-incomplete -->"
 # apart from the provider failures the generic incomplete notice covers.
 _BUDGET_SKIP_REASON = "token budget (max_review_tokens) reached — call skipped"
 
+# When reasoning accounts for at least this share of the `max_tokens` ceiling a
+# truncation hit, the ceiling was spent on THINKING, not on findings — and the
+# split (see _review_split) cannot help, because a smaller payload does not
+# shrink a thinking budget.
+#
+# 0.9 because the two populations are nowhere near it from either side. Measured
+# on one self-review of this repo: five calls truncated at a 32,768 ceiling
+# having spent 25,963–35,463 tokens reasoning — 0.79 to over 1.0 of the cap,
+# clustering at 0.98+ — while the calls that answered normally wrote thousands of
+# tokens of findings after their thinking. The failure mode the split exists for
+# is the opposite shape: little thought, then an answer that runs long, where the
+# ratio is near zero. At 0.9 at most a tenth of the ceiling was left for the
+# answer, so halving the diff cannot buy a complete one — the only lever left is
+# `reasoning_effort`, which bounds the thinking directly.
+#
+# Deliberately not configurable: it is a diagnosis, not a preference, and a knob
+# here would be one more thing to tune in the failure it exists to explain.
+_REASONING_DOMINANT_SHARE = 0.9
+
 
 def _plural(n: int, one: str = "", many: str = "s") -> str:
     """The word (or suffix) for a count of *n*: *one* when it is exactly 1, else *many*."""
     return one if n == 1 else many
 
 
-def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
-    """The fan-out pool size: the explicit cap, else the provider-aware default."""
+def _concurrency_cap(cfg: ReviewConfig) -> int:
+    """How many model calls this run may have in flight: the explicit cap, else
+    the provider-aware default.
+
+    A property of the *backend*, independent of how much work there is — which
+    is why it is separate from the pool size below. The oversized-batch split
+    runs its pieces in a pool of its own, and needs this figure rather than the
+    fan-out's: a one-lens review sizes its pool to one task, but that says
+    nothing about what the provider will serve at once.
+    """
     if cfg.max_concurrency is not None:
-        return max(1, min(cfg.max_concurrency, task_count))
+        return max(1, cfg.max_concurrency)
     if cfg.provider in _SINGLE_STREAM_PROVIDERS:
         return 1
-    return min(_CLOUD_MAX_WORKERS, task_count) or 1
+    return _CLOUD_MAX_WORKERS
+
+
+def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
+    """The fan-out pool size: the cap above, narrowed to the work there is."""
+    return max(1, min(_concurrency_cap(cfg), task_count))
 
 
 @dataclass(frozen=True)
@@ -303,6 +335,10 @@ class _Run:
     budget_at: int | None
     # Mid-review retrieval budget in tokens, or None when a lens may not defer.
     retrieval_budget: int | None
+    # How many calls this backend will serve at once (_concurrency_cap). Carried
+    # for the oversized-batch split, which runs its pieces in a pool of its own
+    # and must not out-run what the fan-out itself is allowed.
+    concurrency: int
 
 
 def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
@@ -623,6 +659,7 @@ class LLMReviewEngine(ReviewEngine):
             deadline_at=deadline_at,
             budget_at=budget_at,
             retrieval_budget=retrieval_budget,
+            concurrency=_concurrency_cap(cfg),
         )
         workers = _resolve_workers(cfg, len(batches) * len(lenses))
         per_batch: list[tuple[bool, list[_ReviewTask]]] = []
@@ -1153,6 +1190,15 @@ class LLMReviewEngine(ReviewEngine):
         unredacted or unwrapped reaches the model. Returns the original *reason*
         unchanged when the batch cannot be split — a single-hunk file has no
         smaller unit to fall back to.
+
+        The pieces run concurrently (see below) and each still goes through
+        ``_review_lens``, so each re-checks the whole-review deadline and token
+        budget at execution: a split that begins past a ceiling costs nothing,
+        and running the pieces together only shortens the overshoot a split in
+        flight can add — it was already bounded at one call's latency.
+
+        Not attempted at all when the truncation was reasoning-bound; see
+        :func:`_reasoning_exhausted_reason`, which decides that before we get here.
         """
         pieces = _split_batch(batch)
         if len(pieces) < 2:
@@ -1161,10 +1207,9 @@ class LLMReviewEngine(ReviewEngine):
             "review call was too big for one response — retrying on smaller pieces",
             extra={"lens": lens.id, "batch": batch_num, "pieces": len(pieces)},
         )
-        findings: list[ReviewFinding] = []
-        errors: list[str] = []
-        for piece in pieces:
-            piece_findings, piece_error = self._review_lens(
+
+        def review_piece(piece: list[tuple[str, str]]) -> _LensOutcome:
+            return self._review_lens(
                 run,
                 wrap_diff("\n".join(patch for _, patch in piece)),
                 intent_block,
@@ -1173,6 +1218,36 @@ class LLMReviewEngine(ReviewEngine):
                 batch_num,
                 lens,
             )
+
+        # The pieces are independent calls, so they run CONCURRENTLY — serially
+        # a split cost one full model latency per piece, and it does so from
+        # inside a fan-out worker that is already holding a slot, which on a run
+        # where most lenses split is the largest wall-clock multiplier there is.
+        #
+        # In a POOL OF ITS OWN, deliberately, never back into the global fan-out
+        # pool: this code runs on one of that pool's workers, and a worker that
+        # submits to its own pool and then blocks on the result deadlocks the
+        # moment the pool is saturated — every worker waiting on work that only a
+        # free worker could start. A private executor makes that impossible by
+        # construction rather than by argument. It costs at most `width` threads
+        # for the duration of one split, and a split is the exceptional path.
+        #
+        # Width is the backend's own concurrency (never the piece count): a
+        # single-stream server — ollama, a one-slot llama.cpp — serves calls
+        # serially, so two at once would only queue and eat the timeout. At
+        # width 1 the executor runs them in submission order, exactly as the
+        # serial loop did. A splitting worker is blocked, not calling, so the
+        # calls in flight peak at the fan-out's width times this one — the
+        # adapter's backoff absorbs that burst, and it only happens on the run
+        # where every lens is already failing.
+        findings: list[ReviewFinding] = []
+        errors: list[str] = []
+        width = min(len(pieces), run.concurrency)
+        with ThreadPoolExecutor(max_workers=width, thread_name_prefix="lgtmaybe-split") as pool:
+            # map() yields in submission order, so the pieces' findings and the
+            # reported error stay deterministic however the calls interleave.
+            outcomes = list(pool.map(review_piece, pieces))
+        for piece_findings, piece_error in outcomes:
             findings.extend(piece_findings)
             if piece_error is not None:
                 errors.append(piece_error)
@@ -1233,6 +1308,18 @@ class LLMReviewEngine(ReviewEngine):
                 # schema-valid work — kept, exactly as the parse path keeps it, so
                 # the exception path is not the one place a partial answer is binned.
                 completed = _salvage_truncated(exc, lens)
+                exhausted = _reasoning_exhausted_reason(exc)
+                if exhausted is not None:
+                    # The ceiling went on thinking, not on findings: shrinking the
+                    # payload cannot shrink that, so the split is skipped and the
+                    # reason names the lever that does move it. Checked before the
+                    # "already a piece" case below so a piece reports it too — it is
+                    # the better diagnosis wherever the truncation happens.
+                    _log.warning(
+                        "truncation was reasoning-bound — not splitting",
+                        extra={"lens": lens.id, "batch": batch_num},
+                    )
+                    return completed, exhausted
                 if on_oversized is None:
                     # Already a piece: nothing smaller to try. Report the reason
                     # rather than recurse — an unbounded cascade would spend the
@@ -1284,6 +1371,41 @@ class LLMReviewEngine(ReviewEngine):
                 return on_needs(needs, findings)
         _log.info("lens reviewed", extra={"lens": lens.id, "findings": len(findings)})
         return findings, None
+
+
+def _reasoning_exhausted_reason(exc: BaseException) -> str | None:
+    """Why splitting this failure cannot help, or None when it still can.
+
+    A truncation normally means the payload asked for more answer than one
+    response could hold, and the remedy is to cover less. Not when the ceiling
+    went on *thought*: a reasoning model draws its thinking from the same
+    `max_tokens` budget, and halving the diff does not halve the thinking. The
+    observed proof is a fifteen-line diff truncating at the same ceiling as a
+    thousand-line one. Splitting there re-spends the whole ceiling on every piece
+    and fails identically — pure added latency on a review that is already slow.
+
+    Decided from the numbers the adapter measured (see ProviderTruncated), never
+    from its message: this reads the diagnosis as data, exactly as the structured
+    findings contract requires. Both counts are needed — the reasoning spend is
+    meaningless without the ceiling it is a share of — so a route that reports
+    neither keeps the split it has always had.
+
+    The returned reason replaces the adapter's, whose advice ("raise
+    `max_tokens`") is the one thing that provably does not work here: the cap
+    does not separate thinking from answering, so raising it buys more thinking.
+    """
+    if not isinstance(exc, ProviderTruncated):
+        return None
+    reasoning, ceiling = exc.reasoning_tokens, exc.output_tokens
+    if not reasoning or not ceiling:
+        return None
+    if reasoning < ceiling * _REASONING_DOMINANT_SHARE:
+        return None
+    return (
+        f"{type(exc).__name__}: spent {reasoning} of the {ceiling}-token `max_tokens` "
+        "ceiling on reasoning, so the batch was not split — a smaller payload cannot "
+        "shrink a thinking budget; lower `reasoning_effort` instead"
+    )
 
 
 def _salvage_truncated(exc: BaseException, lens: _Lens) -> list[ReviewFinding]:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -505,6 +505,13 @@ class LiteLLMProvider(ProviderClient):
                 "finishing — raise `max_tokens`, or lower `max_input_tokens` so each call "
                 "covers less",
                 text=text,
+                # The same two numbers as the message, carried as data: the engine
+                # decides whether shrinking the payload can help from the ratio
+                # between them, and re-reading them out of the prose above would be
+                # parsing our own sentence. None, not 0, when the route reported no
+                # breakdown — "it never said" must not read as "it thought nothing".
+                reasoning_tokens=reasoning or None,
+                output_tokens=output_tokens,
             )
         cache_read, cache_creation = _cache_usage(usage)
         if cache_read or cache_creation:

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -98,6 +98,13 @@ def _finding_json(path: str, anchor: str) -> str:
     )
 
 
+def _piece_json(diff: str) -> str:
+    """The answer a split piece gives, anchored in whichever file it carries."""
+    path = "one.py" if "one.py" in diff else "two.py"
+    anchor = "first_change = os.getcwd()" if path == "one.py" else "second_change = sys.maxsize"
+    return _finding_json(path, anchor)
+
+
 class _TimeoutUntilSmaller(FakeProvider):
     """Times out while both files are in one call; answers a single-file call.
 
@@ -227,8 +234,11 @@ def test_a_piece_that_times_out_again_is_not_split_further() -> None:
 class _TimeoutThenSlowPieces(FakeProvider):
     """Times out on the whole batch; each piece then takes real wall time.
 
-    The delay is the measurement: it holds a piece in flight long enough for a
-    sibling to be observed running beside it (or queued behind it).
+    For asserting pieces do NOT overlap. The delay only has to be long enough
+    that a concurrent pair would be caught in the act — and getting that wrong
+    can only cost a missed detection, never a spurious failure, which is the
+    safe direction for a clock in a test. Proving overlap is the direction that
+    would flake, so it uses a rendezvous instead (see below).
     """
 
     def __init__(self, delay: float = 0.05) -> None:
@@ -247,27 +257,65 @@ class _TimeoutThenSlowPieces(FakeProvider):
             self.max_in_flight = max(self.max_in_flight, self._in_flight)
         try:
             time.sleep(self._delay)
-            path = "one.py" if "one.py" in diff else "two.py"
-            anchor = (
-                "first_change = os.getcwd()" if path == "one.py" else "second_change = sys.maxsize"
-            )
-            return ProviderResult(text=_finding_json(path, anchor), input_tokens=5, output_tokens=5)
+            return ProviderResult(text=_piece_json(diff), input_tokens=5, output_tokens=5)
         finally:
             with self._lock:
                 self._in_flight -= 1
+
+
+# How long a piece waits at the rendezvous for its sibling to arrive. Generous
+# enough that a loaded runner scheduling the second thread late cannot fail the
+# test, and bounded so a REGRESSION to serial pieces fails in seconds with a
+# real message instead of hanging the job until CI kills it.
+_RENDEZVOUS_TIMEOUT = 5.0
+
+
+class _TimeoutThenPairedPieces(FakeProvider):
+    """Times out on the whole batch; its pieces then have to meet each other.
+
+    The rendezvous *is* the assertion: each piece blocks at the barrier until
+    the other arrives, so overlap is proven by both getting through rather than
+    inferred from a stopwatch — no sleep long enough to be safe on a loaded
+    runner, and no sleep short enough to flake.
+
+    A serial split can never get both pieces there. The barrier's own timeout
+    turns that into a recorded failure the test can name, rather than the
+    deadlock an unbounded ``wait()`` would leave for the CI job to time out on.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._barrier = threading.Barrier(2, timeout=_RENDEZVOUS_TIMEOUT)
+        self.serialised = False
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        if "one.py" in diff and "two.py" in diff:
+            raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+        try:
+            self._barrier.wait()
+        except threading.BrokenBarrierError:
+            # Recorded, not raised: the review runs to completion either way, so
+            # the test reports "the pieces ran serially" instead of a piece
+            # failing for a reason that reads like a provider error.
+            self.serialised = True
+        return ProviderResult(text=_piece_json(diff), input_tokens=5, output_tokens=5)
 
 
 def test_the_pieces_of_a_split_batch_are_reviewed_concurrently() -> None:
     """A split cost N sequential model calls, inside a worker already holding a
     pool slot — on a run where most lenses split, the biggest wall-clock
     multiplier in the system. The pieces are independent, so they overlap."""
-    provider = _TimeoutThenSlowPieces()
+    provider = _TimeoutThenPairedPieces()
     findings, _summary = LLMReviewEngine(provider).review(
         _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
     )
 
+    assert not provider.serialised, (
+        "the split's pieces ran serially: neither piece was inside the provider "
+        f"while the other was, within {_RENDEZVOUS_TIMEOUT}s"
+    )
     assert sorted(f.path for f in findings) == ["one.py", "two.py"]
-    assert provider.max_in_flight == 2
 
 
 def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> None:
@@ -290,6 +338,35 @@ def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> No
     )
 
     assert provider.max_in_flight == 1
+
+
+def test_an_explicit_concurrency_lifts_the_split_off_the_single_stream_default() -> None:
+    """The user's number wins over the provider default, in the split as in the
+    fan-out.
+
+    ollama's 1 is a default for the usual deployment — one instance, one slot —
+    not a property of the backend: an ollama started with several parallel slots
+    (and a batching vLLM behind `openai-compatible`) serves concurrent calls
+    happily, which is exactly why `max_concurrency` is exposed. Honouring it in
+    only one of the two pools would make one setting mean two different things.
+    """
+    provider = _TimeoutThenPairedPieces()
+    LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]),
+        ReviewConfig(
+            provider=Provider.ollama,
+            model="qwen3-coder",
+            categories=[ReviewCategory.security],
+            reflect=False,
+            prompt_cache=False,
+            max_concurrency=2,
+        ),
+    )
+
+    assert not provider.serialised, (
+        "an explicit max_concurrency=2 did not reach the split: its pieces still "
+        f"ran one at a time (rendezvous timed out after {_RENDEZVOUS_TIMEOUT}s)"
+    )
 
 
 def test_a_split_starting_past_the_deadline_costs_nothing() -> None:

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -10,6 +10,8 @@ with its own fresh budget: the one retry that can actually work.
 from __future__ import annotations
 
 import json
+import threading
+import time
 from typing import Any
 
 import pytest
@@ -220,6 +222,102 @@ def test_a_piece_that_times_out_again_is_not_split_further() -> None:
         LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
 
     assert len(provider.diffs) == 3  # the batch, then its two halves — and stop
+
+
+class _TimeoutThenSlowPieces(FakeProvider):
+    """Times out on the whole batch; each piece then takes real wall time.
+
+    The delay is the measurement: it holds a piece in flight long enough for a
+    sibling to be observed running beside it (or queued behind it).
+    """
+
+    def __init__(self, delay: float = 0.05) -> None:
+        super().__init__()
+        self._delay = delay
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        if "one.py" in diff and "two.py" in diff:
+            raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+        with self._lock:
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            time.sleep(self._delay)
+            path = "one.py" if "one.py" in diff else "two.py"
+            anchor = (
+                "first_change = os.getcwd()" if path == "one.py" else "second_change = sys.maxsize"
+            )
+            return ProviderResult(text=_finding_json(path, anchor), input_tokens=5, output_tokens=5)
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+
+
+def test_the_pieces_of_a_split_batch_are_reviewed_concurrently() -> None:
+    """A split cost N sequential model calls, inside a worker already holding a
+    pool slot — on a run where most lenses split, the biggest wall-clock
+    multiplier in the system. The pieces are independent, so they overlap."""
+    provider = _TimeoutThenSlowPieces()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    assert provider.max_in_flight == 2
+
+
+def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> None:
+    """The split is bounded by the review's own concurrency, not by piece count.
+
+    A single ollama instance serves a model serially: two concurrent calls only
+    queue up and eat the timeout. Whatever the fan-out is allowed, the split is
+    allowed — never more.
+    """
+    provider = _TimeoutThenSlowPieces()
+    LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]),
+        ReviewConfig(
+            provider=Provider.ollama,
+            model="qwen3-coder",
+            categories=[ReviewCategory.security],
+            reflect=False,
+            prompt_cache=False,
+        ),
+    )
+
+    assert provider.max_in_flight == 1
+
+
+def test_a_split_starting_past_the_deadline_costs_nothing() -> None:
+    """Concurrent pieces must still answer to the whole-review deadline.
+
+    Serially, a piece was held back by the previous piece's own check. Running
+    together they check at the same instant — so the check has to be the
+    deadline itself, or a review already over budget would fan out past it.
+    """
+
+    class _SlowTimeout(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+            time.sleep(1.2)
+            raise ProviderWallTimeout("provider request exceeded 1800s (waited 1800.001s)")
+
+    provider = _SlowTimeout()
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(
+            _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg(max_review_seconds=1)
+        )
+
+    assert len(provider.diffs) == 1  # the batch — both pieces skipped, not run
+    assert "deadline" in str(exc_info.value)
 
 
 def test_an_ordinary_failure_is_not_split() -> None:

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -326,6 +326,42 @@ def test_a_truncation_that_spent_its_ceiling_on_findings_is_still_split() -> Non
     assert len(provider.diffs) == 3  # the batch, then one call per half
 
 
+def test_a_piece_that_truncates_on_reasoning_names_the_lever_too() -> None:
+    """The diagnosis has to reach the piece, not only the whole batch.
+
+    A piece has nothing smaller to try, so it reports and stops either way — but
+    *what* it reports is the only thing the reader gets. Falling through to the
+    generic "raise `max_tokens`" there would send them to the one knob that
+    provably does not move this, after the split has already been paid for.
+
+    The batch's own truncation is answer-shaped (little thinking), so the split
+    is right to happen; the pieces are where the thinking wall shows up.
+    """
+
+    class _BatchRunsLongThenPiecesRunDeep(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.diffs: list[str] = []
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            self.diffs.append(diff)
+            whole_batch = "one.py" in diff and "two.py" in diff
+            raise ProviderTruncated(
+                _CEILING,
+                text="",
+                reasoning_tokens=2048 if whole_batch else _REASONING_SPENT,
+                output_tokens=_REASONING_CEILING,
+            )
+
+    provider = _BatchRunsLongThenPiecesRunDeep()
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
+
+    assert len(provider.diffs) == 3  # the batch, then its two halves — and stop
+    assert "reasoning_effort" in str(exc_info.value)
+
+
 def test_a_truncation_with_no_reasoning_breakdown_is_still_split() -> None:
     """Silence from the route is not evidence of thinking.
 

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -14,6 +14,8 @@ Two wrinkles the timeout does not have:
   `max_tokens` budget on thought, so a fifteen-line diff can truncate too. A
   piece that truncates again is a reachable state, not a theoretical one, and it
   must terminate naming the lever that can actually move — never recurse.
+- When the numbers say the ceiling went on thought, the split is skipped
+  outright: it cannot help, and attempting it re-spends the ceiling per piece.
 """
 
 from __future__ import annotations
@@ -69,6 +71,13 @@ _CEILING = (
     "response hit the 16384-token `max_tokens` ceiling (16200 reasoning) before "
     "finishing — raise `max_tokens`, or lower `max_input_tokens` so each call covers less"
 )
+
+
+# The same failure, but the numbers say the ceiling went on *thought*. Measured
+# on a real self-review: five of nine calls spent 25,963–35,463 tokens reasoning
+# against a 32,768 ceiling, i.e. the whole budget, before writing one finding.
+_REASONING_CEILING = 32768
+_REASONING_SPENT = 32194
 
 
 def _ctx(diff: str, files: list[str]) -> PRContext:
@@ -229,6 +238,107 @@ def test_an_unsplittable_batch_reports_the_ceiling_with_its_salvage() -> None:
     # And it names the lever that can still move. Shrinking is spent, so pointing
     # only at `max_input_tokens` would be advice the reader has already taken.
     assert "`max_tokens`" in summary
+
+
+class _TruncatesOnReasoning(FakeProvider):
+    """Every call spends the whole ceiling thinking, whatever the payload is.
+
+    The shape issue #348 measured: a reasoning model's thinking budget is the
+    same `max_tokens` ceiling, and it does not shrink when the diff does.
+    """
+
+    def __init__(self, partial: str = "") -> None:
+        super().__init__()
+        self.diffs: list[str] = []
+        self._partial = partial
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        self.diffs.append("\n".join(str(m.get("content", "")) for m in messages))
+        raise ProviderTruncated(
+            _CEILING,
+            text=self._partial,
+            reasoning_tokens=_REASONING_SPENT,
+            output_tokens=_REASONING_CEILING,
+        )
+
+
+def test_a_reasoning_dominated_truncation_is_not_split() -> None:
+    """Splitting cannot shrink a thinking budget, so it is not attempted.
+
+    Halving the diff halves the payload, not the reasoning the model does before
+    it answers — issue #348 recorded a fifteen-line diff truncating at the same
+    ceiling. Splitting anyway burns the full ceiling again on every piece and
+    fails identically, which is pure added latency on an already-slow review.
+    """
+    provider = _TruncatesOnReasoning()
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
+
+    assert len(provider.diffs) == 1  # the batch — and no pieces
+    # And it names the lever that can actually move. `max_tokens` cannot: the cap
+    # does not separate thinking from answering, so raising it buys more thought.
+    assert "reasoning_effort" in str(exc_info.value)
+
+
+def test_a_reasoning_dominated_truncation_keeps_its_salvage() -> None:
+    """Not splitting must not become "not salvaging".
+
+    The findings the model completed before the cut are real, already-paid-for
+    work on every path — the one that splits and the one that gives up on size.
+    """
+    partial = _cut_off_json("one.py", "early_change = os.sep", "sep is never validated")
+    findings, summary = LLMReviewEngine(_TruncatesOnReasoning(partial)).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert [f.title for f in findings] == ["sep is never validated"]
+    assert "results may be incomplete" in summary
+    assert "reasoning_effort" in summary
+
+
+def test_a_truncation_that_spent_its_ceiling_on_findings_is_still_split() -> None:
+    """The output-length truncation the split was built for is untouched.
+
+    A model that thought briefly and then wrote to the ceiling really did have
+    more to say than one response could hold — for that one, less to cover is
+    exactly the fix.
+    """
+
+    class _TruncatesWithLittleThought(_TruncatesUntilSmaller):
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            if "one.py" in diff and "two.py" in diff:
+                self.diffs.append(diff)
+                raise ProviderTruncated(
+                    _CEILING,
+                    text="",
+                    reasoning_tokens=2048,
+                    output_tokens=_REASONING_CEILING,
+                )
+            return super().complete(messages, model, **opts)
+
+    provider = _TruncatesWithLittleThought()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    assert len(provider.diffs) == 3  # the batch, then one call per half
+
+
+def test_a_truncation_with_no_reasoning_breakdown_is_still_split() -> None:
+    """Silence from the route is not evidence of thinking.
+
+    Most routes report no reasoning count at all. Reading that as "reasoning
+    dominated" would switch off the split for every provider that stays quiet.
+    """
+    provider = _TruncatesUntilSmaller()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    assert len(provider.diffs) == 3
 
 
 def test_a_piece_that_fails_is_still_reported() -> None:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -467,6 +467,50 @@ class TestOutputCeilingTruncation:
         assert "reasoning" not in str(exc_info.value)
         assert "65536" in str(exc_info.value)
 
+    def test_the_counts_travel_as_numbers_not_only_as_prose(self) -> None:
+        """The diagnosis is data, not a sentence.
+
+        The engine reacts differently to "the answer was too long" and "the
+        thinking ate the ceiling" — the first is fixed by covering less, the
+        second is not fixable by size at all. It can only tell them apart from
+        the two numbers, and re-reading them out of the message would be
+        parsing our own prose.
+        """
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=""),
+                    finish_reason="length",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=900,
+                completion_tokens=16384,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=16200),
+            ),
+        )
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert exc_info.value.reasoning_tokens == 16200
+        assert exc_info.value.output_tokens == 16384
+
+    def test_a_route_without_reasoning_detail_carries_no_reasoning_count(self) -> None:
+        """None, not 0: "the route never said" is not "it thought nothing".
+
+        A caller reading 0 as a measurement would conclude the ceiling went
+        entirely on findings — the opposite diagnosis — from an absence of data.
+        """
+        with patch("litellm.completion", return_value=self._truncated()):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert exc_info.value.reasoning_tokens is None
+        assert exc_info.value.output_tokens == 65536
+
     def test_truncation_still_falls_back_to_the_secondary_model(self) -> None:
         """Permanent stops the *retry*, not the fallback — a different model is a
         genuinely different request and may well fit its answer in budget."""


### PR DESCRIPTION
## What

Two changes to how a truncated review call is handled, both aimed at the failure in #348.

**1. The truncation diagnosis is structured, and a split that cannot help is not attempted.**

`ProviderTruncated` now carries `reasoning_tokens` (`None` — not `0` — when the route reports no breakdown) and `output_tokens`, the ceiling actually reached. The adapter already computed both and then formatted them into a sentence and discarded the numbers; the engine now reads the diagnosis as data, per the "structured output only, never parse prose" rule.

When reasoning accounts for **≥ 90%** of the ceiling, the batch is **not split**. Splitting is right for a wall timeout and for a truncation caused by output length. It is wrong for one caused by reasoning exhaustion: a smaller payload does not shrink a thinking budget, so every piece re-spends the full ceiling and fails identically — pure added latency on an already-slow review. The failure instead names `reasoning_effort`, the lever that bounds thinking. Salvage (`_salvage_truncated`) is preserved on this path exactly as on the others.

**2. The pieces of a split run concurrently.**

`_review_split` looped its pieces serially, from inside a worker already holding a slot in the global fan-out pool — so a splitting lens cost one full model latency per piece. On a run where most lenses truncate (#348: 5+ of 9), that was the single biggest wall-clock multiplier in the system.

## Why 90%

From the measurements in #348 and `.lgtmaybe.yml`, on one self-review against a 32,768-token ceiling:

| lens | reasoning | outcome |
| --- | --- | --- |
| security | 33,660 | truncated |
| security | 35,463 | truncated |
| security | 33,180 | truncated |
| artefacts | 33,775 | truncated |
| artefacts | 25,963 | truncated |
| correctness | 32,194 | truncated (1,003s) |
| correctness | 33,232 | truncated |
| code-health | 28,909 | OK — 97.5% of 29,642 output tokens |
| artefacts | 2,443 | OK — of 2,939 output tokens |

Five of nine calls spent the **entire** ceiling on thought before writing a finding — 0.79 to over 1.0 of the cap, clustering at 0.98+. The failure mode the split exists for is the opposite shape: little thinking, then an answer that runs long, where the ratio sits near zero. The two populations are nowhere near 90% from either side, so the threshold is not delicately placed. At 90%, at most a tenth of the ceiling was left for the answer, so halving the diff cannot buy a complete one.

#348 also records the case that proves shrinking is not the lever at all: a **fifteen-line diff still truncated at 16,384**.

It is deliberately not configurable — it is a diagnosis, not a preference.

## Avoiding the deadlock

The pieces are **not** resubmitted into the global `ThreadPoolExecutor`. A pool worker that submits to its own pool and blocks on the result deadlocks the moment the pool is saturated: every worker waits on work only a free worker could start. They run in a private, bounded executor instead, so that is impossible by construction rather than by argument.

Width is the **backend's** concurrency, not the piece count. `_resolve_workers` was split into `_concurrency_cap(cfg)` (explicit `max_concurrency`, else 1 for single-stream providers, else 8) and the fan-out's task-count clamp on top of it — otherwise a one-lens review, whose pool is sized to one task, would have bounded its split to one too. A single ollama instance still gets its pieces one at a time; at width 1 the executor runs them in submission order, exactly as the old loop did. A splitting worker is blocked rather than calling, so calls in flight peak at fan-out width × piece count, which the adapter's backoff absorbs.

Semantics preserved: `pool.map` yields in submission order, so findings and the reported error stay deterministic; `self._split_batches.add(batch_num)` still fires only when at least one piece answered; and **any** failed piece is still a failed call.

## The deadline

`max_review_seconds` still bounds the split correctly, and slightly better than before. Each piece goes through `_review_lens`, which re-checks the deadline and token budget at execution — so a split beginning past a ceiling costs nothing. Concurrent pieces are both in flight at once rather than sequential, so the overshoot a split in flight can add is still one call's latency, over a shorter wall clock. Guarded by a new test.

## Tests (TDD, red first)

- `tests/providers/test_retry.py` — `test_the_counts_travel_as_numbers_not_only_as_prose`, `test_a_route_without_reasoning_detail_carries_no_reasoning_count`
- `tests/engine/test_truncation_split.py` — `test_a_reasoning_dominated_truncation_is_not_split`, `test_a_reasoning_dominated_truncation_keeps_its_salvage`, `test_a_truncation_that_spent_its_ceiling_on_findings_is_still_split`, `test_a_truncation_with_no_reasoning_breakdown_is_still_split`
- `tests/engine/test_timeout_split.py` — `test_the_pieces_of_a_split_batch_are_reviewed_concurrently`, `test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time`, `test_a_split_starting_past_the_deadline_costs_nothing`

## Specs & docs

- `provider-gateway` / `provider.truncation`: the counts travel as data; a route reporting no breakdown carries `None`, never `0`.
- `review-pipeline` / `engine.timeout-split`: pieces are reviewed concurrently.
- `review-pipeline` / **new** `engine.reasoning-ceiling` (+ `anchors.yml` rule on `_reasoning_exhausted_reason`): a split is only attempted when covering less can help. The old "the failure says nothing about size" scenario moved into it, keeping both sections under the 40-line cap.
- `docs/how-to/reduce-review-cost.md` updated (and `llms-full.txt` regenerated). No `ReviewConfig` field added, so the generated config reference is unchanged.

Gate: `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (1,836 passed), `pytest tests/specs -q`, and `openspec validate --specs` all green.

Fixes #348

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1zKeXbpsNjxkBW6N7oV9P)_