### PR TITLE
feat: default to medium reasoning, and stop capping local models

### DIFF
--- a/.lgtmaybe.yml
+++ b/.lgtmaybe.yml
@@ -57,9 +57,26 @@ max_tokens: 8192
 # silence. It now goes out in OpenRouter's own top-level `reasoning` object, and
 # a param that would be dropped is warned about at startup instead of vanishing.
 #
-# Measured at `low`: ~343-914 reasoning tokens per lens, i.e. the bound holds.
-# `medium` costs 3.3x the output tokens (91% of them thinking) and found 5
-# findings against `low`'s 2 on the same diff — a real quality difference, and a
-# real bill. Left at `low` deliberately; moving it is a quality decision that
-# wants its own change and its own evidence, not a side effect of this one.
-reasoning_effort: low
+# `medium`, on four measured runs — two per setting, same 18-file diff, same cap,
+# so the setting was the only variable:
+#
+#   setting   findings   true positives   false positives   truncated lens
+#   low        2, 2          2, 1               0, 1         code-health x2
+#   medium     5, 4          5, 4               0, 0         security, none
+#
+# What decided it was not the count. The rate-limit ladder bug that shipped in
+# 1.14.0 and needed a follow-up PR was found by `medium` in BOTH runs and missed
+# by `low` in both. `low` also produced the only false positive across all four —
+# a confident 9/10 claim about tenacity's internals that was exactly inverted.
+#
+# The cost is smaller than it looks. `medium` roughly triples OUTPUT tokens
+# (~90% of them thinking), but this workload is input-dominated: total billable
+# went 180,704 -> 187,191 on the same diff, about 4% more, or nearer 20% once
+# output's higher unit price is applied. Not the 3x the token counts suggest.
+#
+# Two things to watch. `max_tokens` above pays for thinking as well, and the
+# largest healthy output at `medium` was 3,986 tokens against that 8,192 cap —
+# roughly 2x headroom, where `low` had 9x. And `medium` truncated once in two
+# runs where `low` truncated twice, which is directionally interesting but n=2:
+# do not read it as a fix for the runaway.
+reasoning_effort: medium

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -295,10 +295,16 @@ network recovers but a dead-end failure surfaces fast:
   clock — see the formula below — but the fan-out is *one* API key, and past
   some width the burst
   rate-limits itself against a per-minute-metered gateway; raise it if your rate
-  tier is generous), **1** for ollama (a single local instance serves a model
-  one request at a time, so concurrent calls would only queue up and time out)
-  and **1** for openai-compatible (honest about a single-slot llama.cpp/LM
-  Studio server; raise it explicitly for a batching vLLM server). Flattening
+  tier is generous), and the same **6** for local
+  providers. Local used to be pinned to 1 because a default ollama serves one
+  request at a time — but that is a property of the *server*, not a reason to cap
+  the client: a server that can batch was capped for nothing, and one that cannot
+  loses nothing by having work queued for it (ollama queues up to
+  `OLLAMA_MAX_QUEUE` rather than failing). What decides local throughput is
+  `OLLAMA_NUM_PARALLEL` / llama.cpp's `-np` / vLLM's batching, and raising those
+  costs memory per slot — see
+  [running locally](../how-to/run-locally-with-ollama.md). Drop this to 1 for a
+  very slow local model, where six queued calls could each wait out the timeout. Flattening
   the pool across batches means wall time is `ceil(batches × lenses / workers)`
   call-latencies rather than `batches × ceil(lenses / workers)`.
 

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -262,6 +262,30 @@ model more room to think.
 
 Unset sends nothing, so a route without a reasoning channel is unaffected.
 
+#### But do not read "cheaper" as "better value"
+
+Bounding thinking is the fix for a **reasoning-bound truncation**. It is not a
+free saving, and the direction that saves tokens is not the direction that finds
+bugs. Measured on lgtmaybe's own repo, two runs per setting on the same diff:
+
+| | `low` | `medium` |
+|---|---|---|
+| findings | 2, 2 | 5, 4 |
+| false positives | 0, 1 | 0, 0 |
+| output tokens | ~4–5k | ~14k |
+| **total billable** | 180,704 | 187,191 |
+
+`medium` roughly triples output tokens and still costs about **4% more in total**,
+because a review is overwhelmingly input: the diff, the context, the system
+prompt. Weighting output at 4× its input price puts it nearer 20%. Either way,
+nothing like the 3× the output column suggests.
+
+What it bought was a bug in lgtmaybe's own retry backoff that `low` missed in
+both its runs — and `low` produced the only false positive of the four. So treat
+`reasoning_effort` as a **quality** dial that happens to move cost a little, not a
+cost dial that happens to move quality. Turn it down when reasoning is eating your
+`max_tokens` ceiling; do not turn it down to save money.
+
 #### On OpenRouter, check the log line
 
 litellm forwards `reasoning_effort` to OpenRouter only for models its capability

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -27,6 +27,7 @@ the findings; to post reviews on real pull requests, use the
 - [Inside the GitHub Action's container](#inside-the-github-actions-container)
 - [Get findings as JSON](#get-findings-as-json)
 - [Let an AI agent apply the fixes](#let-an-ai-agent-apply-the-fixes)
+- [Concurrency on a local server](#concurrency-on-a-local-server)
 - [Slow models and timeouts](#slow-models-and-timeouts)
 - [Troubleshooting](#troubleshooting)
 
@@ -180,6 +181,52 @@ agent (such as Claude Code) can read and apply, so you can review and fix a
 branch locally before opening a PR. See
 [Fix findings with an AI agent](fix-findings-with-an-ai-agent.md).
 
+## Concurrency on a local server
+
+lgtmaybe fans its review calls out across a pool sized by `max_concurrency`,
+**6 by default on every provider, local included**. That is a ceiling on what
+lgtmaybe will have in flight — it is not a promise your server will run them at
+once, and the distinction matters:
+
+- **A default ollama runs one at a time.** `OLLAMA_NUM_PARALLEL` is `1` unless you
+  set it, so five of six calls simply queue (up to `OLLAMA_MAX_QUEUE`, 512). They
+  are not lost and nothing fails; the wall clock is your server's throughput
+  either way. Raising `max_concurrency` alone therefore changes nothing.
+- **The knob that matters is on the server.** Start ollama with
+  `OLLAMA_NUM_PARALLEL=4` and four calls genuinely run together.
+- **It costs memory, in proportion.** Ollama allocates the context window *per
+  parallel slot*: four slots at `num_ctx` 32768 needs 128k of context allocated,
+  not 32k. This is the usual reason a machine that reviewed happily at one slot
+  falls over at four.
+
+So the two settings want to match. If you have raised the server, tell lgtmaybe:
+
+```bash
+lgtmaybe review --max-concurrency 4
+```
+
+**How to tell which you got.** `--profile` already answers it, no extra flag
+needed: compare the per-call `elapsed` column against the `review` stage total.
+If the calls' elapsed times sum to roughly the stage time, they ran one after
+another; if they sum to well over it, they genuinely overlapped.
+
+```
+review             95.32s        <- stage total
+correctness         52.02s   |
+spec                45.64s   |   sum is ~3x the stage,
+artefacts           43.67s   |   so these overlapped
+security            43.30s   |
+```
+
+**When to go the other way.** On a very slow model — a large one on CPU, minutes
+per call — six queued calls can each sit waiting long enough to run out the
+per-request timeout below. Pin it down:
+
+```yaml
+# .lgtmaybe.yml
+max_concurrency: 1
+```
+
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
@@ -233,9 +280,15 @@ pretending the PR is clean.
 
 For a **large diff** this can mean the prompt plus the findings don't fit in
 ollama's context window and the output gets truncated. lgtmaybe runs ollama with
-a generous context (`num_ctx` of 32768) and **structured JSON output** (it also
-disables "thinking" so reasoning models like qwen3.x emit the findings directly),
-which covers most reviews.
+a generous context (`num_ctx` of 32768) and **structured JSON output**, which
+covers most reviews.
+
+lgtmaybe does not pass ollama's `think` flag either way. Ollama already defaults
+thinking **on** for a model that supports it and rejects the flag outright for one
+that does not, so sending nothing is the only choice that is right for both.
+lgtmaybe used to force it off — that made reasoning models review with their
+reasoning switched off, which measurement says is the single biggest lever on
+finding quality there is.
 
 For a big multi-file change ("vibe-coded" commits across many files), raise the
 context window with `--num-ctx` so the whole diff and the findings fit — this is

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -25,6 +25,7 @@ anything that exposes an OpenAI-compatible `/v1` endpoint works through one flag
 - [llama.cpp (local, keyless)](#llamacpp-local-keyless)
 - [LM Studio (local, keyless)](#lm-studio-local-keyless)
 - [vLLM (local or self-hosted, keyless)](#vllm-local-or-self-hosted-keyless)
+- [Concurrency: what each server can actually take](#concurrency-what-each-server-can-actually-take)
 - [Persist it in `.lgtmaybe.yml`](#persist-it-in-lgtmaybeyml)
 - [Gateways that don't support JSON mode (`response_format`)](#gateways-that-dont-support-json-mode-response_format)
 
@@ -122,6 +123,46 @@ lgtmaybe review \
   --provider openai-compatible \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --api-base http://localhost:8000/v1
+```
+
+## Concurrency: what each server can actually take
+
+lgtmaybe fans out across a pool sized by `max_concurrency`, **6 by default on
+every provider**. That is a ceiling on what it will have in flight; whether your
+server runs them together is the server's business, and the three above differ
+sharply.
+
+| server | concurrent by default? | raising it |
+|---|---|---|
+| **vLLM** | yes — continuous batching | close to free; each request keeps the full `--max-model-len` |
+| **llama.cpp** | no, one slot | `-np N` adds slots, but **splits one KV cache between them** |
+| **LM Studio** | no, single-slot | not exposed; leave `max_concurrency` at 1 |
+
+The llama.cpp trap is worth spelling out, because it fails as a quality problem
+rather than an error. `-np` divides the context you asked for: `-c 32768 -np 4`
+leaves each slot **8k**, and a lgtmaybe review prompt is comfortably larger than
+that, so the diff is silently truncated and the model reviews something it was
+never fully shown. Size `-c` as `slots × per-slot-context`:
+
+```bash
+llama-server -m ./model.gguf --port 8000 -np 4 -c 131072   # 4 slots × 32k each
+```
+
+vLLM allocates KV blocks dynamically rather than carving them up front, so
+concurrent requests each keep the full `--max-model-len`. That is why it is the
+local server to reach for when review latency matters:
+
+```bash
+vllm serve <model> --port 8000 --max-model-len 32768
+lgtmaybe review --provider openai-compatible --model <model> \
+  --api-base http://localhost:8000/v1 --max-concurrency 6
+```
+
+For a single-slot server, say so and let lgtmaybe queue nothing:
+
+```yaml
+# .lgtmaybe.yml
+max_concurrency: 1
 ```
 
 ## Persist it in `.lgtmaybe.yml`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1717,6 +1717,7 @@ the findings; to post reviews on real pull requests, use the
 - [Inside the GitHub Action's container](#inside-the-github-actions-container)
 - [Get findings as JSON](#get-findings-as-json)
 - [Let an AI agent apply the fixes](#let-an-ai-agent-apply-the-fixes)
+- [Concurrency on a local server](#concurrency-on-a-local-server)
 - [Slow models and timeouts](#slow-models-and-timeouts)
 - [Troubleshooting](#troubleshooting)
 
@@ -1870,6 +1871,52 @@ agent (such as Claude Code) can read and apply, so you can review and fix a
 branch locally before opening a PR. See
 [Fix findings with an AI agent](fix-findings-with-an-ai-agent.md).
 
+## Concurrency on a local server
+
+lgtmaybe fans its review calls out across a pool sized by `max_concurrency`,
+**6 by default on every provider, local included**. That is a ceiling on what
+lgtmaybe will have in flight — it is not a promise your server will run them at
+once, and the distinction matters:
+
+- **A default ollama runs one at a time.** `OLLAMA_NUM_PARALLEL` is `1` unless you
+  set it, so five of six calls simply queue (up to `OLLAMA_MAX_QUEUE`, 512). They
+  are not lost and nothing fails; the wall clock is your server's throughput
+  either way. Raising `max_concurrency` alone therefore changes nothing.
+- **The knob that matters is on the server.** Start ollama with
+  `OLLAMA_NUM_PARALLEL=4` and four calls genuinely run together.
+- **It costs memory, in proportion.** Ollama allocates the context window *per
+  parallel slot*: four slots at `num_ctx` 32768 needs 128k of context allocated,
+  not 32k. This is the usual reason a machine that reviewed happily at one slot
+  falls over at four.
+
+So the two settings want to match. If you have raised the server, tell lgtmaybe:
+
+```bash
+lgtmaybe review --max-concurrency 4
+```
+
+**How to tell which you got.** `--profile` already answers it, no extra flag
+needed: compare the per-call `elapsed` column against the `review` stage total.
+If the calls' elapsed times sum to roughly the stage time, they ran one after
+another; if they sum to well over it, they genuinely overlapped.
+
+```
+review             95.32s        <- stage total
+correctness         52.02s   |
+spec                45.64s   |   sum is ~3x the stage,
+artefacts           43.67s   |   so these overlapped
+security            43.30s   |
+```
+
+**When to go the other way.** On a very slow model — a large one on CPU, minutes
+per call — six queued calls can each sit waiting long enough to run out the
+per-request timeout below. Pin it down:
+
+```yaml
+# .lgtmaybe.yml
+max_concurrency: 1
+```
+
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
@@ -1923,9 +1970,15 @@ pretending the PR is clean.
 
 For a **large diff** this can mean the prompt plus the findings don't fit in
 ollama's context window and the output gets truncated. lgtmaybe runs ollama with
-a generous context (`num_ctx` of 32768) and **structured JSON output** (it also
-disables "thinking" so reasoning models like qwen3.x emit the findings directly),
-which covers most reviews.
+a generous context (`num_ctx` of 32768) and **structured JSON output**, which
+covers most reviews.
+
+lgtmaybe does not pass ollama's `think` flag either way. Ollama already defaults
+thinking **on** for a model that supports it and rejects the flag outright for one
+that does not, so sending nothing is the only choice that is right for both.
+lgtmaybe used to force it off — that made reasoning models review with their
+reasoning switched off, which measurement says is the single biggest lever on
+finding quality there is.
 
 For a big multi-file change ("vibe-coded" commits across many files), raise the
 context window with `--num-ctx` so the whole diff and the findings fit — this is
@@ -1994,6 +2047,7 @@ anything that exposes an OpenAI-compatible `/v1` endpoint works through one flag
 - [llama.cpp (local, keyless)](#llamacpp-local-keyless)
 - [LM Studio (local, keyless)](#lm-studio-local-keyless)
 - [vLLM (local or self-hosted, keyless)](#vllm-local-or-self-hosted-keyless)
+- [Concurrency: what each server can actually take](#concurrency-what-each-server-can-actually-take)
 - [Persist it in `.lgtmaybe.yml`](#persist-it-in-lgtmaybeyml)
 - [Gateways that don't support JSON mode (`response_format`)](#gateways-that-dont-support-json-mode-response_format)
 
@@ -2091,6 +2145,46 @@ lgtmaybe review \
   --provider openai-compatible \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --api-base http://localhost:8000/v1
+```
+
+## Concurrency: what each server can actually take
+
+lgtmaybe fans out across a pool sized by `max_concurrency`, **6 by default on
+every provider**. That is a ceiling on what it will have in flight; whether your
+server runs them together is the server's business, and the three above differ
+sharply.
+
+| server | concurrent by default? | raising it |
+|---|---|---|
+| **vLLM** | yes — continuous batching | close to free; each request keeps the full `--max-model-len` |
+| **llama.cpp** | no, one slot | `-np N` adds slots, but **splits one KV cache between them** |
+| **LM Studio** | no, single-slot | not exposed; leave `max_concurrency` at 1 |
+
+The llama.cpp trap is worth spelling out, because it fails as a quality problem
+rather than an error. `-np` divides the context you asked for: `-c 32768 -np 4`
+leaves each slot **8k**, and a lgtmaybe review prompt is comfortably larger than
+that, so the diff is silently truncated and the model reviews something it was
+never fully shown. Size `-c` as `slots × per-slot-context`:
+
+```bash
+llama-server -m ./model.gguf --port 8000 -np 4 -c 131072   # 4 slots × 32k each
+```
+
+vLLM allocates KV blocks dynamically rather than carving them up front, so
+concurrent requests each keep the full `--max-model-len`. That is why it is the
+local server to reach for when review latency matters:
+
+```bash
+vllm serve <model> --port 8000 --max-model-len 32768
+lgtmaybe review --provider openai-compatible --model <model> \
+  --api-base http://localhost:8000/v1 --max-concurrency 6
+```
+
+For a single-slot server, say so and let lgtmaybe queue nothing:
+
+```yaml
+# .lgtmaybe.yml
+max_concurrency: 1
 ```
 
 ## Persist it in `.lgtmaybe.yml`
@@ -3785,6 +3879,30 @@ of thought. Raising the cap from 16k to 32k had not helped; it only bought the
 model more room to think.
 
 Unset sends nothing, so a route without a reasoning channel is unaffected.
+
+#### But do not read "cheaper" as "better value"
+
+Bounding thinking is the fix for a **reasoning-bound truncation**. It is not a
+free saving, and the direction that saves tokens is not the direction that finds
+bugs. Measured on lgtmaybe's own repo, two runs per setting on the same diff:
+
+| | `low` | `medium` |
+|---|---|---|
+| findings | 2, 2 | 5, 4 |
+| false positives | 0, 1 | 0, 0 |
+| output tokens | ~4–5k | ~14k |
+| **total billable** | 180,704 | 187,191 |
+
+`medium` roughly triples output tokens and still costs about **4% more in total**,
+because a review is overwhelmingly input: the diff, the context, the system
+prompt. Weighting output at 4× its input price puts it nearer 20%. Either way,
+nothing like the 3× the output column suggests.
+
+What it bought was a bug in lgtmaybe's own retry backoff that `low` missed in
+both its runs — and `low` produced the only false positive of the four. So treat
+`reasoning_effort` as a **quality** dial that happens to move cost a little, not a
+cost dial that happens to move quality. Turn it down when reasoning is eating your
+`max_tokens` ceiling; do not turn it down to save money.
 
 #### On OpenRouter, check the log line
 
@@ -6166,10 +6284,16 @@ network recovers but a dead-end failure surfaces fast:
   clock — see the formula below — but the fan-out is *one* API key, and past
   some width the burst
   rate-limits itself against a per-minute-metered gateway; raise it if your rate
-  tier is generous), **1** for ollama (a single local instance serves a model
-  one request at a time, so concurrent calls would only queue up and time out)
-  and **1** for openai-compatible (honest about a single-slot llama.cpp/LM
-  Studio server; raise it explicitly for a batching vLLM server). Flattening
+  tier is generous), and the same **6** for local
+  providers. Local used to be pinned to 1 because a default ollama serves one
+  request at a time — but that is a property of the *server*, not a reason to cap
+  the client: a server that can batch was capped for nothing, and one that cannot
+  loses nothing by having work queued for it (ollama queues up to
+  `OLLAMA_MAX_QUEUE` rather than failing). What decides local throughput is
+  `OLLAMA_NUM_PARALLEL` / llama.cpp's `-np` / vLLM's batching, and raising those
+  costs memory per slot — see
+  [running locally](../how-to/run-locally-with-ollama.md). Drop this to 1 for a
+  very slow local model, where six queued calls could each wait out the timeout. Flattening
   the pool across batches means wall time is `ceil(batches × lenses / workers)`
   call-latencies rather than `batches × ceil(lenses / workers)`.
 

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -49,7 +49,7 @@ stage failure surfaces to the caller.
 ### Requirement: Per-lens fan-out through one bounded executor
 
 Every `(batch, lens)` call SHALL run through one global bounded executor sized
-by `max_concurrency` (auto: six cloud, one for Ollama/OpenAI-compatible). The
+by `max_concurrency` (auto: six, every provider). The
 executor size SHALL determine only how the preset's calls are scheduled, never
 how many there are. The rescue wave and the oversized-batch split each run in a
 pool of their own, entered only after the fan-out's has closed or from a worker
@@ -62,8 +62,9 @@ result deadlocks once that pool saturates.
 - **THEN** the security, correctness, code-health, and artefacts calls share the
   bounded executor and may overlap
 
-#### Scenario: single-worker default review
-- **WHEN** a fast review uses Ollama auto-concurrency or `max_concurrency: 1`
+#### Scenario: single-worker review
+- **WHEN** a review sets `max_concurrency: 1` — a very slow local model, or a
+  server whose own parallelism is one and whose calls must not queue
 - **THEN** the same four calls run within the single-worker pool, serially
 
 #### Scenario: deep audit

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1481,10 +1481,11 @@ class LLMReviewEngine:
         # construction rather than by argument. It costs at most `width` threads
         # for the duration of one split, and a split is the exceptional path.
         #
-        # Width is the backend's own concurrency (never the piece count): a
-        # single-stream server — ollama, a one-slot llama.cpp — serves calls
-        # serially, so two at once would only queue and eat the timeout. At
-        # width 1 the executor runs them in submission order, exactly as the
+        # Width is the review's own concurrency (never the piece count), so a
+        # user who has told us what their backend can take — `max_concurrency`,
+        # which on a local server is how they describe its parallelism — gets
+        # that answer in both pools rather than one setting meaning two things.
+        # At width 1 the executor runs them in submission order, exactly as the
         # serial loop did. A splitting worker is blocked, not calling, so the
         # calls in flight peak at the fan-out's width times this one — the
         # adapter's backoff absorbs that burst, and it only happens on the run

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -98,13 +98,25 @@ _log = get_logger(__name__)
 #   the rescue wave both make that survivable rather than fatal; six is the same
 #   fix from the other end — a quarter less burst for a quarter less parallelism.
 #   Teams on a high rate tier can raise it with `max_concurrency`.
-# - A single ollama instance serves a model serially, so concurrent calls only
-#   queue up and time out: 1.
-# - openai-compatible is honest about the worst case: a llama.cpp / LM Studio
-#   single-slot server wants 1, while a vLLM server batches happily —
-#   default to 1 and let --max-concurrency raise it for batching servers.
+# - Local providers (ollama, openai-compatible) get the same 6. They used to get
+#   1, on the reasoning that a local server processes one request at a time so a
+#   wider pool would only queue. The queueing is real, but the conclusion was
+#   wrong in both directions: a server that CAN batch was capped at 1 for no
+#   reason, and a server that cannot loses nothing by having work queued for it —
+#   ollama queues (up to OLLAMA_MAX_QUEUE, 512) rather than failing, so the wall
+#   clock is the server's throughput either way.
+#
+#   The knob that actually decides local throughput is on the SERVER, not here:
+#   `OLLAMA_NUM_PARALLEL` (1 by default), llama.cpp's `-np`, vLLM's batching.
+#   Raising those costs memory in proportion — ollama allocates context per
+#   parallel slot, and llama.cpp splits one KV cache across slots, so `-c 32768
+#   -np 4` leaves each slot 8k, well under a single review prompt. vLLM is the
+#   exception: it batches and keeps full `--max-model-len` per request.
+#
+#   The one case for lowering this back to 1 is a very slow local model, where
+#   six queued calls could each wait out the per-request timeout.
 _CLOUD_MAX_WORKERS = 6
-_SINGLE_STREAM_PROVIDERS = frozenset({Provider.ollama, Provider.openai_compatible})
+_SINGLE_STREAM_PROVIDERS: frozenset[Provider] = frozenset()
 _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     {
         ReviewCategory.security.value,

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -230,11 +230,23 @@ def build_provider(
     is_ollama = provider is Provider.ollama
     if is_ollama:
         opts["api_base"] = api_base or DEFAULT_OLLAMA_BASE
-        # Disable "thinking" for ollama models. Thinking models (qwen3.x) otherwise
-        # route their whole answer to the reasoning channel and return EMPTY content
-        # under structured output — so JSON-mode yields nothing to parse. With
-        # think=False they emit the findings JSON directly.
-        opts["think"] = False
+        # `think` is deliberately NOT sent. Ollama already decides it per model —
+        # its chat route defaults thinking ON for a thinking-capable model when the
+        # field is unset, and 400s outright if you ask a non-thinking model for it.
+        # So sending nothing gets the right answer for both, where sending either
+        # literal gets one of them wrong.
+        #
+        # This used to be pinned to False, because a thinking model routed its whole
+        # answer into the reasoning channel and returned EMPTY content under
+        # structured output, leaving JSON mode nothing to parse. Two things have
+        # since made that the wrong trade. Ollama now separates the trace into
+        # `message.thinking` and leaves the answer in `message.content`; and when a
+        # backend does still come back empty under a schema, the adapter drops
+        # `response_format` and re-sends (see LiteLLMProvider._call), remembering it
+        # for the rest of the run. The cost of being wrong is one re-send; the cost
+        # of pinning it False was every local reasoning model reviewing with its
+        # reasoning switched off, which four measured runs say is the single
+        # biggest lever on finding quality there is.
         # Ollama's default context window (~4k) is smaller than a real review
         # prompt (system prompt + wrapped diff + context lines), which truncates
         # the output to a stub. Give it enough room to read the prompt AND emit the

--- a/tests/engine/test_concurrency.py
+++ b/tests/engine/test_concurrency.py
@@ -27,17 +27,20 @@ def _cfg(provider: Provider, **overrides: object) -> ReviewConfig:
 
 
 class TestResolveWorkers:
-    @pytest.mark.parametrize("provider", _CLOUD_PROVIDERS)
-    def test_cloud_defaults_to_six(self, provider: Provider) -> None:
-        """Six, not eight: the fan-out is one API key, and eight concurrent calls
-        against a per-minute-metered gateway rate-limits itself."""
-        assert _resolve_workers(_cfg(provider), task_count=100) == 6
+    @pytest.mark.parametrize("provider", list(Provider))
+    def test_every_provider_defaults_to_six(self, provider: Provider) -> None:
+        """Six everywhere, local included.
 
-    @pytest.mark.parametrize("provider", [Provider.ollama, Provider.openai_compatible])
-    def test_single_stream_providers_default_to_one(self, provider: Provider) -> None:
-        """ollama serves serially; openai-compatible may front a single-slot
-        llama.cpp server, so the honest default is 1 (vLLM users raise it)."""
-        assert _resolve_workers(_cfg(provider), task_count=100) == 1
+        Six rather than eight because the fan-out is one API key and eight
+        concurrent calls against a per-minute-metered gateway rate-limits itself.
+        Local providers used to be pinned to 1 on the reasoning that a local
+        server handles one request at a time — true of a default ollama, but the
+        conclusion did not follow: a server that CAN batch was capped for no
+        reason, and one that cannot loses nothing by having work queued for it.
+        What decides local throughput is the server's own setting
+        (`OLLAMA_NUM_PARALLEL`, llama.cpp `-np`, vLLM batching), not this.
+        """
+        assert _resolve_workers(_cfg(provider), task_count=100) == 6
 
     @pytest.mark.parametrize("provider", list(Provider))
     def test_explicit_max_concurrency_wins_everywhere(self, provider: Provider) -> None:

--- a/tests/engine/test_deadline.py
+++ b/tests/engine/test_deadline.py
@@ -46,7 +46,12 @@ class _SlowProvider(FakeProvider):
 
 def _cfg(**overrides: object) -> ReviewConfig:
     defaults: dict[str, object] = {
-        "provider": Provider.ollama,  # serial: calls execute one at a time
+        "provider": Provider.openai,
+        # Serial on purpose, so a deadline crossed during the first call leaves
+        # the rest queued and skippable. Stated outright rather than leaning on a
+        # provider that used to resolve to one worker — local providers now get
+        # the same six as cloud, so the proxy no longer holds.
+        "max_concurrency": 1,
         "model": "m",
         "categories": [
             ReviewCategory.security,

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -387,8 +387,8 @@ class TestRescueWave:
             return base + (10_000.0 if crossed.is_set() else 0.0)
 
         provider = _CrossesTheDeadline()
-        # ollama resolves to one worker, so the calls are strictly serial: the
-        # first runs, crosses the deadline, and the second is skipped by it.
+        # One worker, so the calls are strictly serial: the first runs, crosses
+        # the deadline, and the second is skipped by it.
         cfg = _cfg(max_concurrency=1, max_review_seconds=1)
         with patch.object(engine_module.time, "perf_counter", stepped):
             _, summary = LLMReviewEngine(provider).review(_CTX, cfg)

--- a/tests/engine/test_rescue.py
+++ b/tests/engine/test_rescue.py
@@ -352,12 +352,12 @@ class TestRescueWave:
         deterministically and instantly; the deadline's route is pinned
         separately below.
 
-        Serial provider, so the first call raises the flag and the second is
+        One worker, so the first call raises the flag and the second is
         skipped.
         """
         provider = _InterruptOnFirstCall()
 
-        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(provider=Provider.ollama))
+        _, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_concurrency=1))
 
         assert len(provider.calls) == 1
         assert "interrupted" in summary
@@ -389,7 +389,7 @@ class TestRescueWave:
         provider = _CrossesTheDeadline()
         # ollama resolves to one worker, so the calls are strictly serial: the
         # first runs, crosses the deadline, and the second is skipped by it.
-        cfg = _cfg(provider=Provider.ollama, max_review_seconds=1)
+        cfg = _cfg(max_concurrency=1, max_review_seconds=1)
         with patch.object(engine_module.time, "perf_counter", stepped):
             _, summary = LLMReviewEngine(provider).review(_CTX, cfg)
 

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -318,12 +318,13 @@ def test_the_pieces_of_a_split_batch_are_reviewed_concurrently() -> None:
     assert sorted(f.path for f in findings) == ["one.py", "two.py"]
 
 
-def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> None:
+def test_one_worker_reviews_the_split_pieces_one_at_a_time() -> None:
     """The split is bounded by the review's own concurrency, not by piece count.
 
-    A single ollama instance serves a model serially: two concurrent calls only
-    queue up and eat the timeout. Whatever the fan-out is allowed, the split is
-    allowed — never more.
+    Whatever the fan-out is allowed, the split is allowed — never more. Pinned
+    with `max_concurrency=1` outright: this used to lean on ollama resolving to a
+    single worker, which is no longer true, and serialism was always what the
+    test meant rather than any particular provider.
     """
     provider = _TimeoutThenSlowPieces()
     LLMReviewEngine(provider).review(
@@ -331,6 +332,7 @@ def test_a_single_stream_provider_still_reviews_its_pieces_one_at_a_time() -> No
         ReviewConfig(
             provider=Provider.ollama,
             model="qwen3-coder",
+            max_concurrency=1,
             categories=[ReviewCategory.security],
             reflect=False,
             prompt_cache=False,
@@ -344,11 +346,10 @@ def test_an_explicit_concurrency_lifts_the_split_off_the_single_stream_default()
     """The user's number wins over the provider default, in the split as in the
     fan-out.
 
-    ollama's 1 is a default for the usual deployment — one instance, one slot —
-    not a property of the backend: an ollama started with several parallel slots
-    (and a batching vLLM behind `openai-compatible`) serves concurrent calls
-    happily, which is exactly why `max_concurrency` is exposed. Honouring it in
-    only one of the two pools would make one setting mean two different things.
+    A local server's throughput is set on the server (`OLLAMA_NUM_PARALLEL`,
+    llama.cpp `-np`, vLLM's batching), so `max_concurrency` is how the user tells
+    lgtmaybe what their server can take. Honouring it in only one of the two
+    pools would make one setting mean two different things.
     """
     provider = _TimeoutThenPairedPieces()
     LLMReviewEngine(provider).review(

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -161,10 +161,16 @@ class TestBuildProvider:
         provider = build_provider(Provider.ollama, "llama2", timeout=45)
         assert provider.default_opts.get("timeout") == 45
 
-    def test_ollama_disables_thinking(self) -> None:
-        # Thinking models return empty content under structured output otherwise.
+    def test_ollama_leaves_thinking_to_ollama(self) -> None:
+        """Send nothing, because either literal is wrong for some model.
+
+        Ollama's chat route defaults thinking ON for a thinking-capable model
+        when the field is unset, and 400s if a non-thinking model is asked for
+        it. Pinning False switched reasoning off for every local reasoning
+        model; pinning True would break every non-reasoning one.
+        """
         provider = build_provider(Provider.ollama, "qwen3.6:35b", api_base="http://localhost:11434")
-        assert provider.default_opts.get("think") is False
+        assert "think" not in provider.default_opts
 
     def test_cloud_does_not_set_think(self) -> None:
         provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -174,20 +174,17 @@ class TestEngineBehaviourMatrix:
     behaviour must hold whatever the backend is.
     """
 
-    # Auto max_concurrency per provider: 1 for single-stream backends (ollama
-    # serves serially; openai-compatible may front a single-slot llama.cpp/LM
-    # Studio server), 6 for hosted cloud — wide enough to overlap the fan-out,
-    # narrow enough that one API key does not rate-limit itself.
-    SINGLE_STREAM = (Provider.ollama, Provider.openai_compatible)
-
+    # Auto max_concurrency is 6 for every provider — wide enough to overlap the
+    # fan-out, narrow enough that one API key does not rate-limit itself. Local
+    # backends are no longer special-cased: what bounds their throughput is the
+    # server's own parallelism setting, not this pool's width.
     @pytest.mark.parametrize("provider", list(Provider))
     def test_auto_concurrency_default(self, provider: Provider) -> None:
         from lgtmaybe.core.models import ReviewConfig
         from lgtmaybe.engine.engine import _resolve_workers
 
         cfg = ReviewConfig(provider=provider, model="m")
-        expected = 1 if provider in self.SINGLE_STREAM else 6
-        assert _resolve_workers(cfg, task_count=99) == expected
+        assert _resolve_workers(cfg, task_count=99) == 6
 
     @pytest.mark.parametrize("provider", list(Provider))
     def test_fast_preset_makes_four_calls_on_every_provider(self, provider: Provider) -> None:


### PR DESCRIPTION
Three changes, each resting on a claim that stopped being true.

## `reasoning_effort: medium` in the dogfood config

Four measured runs, two per setting, same 18-file diff and same cap so the setting was the only variable:

| | `low` | `medium` |
|---|---|---|
| findings | 2, 2 | 5, 4 |
| false positives | 0, **1** | 0, 0 |
| truncated lens | code-health ×2 | security, none |
| total billable | 180,704 | 187,191 |

The count wasn't what decided it. The rate-limit ladder bug that shipped in 1.14.0 and needed #395 was found by `medium` in **both** runs and missed by `low` in both — and `low` produced the only false positive across all four, a confident 9/10 claim about tenacity's internals that was exactly inverted.

The cost is smaller than it looks: `medium` roughly triples *output* tokens, but a review is overwhelmingly input, so total billable rises ~4% (nearer 20% weighting output at 4× unit price). Not the 3× the output column implies. `docs/how-to/reduce-review-cost.md` now says this outright, because the previous framing invited reading `reasoning_effort` as a cost dial — it's a quality dial that moves cost a little.

**`ReviewConfig.reasoning_effort` stays `None`.** Four runs of one model on one provider don't justify forcing reasoning on for every user, and `None` sends nothing so routes without a reasoning channel are unaffected.

## Thinking is no longer forced off for ollama

`factory.py` pinned `think=False` because a reasoning model used to route its whole answer into the reasoning channel and return empty content under structured output. Ollama's chat route today:

```go
if slices.Contains(modelCaps, model.CapabilityThinking) {
    if req.Think == nil { req.Think = &api.ThinkValue{Value: true} }   // defaults ON
} else {
    if req.Think != nil && req.Think.Bool() { 400 "does not support thinking" }
}
```

So it already decides correctly per model, and **sending `true` would be as wrong as sending `false`** — just for different models. lgtmaybe now sends nothing. The old failure mode has a net regardless: the adapter drops `response_format` and re-sends when a backend comes back empty under a schema, remembering it for the run.

Given the table above, forcing it off meant every local reasoning model was reviewing with its reasoning switched off.

## Local providers get the same six workers as cloud

The cap said a local server handles one request at a time. True of a default ollama — but that's a property of the **server**, not a reason to cap the client. A server that *can* batch was capped for nothing, and one that cannot loses nothing by having work queued for it: ollama queues up to `OLLAMA_MAX_QUEUE` (512) rather than failing, so the wall clock is its throughput either way.

What decides local throughput is `OLLAMA_NUM_PARALLEL` (1 by default), llama.cpp's `-np`, or vLLM's batching — and raising those costs memory in proportion. Both how-to guides now cover it, including the llama.cpp trap that fails as a quality problem rather than an error: `-np` splits **one** KV cache, so `-c 32768 -np 4` leaves each slot 8k, well under a review prompt, and the diff is silently truncated.

Three tests used `Provider.ollama` as a proxy for serial execution. They now say `max_concurrency=1`, which is what they meant.

## Verification, and what it does *not* cover

1981 passing, ruff, mypy, `pytest tests/specs`, `openspec validate --specs`.

**Neither local change is testable in CI or from my environment** — there's no ollama available and outbound model hosts are blocked. The suite proves the wiring and nothing about behaviour against a real server. Two things want a local run before this is relied on:

- **Thinking on:** a local reasoning model under JSON mode may return empty on its first call; confirm the adapter's `response_format` drop recovers and findings parse, rather than the run degrading.
- **Concurrency 6:** against a default ollama expect *queueing, not speedup* — wall time roughly unchanged is the null result that confirms nothing broke. `--profile` shows which you got: per-call elapsed summing to ~the review stage means serial, summing well over means overlap.

The one risk is a very slow local model where six queued calls each wait out the per-request timeout; `max_concurrency: 1` is the remedy and is documented as such.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dbQVinBgkosiR6rpZy4gP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local and hosted providers now support up to six concurrent review tasks by default.
  * Added guidance for tuning concurrency across Ollama and OpenAI-compatible servers.
  * Ollama models now retain their default thinking behavior.

* **Documentation**
  * Clarified memory, batching, queueing, and single-worker configuration considerations.
  * Added guidance explaining that reasoning effort primarily affects review quality rather than cost.

* **Improvements**
  * Medium reasoning effort is now the default for improved review quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->