### PR TITLE
fix(github): render finding confidence as a percentage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,9 @@ autocrlf before checkout.
 - **License:** MIT (already in `LICENSE`).
 - **Posting:** REST review API — batched inline comments + one summary. Every
   posted finding's title line carries its provenance inside the severity
-  brackets — `**[HIGH · security · 8/10] Title**`, the originating lens and the
-  reflection auditor's confidence (`rest_gateway._finding_badge`, each half
+  brackets — `**[HIGH · security · 80%] Title**`, the originating lens and the
+  reflection auditor's confidence as a percentage of its 0-10 score
+  (`rest_gateway._finding_badge`, each half
   omitted when absent; inline, demoted, and broad render it identically). It is
   visible prose only — never part of the hidden ids below.
   Idempotent updates via a hidden marker comment (which also carries the

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -378,7 +378,7 @@ same PR **updates** the existing review instead of creating duplicates.
 A comment's title line carries the finding's provenance in its brackets:
 
 ```
-**[HIGH · security · 8/10] User input is concatenated into the SQL string**
+**[HIGH · security · 80%] User input is concatenated into the SQL string**
 ```
 
 - **`HIGH`** — the severity.
@@ -386,9 +386,10 @@ A comment's title line carries the finding's provenance in its brackets:
   (or your own id if you added a [custom lens](../how-to/add-a-custom-lens.md)),
   and the same value you match on in `finding_rules` — so a badge you keep seeing
   and don't want tells you exactly what rule to write.
-- **`8/10`** — the self-reflection auditor's confidence that the finding is real,
-  reached by actively trying to disprove it. Set the `min_confidence` floor to
-  drop everything below a score you choose.
+- **`80%`** — the self-reflection auditor's confidence that the finding is real,
+  reached by actively trying to disprove it. It is the auditor's 0-10 score shown
+  as a percentage, so `min_confidence: 5` is the same floor as `50%`. Set that
+  floor to drop everything below a score you choose.
 
 Each half drops away when it isn't there: with `reflect: false` there is no score
 and the badge is just the lens.

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -337,9 +337,9 @@ During reflection the auditor also scores each kept finding's confidence from
 0 (certainly a false positive) to 10 (certain it is real), reached by actively
 trying to disprove the finding against the diff and the file text. Findings
 scored **below** `min_confidence` are dropped before posting; the surviving
-score is shown in the CLI output, the JSON export, and on the posted GitHub
-comment itself — `**[HIGH · security · 8/10] Title**`, alongside the lens that
-raised it. A finding the auditor keeps but doesn't score always survives the
+score is shown in the CLI output, the JSON export, and — as a percentage — on the
+posted GitHub comment itself: `**[HIGH · security · 80%] Title**`, alongside the
+lens that raised it. A finding the auditor keeps but doesn't score always survives the
 threshold — a missing score never drops a real finding, and the comment simply
 omits that half of the badge (as it does for every finding when `reflect:
 false`). CLI: `--min-confidence`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2459,9 +2459,9 @@ During reflection the auditor also scores each kept finding's confidence from
 0 (certainly a false positive) to 10 (certain it is real), reached by actively
 trying to disprove the finding against the diff and the file text. Findings
 scored **below** `min_confidence` are dropped before posting; the surviving
-score is shown in the CLI output, the JSON export, and on the posted GitHub
-comment itself — `**[HIGH · security · 8/10] Title**`, alongside the lens that
-raised it. A finding the auditor keeps but doesn't score always survives the
+score is shown in the CLI output, the JSON export, and — as a percentage — on the
+posted GitHub comment itself: `**[HIGH · security · 80%] Title**`, alongside the
+lens that raised it. A finding the auditor keeps but doesn't score always survives the
 threshold — a missing score never drops a real finding, and the comment simply
 omits that half of the badge (as it does for every finding when `reflect:
 false`). CLI: `--min-confidence`.
@@ -5633,7 +5633,7 @@ same PR **updates** the existing review instead of creating duplicates.
 A comment's title line carries the finding's provenance in its brackets:
 
 ```
-**[HIGH · security · 8/10] User input is concatenated into the SQL string**
+**[HIGH · security · 80%] User input is concatenated into the SQL string**
 ```
 
 - **`HIGH`** — the severity.
@@ -5641,9 +5641,10 @@ A comment's title line carries the finding's provenance in its brackets:
   (or your own id if you added a [custom lens](../how-to/add-a-custom-lens.md)),
   and the same value you match on in `finding_rules` — so a badge you keep seeing
   and don't want tells you exactly what rule to write.
-- **`8/10`** — the self-reflection auditor's confidence that the finding is real,
-  reached by actively trying to disprove it. Set the `min_confidence` floor to
-  drop everything below a score you choose.
+- **`80%`** — the self-reflection auditor's confidence that the finding is real,
+  reached by actively trying to disprove it. It is the auditor's 0-10 score shown
+  as a percentage, so `min_confidence: 5` is the same floor as `50%`. Set that
+  floor to drop everything below a score you choose.
 
 Each half drops away when it isn't there: with `reflect: false` there is no score
 and the badge is just the lens.

--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -77,17 +77,17 @@ floors what is worth demoting.
 ### Requirement: A posted finding names its lens and confidence
 
 Every posted finding SHALL carry the lens that raised it and the reflection
-auditor's confidence in its title line, so a GitHub reader can weigh it without
-leaving the PR. Both halves are omitted when absent — no category renders no
-badge at all, and no score renders the lens alone — and the badge is visible
-prose only, never part of the hidden fingerprint/identity markers that key
-re-run dedupe and resolve-on-fix. Inline, demoted, and broad findings SHALL
-render it identically.
+auditor's confidence in its title line — the 0-10 score rendered as a
+percentage — so a GitHub reader can weigh it without leaving the PR. Both halves
+are omitted when absent — no category renders no badge at all, and no score
+renders the lens alone — and the badge is visible prose only, never part of the
+hidden fingerprint/identity markers that key re-run dedupe and resolve-on-fix.
+Inline, demoted, and broad findings SHALL render it identically.
 <!-- anchor: github.finding-badge -->
 
 #### Scenario: a scored finding from a lens
 - **WHEN** a finding carries a category and a confidence score
-- **THEN** its title line reads `**[HIGH · security · 8/10] Title**`
+- **THEN** its title line reads `**[HIGH · security · 80%] Title**`
 
 #### Scenario: reflection is off
 - **WHEN** a finding has a category but no score

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -196,9 +196,13 @@ def _finding_badge(f: ReviewFinding) -> str:
     auditor gave it (``confidence``) — but a GitHub reader could never see them.
     They answer the two questions a reviewer asks of a bot comment: which pass
     raised this, and how sure was it. Rendered inside the existing severity
-    brackets (``**[HIGH · security · 8/10] Title**``) so the title line gains no
+    brackets (``**[HIGH · security · 80%] Title**``) so the title line gains no
     new visual furniture, and appended by the caller so it can never displace the
     hidden fingerprint/identity markers that key re-run dedupe.
+
+    The 0-10 score is shown as a **percentage** — "how likely is this a real
+    issue" reads plainly as ``80%``, where ``8/10`` invites a reader to mistake
+    it for a rating out of ten. The scale is unchanged; only the rendering is.
 
     Each half is omitted when absent, so nothing renders empty: no category (a
     legacy finding) means no badge at all — byte-identical to the pre-badge
@@ -209,7 +213,7 @@ def _finding_badge(f: ReviewFinding) -> str:
     if not f.category:
         return ""
     badge = f" · {_defang_fences(f.category)}"
-    return badge if f.confidence is None else f"{badge} · {f.confidence}/10"
+    return badge if f.confidence is None else f"{badge} · {f.confidence * 10}%"
 
 
 def _marker(family: str, key: str | None) -> str:

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1411,7 +1411,7 @@ def test_inline_comment_title_carries_lens_and_confidence() -> None:
     gw.post_review([_badged()], "Summary text", diff=SAMPLE_DIFF)
 
     body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
-    assert body.startswith("**[MEDIUM · security · 8/10] Import order**")
+    assert body.startswith("**[MEDIUM · security · 80%] Import order**")
 
 
 @respx.mock
@@ -1425,12 +1425,12 @@ def test_inline_comment_badge_omits_confidence_when_unscored() -> None:
 
     body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
     assert body.startswith("**[MEDIUM · security] Import order**")
-    assert "/10" not in body
+    assert "%" not in body
 
 
 @respx.mock
 def test_inline_comment_badge_renders_a_zero_score() -> None:
-    """0/10 is a real verdict, not a missing one — it must still render (the
+    """0% is a real verdict, not a missing one — it must still render (the
     falsy-vs-None trap)."""
     created = _capture_created_review()
 
@@ -1438,7 +1438,7 @@ def test_inline_comment_badge_renders_a_zero_score() -> None:
     gw.post_review([_badged(confidence=0)], "Summary text", diff=SAMPLE_DIFF)
 
     body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
-    assert body.startswith("**[MEDIUM · security · 0/10] Import order**")
+    assert body.startswith("**[MEDIUM · security · 0%] Import order**")
 
 
 @respx.mock
@@ -1469,7 +1469,7 @@ def test_demoted_finding_carries_the_badge() -> None:
 
     rendered = str(created[0].get("body", ""))
     assert "### Additional findings" in rendered
-    assert "**[MEDIUM · security · 8/10] Import order**" in rendered
+    assert "**[MEDIUM · security · 80%] Import order**" in rendered
 
 
 @respx.mock
@@ -1482,7 +1482,7 @@ def test_broad_finding_carries_the_badge() -> None:
 
     rendered = str(created[0].get("body", ""))
     assert "Broader observations" in rendered
-    assert "**[MEDIUM · security · 8/10] Import order**" in rendered
+    assert "**[MEDIUM · security · 80%] Import order**" in rendered
 
 
 @respx.mock
@@ -1501,8 +1501,8 @@ def test_badge_leaves_the_hidden_markers_byte_identical() -> None:
     gw.post_review([unscored], "Summary text", diff=SAMPLE_DIFF)
     unscored_body = str(created[0]["comments"][0]["body"])  # type: ignore[index]
 
-    assert "· security · 8/10" in scored_body
-    assert "8/10" not in unscored_body
+    assert "· security · 80%" in scored_body
+    assert "80%" not in unscored_body
     marker_tail = scored_body[scored_body.index("\n\n<!-- lgtmaybe-finding:") :]
     assert marker_tail == unscored_body[unscored_body.index("\n\n<!-- lgtmaybe-finding:") :]
     # And they are exactly the ids derived from the finding — no badge text leaks in.


### PR DESCRIPTION
## What

The posted finding badge showed the reflection auditor's confidence as `8/10`, which reads as a rating out of ten rather than "how likely is this a real issue". It now renders as a percentage:

```
before:  **[MEDIUM · security · 9/10] Title**
after:   **[MEDIUM · security · 90%] Title**
```

## Why

`x/10` invites a reader to weigh the finding on a quality scale. The number is a *certainty* — the probability the auditor puts on the finding being a real issue after actively trying to disprove it — and a percentage says that plainly.

## Scope

One expression in `rest_gateway._finding_badge`. Everything around it is unchanged:

- the 0–10 scale, `min_confidence`, and the CLI human/JSON output keep their existing form (`min_confidence: 5` is the same floor as the badge's `50%`)
- both badge halves still drop away when absent — no category renders no badge, no score renders the lens alone
- `0` is still a real verdict and still renders, now as `0%`
- the hidden fingerprint/identity markers are untouched, so re-run dedupe and resolve-on-fix still match comments posted with the old format

Inline, demoted, and broad findings all pick up the new rendering together, since they share the one badge function.

## Tests

Red-first: the badge assertions in `tests/github/test_post_review.py` were updated to `80%` / `0%` (and the unscored case now asserts no `%` at all), watched fail, then the renderer changed. Full suite green — 1871 passed, ruff clean.

## Docs & specs

`openspec/specs/github-posting/spec.md` (the `github.finding-badge` requirement + its scored scenario), `docs/explanation/what-gets-reviewed.md`, `docs/how-to/configure-lgtmaybe-yml.md`, `CLAUDE.md`, and the regenerated `docs/llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbLs9kVi2MR2nqA4JM67fk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbLs9kVi2MR2nqA4JM67fk)_