### PR TITLE
fix(providers): deliver the reasoning budget on OpenRouter, and never drop a param in silence

### DIFF
--- a/.lgtmaybe.yml
+++ b/.lgtmaybe.yml
@@ -48,6 +48,19 @@ max_tokens: 32768
 # tokens of thinking. Raising the cap never worked because the cap does not
 # separate thinking from answering — it buys the model more room to think.
 #
-# `low` is the separate lever. If findings start looking shallow, step up to
-# `medium` rather than raising max_tokens again.
+# The table above is real. The conclusion first drawn from it — "`low` is the
+# separate lever, step up to `medium` if findings look shallow" — was not: the
+# lever was never connected. litellm forwards `reasoning_effort` on openrouter
+# only for models its capability map already flags reasoning-capable, and the
+# model this repo points at is not in that map, so `drop_params` discarded the
+# value in silence. The proof it was still being discarded after this line was
+# added: #367's review, with `low` set right here, spent 34,012 reasoning tokens
+# on one lens against the 32,768 ceiling above and truncated.
+#
+# It is connected now — the budget goes out in OpenRouter's own top-level
+# `reasoning` object for models litellm won't forward it for, and a param that
+# would be dropped is warned about at startup instead of vanishing. So the
+# numbers below have yet to be re-measured against a budget that was actually
+# enforced. Read them as the evidence that the cap is the wrong lever, not as
+# evidence about what `low` does. Re-measure before moving this value.
 reasoning_effort: low

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -259,6 +259,28 @@ model more room to think.
 
 Unset sends nothing, so a route without a reasoning channel is unaffected.
 
+#### On OpenRouter, check the log line
+
+litellm forwards `reasoning_effort` to OpenRouter only for models its capability
+map already flags reasoning-capable, and the newest models — the ones a
+reasoning budget is usually set for — are not in it. lgtmaybe sends the budget
+in OpenRouter's own top-level `reasoning` object for those, so the setting is
+enforced either way.
+
+More generally, any configured param the resolved model will not accept is named
+once at startup rather than discarded in silence:
+
+```
+configured params are not supported by this model and will be ignored
+```
+
+If you see that line naming a setting you meant to apply, the setting is not in
+force — pick a different model, or drop the setting. `reasoning_effort: default`
+on OpenRouter is one real case: it is in litellm's vocabulary but not in
+OpenRouter's `reasoning.effort` enum (`none`, `minimal`, `low`, `medium`,
+`high`, `xhigh`), so it is reported rather than quietly turned into a nearby
+level.
+
 ## What costs more, on purpose
 
 One setting in this guide runs the other way: **`mid_review_retrieval`** buys

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3720,6 +3720,28 @@ model more room to think.
 
 Unset sends nothing, so a route without a reasoning channel is unaffected.
 
+#### On OpenRouter, check the log line
+
+litellm forwards `reasoning_effort` to OpenRouter only for models its capability
+map already flags reasoning-capable, and the newest models — the ones a
+reasoning budget is usually set for — are not in it. lgtmaybe sends the budget
+in OpenRouter's own top-level `reasoning` object for those, so the setting is
+enforced either way.
+
+More generally, any configured param the resolved model will not accept is named
+once at startup rather than discarded in silence:
+
+```
+configured params are not supported by this model and will be ignored
+```
+
+If you see that line naming a setting you meant to apply, the setting is not in
+force — pick a different model, or drop the setting. `reasoning_effort: default`
+on OpenRouter is one real case: it is in litellm's vocabulary but not in
+OpenRouter's `reasoning.effort` enum (`none`, `minimal`, `low`, `medium`,
+`high`, `xhigh`), so it is reported rather than quietly turned into a nearby
+level.
+
 ## What costs more, on purpose
 
 One setting in this guide runs the other way: **`mid_review_retrieval`** buys

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -28,6 +28,12 @@ provider.param-drop:
     has: { field: name, regex: '^_drop_rejected_param$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.param-support:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^dropped_params$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.truncation:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -124,6 +124,38 @@ stdout banner SHALL be suppressed, since stdout carries machine-readable output.
 - **WHEN** litellm maps a provider error while `--format json` is in force
 - **THEN** nothing is printed to stdout, so the findings array stays parseable
 
+### Requirement: A configured param is never discarded in silence
+
+The factory SHALL name at startup every param the user configured that litellm's
+capability map says the resolved model will not accept. `drop_params` is on so
+one unsupported param cannot fail a whole review; the cost is that a knob which
+was never connected is otherwise indistinguishable from one that did not help.
+The check is keyed off litellm's own maps rather than a per-param special case,
+and judges only OpenAI-vocabulary params — a provider-native option (ollama's
+`num_ctx`) is not litellm's to drop. As a deliberate, narrowly scoped exception
+to normalising every provider through litellm, a reasoning budget litellm will
+not forward to OpenRouter SHALL instead be sent as OpenRouter's own top-level
+`reasoning` object — and never beside the flat param, which OpenRouter rejects.
+<!-- anchor: provider.param-support -->
+
+#### Scenario: the model has no channel for a configured param
+- **WHEN** a reasoning budget is configured for a model litellm's map says has
+  no reasoning channel
+- **THEN** the run names the ignored param up front, rather than the budget
+  vanishing and leaving a truncated review to be blamed on the diff
+
+#### Scenario: OpenRouter fronts a model litellm's map does not know
+- **WHEN** a reasoning budget is configured on openrouter and litellm would drop
+  it — its transformation forwards the flat param only for models already flagged
+  reasoning-capable, which the newest models are not
+- **THEN** the budget goes out in OpenRouter's native `reasoning` object, and the
+  flat param is not sent alongside it
+
+#### Scenario: the configured value has no equivalent on the route
+- **WHEN** a configured value is outside the route's own vocabulary
+- **THEN** it is reported as ignored rather than translated into a nearby value,
+  which would buy a budget nobody asked for
+
 ### Requirement: A blown output ceiling is named, not retried
 
 A completion that stopped because it ran out of output tokens SHALL be raised

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -14,13 +14,17 @@ litellm model-string conventions:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
+from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.constants import CLOUD_TIMEOUT, DEFAULT_OLLAMA_BASE
 
 if TYPE_CHECKING:
     from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+_log = get_logger(__name__)
 
 _PREFIXES: dict[Provider, str] = {
     Provider.openai: "openai",
@@ -100,6 +104,85 @@ def litellm_model_string(provider: Provider, model: str) -> str:
     return f"{_PREFIXES[provider]}/{model}"
 
 
+# The values OpenRouter's own `reasoning.effort` field accepts. `default` — which
+# litellm's normalised set includes — has no equivalent here, so it is reported
+# as dropped rather than translated into a nearby level nobody asked for.
+_OPENROUTER_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
+
+
+def dropped_params(provider: Provider, model: str, params: Iterable[str]) -> list[str]:
+    """The names in *params* that litellm will silently discard for this model.
+
+    The adapter runs with ``drop_params`` on so one unsupported param can't fail
+    a whole review — the cost is that a param litellm's capability map doesn't
+    list for a model vanishes with no warning at all, and a knob that was never
+    connected is indistinguishable from a knob that didn't help.
+
+    Keyed off litellm's own two maps rather than a per-param special case, so a
+    param added to the config later is covered without touching this function.
+    Only OpenAI-vocabulary params are judged: a provider-native option (ollama's
+    ``num_ctx``/``think``) never appears in the capability map and is not
+    litellm's to drop, so flagging it would only teach the reader to ignore the
+    warning. A lookup failure reports nothing — this is instrumentation, and it
+    must never be the reason a review doesn't run.
+    """
+    import litellm
+
+    # litellm re-exports this but doesn't list it in __all__, so mypy rejects
+    # litellm.OPENAI_CHAT_COMPLETION_PARAMS — import it from where it's defined.
+    from litellm.constants import OPENAI_CHAT_COMPLETION_PARAMS
+
+    try:
+        supported = set(
+            litellm.get_supported_openai_params(
+                model=model, custom_llm_provider=_PREFIXES[provider]
+            )
+            or []
+        )
+    except Exception:  # pragma: no cover - defensive; litellm raises on odd ids
+        return []
+    return sorted(
+        name for name in params if name in OPENAI_CHAT_COMPLETION_PARAMS and name not in supported
+    )
+
+
+def _honour_param_support(provider: Provider, model: str, opts: dict[str, Any]) -> None:
+    """Say (once, up front) which configured params this model will discard, and
+    re-route the one that has a native home on OpenRouter.
+
+    The OpenRouter branch is a DELIBERATE, narrowly scoped exception to the
+    "litellm normalises every provider to one `completion()` call" decision in
+    CLAUDE.md — not licence for general per-provider plumbing. The reason it has
+    to exist here: litellm's openrouter transformation only forwards
+    ``reasoning_effort`` when its capability map already flags the model
+    reasoning-capable, and the newest models are not in that map — which is
+    exactly the set a reasoning budget gets configured for. OpenRouter itself
+    accepts the budget as a top-level ``reasoning`` object regardless of model,
+    so that is what gets sent, via ``extra_body``.
+
+    Never both: OpenRouter answers a request carrying ``reasoning`` *and*
+    ``reasoning_effort`` with ``400 Only one of "reasoning" and
+    "reasoning_effort" may be provided``. So the object is only added on the
+    branch where litellm has already been observed to drop the flat param, and
+    the flat param is removed when it is.
+    """
+    dropped = dropped_params(provider, model, opts)
+    if provider is Provider.openrouter and "reasoning_effort" in dropped:
+        effort = opts.pop("reasoning_effort")
+        if effort in _OPENROUTER_REASONING_EFFORTS:
+            opts["extra_body"] = {**opts.get("extra_body", {}), "reasoning": {"effort": effort}}
+            dropped.remove("reasoning_effort")
+    if dropped:
+        _log.warning(
+            "configured params are not supported by this model and will be ignored",
+            extra={
+                "provider": provider.value,
+                "model": litellm_model_string(provider, model),
+                "ignored_params": dropped,
+            },
+        )
+
+
 def build_provider(
     provider: Provider,
     model: str,
@@ -125,6 +208,12 @@ def build_provider(
     resolved_model = litellm_model_string(provider, model)
     resolved_fallback = litellm_model_string(provider, fallback_model) if fallback_model else None
     opts: dict[str, Any] = dict(extra_opts)
+
+    # Before anything the factory itself adds (timeout, credentials, ollama's own
+    # options), so what is judged is exactly what the USER configured — and it is
+    # judged here because this is where the litellm model string the capability
+    # map keys on comes into existence.
+    _honour_param_support(provider, model, opts)
 
     opts["timeout"] = timeout if timeout is not None else default_timeout_for(provider)
 

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -342,6 +342,32 @@ def test_reasoning_effort_flag_reaches_litellm(captured_completion: list[dict[st
         [
             "review",
             "--provider",
+            "ollama",
+            "--model",
+            "llama3",
+            "--no-reflect",
+            "--reasoning-effort",
+            "low",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured_completion[0].get("reasoning_effort") == "low"
+
+
+def test_reasoning_effort_reaches_openrouter_as_its_native_field(
+    captured_completion: list[dict[str, Any]],
+) -> None:
+    """On openrouter, litellm forwards `reasoning_effort` only for models its
+    capability map flags reasoning-capable — the newest models are not in it, so
+    the budget was silently discarded on exactly the models it was set for. It
+    goes out as OpenRouter's own top-level `reasoning` object instead, and never
+    alongside the flat param (OpenRouter 400s on both together)."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "review",
+            "--provider",
             "openrouter",
             "--model",
             "vendor/m",
@@ -354,7 +380,8 @@ def test_reasoning_effort_flag_reaches_litellm(captured_completion: list[dict[st
     )
 
     assert result.exit_code == 0, result.output
-    assert captured_completion[0].get("reasoning_effort") == "low"
+    assert captured_completion[0].get("extra_body") == {"reasoning": {"effort": "low"}}
+    assert "reasoning_effort" not in captured_completion[0]
 
 
 def test_reasoning_effort_is_absent_by_default(captured_completion: list[dict[str, Any]]) -> None:

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+
+import pytest
+
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.factory import build_provider, litellm_model_string
 
@@ -243,3 +247,132 @@ class TestDefaultTimeout:
             provider.complete([{"role": "user", "content": "hi"}], model="qwen3:27b")
 
         assert mock_completion.call_args.kwargs["model"] == "ollama/qwen3:27b"
+
+
+class TestParamSupport:
+    """A configured param the model will not honour is named, not swallowed.
+
+    litellm runs with ``drop_params`` on (so one unsupported param can't fail a
+    whole review), which means a param its capability map doesn't recognise for
+    a model is discarded with no warning at all. Every case below is judged
+    against litellm's REAL map, except the one that says it stubs it.
+    """
+
+    def test_an_unsupported_param_is_named_at_build_time(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """gpt-4o has no reasoning channel, so litellm drops ``reasoning_effort``.
+        The run has to say so — a silently dropped knob is indistinguishable from
+        a knob that did not work."""
+        with caplog.at_level(logging.WARNING, logger="lgtmaybe.providers.factory"):
+            build_provider(Provider.openai, "gpt-4o", api_key="k", reasoning_effort="low")
+
+        assert any("reasoning_effort" in str(record.__dict__) for record in caplog.records)
+
+    def test_a_supported_param_is_not_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="lgtmaybe.providers.factory"):
+            build_provider(Provider.openai, "gpt-4o", api_key="k", max_tokens=8192)
+
+        assert caplog.records == []
+
+    def test_a_provider_native_option_is_not_warned_about(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``num_ctx`` is ollama's own option, not an OpenAI-vocabulary param, so
+        litellm's map never lists it and it is not litellm's to drop. Warning
+        about it would only train the reader to ignore the warning."""
+        with caplog.at_level(logging.WARNING, logger="lgtmaybe.providers.factory"):
+            build_provider(Provider.ollama, "llama2", num_ctx=32768)
+
+        assert caplog.records == []
+
+    def test_the_check_is_not_a_hardcoded_param_list(self) -> None:
+        """Keyed off litellm's capability map, so a param nobody wrote a special
+        case for is covered too — which is the whole point of the mechanism."""
+        from lgtmaybe.providers.factory import dropped_params
+
+        assert dropped_params(Provider.anthropic, "claude-3-haiku-20240307", ["logprobs"]) == [
+            "logprobs"
+        ]
+
+    def test_a_non_openai_option_is_never_reported_as_dropped(self) -> None:
+        """Only OpenAI-vocabulary params are judged; anything else rides through
+        to the provider as a passthrough."""
+        from lgtmaybe.providers.factory import dropped_params
+
+        assert dropped_params(Provider.ollama, "llama2", ["num_ctx", "think"]) == []
+
+
+class TestOpenRouterReasoning:
+    """OpenRouter's native ``reasoning`` field, for models litellm's map misses."""
+
+    def test_unmapped_model_gets_the_native_reasoning_field(self) -> None:
+        """litellm only forwards ``reasoning_effort`` on openrouter for a model
+        its capability map flags reasoning-capable — which the newest models are
+        not. Those are exactly the models a reasoning budget gets set for, so the
+        budget goes out in OpenRouter's own top-level ``reasoning`` object."""
+        built = build_provider(Provider.openrouter, "vendor/unmapped-model", reasoning_effort="low")
+
+        assert built.default_opts["extra_body"] == {"reasoning": {"effort": "low"}}
+        assert "reasoning_effort" not in built.default_opts
+
+    def test_a_natively_forwarded_model_is_left_alone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OpenRouter rejects a request carrying BOTH fields with ``400 Only one
+        of "reasoning" and "reasoning_effort" may be provided`` — so when litellm
+        will forward the flat param itself, nothing may be injected beside it.
+        The capability map is stubbed here so the guarantee does not depend on a
+        particular model staying in litellm's map across a dependency bump."""
+        import litellm
+
+        real = litellm.get_supported_openai_params
+        monkeypatch.setattr(
+            litellm,
+            "get_supported_openai_params",
+            lambda **kw: [*(real(**kw) or []), "reasoning_effort"],
+        )
+        built = build_provider(
+            Provider.openrouter, "vendor/reasoning-model", reasoning_effort="low"
+        )
+
+        assert built.default_opts.get("reasoning_effort") == "low"
+        assert "extra_body" not in built.default_opts
+
+    def test_a_value_with_no_native_equivalent_is_reported_not_translated(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``default`` is in litellm's normalised set but not in OpenRouter's
+        ``reasoning.effort`` enum (none/minimal/low/medium/high/xhigh). Sending a
+        nearby value instead would quietly buy a budget nobody asked for."""
+        with caplog.at_level(logging.WARNING, logger="lgtmaybe.providers.factory"):
+            built = build_provider(
+                Provider.openrouter, "vendor/unmapped-model", reasoning_effort="default"
+            )
+
+        assert "extra_body" not in built.default_opts
+        assert any("reasoning_effort" in str(record.__dict__) for record in caplog.records)
+
+    def test_the_native_field_survives_litellms_own_transformation(self) -> None:
+        """One layer past our own kwargs: litellm's openrouter transformation
+        assigns its own `extra_body` (for `transforms`/`models`/`route`), so a
+        bump that made that assignment clobber rather than merge would put us
+        back where we started — a budget that looks sent and never leaves."""
+        import litellm
+
+        built = build_provider(Provider.openrouter, "vendor/unmapped-model", reasoning_effort="low")
+        outbound = litellm.get_optional_params(
+            model="vendor/unmapped-model",
+            custom_llm_provider="openrouter",
+            drop_params=True,
+            extra_body=built.default_opts["extra_body"],
+        )
+
+        assert outbound["extra_body"]["reasoning"] == {"effort": "low"}
+
+    def test_no_other_route_is_reshaped(self) -> None:
+        """Scoped to openrouter: every other route keeps the request shape it has
+        always sent."""
+        built = build_provider(Provider.openai, "gpt-4o", api_key="k", reasoning_effort="low")
+
+        assert "extra_body" not in built.default_opts


### PR DESCRIPTION
Closes the loop on #348. `reasoning_effort` has been set in this repo's `.lgtmaybe.yml` since 1.12.0 and was never reaching the model.

## The bug

`cli/__init__.py` puts `reasoning_effort` into the provider opts correctly and ungated. The adapter sets `litellm.drop_params = True` (so one unsupported param can't fail a whole review). litellm's openrouter transformation adds `reasoning_effort` to its supported-params list **only** when `litellm.supports_reasoning(model=...)` is true — i.e. only for models already in litellm's capability map. Everything else is dropped with no warning.

Re-verified against the installed litellm (1.94.1), reading `OpenrouterConfig.get_supported_openai_params` and calling `get_optional_params` directly:

| model | `supports_reasoning` | param forwarded |
|---|---|---|
| `openrouter/~deepseek/deepseek-v4-flash-latest` | False | **no** |
| `openrouter/deepseek/deepseek-v4-flash-latest` | False | **no** |
| `openrouter/deepseek/deepseek-r1` | True | yes |
| `openrouter/anthropic/claude-sonnet-4.5` | True | yes |

It is not the `~` floating-alias prefix — the bare name is unmapped too. The models a reasoning budget gets configured for are precisely the newest ones, which are precisely the ones the map does not know yet.

Live consequence: #367's review, with `reasoning_effort: low` set in this repo's config, still had a lens spend **34,012 reasoning tokens** against the 32,768 `max_tokens` ceiling and truncate.

## Part 1 — never silently discard a configured param

`providers/factory.dropped_params` reads litellm's own two maps — `get_supported_openai_params` for the resolved model, and `OPENAI_CHAT_COMPLETION_PARAMS` for the vocabulary — and names every param the user configured that the model will not accept. One structured warning at startup, next in spirit to the existing "per-call timeout resolved" line:

```
configured params are not supported by this model and will be ignored
  provider=openai model=openai/gpt-4o ignored_params=['reasoning_effort']
```

It runs in the factory rather than the CLI because that is where the litellm model string the capability map keys on comes into existence, and it judges exactly the user-configured opts — before the factory adds its own timeout, credentials, and ollama options.

Deliberately general, deliberately small: keyed off the capability map, so a param added to `ReviewConfig` later is covered without touching this function. Only OpenAI-vocabulary params are judged — a provider-native passthrough like ollama's `num_ctx` never appears in the map and is not litellm's to drop, so flagging it would only train the reader to ignore the warning. A lookup failure reports nothing; this is instrumentation and must never be why a review doesn't run.

## Part 2 — actually deliver the budget on OpenRouter

Verified against OpenRouter's current documentation (`openrouter.ai/docs/guides/best-practices/reasoning-tokens` and the `ChatRequestReasoningEffort` schema in its API reference, via Context7 — the docs site 403s direct fetches):

- the field is a top-level **`reasoning`** object: `{"effort": ..., "max_tokens": ..., "exclude": ..., "enabled": ...}`
- `reasoning.effort` accepts **`xhigh` | `high` | `medium` | `low` | `minimal` | `none`**
- `reasoning_effort` exists as a flat shorthand, and the docs state it "cannot be used simultaneously with reasoning.effort if they differ"

So on the openrouter route only, when litellm has been observed to drop the flat param, the budget goes out as `extra_body={"reasoning": {"effort": ...}}` instead.

**No double-send.** OpenRouter rejects a request carrying both with `400 Only one of "reasoning" and "reasoning_effort" may be provided`. The `extra_body` is added *only* on the branch where `dropped_params` already reported the flat param dropped, and the flat param is popped when it is. When litellm will forward natively (the `deepseek-r1` case), nothing is injected.

**Value mapping.** `ReviewConfig.reasoning_effort` is litellm's normalised set: `none | minimal | low | medium | high | xhigh | default`. Six of the seven are in OpenRouter's enum verbatim and pass through unchanged. **`default` has no equivalent** — it is omitted and reported through Part 1's warning rather than translated into a nearby level, which would quietly buy a budget nobody asked for. (litellm's own openrouter transformation translating `max`→`xhigh` is the hint that this is their vocabulary, not OpenAI's.)

**Scope.** Every other route is byte-identical — asserted directly (`test_no_other_route_is_reshaped`), and the whole existing provider matrix still passes unchanged.

### A deliberate exception, not a precedent

CLAUDE.md's "Key decisions (do not relitigate)" names litellm as the provider spine that "normalises … to one `completion()` call". This is a maintainer-approved exception to that, for **one param on one route**, because litellm's normalisation is keyed on a model list that structurally lags the models people point at. It is called out as such in `_honour_param_support`'s docstring and in the spec. It is not licence for general per-provider plumbing.

## Part 3 — correcting the record

`.lgtmaybe.yml`'s comments concluded `reasoning_effort` was "the separate lever" and told the reader to step up to `medium` if findings looked shallow. That conclusion was reached against a knob that was never connected. The measured table stays — it is real, and it is still the evidence that `max_tokens` is the wrong lever — but the conclusion drawn from it is corrected, with a note to re-measure before moving the value now that the budget is actually enforced.

`docs/how-to/reduce-review-cost.md` gains a short subsection on the OpenRouter path and the new warning line; `docs/llms-full.txt` regenerated.

## Verification — what is genuinely verified vs mock-asserted

**Genuinely verified against real litellm (no mocks):**
- `openrouter/vendor/unmapped-model` drops `reasoning_effort` and `openai/gpt-4o` drops it — both read from litellm's real capability map at test time
- `num_ctx` / `think` are never reported as dropped (real `OPENAI_CHAT_COMPLETION_PARAMS`)
- the mechanism is not param-specific — `logprobs` on `anthropic/claude-3-haiku` is reported, and nobody wrote a case for it
- **the `reasoning` object survives litellm's own openrouter transformation** — `test_the_native_field_survives_litellms_own_transformation` runs the built opts through the real `litellm.get_optional_params`. This matters: `OpenrouterConfig.map_openai_params` *assigns* `mapped_openai_params["extra_body"]` for its own `transforms`/`models`/`route` params, so a future bump that made that assignment clobber rather than merge would put us straight back to a budget that looks sent and never leaves. The test catches that.

**Asserted against a mock:**
- the end-to-end CLI test mocks `litellm.completion` and asserts the kwargs handed to it (the existing `tests/cli/test_provider_threading.py` seam) — real CLI, real config load, real factory, real engine, fake transport
- the "litellm forwards it natively, so don't inject" case stubs `get_supported_openai_params` rather than naming a specific model, so the no-double-send guarantee can't rot into a false pass when a model leaves litellm's map on a dependency bump

**Not verified:** no live OpenRouter call was made (no key). OpenRouter's acceptance of the field is from its published documentation, not from a 200 response. The wire format is documented in two independent places in their docs and corroborated by the 400 error text quoted above.

`test_reasoning_effort_flag_reaches_litellm` previously asserted the flat param reached litellm on `openrouter/vendor/m` — i.e. it asserted the broken behaviour and passed because it stopped one layer above where the drop happens. It now points at ollama, where litellm's map really does forward it.

## Coordination

Stayed entirely out of `providers/litellm_provider.py` — this is request/param assembly, in the factory. **#368** owns the response-mapping region (`ProviderTruncated`, `reasoning_tokens`) and its truncation message. Worth noting: that message names `reasoning_effort` as the lever to reach for, which **becomes accurate once this lands** — today it points at a knob that does nothing on the route this repo actually runs on.

## Gate

`uv run ruff check .` · `uv run ruff format --check .` · `uv run mypy` · `uv run pytest -q` — all green (1838 passed, 3 skipped). `uv run pytest tests/specs -q` green; `openspec validate --specs` green. Spec: one new requirement under `provider-gateway` with a `provider.param-support` anchor bound to `dropped_params`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1zKeXbpsNjxkBW6N7oV9P)_