### PR TITLE
fix: stop one flaky provider call voiding a whole review round

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ changes only how they are scheduled, so a cloud review overlaps them while a
 single-slot local one runs them in turn. `--preset full` (or `preset: full` in
 `.lgtmaybe.yml`) restores the one-call-per-lens deep audit for release branches.
 On top of that, all calls across all batches share **one concurrency pool**
-(`max_concurrency`, default 8 on cloud providers) and share a **cached
+(`max_concurrency`, default 6 on cloud providers) and share a **cached
 preamble-plus-diff prefix** on the routes that support it, so the diff is
 processed once per batch, not once per lens. Add `--profile` to any run to see exactly where
 the time and tokens went.
@@ -80,7 +80,7 @@ latency:
 - `preset` (default `fast`) — four calls, one per concern (security, correctness, code health, artefacts), the same on every provider; `full` runs one call per lens.
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
-- `max_concurrency` (default 8 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.
+- `max_concurrency` (default 6 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.
 - `recursive` (default on) — when a single file's diff exceeds that budget, walks it hunk-by-hunk instead of sending it whole; `--no-recursive` sends files whole.
 - `categories` (default all nine) — which review lenses to run; an explicit list overrides the preset grouping and runs exactly those lenses, one call each.
 - `min_severity` (default `low`) plus `include_paths` / `exclude_paths` — focus the review on what you care about.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -226,18 +226,22 @@ network recovers but a dead-end failure surfaces fast:
   few seconds lands all four in the same window, where they can only fail
   identically. Rate limits therefore back off on a 5s–60s ladder instead, and
   prefer the server's own **`Retry-After`** when it sends one (in either RFC
-  form, clamped so a gateway asking for an hour can't eat the run's wall clock).
-  Both ladders stay inside the same 2.5× retry budget below.
+  form, clamped at 120s so a gateway asking for an hour can't eat the run's wall
+  clock). Both ladders stay inside the same 2.5× retry budget below — which is
+  weighed against the *upcoming* wait, so a backoff that would blow the budget
+  ends the call instead of being slept.
 
 - **A call that failed on the provider gets one more go.** Once the fan-out has
   drained, the calls that failed *provider-side* are re-run once, in a narrow
   pool of their own. This is the difference between a review and a partial one:
   a single flaky call used to void the whole round's verdict, and the findings
   that lens would have made were lost until somebody re-ran by hand. Nothing
-  else is rescued — unparseable output re-runs to the same unparseable answer at
-  temperature 0, a truncation runs to the same output ceiling, a batch the split
-  (below) already retried has had the one retry that can help, and a ceiling you
-  set is not a fault to retry past. Every rescue re-checks the deadline, the
+  else is left alone, because a second attempt would repeat the same failure at
+  full price: unparseable output returns the same unparseable answer at
+  temperature 0, a truncation runs to the same output ceiling, a batch already
+  retried by the split (below) has had the one retry that can help, a dead key
+  or spent quota cannot resolve itself mid-review, and a ceiling you set is not
+  a fault to retry past. Every rescue re-checks the deadline, the
   token budget and the interrupt first, and a healthy run costs **zero** extra
   calls.
 
@@ -275,9 +279,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a
-  provider error, unparseable output) raises it — naming the lenses it lost, since
-  a missing security lens and a missing documentation lens are the same count and
-  very different news — and the engine stamps a hidden
+  provider error, unparseable output) raises it — naming the lenses it lost and
+  why, since a missing security lens and a missing documentation lens are the
+  same count and very different news — and the engine stamps a hidden
   `<!-- lgtmaybe-incomplete -->` marker alongside it. Because a re-run can only
   update the *first* run's review body in place — a silent edit, while this run's
   new findings arrive as individual review comments GitHub wraps in bodyless
@@ -287,8 +291,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **One global fan-out pool.** Every (batch, lens) call runs through a single
   `ThreadPoolExecutor` sized by `max_concurrency` — default **6 workers** for
-  hosted providers (every extra worker cuts a full-latency wave off the wall
-  clock, but the fan-out is *one* API key, and past some width the burst
+  hosted providers (an extra worker can cut a full-latency wave off the wall
+  clock — see the formula below — but the fan-out is *one* API key, and past
+  some width the burst
   rate-limits itself against a per-minute-metered gateway; raise it if your rate
   tier is generous), **1** for ollama (a single local instance serves a model
   one request at a time, so concurrent calls would only queue up and time out)

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -87,7 +87,7 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    same four run on every provider — worker count changes only how they are
    scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
-   provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
+   provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
 
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
@@ -218,6 +218,29 @@ network recovers but a dead-end failure surfaces fast:
   to be shrunk — a silent split would hide that every run is at the edge of what
   the model finishes in time.
 
+- **A rate limit waits on its own, much slower ladder.** The general ladder
+  starts at a tenth of a second, which is right for a blip — a connection reset,
+  an ollama server warming up — because the condition is gone by the time the
+  next request lands. A capacity 429 is not a blip: the gateways that meter an
+  API key meter it *per minute*, so a ladder that fits all four attempts inside a
+  few seconds lands all four in the same window, where they can only fail
+  identically. Rate limits therefore back off on a 5s–60s ladder instead, and
+  prefer the server's own **`Retry-After`** when it sends one (in either RFC
+  form, clamped so a gateway asking for an hour can't eat the run's wall clock).
+  Both ladders stay inside the same 2.5× retry budget below.
+
+- **A call that failed on the provider gets one more go.** Once the fan-out has
+  drained, the calls that failed *provider-side* are re-run once, in a narrow
+  pool of their own. This is the difference between a review and a partial one:
+  a single flaky call used to void the whole round's verdict, and the findings
+  that lens would have made were lost until somebody re-ran by hand. Nothing
+  else is rescued — unparseable output re-runs to the same unparseable answer at
+  temperature 0, a truncation runs to the same output ceiling, a batch the split
+  (below) already retried has had the one retry that can help, and a ceiling you
+  set is not a fault to retry past. Every rescue re-checks the deadline, the
+  token budget and the interrupt first, and a healthy run costs **zero** extra
+  calls.
+
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers
   — lgtmaybe owns the retry policy in one place.
@@ -252,7 +275,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a
-  provider error, unparseable output) raises it, and the engine stamps a hidden
+  provider error, unparseable output) raises it — naming the lenses it lost, since
+  a missing security lens and a missing documentation lens are the same count and
+  very different news — and the engine stamps a hidden
   `<!-- lgtmaybe-incomplete -->` marker alongside it. Because a re-run can only
   update the *first* run's review body in place — a silent edit, while this run's
   new findings arrive as individual review comments GitHub wraps in bodyless
@@ -261,9 +286,11 @@ network recovers but a dead-end failure surfaces fast:
   outright posts its failure notice the same way.
 
 - **One global fan-out pool.** Every (batch, lens) call runs through a single
-  `ThreadPoolExecutor` sized by `max_concurrency` — default **8 workers** for
-  hosted providers (the classified retry backoff absorbs a capacity 429 on a
-  lower-tier account), **1** for ollama (a single local instance serves a model
+  `ThreadPoolExecutor` sized by `max_concurrency` — default **6 workers** for
+  hosted providers (every extra worker cuts a full-latency wave off the wall
+  clock, but the fan-out is *one* API key, and past some width the burst
+  rate-limits itself against a per-minute-metered gateway; raise it if your rate
+  tier is generous), **1** for ollama (a single local instance serves a model
   one request at a time, so concurrent calls would only queue up and time out)
   and **1** for openai-compatible (honest about a single-slot llama.cpp/LM
   Studio server; raise it explicitly for a batching vLLM server). Flattening

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -390,7 +390,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
-| `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
+| `max_concurrency` | 6 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |

--- a/docs/how-to/review-with-openrouter.md
+++ b/docs/how-to/review-with-openrouter.md
@@ -94,6 +94,27 @@ lgtmaybe treats this refusal as permanent and stops after one attempt — your
 balance cannot grow mid-review, so retrying every lens would only waste runner
 time before reporting the same failure.
 
+## Rate limits
+
+A *capacity* 429 is different: it is temporary, and lgtmaybe handles it for you.
+Rate-limited calls back off on a 5s–60s ladder — long enough to reach a fresh
+per-minute window — and honour OpenRouter's own `Retry-After` when it sends one.
+Anything still failing when the fan-out drains is re-run once. You will usually
+see nothing at all; a review that could not recover says so in its summary, and
+names the lens it lost.
+
+If you *are* seeing rate limits, the review's own burst is worth a look before
+the model is. Every `(batch, lens)` call shares one concurrency pool and one API
+key, so a wide fan-out can meter itself:
+
+```yaml
+max_concurrency: 3
+```
+
+OpenRouter's per-key request limits scale with your credit balance, and free
+model variants carry their own hard daily and per-minute caps, so a paid model
+on a topped-up key rate-limits far less than the same review on a free one.
+
 ## Persist non-secret defaults
 
 ```yaml

--- a/docs/how-to/review-with-openrouter.md
+++ b/docs/how-to/review-with-openrouter.md
@@ -98,10 +98,15 @@ time before reporting the same failure.
 
 A *capacity* 429 is different: it is temporary, and lgtmaybe handles it for you.
 Rate-limited calls back off on a 5s–60s ladder — long enough to reach a fresh
-per-minute window — and honour OpenRouter's own `Retry-After` when it sends one.
-Anything still failing when the fan-out drains is re-run once. You will usually
-see nothing at all; a review that could not recover says so in its summary, and
-names the lens it lost.
+per-minute window — and honour OpenRouter's own `Retry-After` when it sends one
+(clamped at 120s). A lens still failing on the provider when the fan-out drains
+is re-run once more. That rescue is only for provider-side failures: unparseable
+output, a blown `max_tokens` ceiling, a batch the oversized-diff split already
+retried, an unrecoverable failure like a spent quota, and any ceiling you set
+(`max_review_seconds`, `max_review_tokens`, a cancelled job) are all left alone,
+because a second attempt would buy the same answer at full price. You will
+usually see none of this; a review that could not recover says so in its
+summary, and names the lens it lost.
 
 If you *are* seeing rate limits, the review's own burst is worth a look before
 the model is. Every `(batch, lens)` call shares one concurrency pool and one API
@@ -111,9 +116,14 @@ key, so a wide fan-out can meter itself:
 max_concurrency: 3
 ```
 
-OpenRouter's per-key request limits scale with your credit balance, and free
-model variants carry their own hard daily and per-minute caps, so a paid model
-on a topped-up key rate-limits far less than the same review on a free one.
+Beyond that it is an account question rather than a lgtmaybe one. OpenRouter's
+limits on **free** model variants (the `:free` suffix) are account-wide rather
+than per-model, and the daily allowance depends on how much credit the account
+has bought — so the same review is far more likely to be throttled on a free
+variant than a paid one. **Paid** models carry no OpenRouter platform request
+cap, though the upstream provider behind a given model can still rate-limit you.
+Neither is the same thing as a per-key credit *spending* cap, which limits what a
+key may spend, not how often it may call.
 
 ## Persist non-secret defaults
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -232,7 +232,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
-| `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
+| `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1072,10 +1072,15 @@ time before reporting the same failure.
 
 A *capacity* 429 is different: it is temporary, and lgtmaybe handles it for you.
 Rate-limited calls back off on a 5s–60s ladder — long enough to reach a fresh
-per-minute window — and honour OpenRouter's own `Retry-After` when it sends one.
-Anything still failing when the fan-out drains is re-run once. You will usually
-see nothing at all; a review that could not recover says so in its summary, and
-names the lens it lost.
+per-minute window — and honour OpenRouter's own `Retry-After` when it sends one
+(clamped at 120s). A lens still failing on the provider when the fan-out drains
+is re-run once more. That rescue is only for provider-side failures: unparseable
+output, a blown `max_tokens` ceiling, a batch the oversized-diff split already
+retried, an unrecoverable failure like a spent quota, and any ceiling you set
+(`max_review_seconds`, `max_review_tokens`, a cancelled job) are all left alone,
+because a second attempt would buy the same answer at full price. You will
+usually see none of this; a review that could not recover says so in its
+summary, and names the lens it lost.
 
 If you *are* seeing rate limits, the review's own burst is worth a look before
 the model is. Every `(batch, lens)` call shares one concurrency pool and one API
@@ -1085,9 +1090,14 @@ key, so a wide fan-out can meter itself:
 max_concurrency: 3
 ```
 
-OpenRouter's per-key request limits scale with your credit balance, and free
-model variants carry their own hard daily and per-minute caps, so a paid model
-on a topped-up key rate-limits far less than the same review on a free one.
+Beyond that it is an account question rather than a lgtmaybe one. OpenRouter's
+limits on **free** model variants (the `:free` suffix) are account-wide rather
+than per-model, and the daily allowance depends on how much credit the account
+has bought — so the same review is far more likely to be throttled on a free
+variant than a paid one. **Paid** models carry no OpenRouter platform request
+cap, though the upstream provider behind a given model can still rate-limit you.
+Neither is the same thing as a per-key credit *spending* cap, which limits what a
+key may spend, not how often it may call.
 
 ## Persist non-secret defaults
 
@@ -5688,7 +5698,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
-| `max_concurrency` | 8 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
+| `max_concurrency` | 6 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
@@ -6087,18 +6097,22 @@ network recovers but a dead-end failure surfaces fast:
   few seconds lands all four in the same window, where they can only fail
   identically. Rate limits therefore back off on a 5s–60s ladder instead, and
   prefer the server's own **`Retry-After`** when it sends one (in either RFC
-  form, clamped so a gateway asking for an hour can't eat the run's wall clock).
-  Both ladders stay inside the same 2.5× retry budget below.
+  form, clamped at 120s so a gateway asking for an hour can't eat the run's wall
+  clock). Both ladders stay inside the same 2.5× retry budget below — which is
+  weighed against the *upcoming* wait, so a backoff that would blow the budget
+  ends the call instead of being slept.
 
 - **A call that failed on the provider gets one more go.** Once the fan-out has
   drained, the calls that failed *provider-side* are re-run once, in a narrow
   pool of their own. This is the difference between a review and a partial one:
   a single flaky call used to void the whole round's verdict, and the findings
   that lens would have made were lost until somebody re-ran by hand. Nothing
-  else is rescued — unparseable output re-runs to the same unparseable answer at
-  temperature 0, a truncation runs to the same output ceiling, a batch the split
-  (below) already retried has had the one retry that can help, and a ceiling you
-  set is not a fault to retry past. Every rescue re-checks the deadline, the
+  else is left alone, because a second attempt would repeat the same failure at
+  full price: unparseable output returns the same unparseable answer at
+  temperature 0, a truncation runs to the same output ceiling, a batch already
+  retried by the split (below) has had the one retry that can help, a dead key
+  or spent quota cannot resolve itself mid-review, and a ceiling you set is not
+  a fault to retry past. Every rescue re-checks the deadline, the
   token budget and the interrupt first, and a healthy run costs **zero** extra
   calls.
 
@@ -6136,9 +6150,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a
-  provider error, unparseable output) raises it — naming the lenses it lost, since
-  a missing security lens and a missing documentation lens are the same count and
-  very different news — and the engine stamps a hidden
+  provider error, unparseable output) raises it — naming the lenses it lost and
+  why, since a missing security lens and a missing documentation lens are the
+  same count and very different news — and the engine stamps a hidden
   `<!-- lgtmaybe-incomplete -->` marker alongside it. Because a re-run can only
   update the *first* run's review body in place — a silent edit, while this run's
   new findings arrive as individual review comments GitHub wraps in bodyless
@@ -6148,8 +6162,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **One global fan-out pool.** Every (batch, lens) call runs through a single
   `ThreadPoolExecutor` sized by `max_concurrency` — default **6 workers** for
-  hosted providers (every extra worker cuts a full-latency wave off the wall
-  clock, but the fan-out is *one* API key, and past some width the burst
+  hosted providers (an extra worker can cut a full-latency wave off the wall
+  clock — see the formula below — but the fan-out is *one* API key, and past
+  some width the burst
   rate-limits itself against a per-minute-metered gateway; raise it if your rate
   tier is generous), **1** for ollama (a single local instance serves a model
   one request at a time, so concurrent calls would only queue up and time out)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -594,7 +594,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
-| `max_concurrency` | auto (8 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
+| `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
@@ -1067,6 +1067,27 @@ them more headroom than a plain model.
 lgtmaybe treats this refusal as permanent and stops after one attempt — your
 balance cannot grow mid-review, so retrying every lens would only waste runner
 time before reporting the same failure.
+
+## Rate limits
+
+A *capacity* 429 is different: it is temporary, and lgtmaybe handles it for you.
+Rate-limited calls back off on a 5s–60s ladder — long enough to reach a fresh
+per-minute window — and honour OpenRouter's own `Retry-After` when it sends one.
+Anything still failing when the fan-out drains is re-run once. You will usually
+see nothing at all; a review that could not recover says so in its summary, and
+names the lens it lost.
+
+If you *are* seeing rate limits, the review's own burst is worth a look before
+the model is. Every `(batch, lens)` call shares one concurrency pool and one API
+key, so a wide fan-out can meter itself:
+
+```yaml
+max_concurrency: 3
+```
+
+OpenRouter's per-key request limits scale with your credit balance, and free
+model variants carry their own hard daily and per-minute caps, so a paid model
+on a topped-up key rate-limits far less than the same review on a free one.
 
 ## Persist non-secret defaults
 
@@ -5927,7 +5948,7 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    same four run on every provider — worker count changes only how they are
    scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
-   provider port, sized by `max_concurrency` (default 8 for cloud, 1 for
+   provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
 
    With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
@@ -6058,6 +6079,29 @@ network recovers but a dead-end failure surfaces fast:
   to be shrunk — a silent split would hide that every run is at the edge of what
   the model finishes in time.
 
+- **A rate limit waits on its own, much slower ladder.** The general ladder
+  starts at a tenth of a second, which is right for a blip — a connection reset,
+  an ollama server warming up — because the condition is gone by the time the
+  next request lands. A capacity 429 is not a blip: the gateways that meter an
+  API key meter it *per minute*, so a ladder that fits all four attempts inside a
+  few seconds lands all four in the same window, where they can only fail
+  identically. Rate limits therefore back off on a 5s–60s ladder instead, and
+  prefer the server's own **`Retry-After`** when it sends one (in either RFC
+  form, clamped so a gateway asking for an hour can't eat the run's wall clock).
+  Both ladders stay inside the same 2.5× retry budget below.
+
+- **A call that failed on the provider gets one more go.** Once the fan-out has
+  drained, the calls that failed *provider-side* are re-run once, in a narrow
+  pool of their own. This is the difference between a review and a partial one:
+  a single flaky call used to void the whole round's verdict, and the findings
+  that lens would have made were lost until somebody re-ran by hand. Nothing
+  else is rescued — unparseable output re-runs to the same unparseable answer at
+  temperature 0, a truncation runs to the same output ceiling, a batch the split
+  (below) already retried has had the one retry that can help, and a ceiling you
+  set is not a fault to retry past. Every rescue re-checks the deadline, the
+  token budget and the interrupt first, and a healthy run costs **zero** extra
+  calls.
+
 - **One retry layer.** litellm's own internal retry loop is disabled
   (`num_retries=0`) so failures aren't ground through two stacked backoff layers
   — lgtmaybe owns the retry policy in one place.
@@ -6092,7 +6136,9 @@ network recovers but a dead-end failure surfaces fast:
 
 - **Incompleteness is visible on the PR, not just in the log.** The notice above
   is not specific to the deadline: *any* failed lens call (a per-call timeout, a
-  provider error, unparseable output) raises it, and the engine stamps a hidden
+  provider error, unparseable output) raises it — naming the lenses it lost, since
+  a missing security lens and a missing documentation lens are the same count and
+  very different news — and the engine stamps a hidden
   `<!-- lgtmaybe-incomplete -->` marker alongside it. Because a re-run can only
   update the *first* run's review body in place — a silent edit, while this run's
   new findings arrive as individual review comments GitHub wraps in bodyless
@@ -6101,9 +6147,11 @@ network recovers but a dead-end failure surfaces fast:
   outright posts its failure notice the same way.
 
 - **One global fan-out pool.** Every (batch, lens) call runs through a single
-  `ThreadPoolExecutor` sized by `max_concurrency` — default **8 workers** for
-  hosted providers (the classified retry backoff absorbs a capacity 429 on a
-  lower-tier account), **1** for ollama (a single local instance serves a model
+  `ThreadPoolExecutor` sized by `max_concurrency` — default **6 workers** for
+  hosted providers (every extra worker cuts a full-latency wave off the wall
+  clock, but the fan-out is *one* API key, and past some width the burst
+  rate-limits itself against a per-minute-metered gateway; raise it if your rate
+  tier is generous), **1** for ollama (a single local instance serves a model
   one request at a time, so concurrent calls would only queue up and time out)
   and **1** for openai-compatible (honest about a single-slot llama.cpp/LM
   Studio server; raise it explicitly for a batching vLLM server). Flattening

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -22,6 +22,12 @@ provider.complete:
       stopBy: end
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.backoff:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_retry_wait$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.param-drop:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -97,6 +97,32 @@ cause, since a ceiling-hitting call offers no healthy call to compare against.
 - **WHEN** retries on the primary model are exhausted and a fallback is set
 - **THEN** the call completes on the fallback model instead of failing the review
 
+### Requirement: Backoff matches what failed
+
+Retry backoff SHALL be chosen by the failure. A capacity rate limit SHALL back
+off far enough to reach a fresh metering window, and SHALL prefer the server's
+own `Retry-After` when one is sent, clamped so a long hint cannot consume the
+run. Every other transient failure SHALL keep the sub-second ladder, and both
+SHALL stay inside the call's existing retry budget.
+<!-- anchor: provider.backoff -->
+
+#### Scenario: the gateway meters the key per minute
+- **WHEN** a call is refused with a capacity 429 and no retry hint
+- **THEN** the attempts are spread across minutes rather than seconds, so they do
+  not all land in the window that just refused them
+
+#### Scenario: the gateway says when to come back
+- **WHEN** a 429 carries a `Retry-After` header, in either delta-seconds or
+  HTTP-date form
+- **THEN** that wait is honoured up to a ceiling, since nothing computed locally
+  can beat the server's own answer
+
+#### Scenario: a brief connection failure
+- **WHEN** a call fails on something other than a rate limit — a reset, a 5xx, a
+  local server still warming up
+- **THEN** it retries in fractions of a second, because the condition is gone by
+  the time the next request lands
+
 ### Requirement: A rejected request param degrades, it does not fail the review
 
 The adapter SHALL drop a request param the model refuses and re-send once

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -102,8 +102,9 @@ cause, since a ceiling-hitting call offers no healthy call to compare against.
 Retry backoff SHALL be chosen by the failure. A capacity rate limit SHALL back
 off far enough to reach a fresh metering window, and SHALL prefer the server's
 own `Retry-After` when one is sent, clamped so a long hint cannot consume the
-run. Every other transient failure SHALL keep the sub-second ladder, and both
-SHALL stay inside the call's existing retry budget.
+run. Every other transient failure SHALL keep the sub-second ladder. The retry
+budget SHALL be weighed against the wait about to be taken, so no backoff is
+slept past it.
 <!-- anchor: provider.backoff -->
 
 #### Scenario: the gateway meters the key per minute
@@ -116,6 +117,12 @@ SHALL stay inside the call's existing retry budget.
   HTTP-date form
 - **THEN** that wait is honoured up to a ceiling, since nothing computed locally
   can beat the server's own answer
+
+#### Scenario: the hint would outlast the call's budget
+- **WHEN** the wait a retry is about to take would carry the call past its
+  retry budget
+- **THEN** the call ends there rather than sleeping through the budget it was
+  given
 
 #### Scenario: a brief connection failure
 - **WHEN** a call fails on something other than a rate limit — a reset, a 5xx, a

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -16,6 +16,12 @@ engine.fan-out:
     has: { field: name, regex: '^_fan_out$' }
   files: [src/lgtmaybe/engine/**/*.py]
 
+engine.rescue:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_rescue$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
 engine.dedupe:
   rule:
     kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -83,8 +83,9 @@ interrupt first, and a run with no failures SHALL cost no extra calls.
   posts as complete instead of partial
 
 #### Scenario: the failure would repeat identically
-- **WHEN** a call returns unparseable output, hits the `max_tokens` ceiling, or
-  fails after the oversized-batch split already retried it smaller
+- **WHEN** a call returns unparseable output, hits the `max_tokens` ceiling,
+  fails after the oversized-batch split already retried it smaller, or fails on
+  a condition that cannot change mid-run — a spent quota, a dead credential
 - **THEN** it is not re-run: the same request fails the same way, at cost
 
 #### Scenario: the re-run fails too

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -49,7 +49,7 @@ stage failure surfaces to the caller.
 ### Requirement: Per-lens fan-out through one bounded executor
 
 Every `(batch, lens)` call SHALL run through one global bounded executor sized
-by `max_concurrency` (auto: eight cloud, one for Ollama/OpenAI-compatible). The
+by `max_concurrency` (auto: six cloud, one for Ollama/OpenAI-compatible). The
 executor size SHALL determine only how the preset's calls are scheduled, never
 how many there are.
 <!-- anchor: engine.fan-out -->
@@ -66,6 +66,31 @@ how many there are.
 #### Scenario: deep audit
 - **WHEN** a review uses the `full` preset
 - **THEN** every built-in category runs, including tests and documentation
+
+### Requirement: A transiently-failed call is re-run once
+
+A `(batch, lens)` call that failed on the provider SHALL be re-run exactly once
+after the fan-out drains, so one flaky call does not void the round's verdict.
+Failures the reviewer's own request caused, and ceilings the user set, SHALL NOT
+be re-run. Every rescue SHALL re-check the deadline, the token budget and the
+interrupt first, and a run with no failures SHALL cost no extra calls.
+<!-- anchor: engine.rescue -->
+
+#### Scenario: one lens hits a transient provider failure
+- **WHEN** a lens call fails on a rate limit, a 5xx or a stalled connection while
+  its siblings succeed
+- **THEN** it runs once more after the wave drains, and a review that recovers
+  posts as complete instead of partial
+
+#### Scenario: the failure would repeat identically
+- **WHEN** a call returns unparseable output, hits the `max_tokens` ceiling, or
+  fails after the oversized-batch split already retried it smaller
+- **THEN** it is not re-run: the same request fails the same way, at cost
+
+#### Scenario: the re-run fails too
+- **WHEN** the rescue attempt fails as well
+- **THEN** the round reports itself incomplete, naming the lens it lost, and no
+  further attempt is made
 
 ### Requirement: Findings merge and dedupe across lenses
 

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -587,6 +587,34 @@ def attempts_of(exc: BaseException) -> int:
     return value if isinstance(value, int) and value > 0 else 0
 
 
+# Whether the adapter judged a failure UNRECOVERABLE: bad credentials, exhausted
+# quota, spent prepaid credit, a request the model refuses. No later attempt in
+# this run can succeed, so nothing downstream should spend a billed call finding
+# that out again. Carried on the exception for the same reason as the attempt
+# count above — a failure has no result object to ride home on — and deliberately
+# NARROWER than the adapter's own "don't retry this immediately" rule: a blown
+# wall clock is not retried in place (the identical request has the identical
+# budget) yet a stalled upstream may well answer a genuinely later request, so it
+# is not stamped.
+_UNRECOVERABLE_ATTR = "lgtmaybe_unrecoverable"
+
+
+def stamp_unrecoverable(exc: BaseException) -> None:
+    """Mark *exc* as a failure no later attempt in this run can fix.
+
+    Best effort, exactly like :func:`stamp_attempts`: an exception type that
+    refuses attributes is not worth failing a review over — it just reports the
+    failure as possibly-transient, which costs at most one extra call.
+    """
+    with suppress(Exception):
+        setattr(exc, _UNRECOVERABLE_ATTR, True)
+
+
+def is_unrecoverable(exc: BaseException) -> bool:
+    """True when the adapter said no later attempt at *exc*'s call can succeed."""
+    return getattr(exc, _UNRECOVERABLE_ATTR, False) is True
+
+
 class PRContext(_Strict):
     """Everything the engine needs about a PR — fetched via API, never checkout."""
 

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -926,12 +926,13 @@ class ReviewConfig(_Strict):
     # this above it. See docs/how-to/reduce-review-cost.md.
     max_review_tokens: int = Field(default=0, ge=0)
     # Ceiling on concurrent review calls across the WHOLE fan-out (every
-    # (batch, lens) task shares one pool). None means auto: 8 for hosted cloud
-    # providers (their retry layer absorbs a capacity 429, and on bedrock cache
-    # reads don't count against rate limits), 1 for ollama (a single instance
+    # (batch, lens) task shares one pool). None means auto: 6 for hosted cloud
+    # providers (wide enough to overlap the fan-out, narrow enough that one API
+    # key does not rate-limit itself against a per-minute-metered gateway —
+    # raise it if your rate tier is generous), 1 for ollama (a single instance
     # serves a model serially — concurrent calls just queue and time out), and
     # 1 for openai-compatible (a llama.cpp/LM Studio single-slot server wants
-    # 1; a vLLM server batches happily at 8 — raise it explicitly for those).
+    # 1; a vLLM server batches happily — raise it explicitly for those).
     max_concurrency: int | None = Field(default=None, ge=1)
     # Constrain model output to the findings JSON schema via litellm
     # response_format (provider-native JSON mode). Keeps models from returning

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -29,6 +29,7 @@ from lgtmaybe.core.models import (
     ReviewResult,
     StaticAnalysisTool,
     ToolMode,
+    is_unrecoverable,
 )
 from lgtmaybe.core.ports import (
     Message,
@@ -87,8 +88,10 @@ _log = get_logger(__name__)
 
 # Auto concurrency (cfg.max_concurrency=None), resolved per provider:
 #
-# - Cloud providers get 6. Every extra worker cuts a full-latency wave off the
-#   wall clock, so the pull is upward — but the fan-out is one API key, and the
+# - Cloud providers get 6. An extra worker can cut a full-latency wave off the
+#   wall clock (only when it changes how many waves there are — wall time is
+#   ceil(batches × lenses / workers)), so the pull is upward — but the fan-out
+#   is one API key, and the
 #   gateways that meter a key meter it per minute, so past some width the burst
 #   rate-limits ITSELF. It did: eight concurrent calls against one OpenRouter key
 #   produced three consecutive reviews reporting "1 of 4 review calls failed" on
@@ -1575,12 +1578,19 @@ class LLMReviewEngine(ReviewEngine):
             result = self._provider.complete(messages, model=model, **opts)
         except Exception as exc:
             # Retryable by default: this is the provider faltering, not us, so the
-            # rescue wave gets one more go once the fan-out has drained. A
-            # truncation is the exception — a blown output CEILING is deterministic
-            # (the same request runs to the same ceiling), so a rescue would only
-            # buy a second identical failure at full generation cost.
+            # rescue wave gets one more go once the fan-out has drained. Two
+            # exceptions, both because the second call is guaranteed to buy the
+            # same answer at full price:
+            #
+            # - a truncation is a blown output CEILING, and the identical request
+            #   runs to the identical ceiling;
+            # - a failure the adapter stamped UNRECOVERABLE — a dead key, a spent
+            #   quota, a refused request — cannot resolve itself mid-review. The
+            #   adapter already made that judgement to decide its own retries;
+            #   re-deriving it here from the message text would be a second copy
+            #   of the rule, drifting from the first.
             reason: str = _error_reason(exc)
-            if not isinstance(exc, ProviderTruncated):
+            if not isinstance(exc, ProviderTruncated) and not is_unrecoverable(exc):
                 reason = _RetryableReason(reason)
             profiler.record_error(lens.id, batch_num, time.perf_counter() - started, exc, reason)
             _log.warning(

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -87,16 +87,21 @@ _log = get_logger(__name__)
 
 # Auto concurrency (cfg.max_concurrency=None), resolved per provider:
 #
-# - Cloud providers get 8. The adapter's exponential backoff absorbs a capacity
-#   429 on a lower-tier account, and on bedrock cache reads don't count against
-#   rate limits — so bursting the fan-out is safe, and every extra worker cuts
-#   a full-latency wave off the wall clock.
+# - Cloud providers get 6. Every extra worker cuts a full-latency wave off the
+#   wall clock, so the pull is upward — but the fan-out is one API key, and the
+#   gateways that meter a key meter it per minute, so past some width the burst
+#   rate-limits ITSELF. It did: eight concurrent calls against one OpenRouter key
+#   produced three consecutive reviews reporting "1 of 4 review calls failed" on
+#   a 429. The adapter's backoff (now long enough to outlast a rate window) and
+#   the rescue wave both make that survivable rather than fatal; six is the same
+#   fix from the other end — a quarter less burst for a sixth less parallelism.
+#   Teams on a high rate tier can raise it with `max_concurrency`.
 # - A single ollama instance serves a model serially, so concurrent calls only
 #   queue up and time out: 1.
 # - openai-compatible is honest about the worst case: a llama.cpp / LM Studio
-#   single-slot server wants 1, while a vLLM server batches happily at 8 —
+#   single-slot server wants 1, while a vLLM server batches happily —
 #   default to 1 and let --max-concurrency raise it for batching servers.
-_CLOUD_MAX_WORKERS = 8
+_CLOUD_MAX_WORKERS = 6
 _SINGLE_STREAM_PROVIDERS = frozenset({Provider.ollama, Provider.openai_compatible})
 _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     {

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -372,6 +372,52 @@ _LensOutcome = tuple[list[ReviewFinding], str | None]
 _ReviewTask = partial[_LensOutcome]
 
 
+class _RetryableReason(str):
+    """A failure reason a later, identical call could still succeed at.
+
+    The provider was briefly unavailable — a capacity 429, a 5xx, a stalled
+    connection, a blown wall clock — so the same request issued once the fan-out
+    has drained is worth one more go (see :meth:`LLMReviewEngine._rescue`). That
+    is the opposite of a failure we caused: unparseable output at temperature 0
+    returns the same unparseable answer, and a ceiling the user set
+    (`max_review_seconds`, `max_review_tokens`, a termination signal) is not a
+    fault to retry past at all.
+
+    A plain ``str`` subclass, deliberately: every existing consumer — the
+    ``errors`` list, the summary's f-strings, the ``_BUDGET_SKIP_REASON``
+    comparison — keeps working byte-for-byte, and the flag rides along beside the
+    text instead of a wider outcome tuple threaded through six call sites.
+    """
+
+    __slots__ = ()
+
+
+def _rescuable(reason: str | None) -> bool:
+    """True when *reason* is a provider-side failure worth one more attempt."""
+    return isinstance(reason, _RetryableReason)
+
+
+# How many rescue calls run at once. The wave exists BECAUSE the backend was
+# under pressure — a capacity limit, an overloaded endpoint — so re-bursting the
+# full fan-out width into it is the one thing most likely to reproduce the
+# failure it is trying to undo. Two is enough to keep a multi-lens rescue from
+# running strictly end-to-end.
+_RESCUE_WORKERS = 2
+
+
+@dataclass(frozen=True)
+class _PreparedCall:
+    """One lens call ready to submit, and the lens it speaks for.
+
+    The lens id travels with the task so a failure can be NAMED — a failed
+    security lens and a failed documentation lens read identically as a bare
+    count, and they are not remotely the same news.
+    """
+
+    lens_id: str
+    task: _ReviewTask
+
+
 @dataclass(frozen=True)
 class _Run:
     """The settings that are fixed for a whole review, resolved once in ``review()``.
@@ -745,6 +791,9 @@ class LLMReviewEngine(ReviewEngine):
         total_calls = 0
         failed_calls = 0
         errors: list[str] = []
+        # The lens ids behind those errors, in the same order — the summary names
+        # them, because "1 of 4 failed" says nothing about whether to worry.
+        failed_lenses: list[str] = []
 
         # 5. Fan out one call per (batch, lens) through ONE global pool. The old
         #    shape — a fresh pool per batch, joined before the next batch starts —
@@ -768,7 +817,7 @@ class LLMReviewEngine(ReviewEngine):
             concurrency=_concurrency_cap(cfg),
         )
         workers = _resolve_workers(cfg, len(batches) * len(lenses))
-        per_batch: list[tuple[bool, list[_ReviewTask]]] = []
+        per_batch: list[tuple[bool, list[_PreparedCall]]] = []
         for batch_num, batch in enumerate(batches, start=1):
             batch_diff = "\n".join(patch for _, patch in batch)
             wrapped = wrap_diff(batch_diff)
@@ -816,32 +865,41 @@ class LLMReviewEngine(ReviewEngine):
                 and len(lenses) > 1
                 and count_tokens(wrapped) >= _WARMUP_MIN_TOKENS
             )
-            batch_tasks = [
-                partial(
-                    self._review_lens,
-                    run,
-                    wrapped,
-                    intent_block,
-                    hint_block,
-                    dir_block,
-                    batch_num,
-                    lens,
-                    batch,
-                    spec_block=spec_block,
+            batch_calls = [
+                _PreparedCall(
+                    lens_id=lens.id,
+                    task=partial(
+                        self._review_lens,
+                        run,
+                        wrapped,
+                        intent_block,
+                        hint_block,
+                        dir_block,
+                        batch_num,
+                        lens,
+                        batch,
+                        spec_block=spec_block,
+                    ),
                 )
                 for lens in lenses
             ]
-            per_batch.append((warm, batch_tasks))
+            per_batch.append((warm, batch_calls))
 
         with profiler.stage("review"):
             # Results keyed by task index and consumed in task order, so the
             # findings stay deterministic (dedupe's first-wins tiebreak is
-            # order-sensitive) whatever order the futures complete in.
-            for findings, error in self._fan_out(per_batch, workers):
+            # order-sensitive) whatever order the futures complete in. Zipped
+            # back against the calls in that same order so a failure can name
+            # the lens it lost.
+            calls = [call for _, batch_calls in per_batch for call in batch_calls]
+            for call, (findings, error) in zip(
+                calls, self._fan_out(per_batch, workers), strict=True
+            ):
                 total_calls += 1
                 if error is not None:
                     failed_calls += 1
                     errors.append(error)
+                    failed_lenses.append(call.lens_id)
                 all_findings.extend(findings)
 
         # 5b. Fail loud: if EVERY call errored or returned unparseable output, we
@@ -1033,9 +1091,15 @@ class LLMReviewEngine(ReviewEngine):
         # without matching prose the user may have restyled (summary_template).
         if failed_calls:
             detail = errors[-1] if errors else "timeout or unparseable output"
+            # Name the lenses, not just a count: a lost security lens and a lost
+            # documentation lens are the same number and very different news, and
+            # the reader has no other way to tell which one this was. Deduped and
+            # sorted so a lens that failed on several batches is named once.
+            lost = ", ".join(sorted(set(failed_lenses)))
+            which = f"{lost} — " if lost else ""
             notices.append(
                 f"⚠️ {failed_calls} of {total_calls} review calls failed "
-                f"({detail}); results may be incomplete.\n{INCOMPLETE_MARKER}"
+                f"({which}{detail}); results may be incomplete.\n{INCOMPLETE_MARKER}"
             )
         # A batch that had to be shrunk is a standing signal that the diff is at
         # the edge of what this model finishes in one call — say it, or the next
@@ -1098,9 +1162,9 @@ class LLMReviewEngine(ReviewEngine):
         return filtered, summary_line
 
     def _fan_out(
-        self, per_batch: list[tuple[bool, list[_ReviewTask]]], workers: int
+        self, per_batch: list[tuple[bool, list[_PreparedCall]]], workers: int
     ) -> list[_LensOutcome]:
-        """Run every (batch, lens) task through one pool; results in task order.
+        """Run every (batch, lens) call through one pool; results in call order.
 
         Batches flagged for cache warm-up submit only their FIRST lens; the
         rest of that batch is released when the primer completes (having
@@ -1108,25 +1172,28 @@ class LLMReviewEngine(ReviewEngine):
         batches submit everything up front. Cross-batch work interleaves
         freely — batch 2's primer runs while batch 1's followers are in
         flight, so warming never re-serialises the whole review.
+
+        Whatever failed transiently then gets one more go; see :meth:`_rescue`.
         """
+        calls = [call for _, batch_calls in per_batch for call in batch_calls]
         results: dict[int, _LensOutcome] = {}
         with ThreadPoolExecutor(max_workers=workers) as pool:
             pending: dict[Future[_LensOutcome], int] = {}
             primer_batch: dict[Future[_LensOutcome], int] = {}
-            deferred: dict[int, list[tuple[int, _ReviewTask]]] = {}
+            deferred: dict[int, list[tuple[int, _PreparedCall]]] = {}
             index = 0
-            for batch_index, (warm, batch_tasks) in enumerate(per_batch):
-                indexed = list(enumerate(batch_tasks, start=index))
-                index += len(batch_tasks)
+            for batch_index, (warm, batch_calls) in enumerate(per_batch):
+                indexed = list(enumerate(batch_calls, start=index))
+                index += len(batch_calls)
                 if warm:
                     primer_index, primer = indexed[0]
-                    future = pool.submit(primer)
+                    future = pool.submit(primer.task)
                     pending[future] = primer_index
                     primer_batch[future] = batch_index
                     deferred[batch_index] = indexed[1:]
                 else:
-                    for task_index, task in indexed:
-                        pending[pool.submit(task)] = task_index
+                    for call_index, call in indexed:
+                        pending[pool.submit(call.task)] = call_index
             while pending:
                 # wait() copies its argument internally, so passing the dict's
                 # keys directly avoids building a second throwaway set per loop.
@@ -1137,9 +1204,60 @@ class LLMReviewEngine(ReviewEngine):
                     if batch_index >= 0:
                         # Primer done (pass or fail — a failed primer must not
                         # strand its batch): release the deferred lens calls.
-                        for task_index, task in deferred.pop(batch_index, []):
-                            pending[pool.submit(task)] = task_index
-        return [results[i] for i in sorted(results)]
+                        for call_index, call in deferred.pop(batch_index, []):
+                            pending[pool.submit(call.task)] = call_index
+        return self._rescue(calls, [results[i] for i in sorted(results)])
+
+    def _rescue(
+        self, calls: list[_PreparedCall], outcomes: list[_LensOutcome]
+    ) -> list[_LensOutcome]:
+        """Re-run the calls that failed on the provider, once, and merge them in.
+
+        One flaky call used to void the whole round: three consecutive reviews
+        each reported "1 of 4 review calls failed" while the other three lenses
+        succeeded, and a run fifteen minutes later found what the partial rounds
+        had missed. The lenses that answered are not the problem — the one that
+        did not is, and the cheapest honest fix is to ask it again.
+
+        Bounded on every axis that matters:
+
+        - **Only provider-side failures** (:class:`_RetryableReason`). Unparseable
+          output re-runs to the same unparseable answer at temperature 0, and a
+          ceiling the user set is not a fault to retry past.
+        - **One wave.** The rescue's own outcome is never rescued again, because
+          this runs once — a lens that is genuinely down costs exactly one extra
+          call and then reports itself, rather than grinding.
+        - **Every ceiling still applies.** Each rescue re-enters ``_review_lens``,
+          which re-checks ``_skip_reason`` first, so `max_review_seconds`, the
+          token budget and a termination signal all still stop it dead.
+        - **A pool of its own, entered only after the fan-out's has closed.** Never
+          submitted from inside a fan-out worker: a worker that submits to its own
+          pool and blocks on the result deadlocks the moment the pool saturates
+          (the same trap ``_review_split`` avoids by construction). And narrow —
+          see :data:`_RESCUE_WORKERS`.
+
+        Findings from both attempts are kept and left to the pipeline's ``_dedupe``
+        to collapse, exactly as a deferral's re-run is: a wall timeout can salvage
+        real findings before it fails, and binning them because the second attempt
+        also produced some would lose work the provider already billed for.
+        """
+        retrying = [i for i, (_, error) in enumerate(outcomes) if _rescuable(error)]
+        if not retrying:
+            return outcomes
+        _log.warning(
+            "re-running review calls that failed on the provider",
+            extra={"calls": len(retrying), "lenses": [calls[i].lens_id for i in retrying]},
+        )
+        merged = list(outcomes)
+        width = min(len(retrying), _RESCUE_WORKERS)
+        with ThreadPoolExecutor(max_workers=width, thread_name_prefix="lgtmaybe-rescue") as pool:
+            # map() yields in submission order, so the merge stays deterministic
+            # however the calls interleave.
+            rescued = list(pool.map(lambda i: calls[i].task(), retrying))
+        for index, (findings, error) in zip(retrying, rescued, strict=True):
+            first_findings, _ = merged[index]
+            merged[index] = (first_findings + findings, error)
+        return merged
 
     def _review_lens(
         self,
@@ -1347,6 +1465,9 @@ class LLMReviewEngine(ReviewEngine):
         """
         pieces = _split_batch(batch)
         if len(pieces) < 2:
+            # Nothing smaller to try, so nothing has retried this call at all —
+            # the reason travels on unchanged, retryable flag and all, and a
+            # transient stall still gets its one go from the rescue wave.
             return [], reason
         _log.warning(
             "review call was too big for one response — retrying on smaller pieces",
@@ -1406,7 +1527,13 @@ class LLMReviewEngine(ReviewEngine):
         # claimed the batch was reviewed — a clean bill of health for code no model
         # ever saw. The last error is reported (the split's own failure, not the
         # original timeout) so the notice names what actually went wrong.
-        return findings, errors[-1] if errors else None
+        #
+        # Reported PLAIN, never retryable: the split is already this call's retry,
+        # and it retried with the one change that can help — a smaller payload. A
+        # rescue on top would re-send the original oversized request, which is
+        # exactly the "identical request against an identical budget" the adapter
+        # refuses to repeat, at up to twice the calls.
+        return findings, str(errors[-1]) if errors else None
 
     def _complete_lens(
         self,
@@ -1442,7 +1569,14 @@ class LLMReviewEngine(ReviewEngine):
         try:
             result = self._provider.complete(messages, model=model, **opts)
         except Exception as exc:
-            reason = _error_reason(exc)
+            # Retryable by default: this is the provider faltering, not us, so the
+            # rescue wave gets one more go once the fan-out has drained. A
+            # truncation is the exception — a blown output CEILING is deterministic
+            # (the same request runs to the same ceiling), so a rescue would only
+            # buy a second identical failure at full generation cost.
+            reason: str = _error_reason(exc)
+            if not isinstance(exc, ProviderTruncated):
+                reason = _RetryableReason(reason)
             profiler.record_error(lens.id, batch_num, time.perf_counter() - started, exc, reason)
             _log.warning(
                 "review call failed",

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -7,6 +7,7 @@ optional fallback model.
 from __future__ import annotations
 
 import hashlib
+import math
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -34,12 +35,17 @@ from tenacity import (
     retry,
     retry_if_exception,
     stop_after_attempt,
-    stop_after_delay,
+    stop_before_delay,
     wait_exponential_jitter,
 )
 
 from lgtmaybe.core.logging import get_logger
-from lgtmaybe.core.models import ProviderResult, attempts_of, stamp_attempts
+from lgtmaybe.core.models import (
+    ProviderResult,
+    attempts_of,
+    stamp_attempts,
+    stamp_unrecoverable,
+)
 from lgtmaybe.core.ports import (
     Message,
     ProviderClient,
@@ -160,9 +166,30 @@ def _mentions(exc: BaseException, markers: tuple[str, ...]) -> bool:
     return any(marker in msg for marker in markers)
 
 
+def _is_unrecoverable(exc: BaseException) -> bool:
+    """True when NO later attempt at this call can succeed — not in this run.
+
+    Bad credentials, exhausted quota, spent prepaid credit, a request the model
+    refuses: the condition cannot change while the review runs. Narrower than
+    :func:`_is_permanent`, which additionally refuses to retry a call *in place*
+    when only an identical immediate re-send is on offer. The engine reads this
+    one (via the stamp in :func:`stamp_unrecoverable`) to decide whether its
+    rescue wave is worth a billed call — and a stalled upstream, which is
+    permanent for an immediate retry, may well answer a genuinely later request.
+    """
+    if isinstance(exc, _PERMANENT_ERROR_TYPES):
+        return True
+    # A 429 is permanent only when it's a quota/billing one; a capacity 429 retries.
+    if isinstance(exc, RateLimitError):
+        return _mentions(exc, _QUOTA_MARKERS)
+    return _mentions(exc, _EXPIRED_CREDENTIAL_MARKERS) or _mentions(
+        exc, _INSUFFICIENT_CREDIT_MARKERS
+    )
+
+
 def _is_permanent(exc: BaseException) -> bool:
     """True when retrying *exc* cannot plausibly succeed, so we should not."""
-    if isinstance(exc, _PERMANENT_ERROR_TYPES):
+    if _is_unrecoverable(exc):
         return True
     # A blown wall clock is not a blip: the retry re-sends the identical request
     # against the identical budget, so attempts 2..N can only fail the same way
@@ -181,14 +208,7 @@ def _is_permanent(exc: BaseException) -> bool:
     # labour. Only the engine holds the batch, so only the engine can change the
     # payload; the adapter can only re-send the same oversized one, which is the
     # attempt worth refusing.
-    if isinstance(exc, ProviderTruncated):
-        return True
-    # A 429 is permanent only when it's a quota/billing one; a capacity 429 retries.
-    if isinstance(exc, RateLimitError):
-        return _mentions(exc, _QUOTA_MARKERS)
-    return _mentions(exc, _EXPIRED_CREDENTIAL_MARKERS) or _mentions(
-        exc, _INSUFFICIENT_CREDIT_MARKERS
-    )
+    return isinstance(exc, ProviderTruncated)
 
 
 # How long to back off between attempts, by what failed.
@@ -265,9 +285,15 @@ def _retry_after_seconds(exc: BaseException) -> float | None:
     if raw is None:
         return None
     try:
-        return max(0.0, float(raw))
+        seconds = float(raw)
     except (TypeError, ValueError):
-        pass
+        seconds = None
+    if seconds is not None:
+        # `float()` parses "nan" and "inf" perfectly happily, and either would
+        # travel through the clamp below into tenacity's sleep — raising from
+        # inside the retry loop, the one place left that can still rescue this
+        # call. A header we can't use is a header we don't have.
+        return max(0.0, seconds) if math.isfinite(seconds) else None
     try:
         when = parsedate_to_datetime(str(raw))
     except (TypeError, ValueError):
@@ -441,8 +467,14 @@ class LiteLLMProvider(ProviderClient):
 
         @retry(
             retry=retry_if_exception(lambda exc: not _is_permanent(exc)),
+            # stop_BEFORE_delay, not after: `after` reads the clock only once a
+            # wait has already been taken, so a call with most of its budget
+            # spent could still sleep out a full `Retry-After` on top of it —
+            # two minutes past a budget that had all but run out. `before` weighs
+            # the UPCOMING sleep, so a wait that would blow the budget ends the
+            # call instead of being taken.
             stop=stop_after_attempt(_MAX_ATTEMPTS)
-            | stop_after_delay(timeout * _CALL_BUDGET_MULTIPLIER),
+            | stop_before_delay(timeout * _CALL_BUDGET_MULTIPLIER),
             wait=_retry_wait,
             reraise=True,
         )
@@ -469,8 +501,12 @@ class LiteLLMProvider(ProviderClient):
         except BaseException as exc:
             # A failure has no ProviderResult to ride home on, so the count goes
             # on the exception — else the instrumentation records a budget-burning
-            # failure as `attempts=0`, which reads as "never retried".
+            # failure as `attempts=0`, which reads as "never retried". The same
+            # channel carries whether any later attempt could have helped, which
+            # is what stops the engine's rescue wave re-billing a dead key.
             stamp_attempts(exc, attempts)
+            if _is_unrecoverable(exc):
+                stamp_unrecoverable(exc)
             raise
         return result.model_copy(update={"attempts": attempts})
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import litellm
@@ -28,6 +30,7 @@ from litellm.exceptions import (
 )
 from litellm.utils import supports_prompt_caching
 from tenacity import (
+    RetryCallState,
     retry,
     retry_if_exception,
     stop_after_attempt,
@@ -188,6 +191,106 @@ def _is_permanent(exc: BaseException) -> bool:
     )
 
 
+# How long to back off between attempts, by what failed.
+#
+# The generic ladder is for a blip — a connection reset, an ollama server still
+# warming up, a 5xx. Sub-second is right there: the condition is gone by the time
+# the next request lands.
+#
+# A capacity 429 is not that. Gateways that meter a key — OpenRouter above all —
+# meter it per MINUTE, so the generic ladder (with tenacity's default `jitter=1`
+# that is roughly 1.1s + 1.2s + 1.4s) puts all four attempts inside the SAME
+# window, where they can only fail identically. That is how three consecutive
+# reviews each came back "1 of 4 review calls failed" on a rate limit while the
+# other three lenses sailed through. So a rate limit gets its own, much slower
+# ladder: long enough for the next attempt to land in a fresh window.
+#
+# Both stay well inside the call's existing `stop_after_delay` budget
+# (2.5 × timeout — 1,500s on direct cloud, 4,500s on the slow-capable routes
+# openrouter/ollama/openai-compatible), so nothing new needs bounding.
+_RATE_LIMIT_BACKOFF_INITIAL = 5.0
+_RATE_LIMIT_BACKOFF_MAX = 60.0
+
+# The most we will honour from a server-supplied `Retry-After`. A gateway that
+# asks for an hour is reporting a limit no single review can outwait, and
+# sleeping on it would burn the whole run's wall clock inside one lens. Clamp,
+# let the attempt fail, and let the engine's rescue wave (or, failing that, the
+# incomplete-results notice) be what handles it.
+_RETRY_AFTER_CEILING = 120.0
+
+_generic_wait = wait_exponential_jitter(initial=0.1, max=5)
+_rate_limit_wait = wait_exponential_jitter(
+    initial=_RATE_LIMIT_BACKOFF_INITIAL, max=_RATE_LIMIT_BACKOFF_MAX
+)
+
+
+def _response_headers(exc: BaseException) -> Mapping[str, str] | None:
+    """The response headers *exc* carries, from wherever litellm put them.
+
+    Three places, because litellm's own ``_get_response_headers`` looks in the
+    same three: the exception's ``headers`` attribute, the ``response`` it wraps,
+    and the ``litellm_response_headers`` its exception mapper stamps on the way
+    out. Which one is populated depends on the route, so reading only one loses
+    the header on the others.
+    """
+    for source in (
+        getattr(exc, "headers", None),
+        getattr(getattr(exc, "response", None), "headers", None),
+        getattr(exc, "litellm_response_headers", None),
+    ):
+        if source:
+            return source  # type: ignore[no-any-return]
+    return None
+
+
+def _retry_after_seconds(exc: BaseException) -> float | None:
+    """Seconds *exc*'s ``Retry-After`` asks us to wait, or None if it said nothing.
+
+    RFC 9110 allows either delta-seconds or an HTTP-date, and the Cloudflare edge
+    these gateways sit behind sends both forms, so both are read. A stale date
+    floors at zero rather than going negative, and an unparseable value is
+    treated as no header at all — a malformed hint must never crash the retry
+    loop, which is the one place left that can still rescue the call.
+
+    Deliberately only ``Retry-After``: it is the one header every 429 route
+    sends, and it says what we actually need in the units we need it. The
+    ``X-RateLimit-Reset`` families disagree on units (seconds here, epoch
+    milliseconds there) between providers, so parsing them would be guesswork
+    dressed as precision.
+    """
+    headers = _response_headers(exc)
+    if not headers:
+        return None
+    raw = headers.get("retry-after") or headers.get("Retry-After")
+    if raw is None:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        pass
+    try:
+        when = parsedate_to_datetime(str(raw))
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return max(0.0, (when - datetime.now(UTC)).total_seconds())
+
+
+def _retry_wait(retry_state: RetryCallState) -> float:
+    """How long to wait before the next attempt, chosen by what just failed."""
+    outcome = retry_state.outcome
+    exc = outcome.exception() if outcome is not None else None
+    if isinstance(exc, RateLimitError):
+        after = _retry_after_seconds(exc)
+        if after is not None:
+            # The server told us when it will take us back. Nothing we compute
+            # can beat that, so honour it — up to the ceiling above.
+            return min(after, _RETRY_AFTER_CEILING)
+        return _rate_limit_wait(retry_state)
+    return _generic_wait(retry_state)
+
+
 def _rejects_response_format(exc: Exception) -> bool:
     """True when an API error means the model won't take our structured-output param.
 
@@ -340,7 +443,7 @@ class LiteLLMProvider(ProviderClient):
             retry=retry_if_exception(lambda exc: not _is_permanent(exc)),
             stop=stop_after_attempt(_MAX_ATTEMPTS)
             | stop_after_delay(timeout * _CALL_BUDGET_MULTIPLIER),
-            wait=wait_exponential_jitter(initial=0.1, max=5),
+            wait=_retry_wait,
             reraise=True,
         )
         def _call() -> ProviderResult:

--- a/tests/engine/test_concurrency.py
+++ b/tests/engine/test_concurrency.py
@@ -151,5 +151,8 @@ class TestFlattenedFanOut:
             reflect=False,
         )
         findings, summary = LLMReviewEngine(_OneBadLens()).review(_multi_file_ctx(1), cfg)
-        assert len(calls) == 2
+        # Two lens calls, plus the rescue wave's one more go at the security lens
+        # — which fails again here, since this provider always refuses it. One
+        # extra call and then the round reports itself; it never grinds.
+        assert len(calls) == 3
         assert "1 of 2 review calls failed" in summary

--- a/tests/engine/test_concurrency.py
+++ b/tests/engine/test_concurrency.py
@@ -28,8 +28,10 @@ def _cfg(provider: Provider, **overrides: object) -> ReviewConfig:
 
 class TestResolveWorkers:
     @pytest.mark.parametrize("provider", _CLOUD_PROVIDERS)
-    def test_cloud_defaults_to_eight(self, provider: Provider) -> None:
-        assert _resolve_workers(_cfg(provider), task_count=100) == 8
+    def test_cloud_defaults_to_six(self, provider: Provider) -> None:
+        """Six, not eight: the fan-out is one API key, and eight concurrent calls
+        against a per-minute-metered gateway rate-limits itself."""
+        assert _resolve_workers(_cfg(provider), task_count=100) == 6
 
     @pytest.mark.parametrize("provider", [Provider.ollama, Provider.openai_compatible])
     def test_single_stream_providers_default_to_one(self, provider: Provider) -> None:

--- a/tests/engine/test_prompt_split.py
+++ b/tests/engine/test_prompt_split.py
@@ -289,8 +289,11 @@ class TestCacheWarmup:
             categories=[ReviewCategory.security, ReviewCategory.performance, ReviewCategory.tests],
         )
         findings, summary = LLMReviewEngine(_FailingPrimer()).review(_big_ctx(), cfg)
-        assert calls["n"] == 3  # the two followers still ran
-        assert "1 of 3 review calls failed" in summary
+        # Three lens calls — the two followers still ran, the primer's failure
+        # never stranded them — plus the rescue wave's one more go at the primer,
+        # which this time succeeds. So the round completes.
+        assert calls["n"] == 4
+        assert "review calls failed" not in summary
 
 
 class TestReflectionSplitShape:

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -18,6 +18,7 @@ from lgtmaybe.core.models import (
     ProviderResult,
     ReviewCategory,
     ReviewConfig,
+    stamp_unrecoverable,
 )
 from lgtmaybe.core.ports import Message, ProviderTruncated, ProviderWallTimeout
 from lgtmaybe.engine import LLMReviewEngine
@@ -170,6 +171,21 @@ class TestRescueWave:
         _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
 
         # A single hunk: nothing smaller to try, and no rescue either.
+        assert provider.security_calls == 1
+        assert INCOMPLETE_MARKER in summary
+
+    def test_an_unrecoverable_provider_failure_is_not_rescued(self) -> None:
+        """A dead key or a spent quota cannot come back mid-review, so a rescue
+        would only pay a second billed call to be told the same thing. The
+        adapter already knows this and stamps the exception; the engine reads it
+        rather than deciding again for itself.
+        """
+        exc = RuntimeError("insufficient_quota — you exceeded your current quota")
+        stamp_unrecoverable(exc)
+        provider = _FlakyLens(failures=99, exc=exc)
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
         assert provider.security_calls == 1
         assert INCOMPLETE_MARKER in summary
 

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -10,7 +10,10 @@ once, after the main wave has drained, and costs nothing at all on a healthy run
 from __future__ import annotations
 
 import threading
+from collections.abc import Iterator
 from typing import Any
+
+import pytest
 
 from lgtmaybe.core.models import (
     PRContext,
@@ -21,8 +24,12 @@ from lgtmaybe.core.models import (
     stamp_unrecoverable,
 )
 from lgtmaybe.core.ports import Message, ProviderTruncated, ProviderWallTimeout
-from lgtmaybe.engine import LLMReviewEngine
-from lgtmaybe.engine.engine import INCOMPLETE_MARKER
+from lgtmaybe.engine import (
+    INCOMPLETE_MARKER,
+    LLMReviewEngine,
+    clear_interrupt,
+    request_interrupt,
+)
 from tests.fakes import FakeProvider
 
 _CTX = PRContext(
@@ -76,6 +83,23 @@ class _FlakyLens(FakeProvider):
                     self._remaining -= 1
                     raise self._exc
         return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
+
+
+class _InterruptOnFirstCall(FakeProvider):
+    """Raises the wind-down flag from inside its first completion."""
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        request_interrupt()
+        return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
+
+
+@pytest.fixture(autouse=True)
+def _clean_interrupt_flag() -> Iterator[None]:
+    """The flag is process-global: never let one test leak into the next."""
+    clear_interrupt()
+    yield
+    clear_interrupt()
 
 
 class TestRescueWave:
@@ -208,30 +232,24 @@ class TestRescueWave:
         assert len(provider.calls) == 2  # no third call
         assert "unparseable model output" in summary
 
-    def test_a_deadline_skipped_call_is_not_rescued(self) -> None:
+    def test_a_ceiling_skipped_call_is_not_rescued(self) -> None:
         """A ceiling the user set is not a fault to retry past.
 
-        Serial provider, a deadline shorter than one call: the first call runs,
-        the deadline passes, the second is skipped. The rescue must leave the
-        skipped one alone — spending past `max_review_seconds` to rescue a call
-        the deadline stopped would defeat the deadline.
+        Driven with the wind-down flag rather than the `max_review_seconds`
+        clock: both land on the same `_skip_reason` gate the rescue must
+        respect, and the flag gets there deterministically and instantly
+        instead of sleeping a call out past a deadline.
+
+        Serial provider, so the first call raises the flag and the second is
+        skipped. The rescue must leave the skipped one alone — spending past a
+        ceiling to rescue the call it stopped would defeat the ceiling.
         """
-        import time as _time
+        provider = _InterruptOnFirstCall()
 
-        class _Slow(FakeProvider):
-            def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
-                self.calls.append({"messages": messages, "model": model, "opts": opts})
-                _time.sleep(1.2)
-                return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
-
-        provider = _Slow()
-        # ollama resolves to one worker, so the calls are strictly serial.
-        cfg = _cfg(provider=Provider.ollama, max_review_seconds=1)
-
-        _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(provider=Provider.ollama))
 
         assert len(provider.calls) == 1
-        assert "deadline" in summary
+        assert "interrupted" in summary
 
     def test_the_notice_names_the_failing_lens(self) -> None:
         """A failed security lens and a failed documentation lens read identically

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -1,0 +1,228 @@
+"""Tests for the rescue wave: one more go at a call that failed transiently.
+
+A single flaky provider call used to void a whole round's verdict — three
+consecutive reviews each reported "1 of 4 review calls failed" while the other
+three lenses succeeded, and the findings the failed lens would have made were
+lost until somebody re-ran by hand. The rescue wave re-runs exactly those calls
+once, after the main wave has drained, and costs nothing at all on a healthy run.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.core.ports import Message, ProviderTruncated, ProviderWallTimeout
+from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine.engine import INCOMPLETE_MARKER
+from tests.fakes import FakeProvider
+
+_CTX = PRContext(
+    diff=(
+        "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n"
+        "@@ -1,1 +1,3 @@\n context\n+new line\n+another line\n"
+    ),
+    changed_files=["a.py"],
+    base_sha="abc",
+    head_sha="def",
+    repo="org/repo",
+    pr_number=1,
+)
+
+_FINDING_JSON = (
+    '[{"path": "a.py", "line": 2, "severity": "high", "title": "bug", "body": "broken",'
+    ' "failure_scenario": "When the changed line runs, the operation fails."}]'
+)
+
+_SECURITY_MARKER = "Security review"
+
+
+def _cfg(**overrides: Any) -> ReviewConfig:
+    defaults: dict[str, Any] = {
+        "provider": Provider.openai,
+        "model": "m",
+        "categories": [ReviewCategory.security, ReviewCategory.performance],
+        "reflect": False,
+    }
+    defaults.update(overrides)
+    return ReviewConfig(**defaults)
+
+
+class _FlakyLens(FakeProvider):
+    """Fails the security lens for its first ``failures`` calls, then answers."""
+
+    def __init__(self, failures: int, exc: BaseException | None = None) -> None:
+        super().__init__()
+        self._remaining = failures
+        self._exc = exc or RuntimeError("upstream hiccup")
+        self._lock = threading.Lock()
+        self.security_calls = 0
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        prompt = "\n".join(str(m.get("content", "")) for m in messages)
+        with self._lock:
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            if _SECURITY_MARKER in prompt:
+                self.security_calls += 1
+                if self._remaining > 0:
+                    self._remaining -= 1
+                    raise self._exc
+        return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
+
+
+class TestRescueWave:
+    def test_a_lens_that_fails_once_is_re_run_and_the_round_completes(self) -> None:
+        """The whole point: one transient failure no longer voids the round."""
+        provider = _FlakyLens(failures=1)
+
+        findings, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert provider.security_calls == 2  # the failure, then the rescue
+        assert "review calls failed" not in summary
+        assert INCOMPLETE_MARKER not in summary
+        assert findings  # the rescued lens's findings are in the review
+
+    def test_the_rescue_happens_once_not_in_a_loop(self) -> None:
+        """Bounded to a single wave. A lens that is genuinely down gets one more
+        go and then the round reports itself incomplete — it never grinds."""
+        provider = _FlakyLens(failures=99)
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert provider.security_calls == 2
+        assert "1 of 2 review calls failed" in summary
+        assert INCOMPLETE_MARKER in summary
+
+    def test_a_healthy_run_costs_no_extra_calls(self) -> None:
+        """Nothing failed, so there is nothing to rescue and nothing to pay for."""
+        provider = _FlakyLens(failures=0)
+
+        LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert len(provider.calls) == 2
+        assert provider.security_calls == 1
+
+    def test_an_unsplittable_wall_timeout_is_rescued(self) -> None:
+        """A stalled upstream is exactly the transient failure this exists for.
+
+        The adapter refuses to re-send it immediately — an identical request
+        against an identical budget can only fail the same way — but a rescue
+        issued after the whole wave has drained is a genuinely later request.
+        This batch is a single hunk, so there is nothing to split: the rescue is
+        the only retry available, and without it the round posts partial.
+        """
+        provider = _FlakyLens(
+            failures=1, exc=ProviderWallTimeout("call exceeded 600s (waited 601.2s)")
+        )
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert provider.security_calls == 2
+        assert "review calls failed" not in summary
+
+    def test_a_wall_timeout_the_split_already_retried_is_not_rescued(self) -> None:
+        """The split IS that call's retry, and it retried with the one change that
+        can help — a smaller payload. Rescuing on top would re-send the original
+        oversized request at up to twice the calls, each burning a full timeout."""
+        provider = _FlakyLens(
+            failures=99, exc=ProviderWallTimeout("call exceeded 600s (waited 601.2s)")
+        )
+        two_files = PRContext(
+            diff=(
+                "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n"
+                "@@ -1,1 +1,2 @@\n context\n+one\n"
+                "diff --git a/b.py b/b.py\n--- a/b.py\n+++ b/b.py\n"
+                "@@ -1,1 +1,2 @@\n context\n+two\n"
+            ),
+            changed_files=["a.py", "b.py"],
+            base_sha="abc",
+            head_sha="def",
+            repo="org/repo",
+            pr_number=1,
+        )
+
+        _, summary = LLMReviewEngine(provider).review(two_files, _cfg())
+
+        # The security call, then its two halves — and stop. No fourth call.
+        assert provider.security_calls == 3
+        assert INCOMPLETE_MARKER in summary
+
+    def test_a_truncated_response_is_not_rescued(self) -> None:
+        """A blown output ceiling is deterministic, not an outage: the same
+        request runs to the same ceiling. Rescuing it would buy a second
+        identical failure at full generation cost."""
+        provider = _FlakyLens(
+            failures=99,
+            exc=ProviderTruncated(
+                "response hit the 16384-token `max_tokens` ceiling before finishing",
+                text="",
+                output_tokens=16384,
+            ),
+        )
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        # A single hunk: nothing smaller to try, and no rescue either.
+        assert provider.security_calls == 1
+        assert INCOMPLETE_MARKER in summary
+
+    def test_unparseable_output_is_not_rescued(self) -> None:
+        """Determinism cuts both ways: at temperature 0 the same request returns
+        the same unparseable answer, so a rescue would only buy a second billed
+        failure. Left to the incomplete notice instead."""
+
+        class _Gibberish(FakeProvider):
+            def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+                prompt = "\n".join(str(m.get("content", "")) for m in messages)
+                self.calls.append({"messages": messages, "model": model, "opts": opts})
+                text = "not json at all" if _SECURITY_MARKER in prompt else _FINDING_JSON
+                return ProviderResult(text=text, input_tokens=1, output_tokens=1)
+
+        provider = _Gibberish()
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert len(provider.calls) == 2  # no third call
+        assert "unparseable model output" in summary
+
+    def test_a_deadline_skipped_call_is_not_rescued(self) -> None:
+        """A ceiling the user set is not a fault to retry past.
+
+        Serial provider, a deadline shorter than one call: the first call runs,
+        the deadline passes, the second is skipped. The rescue must leave the
+        skipped one alone — spending past `max_review_seconds` to rescue a call
+        the deadline stopped would defeat the deadline.
+        """
+        import time as _time
+
+        class _Slow(FakeProvider):
+            def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+                self.calls.append({"messages": messages, "model": model, "opts": opts})
+                _time.sleep(1.2)
+                return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
+
+        provider = _Slow()
+        # ollama resolves to one worker, so the calls are strictly serial.
+        cfg = _cfg(provider=Provider.ollama, max_review_seconds=1)
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
+
+        assert len(provider.calls) == 1
+        assert "deadline" in summary
+
+    def test_the_notice_names_the_failing_lens(self) -> None:
+        """A failed security lens and a failed documentation lens read identically
+        as a bare count. Naming it is the difference between "re-run this" and
+        "this review is fine"."""
+        provider = _FlakyLens(failures=99)
+
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+        assert "security" in summary

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -10,8 +10,10 @@ once, after the main wave has drained, and costs nothing at all on a healthy run
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Iterator
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -30,6 +32,7 @@ from lgtmaybe.engine import (
     clear_interrupt,
     request_interrupt,
 )
+from lgtmaybe.engine import engine as engine_module
 from tests.fakes import FakeProvider
 
 _CTX = PRContext(
@@ -232,17 +235,22 @@ class TestRescueWave:
         assert len(provider.calls) == 2  # no third call
         assert "unparseable model output" in summary
 
-    def test_a_ceiling_skipped_call_is_not_rescued(self) -> None:
-        """A ceiling the user set is not a fault to retry past.
+    def test_a_ceiling_still_holds_through_the_rescue_wave(self) -> None:
+        """A ceiling the user set must survive the rescue, not just precede it.
 
-        Driven with the wind-down flag rather than the `max_review_seconds`
-        clock: both land on the same `_skip_reason` gate the rescue must
-        respect, and the flag gets there deterministically and instantly
-        instead of sleeping a call out past a deadline.
+        Worth being precise about what this pins, because it is NOT the
+        `_rescuable` gate: a rescue re-enters `_review_lens`, which re-checks
+        `_skip_reason` before it calls anything, so an interrupted call costs no
+        model call even if the gate let it through. Belt and braces — and this
+        is the braces. It fails if the rescue is ever changed to reach the
+        provider without going back through that check.
+
+        Driven with the wind-down flag, which reaches `_skip_reason`
+        deterministically and instantly; the deadline's route is pinned
+        separately below.
 
         Serial provider, so the first call raises the flag and the second is
-        skipped. The rescue must leave the skipped one alone — spending past a
-        ceiling to rescue the call it stopped would defeat the ceiling.
+        skipped.
         """
         provider = _InterruptOnFirstCall()
 
@@ -250,6 +258,40 @@ class TestRescueWave:
 
         assert len(provider.calls) == 1
         assert "interrupted" in summary
+
+    def test_the_deadline_still_holds_through_the_rescue_wave(self) -> None:
+        """The same property for `max_review_seconds` specifically.
+
+        The two ceilings reach `_skip_reason` by different routes — a flag
+        versus a clock comparison — and the case above only exercises one of
+        them.
+
+        The clock is stepped, not slept: `perf_counter` reports one instant
+        until the first completion runs, and a far-future one after. That
+        crosses the deadline exactly once, deterministically, with no sleep and
+        no dependence on how loaded the runner is.
+        """
+        crossed = threading.Event()
+        base = time.perf_counter()
+
+        class _CrossesTheDeadline(FakeProvider):
+            def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+                self.calls.append({"messages": messages, "model": model, "opts": opts})
+                crossed.set()
+                return ProviderResult(text=_FINDING_JSON, input_tokens=1, output_tokens=1)
+
+        def stepped() -> float:
+            return base + (10_000.0 if crossed.is_set() else 0.0)
+
+        provider = _CrossesTheDeadline()
+        # ollama resolves to one worker, so the calls are strictly serial: the
+        # first runs, crosses the deadline, and the second is skipped by it.
+        cfg = _cfg(provider=Provider.ollama, max_review_seconds=1)
+        with patch.object(engine_module.time, "perf_counter", stepped):
+            _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
+
+        assert len(provider.calls) == 1
+        assert "deadline" in summary
 
     def test_the_notice_names_the_failing_lens(self) -> None:
         """A failed security lens and a failed documentation lens read identically

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -414,4 +414,8 @@ def test_an_ordinary_failure_is_not_split() -> None:
     with pytest.raises(ReviewIncompleteError):
         LLMReviewEngine(provider).review(_ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg())
 
-    assert len(provider.diffs) == 1
+    # The original call plus the rescue wave's one more go — and both saw the
+    # WHOLE diff. A split would have sent a halved one, which is the thing under
+    # test here; the rescue only ever re-sends the same request.
+    assert len(provider.diffs) == 2
+    assert provider.diffs[0] == provider.diffs[1]

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -176,7 +176,8 @@ class TestEngineBehaviourMatrix:
 
     # Auto max_concurrency per provider: 1 for single-stream backends (ollama
     # serves serially; openai-compatible may front a single-slot llama.cpp/LM
-    # Studio server), 8 for hosted cloud.
+    # Studio server), 6 for hosted cloud — wide enough to overlap the fan-out,
+    # narrow enough that one API key does not rate-limit itself.
     SINGLE_STREAM = (Provider.ollama, Provider.openai_compatible)
 
     @pytest.mark.parametrize("provider", list(Provider))
@@ -185,7 +186,7 @@ class TestEngineBehaviourMatrix:
         from lgtmaybe.engine.engine import _resolve_workers
 
         cfg = ReviewConfig(provider=provider, model="m")
-        expected = 1 if provider in self.SINGLE_STREAM else 8
+        expected = 1 if provider in self.SINGLE_STREAM else 6
         assert _resolve_workers(cfg, task_count=99) == expected
 
     @pytest.mark.parametrize("provider", list(Provider))

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1151,21 +1151,26 @@ class TestRateLimitBackoff:
 
     def test_retry_after_accepts_an_http_date(self) -> None:
         """RFC 9110 allows either delta-seconds or an HTTP-date, and the
-        Cloudflare edge these gateways sit behind sends both forms."""
-        when = datetime.now(UTC) + timedelta(seconds=40)
-        exc = self._rate_limited(response=self._429({"retry-after": format_datetime(when)}))
-        wait = provider_module._retry_wait(self._state(exc))
-        # Deliberately no wall-clock-derived bound in either direction: a
-        # contended CI worker can stall for seconds between the header being
-        # written and the wait computed, and pinning either end to 40 would make
-        # a correct implementation fail. What is under test is that the DATE was
-        # parsed at all — the ladder would answer 5s, so anything above it came
-        # from the header, and the clamp is what keeps it in range.
-        assert (
-            provider_module._RATE_LIMIT_BACKOFF_INITIAL
-            < wait
-            <= provider_module._RETRY_AFTER_CEILING
-        )
+        Cloudflare edge these gateways sit behind sends both forms.
+
+        The clock is frozen rather than read twice. Building the header from
+        `now` and then asserting on what the code computes from its own `now`
+        makes the answer depend on how long the test took: a worker stalled past
+        the header's date drives the wait to zero — correct behaviour, failing
+        test. Pinning both reads to one instant is what lets this assert the
+        exact number the header asked for.
+        """
+        frozen = datetime(2026, 8, 13, 12, 0, 0, tzinfo=UTC)
+
+        class _FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+                return frozen
+
+        header = format_datetime(frozen + timedelta(seconds=40))
+        exc = self._rate_limited(response=self._429({"retry-after": header}))
+        with patch.object(provider_module, "datetime", _FrozenDatetime):
+            assert provider_module._retry_wait(self._state(exc)) == 40.0
 
     def test_a_retry_after_in_the_past_waits_no_time(self) -> None:
         """A stale HTTP-date must not produce a negative wait."""

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1155,12 +1155,17 @@ class TestRateLimitBackoff:
         when = datetime.now(UTC) + timedelta(seconds=40)
         exc = self._rate_limited(response=self._429({"retry-after": format_datetime(when)}))
         wait = provider_module._retry_wait(self._state(exc))
-        # Upper bound is tight (the header is 40s at second granularity); the
-        # lower one is loose on purpose, because a contended CI worker can stall
-        # for seconds between the header being written and the wait computed.
-        # What is under test is that the DATE was parsed at all — the ladder
-        # would answer 5s, and anything above it could only come from the header.
-        assert provider_module._RATE_LIMIT_BACKOFF_INITIAL < wait <= 41
+        # Deliberately no wall-clock-derived bound in either direction: a
+        # contended CI worker can stall for seconds between the header being
+        # written and the wait computed, and pinning either end to 40 would make
+        # a correct implementation fail. What is under test is that the DATE was
+        # parsed at all — the ladder would answer 5s, so anything above it came
+        # from the header, and the clamp is what keeps it in range.
+        assert (
+            provider_module._RATE_LIMIT_BACKOFF_INITIAL
+            < wait
+            <= provider_module._RETRY_AFTER_CEILING
+        )
 
     def test_a_retry_after_in_the_past_waits_no_time(self) -> None:
         """A stale HTTP-date must not produce a negative wait."""

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import threading
 import time
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -799,7 +801,13 @@ class TestFailFastOnPermanentErrors:
                 )
             return good
 
-        with patch("litellm.completion", side_effect=flaky):
+        # The rate-limit ladder starts at five seconds on purpose (see
+        # _RATE_LIMIT_BACKOFF_INITIAL); this test is about the retry happening at
+        # all, so it is not made to sit through one.
+        with (
+            patch("litellm.completion", side_effect=flaky),
+            patch.object(provider_module, "_rate_limit_wait", lambda _: 0.0),
+        ):
             provider = LiteLLMProvider()
             result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
 
@@ -1082,3 +1090,111 @@ class TestFallback:
             provider = LiteLLMProvider()
             with pytest.raises(RuntimeError):
                 provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
+
+
+class TestRateLimitBackoff:
+    """A capacity 429 is a rate *window*, not a blip.
+
+    The generic ladder (`initial=0.1, max=5`, tenacity's default `jitter=1`) puts
+    all four attempts inside about four seconds, which is nothing against a
+    per-minute limit — every attempt lands in the same window and fails
+    identically. So a rate limit waits on its own, much longer, ladder, and
+    prefers the server's own `Retry-After` when it sends one.
+    """
+
+    @staticmethod
+    def _state(exc: BaseException, attempt: int = 1) -> Any:
+        """A minimal tenacity RetryCallState stand-in.
+
+        `wait_exponential_jitter` reads only `attempt_number`, and `_retry_wait`
+        only that plus the outcome's exception — so the real class, which wants a
+        retry object and the called function, buys the test nothing.
+        """
+        return SimpleNamespace(
+            attempt_number=attempt,
+            outcome=SimpleNamespace(exception=lambda: exc),
+        )
+
+    @staticmethod
+    def _rate_limited(**kwargs: Any) -> litellm.RateLimitError:
+        return litellm.RateLimitError(
+            message="RateLimitError: OpenrouterException - rate limit exceeded",
+            model="deepseek/deepseek-v4-flash",
+            llm_provider="openrouter",
+            **kwargs,
+        )
+
+    def _429(self, headers: dict[str, str]) -> httpx.Response:
+        return httpx.Response(
+            429, headers=headers, request=httpx.Request("POST", "https://openrouter.ai")
+        )
+
+    def test_retry_after_header_is_honoured(self) -> None:
+        """The server said when to come back; that beats any ladder we invent."""
+        exc = self._rate_limited(response=self._429({"retry-after": "30"}))
+        assert provider_module._retry_wait(self._state(exc)) == 30.0
+
+    def test_retry_after_is_read_from_the_headers_attribute(self) -> None:
+        """litellm carries headers in three different places depending on the
+        route (its own `_get_response_headers` looks in all three) — the direct
+        `headers` attribute is one of them, and it is set independently of
+        `response`."""
+        exc = self._rate_limited(headers={"retry-after": "45"})
+        assert provider_module._retry_wait(self._state(exc)) == 45.0
+
+    def test_retry_after_is_read_from_litellm_response_headers(self) -> None:
+        """The third place: litellm stamps the mapped exception with
+        `litellm_response_headers` on its way out of the exception mapper."""
+        exc = self._rate_limited()
+        exc.litellm_response_headers = {"Retry-After": "12"}
+        assert provider_module._retry_wait(self._state(exc)) == 12.0
+
+    def test_retry_after_accepts_an_http_date(self) -> None:
+        """RFC 9110 allows either delta-seconds or an HTTP-date, and the
+        Cloudflare edge these gateways sit behind sends both forms."""
+        when = datetime.now(UTC) + timedelta(seconds=40)
+        exc = self._rate_limited(response=self._429({"retry-after": format_datetime(when)}))
+        wait = provider_module._retry_wait(self._state(exc))
+        # Second-granularity header plus the clock moving under the test.
+        assert 35 <= wait <= 41
+
+    def test_a_retry_after_in_the_past_waits_no_time(self) -> None:
+        """A stale HTTP-date must not produce a negative wait."""
+        when = datetime.now(UTC) - timedelta(seconds=120)
+        exc = self._rate_limited(response=self._429({"retry-after": format_datetime(when)}))
+        assert provider_module._retry_wait(self._state(exc)) == 0.0
+
+    def test_an_absurd_retry_after_is_clamped(self) -> None:
+        """A day-long hint is a limit we will never outwait inside one review —
+        clamp it, let the attempt fail, and let the engine's rescue wave or the
+        incomplete notice take it from there."""
+        exc = self._rate_limited(response=self._429({"retry-after": "86400"}))
+        wait = provider_module._retry_wait(self._state(exc))
+        assert wait == provider_module._RETRY_AFTER_CEILING
+
+    def test_a_garbage_retry_after_falls_through_to_the_ladder(self) -> None:
+        """An unparseable header is no header — never a crash inside the wait."""
+        exc = self._rate_limited(response=self._429({"retry-after": "soon"}))
+        wait = provider_module._retry_wait(self._state(exc))
+        assert wait >= provider_module._RATE_LIMIT_BACKOFF_INITIAL
+
+    def test_a_headerless_rate_limit_uses_the_long_ladder(self) -> None:
+        """No hint from the server: back off on the rate-limit ladder, not the
+        generic one — the whole point is to outlast a per-minute window."""
+        exc = self._rate_limited()
+        first = provider_module._retry_wait(self._state(exc, attempt=1))
+        later = provider_module._retry_wait(self._state(exc, attempt=4))
+        assert first >= provider_module._RATE_LIMIT_BACKOFF_INITIAL
+        assert later > first
+        assert later <= provider_module._RATE_LIMIT_BACKOFF_MAX
+
+    def test_other_transient_errors_keep_the_fast_ladder(self) -> None:
+        """The slow ladder is for rate limits only. A connection blip (an ollama
+        server warming up) must still retry in fractions of a second."""
+        wait = provider_module._retry_wait(self._state(RuntimeError("connection reset")))
+        assert wait < provider_module._RATE_LIMIT_BACKOFF_INITIAL
+
+    def test_a_wait_with_no_outcome_does_not_crash(self) -> None:
+        """tenacity computes a wait before the first outcome exists."""
+        state = SimpleNamespace(attempt_number=1, outcome=None)
+        assert provider_module._retry_wait(state) >= 0

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -14,7 +14,7 @@ import httpx
 import litellm
 import pytest
 
-from lgtmaybe.core.models import attempts_of
+from lgtmaybe.core.models import attempts_of, is_unrecoverable
 from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
@@ -1155,8 +1155,12 @@ class TestRateLimitBackoff:
         when = datetime.now(UTC) + timedelta(seconds=40)
         exc = self._rate_limited(response=self._429({"retry-after": format_datetime(when)}))
         wait = provider_module._retry_wait(self._state(exc))
-        # Second-granularity header plus the clock moving under the test.
-        assert 35 <= wait <= 41
+        # Upper bound is tight (the header is 40s at second granularity); the
+        # lower one is loose on purpose, because a contended CI worker can stall
+        # for seconds between the header being written and the wait computed.
+        # What is under test is that the DATE was parsed at all — the ladder
+        # would answer 5s, and anything above it could only come from the header.
+        assert provider_module._RATE_LIMIT_BACKOFF_INITIAL < wait <= 41
 
     def test_a_retry_after_in_the_past_waits_no_time(self) -> None:
         """A stale HTTP-date must not produce a negative wait."""
@@ -1198,3 +1202,129 @@ class TestRateLimitBackoff:
         """tenacity computes a wait before the first outcome exists."""
         state = SimpleNamespace(attempt_number=1, outcome=None)
         assert provider_module._retry_wait(state) >= 0
+
+
+class TestPermanenceIsVisibleToTheEngine:
+    """The adapter knows which failures no later attempt can fix; the engine
+    needs that to decide whether its rescue wave is worth a billed call.
+
+    Stamped onto the exception, in the same place and for the same reason as the
+    attempt count: a failure has no result object to carry anything home on.
+    """
+
+    def test_a_quota_rate_limit_is_stamped_unrecoverable(self) -> None:
+        def quota(*args: Any, **kwargs: Any) -> Any:
+            raise litellm.RateLimitError(
+                message="OpenAIException - You exceeded your current quota",
+                model="m",
+                llm_provider="openai",
+            )
+
+        with patch("litellm.completion", side_effect=quota):
+            with pytest.raises(litellm.RateLimitError) as caught:
+                LiteLLMProvider().complete([{"role": "user", "content": "hi"}], "openai/m")
+
+        assert is_unrecoverable(caught.value)
+
+    def test_a_bad_key_is_stamped_unrecoverable(self) -> None:
+        def bad_key(*args: Any, **kwargs: Any) -> Any:
+            raise litellm.AuthenticationError(
+                message="invalid api key", model="m", llm_provider="openai"
+            )
+
+        with patch("litellm.completion", side_effect=bad_key):
+            with pytest.raises(litellm.AuthenticationError) as caught:
+                LiteLLMProvider().complete([{"role": "user", "content": "hi"}], "openai/m")
+
+        assert is_unrecoverable(caught.value)
+
+    def test_a_capacity_rate_limit_is_not_stamped(self) -> None:
+        """Transient: the engine's rescue wave should still get its go."""
+
+        def busy(*args: Any, **kwargs: Any) -> Any:
+            raise litellm.RateLimitError(
+                message="RateLimitError: OpenrouterException - rate limit exceeded",
+                model="m",
+                llm_provider="openrouter",
+            )
+
+        with (
+            patch("litellm.completion", side_effect=busy),
+            patch.object(provider_module, "_rate_limit_wait", lambda _: 0.0),
+        ):
+            with pytest.raises(litellm.RateLimitError) as caught:
+                LiteLLMProvider().complete([{"role": "user", "content": "hi"}], "openrouter/m")
+
+        assert not is_unrecoverable(caught.value)
+
+    def test_a_wall_timeout_is_not_stamped(self) -> None:
+        """Not retried *here* — an identical request against an identical budget
+        can only fail the same way — but a stalled upstream is not a dead end
+        forever, so the engine's later rescue is still allowed to try."""
+        release = threading.Event()
+
+        def hangs(*args: Any, **kwargs: Any) -> Any:
+            release.wait(timeout=5)
+            return _fake_response()
+
+        try:
+            with patch("litellm.completion", side_effect=hangs):
+                with pytest.raises(TimeoutError) as caught:
+                    LiteLLMProvider(timeout=0.05).complete(
+                        [{"role": "user", "content": "hi"}], "openrouter/m"
+                    )
+        finally:
+            release.set()
+
+        assert not is_unrecoverable(caught.value)
+
+
+class TestRetryBudgetIsNotOvershot:
+    def test_a_long_retry_after_is_not_slept_past_the_call_budget(self) -> None:
+        """`stop_after_delay` checks the clock only AFTER a wait, so a 120s
+        `Retry-After` on a short-timeout call could sleep two minutes past a
+        budget that had all but run out. The stop is evaluated against the
+        UPCOMING sleep instead, so a wait that would blow the budget ends the
+        call rather than being taken."""
+        started = time.perf_counter()
+
+        def rate_limited(*args: Any, **kwargs: Any) -> Any:
+            raise litellm.RateLimitError(
+                message="rate limited",
+                model="m",
+                llm_provider="openrouter",
+                response=httpx.Response(
+                    429,
+                    headers={"retry-after": "120"},
+                    request=httpx.Request("POST", "https://openrouter.ai"),
+                ),
+            )
+
+        with patch("litellm.completion", side_effect=rate_limited):
+            # Budget is 2.5 × 0.05s; the 120s hint cannot fit inside it.
+            with pytest.raises(litellm.RateLimitError):
+                LiteLLMProvider(timeout=0.05).complete(
+                    [{"role": "user", "content": "hi"}], "openrouter/m"
+                )
+
+        assert time.perf_counter() - started < 5
+
+
+class TestMalformedRetryAfter:
+    def test_a_non_finite_retry_after_falls_through_to_the_ladder(self) -> None:
+        """`float()` happily parses "nan" and "inf". Either would reach the
+        sleep and raise from inside the retry loop — the one place left that can
+        still rescue the call — so both are treated as no header at all."""
+        for raw in ("nan", "inf", "-inf"):
+            exc = litellm.RateLimitError(
+                message="rate limited",
+                model="m",
+                llm_provider="openrouter",
+                headers={"retry-after": raw},
+            )
+            state = SimpleNamespace(
+                attempt_number=1, outcome=SimpleNamespace(exception=lambda exc=exc: exc)
+            )
+            wait = provider_module._retry_wait(state)
+            assert wait == wait  # not NaN
+            assert wait <= provider_module._RATE_LIMIT_BACKOFF_MAX


### PR DESCRIPTION
## What happened

Three consecutive lgtmaybe rounds on one PR each posted the `lgtmaybe-incomplete` notice with **1 of 4 review calls failed** — two `RateLimitError`, one `ProviderWallTimeout` — while the other three lenses completed each time. A fourth round fifteen minutes later completed normally and surfaced **2 findings the partial rounds had missed**.

Per-call retry already existed (tenacity, four attempts, capacity 429s explicitly classified retryable). Reading the code says why it didn't help.

## The three causes, and the fix for each

### 1. The backoff was far too short to outlast a 429

`wait_exponential_jitter(initial=0.1, max=5)` — with tenacity's default `jitter=1` that is roughly 1.1s + 1.2s + 1.4s between attempts. The gateways that meter an API key meter it **per minute**, so all four attempts landed in the same window and could only fail identically. `architecture.md` claimed "the classified retry backoff absorbs a capacity 429 on a lower-tier account"; the incident is the counter-example.

Rate limits now wait on their own 5s–60s ladder, and prefer the server's own `Retry-After` when it sends one — read from all three places litellm may have put the headers (matching litellm's own `_get_response_headers`), in either RFC form (delta-seconds or HTTP-date), clamped at 120s so a gateway asking for an hour can't eat the run's wall clock. Every other transient failure keeps the sub-second ladder. Both stay inside the existing `2.5 × timeout` retry budget, so nothing new needs bounding.

### 2. Nothing ever re-ran the failed call

The fan-out drained once; a provider exception became `([], reason)` and the round moved on. The only re-run paths were the oversized-batch split and the lens-deferral re-run — neither covers "upstream was briefly unavailable".

After the fan-out drains, calls that failed **provider-side** now re-run once, in a narrow pool of its own, entered only after the fan-out's has closed (a worker submitting to its own pool and blocking is the deadlock `_review_split` avoids by construction — the rescue must not reintroduce it).

Deliberately **not** rescued, each because a re-run would buy an identical failure at real cost:

| Failure | Why not |
|---|---|
| Unparseable output | Temperature 0 → the same request returns the same unparseable answer |
| `ProviderTruncated` | A blown output ceiling is deterministic; the same request runs to the same ceiling |
| A batch the split already retried | The split *is* that call's retry, with the one change that helps — a smaller payload. A rescue would re-send the original oversized request |
| Deadline / token budget / interrupt skips | A ceiling the user set is not a fault to retry past |

An **unsplittable** wall timeout is rescued: nothing else tried it, and a request issued after the whole wave has drained is a genuinely later one, not the "identical request against an identical budget" the adapter refuses to repeat. Every rescue re-enters `_review_lens`, which re-checks `_skip_reason` first, so `max_review_seconds`, `max_review_tokens` and a termination signal all still stop it dead. **A healthy run costs exactly zero extra calls.**

### 3. The fan-out was partly rate-limiting itself

Eight concurrent calls share one API key. `_CLOUD_MAX_WORKERS` 8 → **6**: a quarter less burst for a sixth less parallelism. `max_concurrency` still overrides in both directions.

## Also

The incomplete notice now names the lenses it lost — `1 of 4 review calls failed (security — RateLimitError: …)`. A missing security lens and a missing documentation lens are the same count and very different news, and the reader had no other way to tell which one it was.

## Not done

- **No new config field.** This is a diagnosis, not a preference — the same call as `_REASONING_DOMINANT_SHARE`.
- **No OpenRouter provider-routing preferences.** `factory._honour_param_support` calls its own openrouter branch "a DELIBERATE, narrowly scoped exception … not licence for general per-provider plumbing".
- **The model's rate tier is an account question.** OpenRouter's per-key limits scale with credit balance and free variants carry hard caps; that is now written down in the OpenRouter how-to, but no code here changes it.

## Tests

Written first, red then green.

**`tests/providers/test_retry.py`** — a new `TestRateLimitBackoff`: `Retry-After` honoured from each of the three header locations, in both RFC forms; a stale date floors at zero; an absurd hint is clamped; garbage falls through to the ladder; a headerless 429 climbs the long ladder; a non-rate-limit transient keeps the fast one; no outcome doesn't crash. The wait is a pure function asserted directly, so the suite never sleeps through a 5–60s backoff.

**`tests/engine/test_rescue.py`** (new) — a lens that fails once completes the round with no notice; one that fails always costs exactly one extra call and then reports; a healthy run makes no extra calls; an unsplittable wall timeout is rescued; a split-retried wall timeout and a truncation are not; unparseable output is not; a deadline-skipped call is not; the notice names the lens.

Existing call-count assertions updated where the rescue legitimately changes them (`test_concurrency.py`, `test_prompt_split.py`, `test_timeout_split.py`), each with a comment saying why.

Full gate green: **1971 passed**, ruff, mypy, `pytest tests/specs`, and `openspec validate --specs`.

## Docs and specs

`architecture.md` reliability section (the 429 claim is now true; rescue wave and worker default documented), a new "Rate limits" section in `review-with-openrouter.md`, the `max_concurrency` default in `README.md` / `use-as-github-action.md` / `ReviewConfig`, regenerated `config.md` + `llms*.txt`, and two new living-spec requirements with anchors: `provider.backoff` → `_retry_wait`, `engine.rescue` → `_rescue`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dbQVinBgkosiR6rpZy4gP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-time recovery retries for eligible provider failures after the initial review pass.
  * Failure notices now identify affected review lenses.
  * Rate-limit handling honors server-provided `Retry-After` delays and uses longer backoff intervals.

* **Improvements**
  * Reduced the default hosted-provider concurrency from 8 to 6.
  * Added safeguards to prevent unsuitable or exhausted requests from being retried.

* **Documentation**
  * Expanded guidance on concurrency, rate limits, retry behavior, and incomplete reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->