### PR TITLE
refactor(cli): use native Click help

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -90,9 +90,9 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or -not $configPath) {
             throw "lgtmaybe.exe config path failed"
           }
-          $reviewHelp = & $exe help review
+          $reviewHelp = & $exe review --help
           if ($LASTEXITCODE -ne 0 -or -not ($reviewHelp | Select-String -Quiet "Usage")) {
-            throw "lgtmaybe.exe help review failed"
+            throw "lgtmaybe.exe review --help failed"
           }
 
           $size = (Get-Item $exe).Length

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ flow it alters — `review` then `diagram` is the pair to run before opening a
 pull request. See
 [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
 
-`lgtmaybe help` lists every command with usage examples; `lgtmaybe help review`
+`lgtmaybe --help` lists every command with usage examples; `lgtmaybe review --help`
 shows the full option reference. To post reviews on real pull requests, wire up
 the
 [GitHub Action](#use-as-a-github-action). See

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -20,11 +20,11 @@ pip install lgtmaybe
 Verify it:
 
 ```bash
-lgtmaybe help
+lgtmaybe --help
 ```
 
-That prints the command list with usage examples; `lgtmaybe help <command>`
-(e.g. `lgtmaybe help review`) shows the full option reference for one command.
+That prints the command list with usage examples; `<command> --help`
+(e.g. `lgtmaybe review --help`) shows the full option reference for one command.
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -253,11 +253,11 @@ pip install lgtmaybe
 Verify it:
 
 ```bash
-lgtmaybe help
+lgtmaybe --help
 ```
 
-That prints the command list with usage examples; `lgtmaybe help <command>`
-(e.g. `lgtmaybe help review`) shows the full option reference for one command.
+That prints the command list with usage examples; `<command> --help`
+(e.g. `lgtmaybe review --help`) shows the full option reference for one command.
 
 Upgrade later with `pip install --upgrade lgtmaybe`.
 

--- a/openspec/changes/archive/2026-08-13-drop-help-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-drop-help-command/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-13
+skip_specs: true

--- a/openspec/changes/archive/2026-08-13-drop-help-command/design.md
+++ b/openspec/changes/archive/2026-08-13-drop-help-command/design.md
@@ -1,0 +1,17 @@
+## Context
+
+Click supplies group, command, and nested-command help through `--help`; the repository additionally maintains a 28-line alias.
+
+## Goals / Non-Goals
+
+**Goals:** Retain full help coverage using Click's native interface and remove the duplicate command tree walk.
+
+**Non-Goals:** Redesign help text or command options.
+
+## Decisions
+
+Use `lgtmaybe --help`, `lgtmaybe review --help`, and nested `--help` forms directly. No replacement alias is added because that would preserve the duplicate surface.
+
+## Risks / Trade-offs
+
+- Existing users of the alias must change spelling → docs and smoke tests are updated in the same change.

--- a/openspec/changes/archive/2026-08-13-drop-help-command/proposal.md
+++ b/openspec/changes/archive/2026-08-13-drop-help-command/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The custom `lgtmaybe help` command manually reconstructs command contexts for behaviour Click already exposes through `--help`.
+
+## What Changes
+
+- Remove the custom help command and its alias-specific tests.
+- Point examples, documentation, and smoke checks at native `--help` invocations.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. Native Click help already remains available; this removes an undocumented implementation duplicate, so `skip_specs` is enabled.
+
+## Impact
+
+CLI registration, help tests, user docs, and the Windows smoke-command list change.

--- a/openspec/changes/archive/2026-08-13-drop-help-command/tasks.md
+++ b/openspec/changes/archive/2026-08-13-drop-help-command/tasks.md
@@ -1,0 +1,9 @@
+## 1. Acceptance Test
+
+- [x] 1.1 Replace alias tests with native top-level, command, and nested-command help coverage and observe the old command-list expectation fail.
+
+## 2. Implementation
+
+- [x] 2.1 Remove `help_command` and update the CLI examples.
+- [x] 2.2 Update documentation and distribution smoke checks to native `--help`.
+- [x] 2.3 Run CLI, docs, distribution, lint, and spec-anchor checks.

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -878,7 +878,7 @@ Examples:
   lgtmaybe review --format json            Machine-readable findings
   lgtmaybe diagram                         Diagram the components you touched
   lgtmaybe config init                     One-time provider/model setup
-  lgtmaybe help COMMAND                    Detailed help for any command
+  lgtmaybe review --help                   Detailed help for a command
 \b
 Docs: https://lgtmaybe.coles.codes/
 """

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -675,27 +675,3 @@ def config_init() -> None:
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(f"Wrote {store.user_config_path()}")
-
-
-@main.command(name="help")
-@click.argument("command_path", nargs=-1, metavar="[COMMAND]...")
-@click.pass_context
-def help_command(ctx: click.Context, command_path: tuple[str, ...]) -> None:
-    """Show help for lgtmaybe or a specific command.
-
-    `lgtmaybe help review` shows the full option reference for `review`;
-    nested paths work too: `lgtmaybe help config set`.
-    """
-    # Walk the command tree from the main group, rebuilding the context chain
-    # so the usage line matches `lgtmaybe <command...> --help` exactly.
-    target_ctx = ctx.parent if ctx.parent is not None else ctx
-    cmd = target_ctx.command
-    for name in command_path:
-        sub = cmd.get_command(target_ctx, name) if isinstance(cmd, click.Group) else None
-        if sub is None:
-            raise click.UsageError(
-                f"No such command {name!r}. Run `lgtmaybe help` to list commands."
-            )
-        target_ctx = click.Context(sub, info_name=name, parent=target_ctx)
-        cmd = sub
-    click.echo(cmd.get_help(target_ctx))

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -1,4 +1,4 @@
-"""The `help` command: overview with examples, per-command help, nested paths."""
+"""Click's native overview, command help, and nested-command help."""
 
 from __future__ import annotations
 
@@ -10,10 +10,11 @@ from lgtmaybe.core.models import Provider, ReviewPreset, Severity
 
 
 def test_help_lists_commands_and_examples() -> None:
-    result = CliRunner().invoke(main, ["help"])
+    result = CliRunner().invoke(main, ["--help"])
     assert result.exit_code == 0
-    for command in ("review", "diagram", "comment", "action", "config", "help"):
+    for command in ("review", "diagram", "comment", "action", "config"):
         assert command in result.output
+    assert "  help " not in result.output
     assert "Examples:" in result.output
     assert "lgtmaybe review" in result.output
     assert "https://lgtmaybe.coles.codes/" in result.output
@@ -23,48 +24,29 @@ def test_help_examples_cover_every_local_command() -> None:
     """The worked examples are the suggested CLI workflow, so a local command
     missing from them reads as one that doesn't exist — which is exactly how
     `lgtmaybe diagram` got reported as unshipped."""
-    result = CliRunner().invoke(main, ["help"])
+    result = CliRunner().invoke(main, ["--help"])
     examples = result.output.split("Examples:", 1)[1]
     for command in ("review", "diagram", "config"):
         assert f"lgtmaybe {command}" in examples
 
 
-def test_help_command_matches_dash_dash_help() -> None:
-    runner = CliRunner()
-    via_help = runner.invoke(main, ["help", "review"])
-    via_flag = runner.invoke(main, ["review", "--help"])
-    assert via_help.exit_code == 0
-    assert via_flag.exit_code == 0
-    assert via_help.output == via_flag.output
+def test_help_alias_is_not_a_command() -> None:
+    result = CliRunner().invoke(main, ["help"])
+    assert result.exit_code == 2
+    assert "No such command 'help'" in result.output
 
 
 def test_help_nested_subcommand() -> None:
-    runner = CliRunner()
-    via_help = runner.invoke(main, ["help", "config", "set"])
-    via_flag = runner.invoke(main, ["config", "set", "--help"])
-    assert via_help.exit_code == 0
-    assert via_help.output == via_flag.output
-    assert "KEY VALUE" in via_help.output
+    result = CliRunner().invoke(main, ["config", "set", "--help"])
+    assert result.exit_code == 0
+    assert "KEY VALUE" in result.output
 
 
 def test_help_group_lists_subcommands() -> None:
-    result = CliRunner().invoke(main, ["help", "config"])
+    result = CliRunner().invoke(main, ["config", "--help"])
     assert result.exit_code == 0
     for sub in ("path", "show", "get", "set", "init"):
         assert sub in result.output
-
-
-def test_help_unknown_command_errors() -> None:
-    result = CliRunner().invoke(main, ["help", "bogus"])
-    assert result.exit_code != 0
-    assert "No such command 'bogus'" in result.output
-    assert "lgtmaybe help" in result.output
-
-
-def test_help_path_through_non_group_errors() -> None:
-    result = CliRunner().invoke(main, ["help", "review", "extra"])
-    assert result.exit_code != 0
-    assert "No such command 'extra'" in result.output
 
 
 def test_bare_invocation_shows_enriched_help() -> None:
@@ -72,7 +54,7 @@ def test_bare_invocation_shows_enriched_help() -> None:
     # (exit 2) while still printing the full help — assert the content only.
     result = CliRunner().invoke(main, [])
     assert "Examples:" in result.output
-    for command in ("review", "comment", "action", "config", "help"):
+    for command in ("review", "comment", "action", "config"):
         assert command in result.output
 
 

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -29,7 +29,7 @@ def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
     assert "workflow_dispatch:" in text
     assert job["runs-on"] == "windows-latest"
     assert "uv run pyinstaller packaging/pyinstaller/lgtmaybe.spec" in runs
-    for command in ("--help", "config path", "help review"):
+    for command in ("--help", "config path", "review --help"):
         assert command in runs
     assert "gh release upload" in runs
     assert runs.count('--repo "$env:GITHUB_REPOSITORY"') == 2


### PR DESCRIPTION
﻿Closes #384.

## What changed

Removed the hand-written `lgtmaybe help` command and switched examples, documentation, tests, and the Windows executable smoke gate to Click's native `--help` forms.

## Why

Click already resolves top-level, command, and nested-command help. Maintaining a second command-tree walker duplicated framework behaviour and added a redundant public spelling.

## Impact

Use `lgtmaybe --help`, `lgtmaybe review --help`, or `lgtmaybe config set --help`.

## Validation

- `uv run pytest -q` — 1,977 passed, 3 skipped, 19 deselected
- `uv run ruff check .`
- `uv run pytest tests/specs -q` — 17 passed
- `git diff --check`
