### PR TITLE
refactor(core): use structural port protocols

### DIFF
--- a/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-13
+skip_specs: true

--- a/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/design.md
+++ b/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/design.md
@@ -1,0 +1,17 @@
+## Context
+
+Each port has one production implementation and several injected test fakes. Runtime subclass checks are not used by production code.
+
+## Goals / Non-Goals
+
+**Goals:** Preserve type-checkable contracts without mandatory inheritance.
+
+**Non-Goals:** Change port methods, exception contracts, or dependency injection.
+
+## Decisions
+
+Use plain `Protocol` classes and ellipsis method bodies. Remove inheritance from concrete classes to prove structural typing is sufficient. Keep the existing port names and imports so annotations remain stable.
+
+## Risks / Trade-offs
+
+- Runtime `issubclass`/instantiation behaviour changes → replace tests with concrete structural assignments and run mypy.

--- a/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/proposal.md
+++ b/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The ports use runtime abstract inheritance even though dependency injection and static method signatures are the actual seams; production implementations and fakes do not need base-class coupling.
+
+## What Changes
+
+- Express all three ports as `typing.Protocol` contracts.
+- Remove port inheritance from adapters, engine, and test fakes.
+- Replace abstractness tests with structural conformance tests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. Port signatures remain frozen; only their runtime representation changes, so `skip_specs` is enabled.
+
+## Impact
+
+Core port definitions and implementing class declarations change; exceptions and public method signatures stay unchanged.

--- a/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/tasks.md
+++ b/openspec/changes/archive/2026-08-13-replace-port-abcs-with-protocols/tasks.md
@@ -1,0 +1,8 @@
+## 1. Acceptance Test
+
+- [x] 1.1 Replace ABC assertions with structural protocol conformance checks and observe them fail against inherited implementations.
+
+## 2. Implementation
+
+- [x] 2.1 Convert the ports to `Protocol` and remove concrete inheritance.
+- [x] 2.2 Run port, engine, CLI, adapter, mypy, lint, and spec-anchor checks.

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -8,8 +8,7 @@ parallel tracks can build against stable signatures.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Protocol
 
 from .models import PRContext, ProviderResult, ReviewConfig, ReviewFinding
 
@@ -71,22 +70,21 @@ class ProviderTruncated(Exception):
         self.output_tokens = output_tokens
 
 
-class ProviderClient(ABC):
+class ProviderClient(Protocol):
     """Port: an LLM backend that returns a normalised completion."""
 
-    @abstractmethod
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         """Run one completion and return text + token usage."""
+        ...
 
 
-class GitHubGateway(ABC):
+class GitHubGateway(Protocol):
     """Port: read a PR's context and post a review back."""
 
-    @abstractmethod
     def get_pr_context(self) -> PRContext:
         """Fetch the PR diff and metadata via API (never check out PR code)."""
+        ...
 
-    @abstractmethod
     def post_review(
         self, findings: list[ReviewFinding], summary: str, diff: str | None = None
     ) -> None:
@@ -96,15 +94,16 @@ class GitHubGateway(ABC):
         positions; when omitted the adapter re-fetches it. Callers that already
         hold the context should pass it to avoid a redundant round-trip.
         """
+        ...
 
-    @abstractmethod
     def post_issue_comment(self, body: str) -> None:
         """Post a standalone comment to the PR conversation (in-thread reply)."""
+        ...
 
 
-class ReviewEngine(ABC):
+class ReviewEngine(Protocol):
     """Port: turn a PR context + config into findings and a summary."""
 
-    @abstractmethod
     def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
         """Produce (findings, summary) for the given PR and config."""
+        ...

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -36,7 +36,6 @@ from lgtmaybe.core.ports import (
     ProviderClient,
     ProviderTruncated,
     ProviderWallTimeout,
-    ReviewEngine,
 )
 from lgtmaybe.core.version import package_version
 from lgtmaybe.github import is_reviewable
@@ -573,7 +572,7 @@ class ReviewIncompleteError(Exception):
     """
 
 
-class LLMReviewEngine(ReviewEngine):
+class LLMReviewEngine:
     """Review engine that runs the full pipeline against an injected ProviderClient."""
 
     def __init__(

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -29,7 +29,6 @@ from lgtmaybe.core.models import (
     PRContext,
     ReviewFinding,
 )
-from lgtmaybe.core.ports import GitHubGateway
 
 from .checkout import clone_base_tree
 from .diff import (
@@ -298,7 +297,7 @@ def _render_broad(broad: list[ReviewFinding]) -> str:
     return "\n".join(lines)
 
 
-class RestGitHubGateway(GitHubGateway):
+class RestGitHubGateway:
     """GitHub REST adapter.
 
     Args:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -48,7 +48,6 @@ from lgtmaybe.core.models import (
 )
 from lgtmaybe.core.ports import (
     Message,
-    ProviderClient,
     ProviderTruncated,
     ProviderWallTimeout,
 )
@@ -377,7 +376,7 @@ litellm.drop_params = True
 litellm.suppress_debug_info = True
 
 
-class LiteLLMProvider(ProviderClient):
+class LiteLLMProvider:
     """ProviderClient backed by litellm with retry and optional fallback."""
 
     def __init__(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,11 +9,10 @@ from click.testing import CliRunner
 
 from lgtmaybe.cli import RuntimeOptions, build_review_context, main, run_review
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
-from lgtmaybe.core.ports import ReviewEngine
 from tests.fakes import FakeEngine, FakeGitHub, FakeProvider
 
 
-class _BoomEngine(ReviewEngine):
+class _BoomEngine:
     """A ReviewEngine that always fails — used to exercise error surfacing."""
 
     def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:

--- a/tests/cli/test_feedback_learning.py
+++ b/tests/cli/test_feedback_learning.py
@@ -19,7 +19,6 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
-from lgtmaybe.core.ports import ReviewEngine
 from lgtmaybe.engine.suppress import apply_suppressions
 from lgtmaybe.github.rest_gateway import finding_fingerprint
 from tests.conftest import make_cfg
@@ -45,7 +44,7 @@ FINDING = ReviewFinding(
 FINDING_FP = finding_fingerprint(FINDING.path, FINDING.title)
 
 
-class SuppressingEngine(ReviewEngine):
+class SuppressingEngine:
     """Returns canned findings after applying suppression like the real engine.
 
     Records the context it was handed so a test can assert the downvoted

--- a/tests/cli/test_incremental_review.py
+++ b/tests/cli/test_incremental_review.py
@@ -17,7 +17,6 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
-from lgtmaybe.core.ports import ReviewEngine
 from tests.conftest import make_cfg
 from tests.fakes import FakeGitHub
 
@@ -37,7 +36,7 @@ CTX = PRContext(
 )
 
 
-class RecordingEngine(ReviewEngine):
+class RecordingEngine:
     """Returns canned findings; records the ctx it was asked to review."""
 
     def __init__(self, findings: list[ReviewFinding] | None = None) -> None:
@@ -295,9 +294,8 @@ def test_run_diagram_falls_back_to_issue_comment_without_upsert() -> None:
 
     from lgtmaybe.cli import run_diagram
     from lgtmaybe.core.models import PRContext, ProviderResult
-    from lgtmaybe.core.ports import GitHubGateway
 
-    class PlainGateway(GitHubGateway):
+    class PlainGateway:
         def __init__(self) -> None:
             self.comments: list[str] = []
 

--- a/tests/cli/test_merge_gate.py
+++ b/tests/cli/test_merge_gate.py
@@ -15,7 +15,6 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
-from lgtmaybe.core.ports import GitHubGateway, ReviewEngine
 from tests.conftest import make_cfg
 from tests.fakes import FakeGitHub
 
@@ -35,7 +34,7 @@ def _finding(severity: Severity) -> ReviewFinding:
     )
 
 
-class CannedEngine(ReviewEngine):
+class CannedEngine:
     def __init__(self, findings: list[ReviewFinding]) -> None:
         self._findings = findings
 
@@ -93,7 +92,7 @@ def test_no_check_run_on_dry_run() -> None:
     assert github.check_runs == []
 
 
-class _PortOnlyGateway(GitHubGateway):
+class _PortOnlyGateway:
     """A gateway implementing only the frozen port — no create_check_run."""
 
     def __init__(self, ctx: PRContext) -> None:

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -14,7 +14,6 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
-from lgtmaybe.core.ports import ProviderClient
 from lgtmaybe.engine.compress import count_tokens
 from lgtmaybe.engine.reflect import _head_tail, reflect_findings
 from tests.fakes import FakeProvider
@@ -222,7 +221,7 @@ def test_unparseable_verdict_keeps_all() -> None:
     assert survivors == [_HIGH, _LOW_CONF]  # safe default
 
 
-class _RaisingProvider(ProviderClient):
+class _RaisingProvider:
     """A ProviderClient whose complete() always raises (quota/auth/network)."""
 
     def complete(self, messages: list[dict[str, str]], model: str, **opts: object):
@@ -437,7 +436,7 @@ def test_head_tail_returns_text_and_accurate_token_count() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _ScriptedProvider(ProviderClient):
+class _ScriptedProvider:
     """A ProviderClient that returns a different canned text per successive call.
 
     Records every call's messages/model/opts (like FakeProvider) so a test can

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -16,7 +16,6 @@ import pytest
 from evals import run as run_mod
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.models import PRContext, Provider, ProviderResult, ReviewConfig, ReviewFinding
-from lgtmaybe.core.ports import ProviderClient
 from lgtmaybe.engine import LLMReviewEngine
 from lgtmaybe.engine.astgrep import build_symbol_resolver
 from lgtmaybe.engine.compress import split_patch_into_hunks
@@ -210,7 +209,7 @@ def test_real_ast_grep_resolves_cross_file_symbols_in_the_corpus() -> None:
     assert resolve("SavedSubmittalSetV2") == ["migrations/models.py"]
 
 
-class _ScriptedProvider(ProviderClient):
+class _ScriptedProvider:
     """Returns a different canned text per successive call (records each call)."""
 
     def __init__(self, texts: list[str]) -> None:

--- a/tests/evals/test_rlm.py
+++ b/tests/evals/test_rlm.py
@@ -12,10 +12,10 @@ from typing import Any
 
 from evals.rlm import RunSample, StrategyReport, _UsageTrackingProvider, verdict
 from lgtmaybe.core.models import ProviderResult
-from lgtmaybe.core.ports import Message, ProviderClient
+from lgtmaybe.core.ports import Message
 
 
-class _Fake(ProviderClient):
+class _Fake:
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         return ProviderResult(text="{}", input_tokens=7, output_tokens=3)
 

--- a/tests/fakes/engine.py
+++ b/tests/fakes/engine.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import json
 
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
-from lgtmaybe.core.ports import ProviderClient, ReviewEngine
+from lgtmaybe.core.ports import ProviderClient
 
 
-class FakeEngine(ReviewEngine):
+class FakeEngine:
     def __init__(self, provider: ProviderClient) -> None:
         self._provider = provider
 

--- a/tests/fakes/github.py
+++ b/tests/fakes/github.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from lgtmaybe.core.models import PRContext, ReviewFinding
-from lgtmaybe.core.ports import GitHubGateway
 
 _DEFAULT_CTX = PRContext(
     diff="--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-old\n+new\n",
@@ -15,7 +14,7 @@ _DEFAULT_CTX = PRContext(
 )
 
 
-class FakeGitHub(GitHubGateway):
+class FakeGitHub:
     """A GitHubGateway backed by in-memory state."""
 
     def __init__(self, ctx: PRContext | None = None) -> None:

--- a/tests/fakes/provider.py
+++ b/tests/fakes/provider.py
@@ -6,7 +6,7 @@ import json
 from typing import Any
 
 from lgtmaybe.core.models import ProviderResult, ReviewFinding, Severity
-from lgtmaybe.core.ports import Message, ProviderClient
+from lgtmaybe.core.ports import Message
 
 _DEFAULT_FINDINGS = [
     ReviewFinding(
@@ -20,7 +20,7 @@ _DEFAULT_FINDINGS = [
 ]
 
 
-class FakeProvider(ProviderClient):
+class FakeProvider:
     """A ProviderClient that returns canned findings as JSON text."""
 
     def __init__(

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,18 +1,19 @@
-"""Boundary interfaces: importable and genuinely abstract."""
+"""Boundary interfaces are structural protocols, not inheritance requirements."""
 
 from __future__ import annotations
 
-import abc
-
-import pytest
-
 from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
+from lgtmaybe.engine.engine import LLMReviewEngine
+from lgtmaybe.github.rest_gateway import RestGitHubGateway
+from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
-PORTS = [ProviderClient, GitHubGateway, ReviewEngine]
+
+def test_ports_are_protocols() -> None:
+    for port in (ProviderClient, GitHubGateway, ReviewEngine):
+        assert getattr(port, "_is_protocol", False)
 
 
-@pytest.mark.parametrize("port", PORTS, ids=lambda p: p.__name__)
-def test_ports_are_abstract(port: type) -> None:
-    assert issubclass(port, abc.ABC)
-    with pytest.raises(TypeError):
-        port()  # type: ignore[abstract]
+def test_production_implementations_do_not_inherit_ports() -> None:
+    assert ProviderClient not in LiteLLMProvider.__mro__
+    assert GitHubGateway not in RestGitHubGateway.__mro__
+    assert ReviewEngine not in LLMReviewEngine.__mro__


### PR DESCRIPTION
﻿Closes #382.

## What changed

Converted `ProviderClient`, `GitHubGateway`, and `ReviewEngine` from ABCs to `typing.Protocol`, removed mandatory inheritance from production adapters/engine and test fakes, and replaced abstractness tests with structural-contract tests.

## Why

Dependency injection and the frozen method signatures are the seams. Runtime inheritance added coupling without being used for dispatch or validation.

## Impact

Port names, annotations, methods, provider exceptions, and runtime review behaviour remain unchanged. Implementations now satisfy the contracts structurally.

## Validation

- `uv run pytest -q` — 1,978 passed, 3 skipped, 19 deselected
- `uv run mypy src`
- `uv run ruff check .`
- `uv run pytest tests/specs -q` — 17 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated service contracts to use structural interfaces instead of required base-class inheritance.
  * Existing method signatures, behavior, exception handling, and dependency-injection patterns remain unchanged.
  * Implementations and test doubles can now satisfy interfaces through compatible methods without explicit inheritance.

* **Tests**
  * Replaced abstract-class checks with structural compatibility validation.
  * Updated test fixtures and validation coverage for the revised interface behavior.

* **Documentation**
  * Added design, proposal, configuration, and completion documentation for the interface updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->