### PR TITLE
refactor(provider): inline token counter wrapper

### DIFF
--- a/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-13
+skip_specs: true

--- a/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/design.md
+++ b/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/design.md
@@ -1,0 +1,22 @@
+## Context
+
+`LiteLLMProvider._with_cache_control` is the only caller of `_count_tokens`. The wrapper exists solely to keep the engine import lazy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the lazy import and token-counting behaviour.
+- Remove the single-use delegating symbol.
+
+**Non-Goals:**
+
+- Change cache thresholds, message shaping, or token counting.
+
+## Decisions
+
+Import `count_tokens` at the start of `_with_cache_control`, after the early returns that do not need token counting. This keeps engine loading lazy and avoids importing it for non-cacheable routes. Direct module-level import was rejected because it would change import-time coupling.
+
+## Risks / Trade-offs
+
+- The function gains a local import → existing Python import caching makes repeated calls negligible, and the current wrapper already performs the same local import per call.

--- a/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/proposal.md
+++ b/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The provider has a private wrapper that only lazily imports and delegates to the engine token counter. Moving that lazy import to its sole caller preserves import behaviour while removing an unnecessary symbol.
+
+## What Changes
+
+- Import `count_tokens` lazily inside `_with_cache_control`.
+- Call `count_tokens` directly for cache-threshold calculations.
+- Delete the `_count_tokens` delegating wrapper.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. This is a behaviour-preserving refactor, so `skip_specs` is enabled.
+
+## Impact
+
+Only `src/lgtmaybe/providers/litellm_provider.py` changes. Provider request shape, token accounting, public APIs, and dependencies remain unchanged.

--- a/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/tasks.md
+++ b/openspec/changes/archive/2026-08-13-inline-count-tokens-wrapper/tasks.md
@@ -1,0 +1,8 @@
+## 1. Verification
+
+- [x] 1.1 Confirm no test monkeypatches or imports `_count_tokens` and capture the existing prompt-cache test baseline.
+
+## 2. Refactor
+
+- [x] 2.1 Move the lazy `count_tokens` import into `_with_cache_control` and delete the delegating wrapper.
+- [x] 2.2 Run provider prompt-cache tests and the spec-anchor suite.

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -592,12 +592,14 @@ class LiteLLMProvider(ProviderClient):
         if not self._cache_capable[model]:
             return _merge_user_messages(messages)
 
+        from lgtmaybe.engine.compress import count_tokens
+
         out = list(messages)
         cumulative = 0
         sys_index = next((i for i, m in enumerate(out) if m.get("role") == "system"), None)
         if sys_index is not None and isinstance(out[sys_index].get("content"), str):
             sys_text = out[sys_index]["content"]
-            cumulative = _count_tokens(sys_text)
+            cumulative = count_tokens(sys_text)
             if cumulative >= _MIN_CACHEABLE_TOKENS:
                 sys_marked: Any = [_cache_block(sys_text)]
                 out[sys_index] = {**out[sys_index], "content": sys_marked}
@@ -606,7 +608,7 @@ class LiteLLMProvider(ProviderClient):
         if len(run) >= 2:
             # Split shape: every user message but the last is shared prefix.
             prefix_texts = [str(m.get("content", "")) for m in run[:-1]]
-            cumulative += sum(_count_tokens(t) for t in prefix_texts)
+            cumulative += sum(count_tokens(t) for t in prefix_texts)
             blocks: list[dict[str, Any]] = [{"type": "text", "text": t} for t in prefix_texts]
             if cumulative >= _MIN_CACHEABLE_TOKENS:
                 blocks[-1] = _cache_block(prefix_texts[-1])
@@ -848,14 +850,3 @@ def _cache_usage(usage: Any) -> tuple[int, int]:
         "cache_creation_tokens", "cache_write_tokens"
     )
     return int(cache_read or 0), int(cache_creation or 0)
-
-
-def _count_tokens(text: str) -> int:
-    """Token count for the minimum-cacheable-block check.
-
-    Reuses the engine's cached tiktoken encoder (len/4 fallback) — imported
-    lazily so building a provider never drags the engine in at import time.
-    """
-    from lgtmaybe.engine.compress import count_tokens
-
-    return count_tokens(text)


### PR DESCRIPTION
﻿Closes #387.

## What changed

Moved the lazy `count_tokens` import into `LiteLLMProvider._with_cache_control`, called it directly at the two cache-threshold sites, and removed the single-use `_count_tokens` delegating wrapper.

## Why

The wrapper added a private symbol without changing behaviour. Keeping the import local to the cache-capable path preserves the provider's lazy engine dependency while making the call flow direct.

## Impact

No public API, provider request shape, cache threshold, or dependency changes.

## Validation

- `uv run pytest -q` — 1,979 passed, 3 skipped, 19 deselected
- `uv run ruff check .`
- `uv run pytest tests/specs -q` — 17 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal token counting used for prompt-cache threshold calculations.
  * Preserved existing cache behavior, token accounting, request formatting, and lazy loading.
* **Documentation**
  * Added design, proposal, and verification documentation for the refactor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->