### PR TITLE
refactor!: remove legacy prompt cache path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ pattern, event bus, plugin framework.
      — defined inline in `.lgtmaybe.yml` or in skill files loaded by the config
      loader's `lens_paths` directive. The engine builds a uniform `_Lens` per
      built-in category **and** per custom lens (`engine._build_lenses`,
-     `prompt.build_lens_prompt`) and fans them all out identically through the same
+     `prompt.build_custom_lens_block`) and fans them all out identically through the same
      merge/dedupe/reflect pipeline. Lens text enters the system prompt, so it is
      **trusted config only** — never sourced from PR-author content (on
      `pull_request_target` config comes from the base, not the PR head). Covered by
@@ -406,8 +406,8 @@ pattern, event bus, plugin framework.
    - **Determinism & timeouts:** `temperature` defaults to `0.0` for reproducible
      reviews; `timeout` is `None` → a provider-aware default (ollama gets a long
      one, cloud a short one). Both are `ReviewConfig` fields and CLI/Action inputs.
-   - **Prompt caching (split prefix):** with `prompt_cache` on (default) every
-     review call is shaped as a shared cacheable prefix — a lens-independent
+   - **Prompt caching (split prefix):** every review call is shaped as a shared
+     cacheable prefix — a lens-independent
      system preamble (`prompt.build_shared_preamble`), then the wrapped diff
      (+hints) as the first user block — with the lens checklist + example as
      the final uncached user block. On routes with an explicit cache breakpoint
@@ -420,11 +420,8 @@ pattern, event bus, plugin framework.
      pay N cache writes. Reflection splits the same way, so deferral re-judges
      read the audit's system+diff prefix. Feature-detected per model (litellm
      capability map); every other provider gets the user blocks joined back
-     into the single plain message it always received. `prompt_cache: false`
-     restores the legacy lens-in-system shape byte-for-byte.
-     `ReviewConfig.prompt_cache` (CLI `--prompt-cache/--no-prompt-cache`,
-     Action input `prompt_cache`); cache read/creation token counts land on
-     `ProviderResult` and are logged.
+     into one plain user message. Cache read/creation token counts land on
+     `ProviderResult` and are logged. There is one prompt shape and no opt-out.
    - **Summary line:** names the **model** used (no cost — lgtmaybe does not
      compute or report cost). `ReviewConfig.summary_template` (default None)
      lets teams restyle it with `{count}`/`{provider}`/`{model}` placeholders;

--- a/action.yml
+++ b/action.yml
@@ -98,10 +98,6 @@ inputs:
     description: "During reflection, use ast-grep to resolve a deferred finding's referenced symbol to the file that defines it — searched in a read-only shallow clone of the PR's base branch — so the auditor re-judges a cross-file finding against the real definition. On by default; set to false to disable."
     required: false
     default: ""
-  prompt_cache:
-    description: "Shape every per-lens call as a shared cacheable prefix, and mark an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax) — cached reads are billed at a steep discount. Feature-detected per model and a safe no-op elsewhere. On by default; set to false to disable."
-    required: false
-    default: ""
   incremental:
     description: "Commit-scoped incremental review: on a synchronize push, review only the diff of the commits added since the last completed review instead of the whole PR. Auto by default (on for synchronize, full review everywhere else); set to true/false to force. Falls back to a full review after a force-push/rebase or when no previous review exists. `/review full` forces a full re-review on demand."
     required: false
@@ -303,7 +299,6 @@ runs:
         INPUT_STRUCTURED_OUTPUT: ${{ inputs.structured_output }}
         INPUT_MID_REVIEW_RETRIEVAL: ${{ inputs.mid_review_retrieval }}
         INPUT_SYMBOL_RESOLUTION: ${{ inputs.symbol_resolution }}
-        INPUT_PROMPT_CACHE: ${{ inputs.prompt_cache }}
         INPUT_INCREMENTAL: ${{ inputs.incremental }}
         INPUT_SPEC_REVIEW: ${{ inputs.spec_review }}
         INPUT_STATIC_ANALYSIS: ${{ inputs.static_analysis }}

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -90,7 +90,7 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
 
-   With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
+   Each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
    the lens-specific instruction as the final user block. On routes that
    take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, vertex

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -98,9 +98,10 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    families)
    the prefix is marked with `cache_control`; on backends that cache
    automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
-   its own. Either way every call after a batch's first reads that
-   preamble-plus-diff prefix from cache, and on big diffs a warm-up primer
-   runs the first lens alone so a concurrent wave doesn't all miss it.
+   its own. On cache-capable routes, every call after a batch's first reads the
+   preamble-plus-diff prefix from cache. Unsupported routes use the merged-message
+   fallback and do not promise cache reads. On big diffs, a warm-up primer runs
+   the first lens alone so a concurrent wave doesn't all miss it.
 
    Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -8,8 +8,15 @@ Place a `.lgtmaybe.yml` file at the root of your repository to control how
 lgtmaybe reviews pull requests. CLI flags override file values; the file
 provides defaults for all runs.
 
+## Upgrading from 1.14
+
+Remove `prompt_cache` from existing `.lgtmaybe.yml` files and remove
+`--prompt-cache` or `--no-prompt-cache` from scripts. Prompt caching is now
+automatic where the provider supports it.
+
 ## Contents
 
+- [Upgrading from 1.14](#upgrading-from-114)
 - [Full example](#full-example)
 - [Field reference](#field-reference)
   - [provider](#provider)

--- a/docs/how-to/configure-lgtmaybe-yml.md
+++ b/docs/how-to/configure-lgtmaybe-yml.md
@@ -24,7 +24,6 @@ provides defaults for all runs.
   - [function_context](#function_context)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
-  - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [min_confidence](#min_confidence)
   - [mid_review_retrieval](#mid_review_retrieval)
@@ -262,58 +261,6 @@ structured_output: false   # only if your gateway rejects JSON-schema mode
 
 Default: `true`. See
 [Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
-
-### prompt_cache
-
-Reuse the expensive shared prefix — system preamble plus the wrapped diff —
-across the per-lens review calls and the reflection call, instead of re-paying
-full input price for it on every one. lgtmaybe fans out several model calls per
-review and they all begin with that same prefix, so it shapes every call
-identically and lets the backend serve it from cache.
-
-Two mechanisms, picked per route:
-
-| Route | How it caches |
-|---|---|
-| **anthropic**, **bedrock** Claude/Nova, **vertex** (Claude and Gemini), **zai** GLM, **openrouter** (claude / gemini / glm / minimax / z-ai models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
-| **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
-| **ollama**, `openai-compatible` | the request is sent unchanged |
-
-Support is feature-detected per model, so a route in the first row whose model
-litellm doesn't know about simply falls back to the second behaviour — a missed
-discount, never an error. The diff-independent parts of the prompt are what get
-reused; per-PR content still enters the prefix, which is why it is only ever
-shared *within* one review.
-
-On a large diff lgtmaybe also runs a **warm-up primer**: the first lens of a
-batch is dispatched alone and the rest release when it returns, so a fully
-concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
-pay the cache-write surcharge). This applies on every provider — it is about the
-shape of the first wave, not about the marker.
-
-Every call also carries a `prompt_cache_key` derived from the prefix itself:
-identical across the lenses of one batch, different for another PR. OpenRouter
-uses it to pin the whole fan-out to a single provider endpoint from the first
-call (without a key it only starts doing that *after* it notices a cache hit,
-which a concurrent wave reaches too late), and OpenAI takes the same field as a
-cache-routing hint. It is a digest, not prompt content.
-
-**Minimums are per model**, and a prefix below one is silently not cached — no
-error, just no discount. Roughly: 1,024 tokens for Claude Sonnet 4.x / Opus
-4–4.1 and Gemini 2.5 Flash, 2,048 for Claude Haiku 3.5, 4,096 for Claude Opus
-4.5+ / Haiku 4.5 and Gemini 2.5 Pro. lgtmaybe marks from 1,024 up so it never
-misses a chance on the lower-minimum models; on a higher-minimum model a small
-diff simply won't cache. Check with `--profile`, which reports cache read and
-write tokens.
-
-Leaving it on costs nothing. Turn it off only to rule caching out while
-debugging provider behaviour. CLI: `--no-prompt-cache`.
-
-```yaml
-prompt_cache: false   # send every call uncached, and never warm the batch
-```
-
-Default: `true`.
 
 ### reflect
 

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -124,7 +124,7 @@ low-value findings as well as spend.
 
 ### 3. Check prompt caching is actually working
 
-`prompt_cache` is **on by default**, and when it works it takes most of the
+Prompt caching is **always enabled**, and when it works it takes most of the
 sting out of the lens multiplier: lenses 2..N read the shared system-preamble
 plus diff prefix from cache instead of paying full input price for it.
 
@@ -310,8 +310,8 @@ Ways to keep the bill honest if you want it:
 
 - pair it with `max_review_tokens`, so the worst case is bounded rather than
   merely unlikely — a deferral arriving past the ceiling is skipped and reported;
-- leave `prompt_cache` on: the fetched text rides the lens's own block, so a
-  deferral never invalidates the prefix its sibling lenses read from cache;
+- fetched text rides the lens's own block, so a deferral never invalidates the
+  prefix its sibling lenses read from cache;
 - turn on `triage_model` first, so fewer files reach the lenses that might defer.
 
 Measure it rather than assume: run `python -m evals.run` with and without

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -311,7 +311,7 @@ Ways to keep the bill honest if you want it:
 - pair it with `max_review_tokens`, so the worst case is bounded rather than
   merely unlikely — a deferral arriving past the ceiling is skipped and reported;
 - fetched text rides the lens's own block, so a deferral never invalidates the
-  prefix its sibling lenses read from cache;
+  shared prefix; on cache-capable routes, sibling lenses can reuse that prefix;
 - turn on `triage_model` first, so fewer files reach the lenses that might defer.
 
 Measure it rather than assume: run `python -m evals.run` with and without

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -234,7 +234,6 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
 | `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2160,8 +2160,15 @@ Place a `.lgtmaybe.yml` file at the root of your repository to control how
 lgtmaybe reviews pull requests. CLI flags override file values; the file
 provides defaults for all runs.
 
+## Upgrading from 1.14
+
+Remove `prompt_cache` from existing `.lgtmaybe.yml` files and remove
+`--prompt-cache` or `--no-prompt-cache` from scripts. Prompt caching is now
+automatic where the provider supports it.
+
 ## Contents
 
+- [Upgrading from 1.14](#upgrading-from-114)
 - [Full example](#full-example)
 - [Field reference](#field-reference)
   - [provider](#provider)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -596,7 +596,6 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
 | `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
-| `prompt_cache` | `true` | Shape calls as a shared cacheable prefix, with an explicit cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM, openrouter claude/gemini/glm/minimax); safe no-op elsewhere |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |
 | `auto_describe` | `false` | Post a structured description comment when a PR is opened/reopened, before the review |
@@ -2177,7 +2176,6 @@ provides defaults for all runs.
   - [function_context](#function_context)
   - [timeout](#timeout)
   - [structured_output](#structured_output)
-  - [prompt_cache](#prompt_cache)
   - [reflect](#reflect)
   - [min_confidence](#min_confidence)
   - [mid_review_retrieval](#mid_review_retrieval)
@@ -2415,58 +2413,6 @@ structured_output: false   # only if your gateway rejects JSON-schema mode
 
 Default: `true`. See
 [Use a custom OpenAI-compatible endpoint](use-a-custom-openai-compatible-endpoint.md#gateways-that-dont-support-json-mode-response_format).
-
-### prompt_cache
-
-Reuse the expensive shared prefix — system preamble plus the wrapped diff —
-across the per-lens review calls and the reflection call, instead of re-paying
-full input price for it on every one. lgtmaybe fans out several model calls per
-review and they all begin with that same prefix, so it shapes every call
-identically and lets the backend serve it from cache.
-
-Two mechanisms, picked per route:
-
-| Route | How it caches |
-|---|---|
-| **anthropic**, **bedrock** Claude/Nova, **vertex** (Claude and Gemini), **zai** GLM, **openrouter** (claude / gemini / glm / minimax / z-ai models) | lgtmaybe marks the prefix with an explicit `cache_control` breakpoint |
-| **openai**, **azure**, **deepseek** (direct or via openrouter) | the backend caches a repeated prefix automatically — the identical shape is all it needs |
-| **ollama**, `openai-compatible` | the request is sent unchanged |
-
-Support is feature-detected per model, so a route in the first row whose model
-litellm doesn't know about simply falls back to the second behaviour — a missed
-discount, never an error. The diff-independent parts of the prompt are what get
-reused; per-PR content still enters the prefix, which is why it is only ever
-shared *within* one review.
-
-On a large diff lgtmaybe also runs a **warm-up primer**: the first lens of a
-batch is dispatched alone and the rest release when it returns, so a fully
-concurrent first wave doesn't all miss the cache (and, on breakpoint routes, all
-pay the cache-write surcharge). This applies on every provider — it is about the
-shape of the first wave, not about the marker.
-
-Every call also carries a `prompt_cache_key` derived from the prefix itself:
-identical across the lenses of one batch, different for another PR. OpenRouter
-uses it to pin the whole fan-out to a single provider endpoint from the first
-call (without a key it only starts doing that *after* it notices a cache hit,
-which a concurrent wave reaches too late), and OpenAI takes the same field as a
-cache-routing hint. It is a digest, not prompt content.
-
-**Minimums are per model**, and a prefix below one is silently not cached — no
-error, just no discount. Roughly: 1,024 tokens for Claude Sonnet 4.x / Opus
-4–4.1 and Gemini 2.5 Flash, 2,048 for Claude Haiku 3.5, 4,096 for Claude Opus
-4.5+ / Haiku 4.5 and Gemini 2.5 Pro. lgtmaybe marks from 1,024 up so it never
-misses a chance on the lower-minimum models; on a higher-minimum model a small
-diff simply won't cache. Check with `--profile`, which reports cache read and
-write tokens.
-
-Leaving it on costs nothing. Turn it off only to rule caching out while
-debugging provider behaviour. CLI: `--no-prompt-cache`.
-
-```yaml
-prompt_cache: false   # send every call uncached, and never warm the batch
-```
-
-Default: `true`.
 
 ### reflect
 
@@ -3648,7 +3594,7 @@ low-value findings as well as spend.
 
 ### 3. Check prompt caching is actually working
 
-`prompt_cache` is **on by default**, and when it works it takes most of the
+Prompt caching is **always enabled**, and when it works it takes most of the
 sting out of the lens multiplier: lenses 2..N read the shared system-preamble
 plus diff prefix from cache instead of paying full input price for it.
 
@@ -3834,8 +3780,8 @@ Ways to keep the bill honest if you want it:
 
 - pair it with `max_review_tokens`, so the worst case is bounded rather than
   merely unlikely — a deferral arriving past the ceiling is skipped and reported;
-- leave `prompt_cache` on: the fetched text rides the lens's own block, so a
-  deferral never invalidates the prefix its sibling lenses read from cache;
+- fetched text rides the lens's own block, so a deferral never invalidates the
+  prefix its sibling lenses read from cache;
 - turn on `triage_model` first, so fewer files reach the lenses that might defer.
 
 Measure it rather than assume: run `python -m evals.run` with and without
@@ -4073,7 +4019,6 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
 | `pr_labels` | boolean | No | `False` | Pr Labels |
 | `preset` | `fast` / `full` | No | `fast` |  |
-| `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `reasoning_effort` | string / null | No | `null` | Reasoning Effort |
 | `recursive` | boolean | No | `True` | Recursive |
@@ -4866,11 +4811,6 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "preset": {
       "$ref": "#/$defs/ReviewPreset",
       "default": "fast"
-    },
-    "prompt_cache": {
-      "default": true,
-      "title": "Prompt Cache",
-      "type": "boolean"
     },
     "provider": {
       "$ref": "#/$defs/Provider"
@@ -5961,7 +5901,7 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
    ollama and openai-compatible), so batches never wait on each other.
 
-   With `prompt_cache` on, each call is shaped as a shared cacheable prefix —
+   Each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by
    the lens-specific instruction as the final user block. On routes that
    take an explicit cache breakpoint (anthropic, bedrock Claude/Nova, vertex

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3781,7 +3781,7 @@ Ways to keep the bill honest if you want it:
 - pair it with `max_review_tokens`, so the worst case is bounded rather than
   merely unlikely — a deferral arriving past the ceiling is skipped and reported;
 - fetched text rides the lens's own block, so a deferral never invalidates the
-  prefix its sibling lenses read from cache;
+  shared prefix; on cache-capable routes, sibling lenses can reuse that prefix;
 - turn on `triage_model` first, so fewer files reach the lenses that might defer.
 
 Measure it rather than assume: run `python -m evals.run` with and without
@@ -5909,9 +5909,10 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    families)
    the prefix is marked with `cache_control`; on backends that cache
    automatically (OpenAI, Azure, DeepSeek) the identical prefix is enough on
-   its own. Either way every call after a batch's first reads that
-   preamble-plus-diff prefix from cache, and on big diffs a warm-up primer
-   runs the first lens alone so a concurrent wave doesn't all miss it.
+   its own. On cache-capable routes, every call after a batch's first reads the
+   preamble-plus-diff prefix from cache. Unsupported routes use the merged-message
+   fallback and do not promise cache reads. On big diffs, a warm-up primer runs
+   the first lens alone so a concurrent wave doesn't all miss it.
 
    Each lens's focused structured prompt requests JSON output with
    the `ReviewFinding` schema (`path`, `line`, `side`, `severity`, `title`,

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -47,7 +47,6 @@ The user-facing configuration model. Fields map directly to `.lgtmaybe.yml` keys
 | `num_ctx` | integer / null | No | `null` | Num Ctx |
 | `pr_labels` | boolean | No | `False` | Pr Labels |
 | `preset` | `fast` / `full` | No | `fast` |  |
-| `prompt_cache` | boolean | No | `True` | Prompt Cache |
 | `provider` | `anthropic` / `azure` / `bedrock` / `ollama` / `openai` / `openai-compatible` / `openrouter` / `vertex` / `zai` | Yes | — |  |
 | `reasoning_effort` | string / null | No | `null` | Reasoning Effort |
 | `recursive` | boolean | No | `True` | Recursive |
@@ -840,11 +839,6 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "preset": {
       "$ref": "#/$defs/ReviewPreset",
       "default": "fast"
-    },
-    "prompt_cache": {
-      "default": true,
-      "title": "Prompt Cache",
-      "type": "boolean"
     },
     "provider": {
       "$ref": "#/$defs/Provider"

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/design.md
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/design.md
@@ -1,0 +1,19 @@
+## Context
+
+Review calls currently build both a legacy lens-in-system layout and the default split-prefix layout. The provider adapter already merges split user blocks for routes without explicit cache support.
+
+## Goals / Non-Goals
+
+**Goals:** Keep one prompt assembly path, preserve prompt content and supported-route cache behavior, and remove the public opt-out.
+
+**Non-Goals:** Change cache eligibility, breakpoints, warm-up thresholds, token accounting, or lens content.
+
+## Decisions
+
+Always construct the split shape in the engine and reflection pass. Remove the provider's boolean switch while retaining automatic route capability detection: cacheable routes receive breakpoints and a stable key; other routes receive merged plain user content. Repoint coverage tests at the shared preamble plus focused block instead of retaining compatibility wrappers.
+
+## Risks / Trade-offs
+
+- Removing a public field can reject old configuration files → document the migration as deleting `prompt_cache`; the previous default already selected the retained path.
+- Prompt content could drift while deleting duplicate builders → update tests first to assert the retained builders and run the complete prompt/provider suites.
+- Anchor rules point at deleted functions → re-point each rule at its retained counterpart in the same change.

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/proposal.md
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The default split-prefix prompt is already safe on every provider, while the disabled-cache rollback path doubles prompt construction and test surface without preserving a distinct capability.
+
+## What Changes
+
+- **BREAKING**: remove the `prompt_cache` configuration field, CLI flag, and Action input.
+- Always assemble review and reflection prompts using the split-prefix shape.
+- Remove the legacy monolithic prompt builders and provider opt-out branches.
+- Keep cache breakpoints automatic on supported routes and plain-message merging elsewhere.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `prompt-and-lenses`: split-prefix prompt composition becomes unconditional rather than configurable.
+
+## Impact
+
+Prompt construction, provider setup, CLI/Action configuration, generated reference documentation, and prompt-cache tests change. Provider compatibility and cache accounting remain unchanged.

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/proposal.md
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/proposal.md
@@ -21,4 +21,4 @@ None.
 
 ## Impact
 
-Prompt construction, provider setup, CLI/Action configuration, generated reference documentation, and prompt-cache tests change. Provider compatibility and cache accounting remain unchanged.
+Prompt construction, provider setup, CLI/Action configuration, generated reference documentation, and prompt-cache tests change. Routes without explicit cache support still receive merged plain user messages; users who previously disabled caching may see different cache usage and token accounting.

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/specs/prompt-and-lenses/spec.md
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/specs/prompt-and-lenses/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Split-prefix prompt shape for caching
+<!-- anchor: prompt.shared-preamble -->
+
+Every review call SHALL share a lens-independent system preamble and diff prefix, with the lens checklist as the final uncached block, so routes with cache breakpoints let lenses 2..N read the preamble-plus-diff from cache. Providers without explicit cache support SHALL receive the user blocks joined into one plain user message.
+
+#### Scenario: provider without cache support
+- **WHEN** the model's route has no explicit cache breakpoint
+- **THEN** the adapter joins the split user blocks into one plain user message
+
+#### Scenario: output language configured
+- **WHEN** `ReviewConfig.language` is set
+- **THEN** the shared preamble carries a directive to write the `title`/`body` prose in that language while leaving structural fields and suggestion code unchanged
+
+#### Scenario: output language unset
+- **WHEN** `ReviewConfig.language` is unset
+- **THEN** the shared preamble is byte-identical to the pre-language prompt

--- a/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/tasks.md
+++ b/openspec/changes/archive/2026-08-13-drop-legacy-prompt-shape/tasks.md
@@ -1,0 +1,11 @@
+## 1. Acceptance Tests
+
+- [x] 1.1 Repoint prompt-content tests at the retained preamble and lens blocks.
+- [x] 1.2 Update engine and provider tests to require one unconditional split path.
+
+## 2. Implementation
+
+- [x] 2.1 Remove the legacy prompt builders and engine assembly branch.
+- [x] 2.2 Remove the prompt-cache public configuration and provider opt-out.
+- [x] 2.3 Update Action, generated reference, contributor docs, living spec, and anchors.
+- [x] 2.4 Run prompt, engine, provider, CLI, docs, OpenSpec, lint, type, anchor, and full test suites.

--- a/openspec/specs/prompt-and-lenses/anchors.yml
+++ b/openspec/specs/prompt-and-lenses/anchors.yml
@@ -9,27 +9,23 @@ prompt.shared-preamble:
 prompt.system:
   rule:
     kind: function_definition
-    has: { field: name, regex: '^build_system_prompt$' }
+    has: { field: name, regex: '^build_lens_block$' }
   files: [src/lgtmaybe/engine/**/*.py]
 
 prompt.custom-lens:
-  - rule:
-      kind: function_definition
-      has: { field: name, regex: '^build_lens_prompt$' }
-    files: [src/lgtmaybe/engine/**/*.py]
-  - rule:
-      kind: function_definition
-      has: { field: name, regex: '^build_custom_lens_block$' }
-    files: [src/lgtmaybe/engine/**/*.py]
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^build_custom_lens_block$' }
+  files: [src/lgtmaybe/engine/**/*.py]
 
 prompt.groups:
   - rule:
       kind: function_definition
-      has: { field: name, regex: '^build_group_prompt$' }
+      has: { field: name, regex: '^build_group_block$' }
     files: [src/lgtmaybe/engine/**/*.py]
   - rule:
       kind: function_definition
-      has: { field: name, regex: '^build_correctness_prompt$' }
+      has: { field: name, regex: '^build_correctness_block$' }
     files: [src/lgtmaybe/engine/**/*.py]
   - rule:
       kind: function_definition

--- a/openspec/specs/prompt-and-lenses/spec.md
+++ b/openspec/specs/prompt-and-lenses/spec.md
@@ -9,22 +9,24 @@ identically to the built-ins.
 ## Requirements
 ### Requirement: Split-prefix prompt shape for caching
 
-With `prompt_cache` on (default), every review call SHALL share a
-lens-independent system preamble and diff prefix, with the lens checklist as
-the final uncached block — so on routes with cache breakpoints, lenses 2..N
-read the preamble-plus-diff from cache. Other providers get the blocks joined
-back into the single plain message they always received.
+Every review call SHALL share a lens-independent system preamble and diff
+prefix, with the lens checklist as the final uncached block, so routes with
+cache breakpoints let lenses 2..N read the preamble-plus-diff from cache.
+Providers without explicit cache support SHALL receive the user blocks joined
+into one plain user message.
 <!-- anchor: prompt.shared-preamble -->
 
 #### Scenario: provider without cache support
 - **WHEN** the model's route has no explicit cache breakpoint
-- **THEN** the call is byte-for-byte the legacy single-message shape
+- **THEN** the adapter joins the split user blocks into one plain user message
 
 #### Scenario: output language configured
 - **WHEN** `ReviewConfig.language` is set
 - **THEN** the shared preamble carries a directive to write the `title`/`body`
-  prose in that language (structural fields and `suggestion` code unchanged),
-  keyed on the language so the prefix stays byte-identical across the fan-out
+  prose in that language while leaving structural fields and suggestion code
+  unchanged
+
+#### Scenario: output language unset
 - **WHEN** `language` is unset
 - **THEN** the preamble is byte-identical to the pre-language prompt
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -248,7 +248,6 @@ def build_provider_engine(
         fallback_model=runtime.fallback_model,
         timeout=cfg.timeout,
         temperature=cfg.temperature,
-        prompt_cache=cfg.prompt_cache,
         **extra,
     )
     engine = LLMReviewEngine(provider, fetch_file=fetch_file, resolve_symbol=resolve_symbol)

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -395,14 +395,6 @@ local_diff_options = _stack(
     "the auditor re-judges with the real definition (--no-symbol-resolution disables)",
 )
 @click.option(
-    "--prompt-cache/--no-prompt-cache",
-    default=None,
-    help="Shape every call as a shared cacheable prefix, and mark an explicit "
-    "cache breakpoint on the routes that take one (anthropic, bedrock Claude/Nova, "
-    "vertex, zai GLM, openrouter) — cached reads are billed at a steep "
-    "discount. Safe no-op elsewhere (--no-prompt-cache disables)",
-)
-@click.option(
     "--spec/--no-spec",
     "spec_review",
     default=None,

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -967,17 +967,6 @@ class ReviewConfig(_Strict):
     # prose/reasoning instead of findings. Disable for a model/provider that
     # doesn't support it (the lenient parser is the fallback).
     structured_output: bool = True
-    # Reuse the shared prefix (system preamble + wrapped diff) across the
-    # per-lens fan-out and the reflection call instead of re-paying full input
-    # price for it on every call. On routes taking an explicit breakpoint
-    # (anthropic, bedrock Claude/Nova, vertex Claude+Gemini, zai GLM,
-    # openrouter's claude/gemini/glm/minimax) the adapter marks it with
-    # cache_control;
-    # backends that cache a repeated prefix automatically (openai, azure,
-    # deepseek) need only the identical shape, which this also gives them. Also
-    # enables the per-batch warm-up primer. Feature-detected per model and a
-    # safe no-op on ollama/openai-compatible, so leaving it on costs nothing.
-    prompt_cache: bool = True
 
     @model_validator(mode="after")
     def _lens_ids_are_unique(self) -> ReviewConfig:

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -58,14 +58,10 @@ from .profiling import profiler
 from .prompt import (
     FAST_GROUPS,
     build_correctness_block,
-    build_correctness_prompt,
     build_custom_lens_block,
     build_group_block,
-    build_group_prompt,
     build_lens_block,
-    build_lens_prompt,
     build_shared_preamble,
-    build_system_prompt,
 )
 from .redact import redact
 from .reflect import reflect_findings
@@ -331,19 +327,14 @@ def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
 class _Lens:
     """One review lens in the fan-out: a built-in category or a user-defined lens.
 
-    Holds both prompt shapes so the fan-out is uniform — the engine no longer
-    cares whether a lens came from ``ReviewCategory`` or ``extra_lenses``.
-    ``system_prompt`` is the legacy monolithic shape (lens text in the system
-    message, used when ``prompt_cache`` is off); ``user_block`` is the split
-    (cache-shaped) layout's final user message (used when it is on — the
-    default), where the system message is the shared preamble instead.
+    ``user_block`` is the split layout's final user message, keeping the lens
+    checklist outside the shared preamble and diff prefix.
     ``carries_intent`` is true only for the built-in intent lens, the one call
     that receives the stated-intent block; ``carries_spec`` likewise for the spec
     lens and the committed-specification block.
     """
 
     id: str
-    system_prompt: str
     user_block: str
     carries_intent: bool = False
     carries_spec: bool = False
@@ -354,9 +345,7 @@ class _Lens:
     allowed_categories: frozenset[str] | None = None
 
 
-def _build_lenses(
-    cfg: ReviewConfig, *, has_intent: bool, has_spec: bool = False, retrieval: bool = False
-) -> list[_Lens]:
+def _build_lenses(cfg: ReviewConfig, *, has_intent: bool, has_spec: bool = False) -> list[_Lens]:
     """All lenses to run: built-ins (grouped per the preset), then user lenses.
 
     The fast preset runs the nine everyday built-ins as FOUR distinct lenses —
@@ -376,9 +365,6 @@ def _build_lenses(
     both on one call degrades it. So a matched spec adds a FIFTH call — paid only
     in repositories that commit a spec the PR is delivering.
 
-    ``retrieval`` adds the one-round deferral ask to the legacy (``prompt_cache:
-    false``) system prompts — the split shape carries it on the shared preamble
-    instead, built per call. Off, every prompt here is byte-identical.
     """
     # Whether the model should still be asked for dependency-advisory claims.
     # Config-derived on purpose: keying this on whether the binary happens to be
@@ -394,12 +380,6 @@ def _build_lenses(
         lenses = [
             _Lens(
                 id=ReviewCategory.security.value,
-                system_prompt=build_system_prompt(
-                    ReviewCategory.security,
-                    cfg.language,
-                    secret_scanning=secrets,
-                    retrieval=retrieval,
-                ),
                 user_block=build_lens_block(ReviewCategory.security, secret_scanning=secrets),
             ),
         ]
@@ -411,7 +391,6 @@ def _build_lenses(
         lenses.append(
             _Lens(
                 id=ReviewCategory.correctness.value,
-                system_prompt=build_correctness_prompt(has_intent, cfg.language, retrieval),
                 user_block=build_correctness_block(has_intent),
                 carries_intent=has_intent,
                 allowed_categories=correctness_categories if has_intent else None,
@@ -420,27 +399,17 @@ def _build_lenses(
         lenses += [
             _Lens(
                 id=group.id,
-                system_prompt=build_group_prompt(
-                    group, cfg.language, dependency_health=deps, retrieval=retrieval
-                ),
                 user_block=build_group_block(group, dependency_health=deps),
                 allowed_categories=frozenset(c.value for c in group.members),
             )
             for group in FAST_GROUPS
         ]
         if has_spec:
-            lenses.append(_spec_lens(cfg, retrieval))
+            lenses.append(_spec_lens())
     else:
         lenses = [
             _Lens(
                 id=category.value,
-                system_prompt=build_system_prompt(
-                    category,
-                    cfg.language,
-                    dependency_health=deps,
-                    secret_scanning=secrets,
-                    retrieval=retrieval,
-                ),
                 user_block=build_lens_block(
                     category, dependency_health=deps, secret_scanning=secrets
                 ),
@@ -458,7 +427,6 @@ def _build_lenses(
     lenses += [
         _Lens(
             id=lens.id,
-            system_prompt=build_lens_prompt(lens, cfg.language, retrieval),
             user_block=build_custom_lens_block(lens),
         )
         for lens in cfg.extra_lenses
@@ -466,11 +434,10 @@ def _build_lenses(
     return lenses
 
 
-def _spec_lens(cfg: ReviewConfig, retrieval: bool) -> _Lens:
+def _spec_lens() -> _Lens:
     """The spec lens, built the same way in either preset."""
     return _Lens(
         id=ReviewCategory.spec.value,
-        system_prompt=build_system_prompt(ReviewCategory.spec, cfg.language, retrieval=retrieval),
         user_block=build_lens_block(ReviewCategory.spec),
         carries_spec=True,
     )
@@ -558,10 +525,6 @@ class _Run:
     # Constrains output to the findings schema (provider-native JSON mode) on
     # review calls only — the reflection call keeps its own format.
     response_format: type[ReviewResult] | None
-    # The message shape: True (prompt_cache on, the default) splits the prompt
-    # into a cacheable shared prefix plus the lens block; False is the legacy
-    # lens-in-system layout.
-    split_prompt: bool
     language: str | None
     deadline_at: float | None
     budget_at: int | None
@@ -629,7 +592,7 @@ def _lens_messages(
     spec_block: str | None = None,
     context: str | None = None,
 ) -> list[Message]:
-    """The messages for one lens call, in whichever prompt shape is configured.
+    """The split-prefix messages for one lens call.
 
     ``context`` is the fetched-for-a-deferral file text (see
     :meth:`LLMReviewEngine._review_with_context`). It rides the lens's own block —
@@ -639,48 +602,27 @@ def _lens_messages(
     instructions stay closest to the answer.
     """
     # Only the intent lens pays the intent-block tokens (and its injection
-    # surface); the other lenses never see PR-authored prose. In the split shape
-    # it rides the lens block — NOT the shared prefix — so their cached prefix
+    # surface); the other lenses never see PR-authored prose. It rides the lens
+    # block — NOT the shared prefix — so their cached prefix
     # stays identical. The spec block is gated the same way, for the same two
     # reasons: it is large, and it is untrusted.
     intent = intent_block if lens.carries_intent else None
     spec = spec_block if lens.carries_spec else None
     retrieval = run.retrieval_budget is not None
-    if run.split_prompt:
-        # The directory block joins the ONE prefix string rather than adding
-        # a fourth message: the adapter puts its cache breakpoint on the last
-        # prefix block, and it varies per batch exactly like the hints do, so
-        # it is warmed once by the primer and read by lenses 2..N.
-        prefix = "\n\n".join(part for part in (dir_block, hint_block, wrapped) if part is not None)
-        suffix = lens.user_block if context is None else f"{context}\n\n{lens.user_block}"
-        if spec is not None:
-            suffix = f"{spec}\n\n{suffix}"
-        if intent is not None:
-            suffix = f"{intent}\n\n{suffix}"
-        return [
-            {"role": "system", "content": build_shared_preamble(run.language, retrieval)},
-            {"role": "user", "content": prefix},
-            {"role": "user", "content": suffix},
-        ]
-
-    user_content = wrapped
+    # The directory block joins the ONE prefix string rather than adding a
+    # fourth message: the adapter puts its cache breakpoint on the last prefix
+    # block, and it varies per batch exactly like the hints do, so it is warmed
+    # once by the primer and read by lenses 2..N.
+    prefix = "\n\n".join(part for part in (dir_block, hint_block, wrapped) if part is not None)
+    suffix = lens.user_block if context is None else f"{context}\n\n{lens.user_block}"
     if spec is not None:
-        user_content = f"{spec}\n\n{user_content}"
+        suffix = f"{spec}\n\n{suffix}"
     if intent is not None:
-        user_content = f"{intent}\n\n{user_content}"
-    if hint_block is not None:
-        # Static-analysis grounding: every lens sees the hints (each judges
-        # relevance to its own concern) ahead of the diff they refer to.
-        user_content = f"{hint_block}\n\n{user_content}"
-    if dir_block is not None:
-        # Directory-scoped instructions/context lead, same as in the split
-        # shape, so the two layouts stay behaviourally comparable.
-        user_content = f"{dir_block}\n\n{user_content}"
-    if context is not None:
-        user_content = f"{user_content}\n\n{context}"
+        suffix = f"{intent}\n\n{suffix}"
     return [
-        {"role": "system", "content": lens.system_prompt},
-        {"role": "user", "content": user_content},
+        {"role": "system", "content": build_shared_preamble(run.language, retrieval)},
+        {"role": "user", "content": prefix},
+        {"role": "user", "content": suffix},
     ]
 
 
@@ -780,7 +722,6 @@ class LLMReviewEngine:
             cfg,
             has_intent=clean_intent is not None,
             has_spec=clean_spec is not None,
-            retrieval=retrieval_budget is not None,
         )
 
         # 2. Split into per-file patches and drop generated/binary/vendored noise,
@@ -936,7 +877,6 @@ class LLMReviewEngine:
             # Constrain output to the findings schema (provider-native JSON mode) per
             # review call — NOT globally, so the reflection call keeps its own format.
             response_format=ReviewResult if cfg.structured_output else None,
-            split_prompt=cfg.prompt_cache,
             language=cfg.language,
             deadline_at=deadline_at,
             budget_at=budget_at,
@@ -986,12 +926,7 @@ class LLMReviewEngine:
             # re-writing it. Gated on diff size (see _WARMUP_MIN_TOKENS) so a
             # small diff keeps full concurrency, and on a fan-out wide enough
             # for there to be a wave at all.
-            warm = (
-                cfg.prompt_cache
-                and workers > 1
-                and len(lenses) > 1
-                and count_tokens(wrapped) >= _WARMUP_MIN_TOKENS
-            )
+            warm = workers > 1 and len(lenses) > 1 and count_tokens(wrapped) >= _WARMUP_MIN_TOKENS
             batch_calls = [
                 _PreparedCall(
                     lens_id=lens.id,
@@ -1324,14 +1259,10 @@ class LLMReviewEngine:
         :meth:`_review_split`). None means "already a piece" — no further
         splitting.
 
-        ``run.split_prompt`` selects the message shape. True (``prompt_cache`` on —
-        the default): shared system preamble, then the shared prefix (hints +
-        diff) as one user message, then the lens block (intent + checklist +
-        example) as a final user message — every lens call shares the same
-        expensive prefix, which caching providers then serve from cache. False:
-        the legacy shape (lens text in the system prompt, one user message),
-        kept as the escape hatch for a model that reviews worse under the
-        split layout.
+        Every call uses the shared system preamble, then the shared prefix
+        (hints + diff) as one user message, then the lens block (intent +
+        checklist + example) as a final user message. Caching providers serve
+        the identical expensive prefix from cache.
 
         ``run.retrieval_budget`` (None = off) opts this call into the one deferral
         a lens may make: answering with ``needs``, it is re-run once with that code

--- a/src/lgtmaybe/engine/prompt.py
+++ b/src/lgtmaybe/engine/prompt.py
@@ -846,33 +846,13 @@ ARTEFACTS_GROUP = LensGroup(
 FAST_GROUPS: tuple[LensGroup, ...] = (CODE_HEALTH_GROUP, ARTEFACTS_GROUP)
 
 
-def _legacy(section: str, example: str, language: str | None, retrieval: bool) -> str:
-    """The legacy (``prompt_cache: false``) lens layout: it all rides the system message.
-
-    Every legacy builder below is this one assembly with a different
-    ``(section, example)`` pair, so the layout lives here once.
-    """
-    rules = f"{_SHARED_RULES}{retrieval_rules(retrieval)}"
-    return f"{_localised_header(language)}\n{example}\n\n{section}\n\n{rules}\n"
-
-
 def _block(section: str, example: str) -> str:
-    """The split layout's final user block — the uncached lens half of :func:`_legacy`."""
+    """The split layout's final uncached lens block."""
     return f"{_LENS_LEAD_IN}\n\n{section}\n\n{example}"
 
 
-def build_group_prompt(
-    group: LensGroup,
-    language: str | None = None,
-    dependency_health: bool = True,
-    retrieval: bool = False,
-) -> str:
-    """A merged lens's system prompt (legacy shape, ``prompt_cache: false``)."""
-    return _legacy(_group_section(group, dependency_health), group.example, language, retrieval)
-
-
 def build_group_block(group: LensGroup, dependency_health: bool = True) -> str:
-    """A merged lens's user block (split shape — see :func:`build_lens_block`)."""
+    """A merged lens's user block."""
     return _block(_group_section(group, dependency_health), group.example)
 
 
@@ -886,15 +866,8 @@ def _correctness_section(include_intent: bool) -> str:
     return f"{_CORRECTNESS_INTENT_PREFIX}\n{_CORRECTNESS_SECTION}\n\n{_INTENT_SECTION}"
 
 
-def build_correctness_prompt(
-    include_intent: bool, language: str | None = None, retrieval: bool = False
-) -> str:
-    """The fast preset's correctness call, system-prompt (legacy) shape."""
-    return _legacy(_correctness_section(include_intent), _CORRECTNESS_EXAMPLE, language, retrieval)
-
-
 def build_correctness_block(include_intent: bool) -> str:
-    """The fast preset's correctness call, user-block (split) shape."""
+    """The fast preset's correctness call user block."""
     return _block(_correctness_section(include_intent), _CORRECTNESS_EXAMPLE)
 
 
@@ -1031,9 +1004,7 @@ Example: {"findings": [...], "needs": ["app/models.py", "already_applied"]}"""
 def retrieval_rules(retrieval: bool) -> str:
     """The deferral ask, or ``""`` when mid-review retrieval is off.
 
-    A single gate shared by every prompt shape (split preamble and all four
-    legacy system prompts), so the ask can never reach one shape and miss
-    another — and so "off" is provably a zero-byte change everywhere.
+    A single gate on the shared preamble makes "off" a zero-byte change.
     """
     return _RETRIEVAL_RULES if retrieval else ""
 
@@ -1107,37 +1078,3 @@ def build_custom_lens_block(lens: CustomLens) -> str:
     lens rides the shared cached prefix exactly like a built-in one.
     """
     return _block(*_custom_lens_parts(lens))
-
-
-@lru_cache(maxsize=len(ReviewCategory) * 16)
-def build_system_prompt(
-    category: ReviewCategory,
-    language: str | None = None,
-    dependency_health: bool = True,
-    secret_scanning: bool = True,
-    retrieval: bool = False,
-) -> str:
-    """Return the system message for the review LLM's *category* lens.
-
-    The prompt carries only that lens's section and a matching worked example.
-
-    Cached: the prompts are deterministic, and the engine rebuilds one per
-    category on every batch — caching makes those rebuilds free. Keyed on
-    *language* too (constant within a run), and byte-identical to the
-    pre-language prompt when unset.
-    """
-    section = _category_section(category, dependency_health, secret_scanning)
-    return _legacy(section, _CATEGORY_EXAMPLES[category], language, retrieval)
-
-
-def build_lens_prompt(
-    lens: CustomLens, language: str | None = None, retrieval: bool = False
-) -> str:
-    """Return the system message for a user-defined ("BYO") lens.
-
-    Same scaffold as a built-in category — shared header, one worked example, the
-    lens section, shared rules — so a custom lens behaves like any other in the
-    fan-out. The example is the lens's own when supplied, else the generic one.
-    """
-    section, example = _custom_lens_parts(lens)
-    return _legacy(section, example, language, retrieval)

--- a/src/lgtmaybe/engine/reflect.py
+++ b/src/lgtmaybe/engine/reflect.py
@@ -307,24 +307,15 @@ def _audit(
         f"Findings (indexed from 0):\n{findings_json}\n\n"
         "Return the confidence verdict JSON object."
     )
-    if cfg.prompt_cache:
-        # Split shape, mirroring the review calls: the diff — identical across
-        # the audit call and every deferral re-judge — rides its own leading
-        # user block, so on breakpoint routes the re-judges read the
-        # system-plus-diff prefix from cache instead of re-paying for it. (The
-        # review calls' prefix can't be reused here: the auditor needs its own
-        # system prompt, and the cache is a strict prefix over system →
-        # messages.) The grounding/findings vary per pass and stay outside.
-        messages = [
-            {"role": "system", "content": _REFLECT_SYSTEM},
-            {"role": "user", "content": diff_part},
-            {"role": "user", "content": rest_part},
-        ]
-    else:
-        messages = [
-            {"role": "system", "content": _REFLECT_SYSTEM},
-            {"role": "user", "content": f"{diff_part}\n\n{rest_part}"},
-        ]
+    # The diff — identical across the audit call and every deferral re-judge —
+    # rides its own leading user block, so breakpoint routes reuse the
+    # system-plus-diff prefix. Grounding and findings vary per pass and stay
+    # outside that prefix.
+    messages = [
+        {"role": "system", "content": _REFLECT_SYSTEM},
+        {"role": "user", "content": diff_part},
+        {"role": "user", "content": rest_part},
+    ]
 
     opts: dict[str, Any] = {"response_format": ReflectionResult} if cfg.structured_output else {}
     result = timed_complete(

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -195,7 +195,6 @@ def build_provider(
     azure_ad_token: str | None = None,
     fallback_model: str | None = None,
     timeout: int | None = None,
-    prompt_cache: bool = False,
     **extra_opts: Any,
 ) -> LiteLLMProvider:
     """Build a configured LiteLLMProvider for the given provider and model.
@@ -248,6 +247,5 @@ def build_provider(
     return LiteLLMProvider(
         model=resolved_model,
         fallback_model=resolved_fallback,
-        prompt_cache=prompt_cache,
         **opts,
     )

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -422,16 +422,10 @@ class LiteLLMProvider:
         *,
         model: str = "",
         fallback_model: str | None = None,
-        prompt_cache: bool = False,
         **default_opts: Any,
     ) -> None:
         self.model = model
         self.fallback_model = fallback_model
-        # Mark the static system prompt cacheable (cache_control) on routes that
-        # support an explicit cache breakpoint; a safe no-op everywhere else.
-        # A named constructor arg — NOT part of default_opts — so it can never
-        # leak into the litellm.completion call as an unknown parameter.
-        self.prompt_cache = prompt_cache
         self.default_opts: dict[str, Any] = default_opts
         # Set once a structured-output call comes back empty (see _call): the
         # backend's JSON-schema decoder is broken for this model, so every
@@ -457,8 +451,7 @@ class LiteLLMProvider:
         # a cache hit — too late for a fan-out that dispatches its lenses at
         # once. OpenAI uses the same field as a hint for prefix-sharing
         # requests, so one param serves both; drop_params strips it elsewhere.
-        if self.prompt_cache:
-            merged.setdefault("prompt_cache_key", _prefix_cache_key(messages))
+        merged.setdefault("prompt_cache_key", _prefix_cache_key(messages))
         # A factory-built provider carries the resolved litellm model string
         # (e.g. "ollama/qwen3:27b"); prefer it over the caller's raw cfg.model.
         effective_model = self.model or model
@@ -599,11 +592,10 @@ class LiteLLMProvider:
     def _with_cache_control(self, messages: list[Message], model: str) -> list[Message]:
         """Return *messages* shaped for the model's caching route, when it pays.
 
-        The engine sends the review prompt in a **split shape** when
-        ``prompt_cache`` is on: a lens-independent system preamble, then the
-        shared prefix (the wrapped diff, plus hints) as one user message, then
-        the lens-specific instruction as a final user message. This adapter is
-        where that shape meets each provider:
+        The engine sends the review prompt as a lens-independent system
+        preamble, then the shared prefix (the wrapped diff, plus hints), then
+        the lens-specific instruction. This adapter is where that shape meets
+        each provider:
 
         - On a route with an explicit cache breakpoint (:data:`_CACHE_CONTROL_PREFIXES`,
           confirmed by litellm's capability map): consecutive user messages are
@@ -617,13 +609,10 @@ class LiteLLMProvider:
           per-model threshold (some Opus/Haiku-class models need 4,096), so
           1,024 is used for all — a too-small block degrades to "not cached",
           never to an error.
-        - Everywhere else (no breakpoint route, capability lookup failure, or
-          ``prompt_cache`` off): consecutive user messages are merged into one
-          plain string and no marker is attached — byte-identical to the single
-          user message these providers have always received.
+        - Everywhere else (no breakpoint route or capability lookup failure):
+          consecutive user messages are merged into one plain string and no
+          marker is attached.
         """
-        if not self.prompt_cache:
-            return _merge_user_messages(messages)
         if model not in self._cache_capable:
             self._cache_capable[model] = _supports_cache_control(model)
         if not self._cache_capable[model]:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -424,6 +424,8 @@ class LiteLLMProvider:
         fallback_model: str | None = None,
         **default_opts: Any,
     ) -> None:
+        if "prompt_cache" in default_opts:
+            raise TypeError("prompt_cache was removed; prompt caching is always enabled")
         self.model = model
         self.fallback_model = fallback_model
         self.default_opts: dict[str, Any] = default_opts

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -74,7 +74,7 @@ def _reflection_calls(provider: FakeProvider) -> list[dict]:
 def _all_text(call: dict) -> str:
     """Every message's content joined — prompt text wherever the shape put it.
 
-    The default (prompt_cache on) message shape is split: shared preamble in
+    The message shape is split: shared preamble in
     the system message, diff in one user message, the lens block in another —
     so assertions about "the prompt" search all of it.
     """
@@ -2311,10 +2311,11 @@ def test_dependency_findings_survive_the_off_diff_drop(monkeypatch) -> None:  # 
 
 def _security_lens_text(cfg: ReviewConfig) -> str:
     from lgtmaybe.engine.engine import _build_lenses
+    from lgtmaybe.engine.prompt import build_shared_preamble
 
     lenses = _build_lenses(cfg, has_intent=False)
     lens = next(lo for lo in lenses if lo.id == ReviewCategory.security.value)
-    return (lens.system_prompt + lens.user_block).lower()
+    return (build_shared_preamble() + lens.user_block).lower()
 
 
 def test_security_lens_asks_for_secrets_by_default() -> None:
@@ -2363,6 +2364,7 @@ def test_every_lens_is_told_the_redaction_marker_is_not_a_finding() -> None:
     being told what it is, a lens reports our own marker as a leaked secret."""
     cfg = ReviewConfig(provider=Provider.openai, model="m")
     from lgtmaybe.engine.engine import _build_lenses
+    from lgtmaybe.engine.prompt import build_shared_preamble
 
     for lens in _build_lenses(cfg, has_intent=False):
-        assert REDACTED_PLACEHOLDER in lens.system_prompt
+        assert REDACTED_PLACEHOLDER in build_shared_preamble() + lens.user_block

--- a/tests/engine/test_mid_review_retrieval.py
+++ b/tests/engine/test_mid_review_retrieval.py
@@ -211,7 +211,7 @@ class TestTheFetchedContextIsBounded:
         provider = _ScriptedProvider(_needs_json("pkg/ledger.py"), _findings_json(_finding()))
         fetch = _reader({"pkg/ledger.py": _LEDGER})
 
-        LLMReviewEngine(provider, fetch_file=fetch).review(_CTX, _cfg(prompt_cache=True))
+        LLMReviewEngine(provider, fetch_file=fetch).review(_CTX, _cfg())
 
         first, retry = provider.calls[0]["messages"], provider.calls[1]["messages"]
         assert len(retry) == 3

--- a/tests/engine/test_prompt.py
+++ b/tests/engine/test_prompt.py
@@ -8,7 +8,11 @@ import pytest
 
 from lgtmaybe.core.models import CustomLens, ReviewCategory, ReviewFinding, Severity
 from lgtmaybe.engine import prompt as prompt_module
-from lgtmaybe.engine.prompt import build_lens_prompt, build_shared_preamble, build_system_prompt
+from lgtmaybe.engine.prompt import (
+    build_custom_lens_block,
+    build_lens_block,
+    build_shared_preamble,
+)
 from lgtmaybe.engine.redact import REDACTED_PLACEHOLDER
 
 
@@ -18,7 +22,28 @@ def _union_prompt() -> str:
     Production only ever builds per-category prompts; asserting against the
     union checks "some lens covers X" without caring which one.
     """
-    return "\n\n".join(build_system_prompt(c) for c in ReviewCategory)
+    return "\n\n".join(_built_in_prompt(c) for c in ReviewCategory)
+
+
+def _built_in_prompt(
+    category: ReviewCategory,
+    language: str | None = None,
+    dependency_health: bool = True,
+    secret_scanning: bool = True,
+    retrieval: bool = False,
+) -> str:
+    return "\n\n".join(
+        (
+            build_shared_preamble(language, retrieval),
+            build_lens_block(category, dependency_health, secret_scanning),
+        )
+    )
+
+
+def _custom_lens_prompt(
+    lens: CustomLens, language: str | None = None, retrieval: bool = False
+) -> str:
+    return "\n\n".join((build_shared_preamble(language, retrieval), build_custom_lens_block(lens)))
 
 
 # A term that appears only in each category's own section, used to prove a
@@ -37,12 +62,9 @@ _SIGNATURE = {
 }
 
 
-def test_build_system_prompt_is_cached() -> None:
-    """The per-category prompts are deterministic, so building one twice must
-    return the identical cached object (the engine rebuilds them every batch)."""
-    assert build_system_prompt(ReviewCategory.security) is build_system_prompt(
-        ReviewCategory.security
-    )
+def test_lens_block_is_cached() -> None:
+    """The engine rebuilds deterministic per-category blocks every batch."""
+    assert build_lens_block(ReviewCategory.security) is build_lens_block(ReviewCategory.security)
 
 
 def test_prompt_contains_all_severity_levels() -> None:
@@ -76,7 +98,7 @@ def test_prompt_contains_json_contract() -> None:
     ],
 )
 def test_defect_examples_include_a_failure_scenario(category: ReviewCategory) -> None:
-    prompt = build_system_prompt(category)
+    prompt = _built_in_prompt(category)
 
     assert '"failure_scenario": "' in prompt
 
@@ -92,7 +114,7 @@ def test_defect_examples_include_a_failure_scenario(category: ReviewCategory) ->
     ],
 )
 def test_gap_examples_use_a_null_failure_scenario(category: ReviewCategory) -> None:
-    prompt = build_system_prompt(category)
+    prompt = _built_in_prompt(category)
 
     assert '"failure_scenario": null' in prompt
 
@@ -128,9 +150,7 @@ def test_contract_binds_suggestion_names_to_the_target_file() -> None:
     there `datetime` is the class, not the module. Committing that suggestion
     replaces working code with a crash.
     """
-    # Asserted on BOTH prompt shapes: prompt_cache defaults on, so the shared
-    # preamble is the one production actually sends. A rule that lived only in
-    # the legacy system prompt would be absent from every default review.
+    # The shared preamble is the one production sends for every lens.
     for prompt in (_union_prompt().lower(), build_shared_preamble().lower()):
         # The contract must scope name resolution to the file under review...
         assert "imports" in prompt
@@ -143,7 +163,7 @@ def test_worked_example_suggestions_are_code_not_prose() -> None:
     instruction — the model copies these verbatim."""
     prose_starts = ("use ", "consider ", "prefer ", "avoid ", "you should ", "add ")
     for category in ReviewCategory:
-        prompt = build_system_prompt(category)
+        prompt = _built_in_prompt(category)
         for line in prompt.splitlines():
             stripped = line.strip()
             if not stripped.startswith('"suggestion":'):
@@ -224,13 +244,13 @@ def test_prompt_reaffirms_diff_is_untrusted_data() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_build_lens_prompt_carries_instructions_and_heading() -> None:
+def test__custom_lens_prompt_carries_instructions_and_heading() -> None:
     lens = CustomLens(
         id="simplify",
         title="Simplify or delete",
         instructions="Flag code that should not exist at all — YAGNI.",
     )
-    prompt = build_lens_prompt(lens)
+    prompt = _custom_lens_prompt(lens)
     assert "Simplify or delete" in prompt  # heading uses the title
     assert "YAGNI" in prompt  # the user's instructions
     # Same scaffold as a built-in: severity rubric, JSON contract, shared rules.
@@ -239,12 +259,12 @@ def test_build_lens_prompt_carries_instructions_and_heading() -> None:
     assert "untrusted data" in prompt
 
 
-def test_build_lens_prompt_falls_back_to_id_heading() -> None:
+def test__custom_lens_prompt_falls_back_to_id_heading() -> None:
     lens = CustomLens(id="house-style", instructions="Enforce house style.")
-    assert "## house-style" in build_lens_prompt(lens)
+    assert "## house-style" in _custom_lens_prompt(lens)
 
 
-def test_build_lens_prompt_renders_supplied_example() -> None:
+def test__custom_lens_prompt_renders_supplied_example() -> None:
     finding = ReviewFinding(
         path="x.py", line=5, severity=Severity.low, title="needless wrapper", body="delete it"
     )
@@ -254,7 +274,7 @@ def test_build_lens_prompt_renders_supplied_example() -> None:
         example_diff="--- a/x.py\n+++ b/x.py\n@@ -4,1 +4,2 @@\n def f():\n+    return g()\n",
         example_finding=finding,
     )
-    prompt = build_lens_prompt(lens)
+    prompt = _custom_lens_prompt(lens)
     assert "## Example" in prompt
     assert "needless wrapper" in prompt
 
@@ -335,7 +355,7 @@ def test_prompt_asks_for_ponytail_review() -> None:
 def test_focused_prompt_carries_its_section_and_the_shared_contract(
     category: ReviewCategory,
 ) -> None:
-    prompt = build_system_prompt(category).lower()
+    prompt = _built_in_prompt(category).lower()
     # Its own section is present...
     assert _SIGNATURE[category] in prompt
     # ...and the shared output contract travels with every category.
@@ -345,7 +365,7 @@ def test_focused_prompt_carries_its_section_and_the_shared_contract(
 
 @pytest.mark.parametrize("category", list(ReviewCategory), ids=lambda c: c.value)
 def test_focused_prompt_excludes_other_categories(category: ReviewCategory) -> None:
-    prompt = build_system_prompt(category).lower()
+    prompt = _built_in_prompt(category).lower()
     for other, marker in _SIGNATURE.items():
         if other is not category:
             assert marker not in prompt, f"{category.value} prompt leaked {other.value} section"
@@ -365,7 +385,7 @@ def test_union_of_focused_prompts_contains_every_category() -> None:
 
 def test_prompt_asks_for_concurrency_and_race_review() -> None:
     """Races, TOCTOU, and async mistakes are first-class correctness targets."""
-    prompt = build_system_prompt(ReviewCategory.correctness).lower()
+    prompt = _built_in_prompt(ReviewCategory.correctness).lower()
     assert "race" in prompt
     assert "toctou" in prompt
     assert "await" in prompt  # coroutine called without await / blocking in async
@@ -373,7 +393,7 @@ def test_prompt_asks_for_concurrency_and_race_review() -> None:
 
 def test_prompt_asks_for_numeric_and_datetime_review() -> None:
     """Numeric and date/time bug classes are cued explicitly."""
-    prompt = build_system_prompt(ReviewCategory.correctness).lower()
+    prompt = _built_in_prompt(ReviewCategory.correctness).lower()
     assert "timezone" in prompt
     assert "division by zero" in prompt
     assert "float" in prompt
@@ -381,7 +401,7 @@ def test_prompt_asks_for_numeric_and_datetime_review() -> None:
 
 
 def test_prompt_names_csrf_redirect_xxe_and_mass_assignment() -> None:
-    prompt = build_system_prompt(ReviewCategory.security).lower()
+    prompt = _built_in_prompt(ReviewCategory.security).lower()
     assert "csrf" in prompt
     assert "redirect" in prompt
     assert "xxe" in prompt
@@ -391,7 +411,7 @@ def test_prompt_names_csrf_redirect_xxe_and_mass_assignment() -> None:
 
 def test_prompt_covers_ci_and_iac_misconfiguration() -> None:
     """Workflow/IaC files are a review surface, not just application code."""
-    prompt = build_system_prompt(ReviewCategory.security).lower()
+    prompt = _built_in_prompt(ReviewCategory.security).lower()
     assert "workflow" in prompt
     assert "iam" in prompt
     assert "container" in prompt
@@ -399,7 +419,7 @@ def test_prompt_covers_ci_and_iac_misconfiguration() -> None:
 
 
 def test_prompt_flags_weak_tests_not_just_missing_ones() -> None:
-    prompt = build_system_prompt(ReviewCategory.tests).lower()
+    prompt = _built_in_prompt(ReviewCategory.tests).lower()
     assert "assertion-free" in prompt or "no assertions" in prompt
     assert "mock" in prompt
     assert "sleep" in prompt
@@ -407,19 +427,19 @@ def test_prompt_flags_weak_tests_not_just_missing_ones() -> None:
 
 def test_prompt_flags_stale_documentation() -> None:
     """A docstring/comment the diff just made wrong is worse than no docs."""
-    prompt = build_system_prompt(ReviewCategory.documentation).lower()
+    prompt = _built_in_prompt(ReviewCategory.documentation).lower()
     assert "stale" in prompt
     assert "contradict" in prompt
 
 
 def test_prompt_flags_unbounded_growth_and_leaks() -> None:
-    prompt = build_system_prompt(ReviewCategory.performance).lower()
+    prompt = _built_in_prompt(ReviewCategory.performance).lower()
     assert "cache" in prompt
     assert "eviction" in prompt
 
 
 def test_prompt_flags_typosquats_and_license_conflicts() -> None:
-    prompt = build_system_prompt(ReviewCategory.deprecation).lower()
+    prompt = _built_in_prompt(ReviewCategory.deprecation).lower()
     assert "typosquat" in prompt
     assert "license" in prompt
 
@@ -430,7 +450,7 @@ def test_prompt_flags_typosquats_and_license_conflicts() -> None:
 
 
 def test_prompt_asks_for_intent_review() -> None:
-    prompt = build_system_prompt(ReviewCategory.intent).lower()
+    prompt = _built_in_prompt(ReviewCategory.intent).lower()
     assert "stated intent" in prompt
     assert "out-of-scope" in prompt or "out of scope" in prompt
     assert "commit" in prompt  # commit messages carry the intent on the CLI
@@ -439,7 +459,7 @@ def test_prompt_asks_for_intent_review() -> None:
 def test_prompt_asks_for_spec_review() -> None:
     """The spec lens judges the diff against the repository's committed spec —
     OpenSpec / Spec Kit / Kiro all commit requirements, a design and a task list."""
-    prompt = build_system_prompt(ReviewCategory.spec).lower()
+    prompt = _built_in_prompt(ReviewCategory.spec).lower()
     assert "specification" in prompt
     assert "requirement" in prompt
     # Both halves: does the diff deliver the spec, and does the spec cover the diff.
@@ -450,7 +470,7 @@ def test_prompt_asks_for_spec_review() -> None:
 def test_spec_prompt_asks_for_gaps_in_the_spec_itself() -> None:
     """The other direction, and the reason the lens is worth its call: the diff
     ships behaviour no requirement covers, so the SPEC is what is incomplete."""
-    prompt = build_system_prompt(ReviewCategory.spec).lower()
+    prompt = _built_in_prompt(ReviewCategory.spec).lower()
     assert "no requirement" in prompt or "not covered" in prompt
     assert "clarification" in prompt  # a [NEEDS CLARIFICATION] marker left behind
 
@@ -459,14 +479,14 @@ def test_spec_prompt_says_a_file_not_shown_is_not_undelivered() -> None:
     """The same trap the intent lens fell into on #315, and sharper here: a
     requirement is delivered by code, so a requirement implemented in a file this
     call was never given must not be reported as missing."""
-    prompt = build_system_prompt(ReviewCategory.spec).lower()
+    prompt = _built_in_prompt(ReviewCategory.spec).lower()
     assert "not shown" in prompt
     assert "undelivered" in prompt or "not delivered" in prompt
 
 
 def test_spec_prompt_forbids_flagging_a_ticked_task_it_cannot_check() -> None:
     """Ticked checkboxes are claims to verify, not claims to assume false."""
-    prompt = build_system_prompt(ReviewCategory.spec).lower()
+    prompt = _built_in_prompt(ReviewCategory.spec).lower()
     assert "ticked" in prompt or "checked" in prompt
 
 
@@ -479,14 +499,14 @@ def test_intent_prompt_says_a_file_not_shown_is_not_a_broken_promise() -> None:
     DATA block; the two cannot swap, because `_correctness_section` is cached on
     `include_intent` alone and per-review text here would poison that cache.
     """
-    prompt = build_system_prompt(ReviewCategory.intent).lower()
+    prompt = _built_in_prompt(ReviewCategory.intent).lower()
     assert "not shown" in prompt
     assert "unfulfilled" in prompt
 
 
 def test_intent_prompt_treats_intent_text_as_data() -> None:
     """Intent text is attacker-controlled; the lens must not obey it."""
-    prompt = build_system_prompt(ReviewCategory.intent).lower()
+    prompt = _built_in_prompt(ReviewCategory.intent).lower()
     assert "untrusted" in prompt or "not" in prompt and "instructions" in prompt
 
 
@@ -499,7 +519,7 @@ def test_intent_prompt_treats_intent_text_as_data() -> None:
 def test_each_focused_prompt_carries_a_worked_example(category: ReviewCategory) -> None:
     """Every lens gets a category-appropriate few-shot example (a security-flavoured
     example on a docs/tests lens anchors the model to the wrong finding type)."""
-    prompt = build_system_prompt(category)
+    prompt = _built_in_prompt(category)
     assert prompt.count("## Example") == 1
     assert "@@ -" in prompt  # the example diff shows a real hunk header
 
@@ -528,7 +548,7 @@ def test_prompt_asks_for_a_verbatim_anchor() -> None:
 
 def test_every_category_example_includes_an_anchor() -> None:
     for category in ReviewCategory:
-        prompt = build_system_prompt(category)
+        prompt = _built_in_prompt(category)
         assert '"anchor"' in prompt, f"{category} example missing an anchor field"
 
 
@@ -545,7 +565,7 @@ def test_prompt_demands_codebase_humility_about_unseen_code() -> None:
     unshown file — so every lens must be told to hedge such claims, not assert
     them. The rule lives in shared rules, so it appears in every focused prompt."""
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "cannot see" in prompt or "not shown" in prompt
         assert "missing" in prompt
         # tells the model to hedge + lower severity rather than assert absence
@@ -555,19 +575,19 @@ def test_prompt_demands_codebase_humility_about_unseen_code() -> None:
 
 def test_humility_rule_present_in_custom_lens_prompt() -> None:
     lens = CustomLens(id="x", instructions="flag foo")
-    assert "cannot see" in build_lens_prompt(lens).lower()
+    assert "cannot see" in _custom_lens_prompt(lens).lower()
 
 
 def test_prompt_warns_cross_hunk_is_one_file_not_duplicate() -> None:
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "windows into the same file" in prompt
         assert "defined twice" in prompt
 
 
 def test_prompt_guards_whole_file_symbol_claims() -> None:
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "undefined" in prompt
         assert "unless the diff" in prompt
         assert "hedge" in prompt
@@ -575,14 +595,14 @@ def test_prompt_guards_whole_file_symbol_claims() -> None:
 
 def test_prompt_guards_unused_import_inside_functions() -> None:
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "unused" in prompt
         assert "depends(" in prompt
 
 
 def test_prompt_demands_library_and_cloud_semantics_humility() -> None:
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "sdk" in prompt
         assert "encoding" in prompt
         assert "iam" in prompt or "access policy" in prompt
@@ -590,14 +610,14 @@ def test_prompt_demands_library_and_cloud_semantics_humility() -> None:
 
 
 def test_prompt_does_not_predict_test_runtime_failures() -> None:
-    prompt = build_system_prompt(ReviewCategory.tests).lower()
+    prompt = _built_in_prompt(ReviewCategory.tests).lower()
     assert "cannot run the suite" in prompt
     assert "fixtures" in prompt
     assert "predict" in prompt
 
 
 def test_prompt_intent_fulfilment_is_not_a_defect() -> None:
-    prompt = build_system_prompt(ReviewCategory.intent).lower()
+    prompt = _built_in_prompt(ReviewCategory.intent).lower()
     assert "fulfils the stated intent" in prompt or "fulfils the intent" in prompt
     assert "deliberate removal" in prompt
 
@@ -612,14 +632,14 @@ def test_empty_review_shape_stated_once(category: ReviewCategory) -> None:
     """`{"findings": []}` is stated once (in the shared rules), not repeated in
     every worked example — the examples ride the uncached per-lens block, so a
     per-example restatement is paid on every fan-out call."""
-    assert build_system_prompt(category).count('{"findings": []}') == 1
+    assert _built_in_prompt(category).count('{"findings": []}') == 1
 
 
 @pytest.mark.parametrize("category", list(ReviewCategory))
 def test_lens_sections_do_not_restate_the_changed_lines_rule(category: ReviewCategory) -> None:
     """The changed-lines-only rule lives in the shared rules (cached preamble);
     per-lens restatements ride the uncached suffix on every call."""
-    prompt = build_system_prompt(category)
+    prompt = _built_in_prompt(category)
     assert "only raise findings on changed lines" not in prompt
     # The authoritative shared-rules statement remains.
     assert "Comment ONLY on changed lines" in prompt
@@ -637,35 +657,33 @@ _LANG = "Japanese"
 
 
 def test_language_directive_absent_by_default() -> None:
-    """Unset language ⇒ the preamble and every legacy per-category prompt are
-    byte-identical to the pre-language build — the prompt-cache contract depends
-    on this default staying stable."""
+    """Unset language leaves every retained prompt byte-identical."""
     default = build_shared_preamble()
     assert build_shared_preamble(None) == default
     assert "Output language" not in default
     assert "do not translate" not in default
     for category in ReviewCategory:
-        assert build_system_prompt(category, None) == build_system_prompt(category)
-        assert "Output language" not in build_system_prompt(category)
+        assert _built_in_prompt(category, None) == _built_in_prompt(category)
+        assert "Output language" not in _built_in_prompt(category)
 
 
 def test_language_directive_present_when_set() -> None:
     """A set language adds a directive naming the prose fields (`title`/`body`)
-    and the language, in both the split preamble and the legacy prompt."""
+    and the language to the shared preamble."""
     preamble = build_shared_preamble(_LANG)
     assert preamble != build_shared_preamble()
     assert _LANG in preamble
     assert "`title`" in preamble and "`body`" in preamble
     # Structural fields + suggestion code stay untranslated.
     assert "do not translate" in preamble
-    legacy = build_system_prompt(ReviewCategory.security, _LANG)
-    assert _LANG in legacy and "`title`" in legacy and "do not translate" in legacy
+    prompt = _built_in_prompt(ReviewCategory.security, _LANG)
+    assert _LANG in prompt and "`title`" in prompt and "do not translate" in prompt
 
 
 def test_custom_lens_prompt_carries_language_directive() -> None:
     lens = CustomLens(id="naming", instructions="Flag bad names.")
-    assert build_lens_prompt(lens, None) == build_lens_prompt(lens)
-    assert _LANG in build_lens_prompt(lens, _LANG)
+    assert _custom_lens_prompt(lens, None) == _custom_lens_prompt(lens)
+    assert _LANG in _custom_lens_prompt(lens, _LANG)
 
 
 # ---------------------------------------------------------------------------
@@ -684,7 +702,7 @@ def test_scanner_carveouts_are_composed_without_prose_subtraction() -> None:
 
 def test_dependency_health_bullets_are_present_by_default() -> None:
     """Nothing changes for the vast majority — static analysis is opt-in."""
-    prompt = build_system_prompt(ReviewCategory.deprecation).lower()
+    prompt = _built_in_prompt(ReviewCategory.deprecation).lower()
 
     assert "known" in prompt and "advisor" in prompt
     assert "abandoned" in prompt or "yanked" in prompt
@@ -696,7 +714,7 @@ def test_advisory_claims_drop_when_a_scanner_covers_them() -> None:
     With osv-scanner reporting advisories deterministically, asking the model
     for them too only invites a confident wrong answer beside an accurate one.
     """
-    narrowed = build_system_prompt(ReviewCategory.deprecation, dependency_health=False).lower()
+    narrowed = _built_in_prompt(ReviewCategory.deprecation, dependency_health=False).lower()
 
     assert "advisor" not in narrowed
     assert "abandoned" not in narrowed and "yanked" not in narrowed
@@ -704,7 +722,7 @@ def test_advisory_claims_drop_when_a_scanner_covers_them() -> None:
 
 def test_narrowing_keeps_what_a_scanner_cannot_answer() -> None:
     """Deprecated APIs, EOL runtimes and typosquats are not in a CVE database."""
-    narrowed = build_system_prompt(ReviewCategory.deprecation, dependency_health=False).lower()
+    narrowed = _built_in_prompt(ReviewCategory.deprecation, dependency_health=False).lower()
 
     assert "deprecat" in narrowed
     assert "end-of-life" in narrowed
@@ -744,7 +762,7 @@ def test_no_lens_is_told_to_flag_redacted_placeholders() -> None:
     """The security lens used to say "even if they look redacted, flag the
     practice" — which turns every redacted diff into a finding."""
     for category in ReviewCategory:
-        prompt = build_system_prompt(category).lower()
+        prompt = _built_in_prompt(category).lower()
         assert "look redacted" not in prompt
         assert "even if they look" not in prompt
 
@@ -756,7 +774,7 @@ def test_no_lens_is_told_to_flag_redacted_placeholders() -> None:
 
 def test_hardcoded_secret_bullet_is_present_by_default() -> None:
     """Static analysis is opt-in, so the default prompt is unchanged."""
-    prompt = build_system_prompt(ReviewCategory.security).lower()
+    prompt = _built_in_prompt(ReviewCategory.security).lower()
 
     assert "hardcoded secrets" in prompt
 
@@ -765,14 +783,14 @@ def test_secret_claims_drop_when_a_scanner_covers_them() -> None:
     """gitleaks reports committed secrets deterministically, and redaction has
     already stripped them from the diff — so the lens cannot see what it is
     being asked to find, while the ask still costs tokens on every call."""
-    narrowed = build_system_prompt(ReviewCategory.security, secret_scanning=False).lower()
+    narrowed = _built_in_prompt(ReviewCategory.security, secret_scanning=False).lower()
 
     assert "hardcoded secrets" not in narrowed
 
 
 def test_secret_narrowing_keeps_the_rest_of_the_security_lens() -> None:
     """Only the bullet a scanner owns goes; the OWASP checklist stays."""
-    narrowed = build_system_prompt(ReviewCategory.security, secret_scanning=False).lower()
+    narrowed = _built_in_prompt(ReviewCategory.security, secret_scanning=False).lower()
 
     assert "owasp" in narrowed
     assert "ssrf" in narrowed
@@ -807,7 +825,7 @@ def test_preamble_is_byte_identical_when_retrieval_is_off() -> None:
     assert build_shared_preamble(retrieval=False) == default
     assert '"needs"' not in default
     for category in ReviewCategory:
-        assert build_system_prompt(category, retrieval=False) == build_system_prompt(category)
+        assert _built_in_prompt(category, retrieval=False) == _built_in_prompt(category)
 
 
 def test_preamble_asks_for_needs_when_retrieval_is_on() -> None:
@@ -822,21 +840,6 @@ def test_preamble_asks_for_needs_when_retrieval_is_on() -> None:
     assert "only" in preamble.lower()
 
 
-def test_legacy_system_prompts_carry_the_same_gate() -> None:
-    """`prompt_cache: false` keeps the lens in the system prompt — the deferral
-    ask has to reach that shape too, or the feature is silently off there."""
-    from lgtmaybe.engine.prompt import (
-        CODE_HEALTH_GROUP,
-        build_correctness_prompt,
-        build_group_prompt,
-    )
-
-    assert '"needs"' in build_system_prompt(ReviewCategory.security, retrieval=True)
-    assert '"needs"' in build_group_prompt(CODE_HEALTH_GROUP, retrieval=True)
-    assert '"needs"' in build_correctness_prompt(False, retrieval=True)
-    assert '"needs"' in build_lens_prompt(CustomLens(id="x", instructions="y"), retrieval=True)
-    # …and every one of them is unchanged when it is off.
-    assert build_group_prompt(CODE_HEALTH_GROUP, retrieval=False) == build_group_prompt(
-        CODE_HEALTH_GROUP
-    )
-    assert build_correctness_prompt(False, retrieval=False) == build_correctness_prompt(False)
+def test_all_lenses_receive_the_shared_retrieval_gate() -> None:
+    assert '"needs"' in _built_in_prompt(ReviewCategory.security, retrieval=True)
+    assert '"needs"' in _custom_lens_prompt(CustomLens(id="x", instructions="y"), retrieval=True)

--- a/tests/engine/test_prompt_split.py
+++ b/tests/engine/test_prompt_split.py
@@ -1,10 +1,8 @@
-"""Tests for the split (cache-shaped) prompt layout and the cache warm-up primer.
+"""Tests for the split prompt layout and cache warm-up primer.
 
-With ``prompt_cache`` on (the default) every review call shares one expensive
-prefix — shared system preamble + wrapped diff — and carries its lens-specific
-instruction as the final user block, so caching providers serve the prefix from
-cache across the whole fan-out. ``prompt_cache: false`` restores the legacy
-shape (lens text in the system prompt) byte-for-byte.
+Every review call shares one expensive prefix — shared system preamble plus
+wrapped diff — and carries its lens-specific instruction as the final user
+block, so caching providers reuse the prefix across the fan-out.
 """
 
 from __future__ import annotations
@@ -23,7 +21,7 @@ from lgtmaybe.core.models import (
 )
 from lgtmaybe.engine import LLMReviewEngine
 from lgtmaybe.engine.compress import count_tokens
-from lgtmaybe.engine.prompt import build_shared_preamble, build_system_prompt
+from lgtmaybe.engine.prompt import build_shared_preamble
 from tests.fakes import FakeProvider
 
 _CTX = PRContext(
@@ -76,17 +74,6 @@ class TestSplitShape:
         joined = "\n".join(blocks)
         assert "Security review" in joined
         assert "Performance" in joined
-
-    def test_prompt_cache_off_restores_the_legacy_shape(self) -> None:
-        provider = FakeProvider()
-        LLMReviewEngine(provider).review(_CTX, _cfg(prompt_cache=False))
-        systems = {c["messages"][0]["content"] for c in provider.calls}
-        assert systems == {
-            build_system_prompt(ReviewCategory.security),
-            build_system_prompt(ReviewCategory.performance),
-        }
-        for call in provider.calls:
-            assert [m["role"] for m in call["messages"]] == ["system", "user"]
 
     def test_intent_block_rides_the_lens_suffix_not_the_shared_prefix(self) -> None:
         ctx = _CTX.model_copy(update={"title": "Fix the frobnicator"})
@@ -255,21 +242,6 @@ class TestCacheWarmup:
         LLMReviewEngine(provider).review(_big_ctx(), cfg)
         assert provider.events[0] == "start-0"
         assert provider.events[1] == "end-0"
-
-    def test_no_warmup_when_prompt_cache_is_off(self) -> None:
-        """`prompt_cache: false` restores the legacy shape byte-for-byte, and
-        that includes dispatching the batch fully concurrently."""
-        provider = _EventOrderProvider()
-        cfg = _cfg(
-            provider=Provider.anthropic,
-            prompt_cache=False,
-            categories=[ReviewCategory.security, ReviewCategory.performance, ReviewCategory.tests],
-        )
-        LLMReviewEngine(provider).review(_big_ctx(), cfg)
-        starts_before_first_end = [
-            e for e in provider.events[: provider.events.index("end-0")] if e.startswith("start")
-        ]
-        assert len(starts_before_first_end) >= 2
 
     def test_failed_primer_still_releases_its_batch(self) -> None:
         calls = {"n": 0}

--- a/tests/engine/test_reflect.py
+++ b/tests/engine/test_reflect.py
@@ -37,7 +37,7 @@ _CFG = ReviewConfig(provider=Provider.ollama, model="llama3")
 def _user_text(call: dict) -> str:
     """All user-message content joined.
 
-    With prompt_cache on (the default) the audit prompt is split — diff in one
+    The audit prompt is split — diff in one
     user message, grounding + findings in another — so assertions about "the
     user content" search both.
     """

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -75,7 +75,6 @@ def _cfg(**overrides: Any) -> ReviewConfig:
         model="deepseek/deepseek-v4-pro",
         categories=[ReviewCategory.security],
         reflect=False,
-        prompt_cache=False,
         **overrides,
     )
 
@@ -333,7 +332,6 @@ def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> No
             model="qwen3-coder",
             categories=[ReviewCategory.security],
             reflect=False,
-            prompt_cache=False,
         ),
     )
 
@@ -358,7 +356,6 @@ def test_an_explicit_concurrency_lifts_the_split_off_the_single_stream_default()
             model="qwen3-coder",
             categories=[ReviewCategory.security],
             reflect=False,
-            prompt_cache=False,
             max_concurrency=2,
         ),
     )

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -97,7 +97,6 @@ def _cfg(**overrides: Any) -> ReviewConfig:
         model="deepseek/deepseek-v4-pro",
         categories=[ReviewCategory.security],
         reflect=False,
-        prompt_cache=False,
         **overrides,
     )
 

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -90,6 +90,11 @@ def _messages(system: str = _BIG_SYSTEM) -> list[dict[str, str]]:
     ]
 
 
+def test_removed_prompt_cache_option_is_rejected_at_construction() -> None:
+    with pytest.raises(TypeError, match="prompt_cache.*removed"):
+        LiteLLMProvider(prompt_cache=False)
+
+
 def _sent_messages(model: str, *, system: str = _BIG_SYSTEM) -> list[Any]:
     """Run one completion and return the messages litellm actually received."""
     with patch("litellm.completion", return_value=_fake_response()) as mock_completion:

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -15,9 +15,8 @@ network. The contract under test:
 - only the shared prefix is marked — the per-lens block stays outside it;
 - below the lowest documented minimum cacheable block (1,024 tokens) the request
   is sent unchanged, since no model can cache a prefix that small;
-- with ``prompt_cache`` off, or on a route with neither mechanism (ollama,
-  openai-compatible), the request is byte-for-byte what it was before this
-  feature existed;
+- on a route with neither mechanism (ollama, openai-compatible), split user
+  blocks are merged into one plain message;
 - a sticky ``prompt_cache_key`` derived from the prefix pins the fan-out to one
   provider endpoint;
 - cache read / write token counts are mapped into ``ProviderResult`` under every
@@ -91,10 +90,10 @@ def _messages(system: str = _BIG_SYSTEM) -> list[dict[str, str]]:
     ]
 
 
-def _sent_messages(model: str, *, prompt_cache: bool, system: str = _BIG_SYSTEM) -> list[Any]:
+def _sent_messages(model: str, *, system: str = _BIG_SYSTEM) -> list[Any]:
     """Run one completion and return the messages litellm actually received."""
     with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
-        provider = LiteLLMProvider(model=model, prompt_cache=prompt_cache)
+        provider = LiteLLMProvider(model=model)
         provider.complete(_messages(system), model)
     return mock_completion.call_args.kwargs["messages"]
 
@@ -102,7 +101,7 @@ def _sent_messages(model: str, *, prompt_cache: bool, system: str = _BIG_SYSTEM)
 class TestCacheControlMarking:
     @pytest.mark.parametrize("model", _CACHEABLE_MODELS)
     def test_system_prompt_marked_cacheable_on_supported_models(self, model: str) -> None:
-        sent = _sent_messages(model, prompt_cache=True)
+        sent = _sent_messages(model)
         system = sent[0]
         assert system["role"] == "system"
         # Content becomes a single text block carrying the cache breakpoint.
@@ -114,7 +113,7 @@ class TestCacheControlMarking:
 
     @pytest.mark.parametrize("model", _CACHEABLE_MODELS)
     def test_dynamic_user_content_stays_outside_the_cached_region(self, model: str) -> None:
-        sent = _sent_messages(model, prompt_cache=True)
+        sent = _sent_messages(model)
         user = sent[1]
         assert user["role"] == "user"
         # The user message (diff + intent — volatile) is untouched: a plain
@@ -123,23 +122,19 @@ class TestCacheControlMarking:
 
     @pytest.mark.parametrize("model", _UNCACHEABLE_MODELS)
     def test_request_unchanged_on_providers_without_cache_control(self, model: str) -> None:
-        sent = _sent_messages(model, prompt_cache=True)
-        assert sent == _messages()
-
-    def test_request_unchanged_when_prompt_cache_disabled(self) -> None:
-        sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=False)
+        sent = _sent_messages(model)
         assert sent == _messages()
 
     def test_request_unchanged_below_minimum_cacheable_tokens(self) -> None:
         """Anthropic silently ignores cache blocks under 1,024 tokens — sending
         the marker would be a no-op, so the adapter doesn't rewrite the message."""
-        sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=True, system=_SMALL_SYSTEM)
+        sent = _sent_messages(_CACHEABLE_MODELS[0], system=_SMALL_SYSTEM)
         assert sent == _messages(_SMALL_SYSTEM)
 
     def test_request_unchanged_without_a_system_message(self) -> None:
         messages = [{"role": "user", "content": "hi"}]
         with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
-            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0])
             provider.complete(list(messages), _CACHEABLE_MODELS[0])
         assert mock_completion.call_args.kwargs["messages"] == messages
 
@@ -150,13 +145,13 @@ class TestCacheControlMarking:
             "lgtmaybe.providers.litellm_provider.supports_prompt_caching",
             side_effect=RuntimeError("boom"),
         ):
-            sent = _sent_messages(_CACHEABLE_MODELS[0], prompt_cache=True)
+            sent = _sent_messages(_CACHEABLE_MODELS[0])
         assert sent == _messages()
 
     def test_original_messages_list_is_not_mutated(self) -> None:
         messages = _messages()
         with patch("litellm.completion", return_value=_fake_response()):
-            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0])
             provider.complete(messages, _CACHEABLE_MODELS[0])
         assert messages == _messages()
 
@@ -174,9 +169,9 @@ def _split_messages(system: str = _BIG_SYSTEM, prefix: str = _DIFF_PREFIX) -> li
     ]
 
 
-def _sent_split(model: str, *, prompt_cache: bool, system: str = _BIG_SYSTEM) -> list[Any]:
+def _sent_split(model: str, *, system: str = _BIG_SYSTEM) -> list[Any]:
     with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
-        provider = LiteLLMProvider(model=model, prompt_cache=prompt_cache)
+        provider = LiteLLMProvider(model=model)
         provider.complete(_split_messages(system), model)
     return mock_completion.call_args.kwargs["messages"]
 
@@ -192,7 +187,7 @@ class TestSplitShapeCacheMarking:
 
     @pytest.mark.parametrize("model", _CACHEABLE_MODELS)
     def test_prefix_block_carries_the_breakpoint_and_lens_block_does_not(self, model: str) -> None:
-        sent = _sent_split(model, prompt_cache=True)
+        sent = _sent_split(model)
         assert len(sent) == 2  # system + ONE merged user message
         [sys_block] = sent[0]["content"]
         assert sys_block["cache_control"] == {"type": "ephemeral"}
@@ -205,7 +200,7 @@ class TestSplitShapeCacheMarking:
     def test_small_system_still_caches_once_the_diff_crosses_the_minimum(self) -> None:
         """The 1,024-token minimum applies to the cumulative prefix, not per
         block: a small preamble plus a big diff still earns the diff breakpoint."""
-        sent = _sent_split(_CACHEABLE_MODELS[0], prompt_cache=True, system=_SMALL_SYSTEM)
+        sent = _sent_split(_CACHEABLE_MODELS[0], system=_SMALL_SYSTEM)
         # System alone is under the minimum → left as a plain string.
         assert sent[0]["content"] == _SMALL_SYSTEM
         prefix_block, lens_block = sent[1]["content"]
@@ -214,15 +209,10 @@ class TestSplitShapeCacheMarking:
 
     @pytest.mark.parametrize("model", _UNCACHEABLE_MODELS)
     def test_split_shape_merges_to_one_plain_user_message_elsewhere(self, model: str) -> None:
-        sent = _sent_split(model, prompt_cache=True)
+        sent = _sent_split(model)
         assert len(sent) == 2
         assert sent[0] == {"role": "system", "content": _BIG_SYSTEM}
         assert sent[1] == {"role": "user", "content": f"{_DIFF_PREFIX}\n\n{_LENS_BLOCK}"}
-
-    def test_split_shape_merges_plain_when_prompt_cache_off(self) -> None:
-        sent = _sent_split(_CACHEABLE_MODELS[0], prompt_cache=False)
-        assert sent[1] == {"role": "user", "content": f"{_DIFF_PREFIX}\n\n{_LENS_BLOCK}"}
-        assert sent[0]["content"] == _BIG_SYSTEM
 
 
 class TestOpenRouterBreakpoints:
@@ -277,7 +267,7 @@ class TestOpenRouterBreakpoints:
         """deepseek via openrouter still gets our breakpoint — harmless (litellm
         removes it) and it keeps the split prefix identical across lenses, which
         is what deepseek's automatic caching keys on."""
-        sent = _sent_split("openrouter/deepseek/deepseek-chat", prompt_cache=True)
+        sent = _sent_split("openrouter/deepseek/deepseek-chat")
         assert len(sent) == 2
         assert sent[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
 
@@ -289,7 +279,7 @@ class TestCacheUsageMapping:
             cache_creation_input_tokens=345,
         )
         with patch("litellm.completion", return_value=response):
-            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0], prompt_cache=True)
+            provider = LiteLLMProvider(model=_CACHEABLE_MODELS[0])
             result = provider.complete(_messages(), _CACHEABLE_MODELS[0])
         assert result.cache_read_tokens == 1200
         assert result.cache_creation_tokens == 345
@@ -342,33 +332,12 @@ class TestCacheUsageMapping:
         assert result.cache_creation_tokens == 0
 
 
-class TestFactoryThreading:
-    def test_factory_passes_prompt_cache_to_the_provider(self) -> None:
-        provider = build_provider(Provider.anthropic, "claude-sonnet-4", prompt_cache=True)
-        assert provider.prompt_cache is True
-
-    def test_factory_default_is_off_for_direct_construction(self) -> None:
-        provider = build_provider(Provider.anthropic, "claude-sonnet-4")
-        assert provider.prompt_cache is False
-
-    def test_prompt_cache_never_reaches_litellm_kwargs(self) -> None:
-        """`prompt_cache` steers the adapter; it must not leak into the
-        completion call as an (unknown) litellm parameter."""
-        provider = build_provider(Provider.anthropic, "claude-sonnet-4", prompt_cache=True)
-        assert "prompt_cache" not in provider.default_opts
-        with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
-            provider.complete(_messages(), "anthropic/claude-sonnet-4")
-        assert "prompt_cache" not in mock_completion.call_args.kwargs
-
-
 class TestProviderMatrix:
     """Every provider either applies the marker or safely no-ops — never errors."""
 
     @pytest.mark.parametrize("provider", list(Provider))
-    def test_prompt_cache_on_is_safe_for_every_provider(self, provider: Provider) -> None:
-        client = build_provider(
-            provider, "some-model", api_base="http://localhost:1234", prompt_cache=True
-        )
+    def test_prompt_caching_is_safe_for_every_provider(self, provider: Provider) -> None:
+        client = build_provider(provider, "some-model", api_base="http://localhost:1234")
         with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
             result = client.complete(_messages(), "some-model")
         assert result.text == "ok"
@@ -392,7 +361,7 @@ def test_capability_lookup_memoized_per_model() -> None:
             return_value=True,
         ) as lookup,
     ):
-        provider = LiteLLMProvider(model=model, prompt_cache=True)
+        provider = LiteLLMProvider(model=model)
         for _ in range(3):
             provider.complete(_messages(), model)
     assert lookup.call_count == 1
@@ -409,9 +378,9 @@ class TestStickyCacheKey:
     """
 
     @staticmethod
-    def _sent_kwargs(model: str, *, prompt_cache: bool = True) -> dict[str, Any]:
+    def _sent_kwargs(model: str) -> dict[str, Any]:
         with patch("litellm.completion", return_value=_fake_response()) as mock_completion:
-            provider = LiteLLMProvider(model=model, prompt_cache=prompt_cache)
+            provider = LiteLLMProvider(model=model)
             provider.complete(_split_messages(), model)
         return dict(mock_completion.call_args.kwargs)
 
@@ -425,7 +394,7 @@ class TestStickyCacheKey:
     def test_a_different_prefix_gets_a_different_key(self) -> None:
         model = "openrouter/anthropic/claude-sonnet-4.5"
         with patch("litellm.completion", return_value=_fake_response()) as mock:
-            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider = LiteLLMProvider(model=model)
             provider.complete(_split_messages(), model)
             provider.complete(_split_messages(prefix=_DIFF_PREFIX + "\n+another"), model)
         keys = [c.kwargs["prompt_cache_key"] for c in mock.call_args_list]
@@ -438,20 +407,15 @@ class TestStickyCacheKey:
         messages = _split_messages()
         other = [*messages[:-1], {"role": "user", "content": "A totally different lens block."}]
         with patch("litellm.completion", return_value=_fake_response()) as mock:
-            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider = LiteLLMProvider(model=model)
             provider.complete(messages, model)
             provider.complete(other, model)
         keys = [c.kwargs["prompt_cache_key"] for c in mock.call_args_list]
         assert keys[0] == keys[1]
 
-    def test_no_key_when_prompt_cache_is_off(self) -> None:
-        assert "prompt_cache_key" not in self._sent_kwargs(
-            "openrouter/anthropic/claude-sonnet-4.5", prompt_cache=False
-        )
-
     def test_caller_supplied_key_wins(self) -> None:
         model = "openrouter/anthropic/claude-sonnet-4.5"
         with patch("litellm.completion", return_value=_fake_response()) as mock:
-            provider = LiteLLMProvider(model=model, prompt_cache=True)
+            provider = LiteLLMProvider(model=model)
             provider.complete(_split_messages(), model, prompt_cache_key="mine")
         assert mock.call_args.kwargs["prompt_cache_key"] == "mine"

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -686,11 +686,6 @@
       "$ref": "#/$defs/ReviewPreset",
       "default": "fast"
     },
-    "prompt_cache": {
-      "default": true,
-      "title": "Prompt Cache",
-      "type": "boolean"
-    },
     "provider": {
       "$ref": "#/$defs/Provider"
     },


### PR DESCRIPTION
Closes #380

Breaking change: removes the prompt_cache config field, CLI flag, and Action input; prompt caching is always enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt caching is now automatic, with shared prompt prefixes reused where supported.
  * Providers without cache support continue using a compatible single-message format.
  * Cache usage remains tracked and logged.

* **Breaking Changes**
  * Removed the `prompt_cache` configuration option and CLI/Action inputs.
  * Review and reflection prompts now consistently use the updated split structure.

* **Documentation**
  * Updated configuration, architecture, cost guidance, and GitHub Action documentation to reflect automatic caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->