### PR TITLE
test: assert retry budget skips sleep

### DIFF
--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1368,13 +1368,17 @@ class TestRetryBudgetIsNotOvershot:
                 ),
             )
 
-        with patch("litellm.completion", side_effect=rate_limited):
+        with (
+            patch("litellm.completion", side_effect=rate_limited),
+            patch("tenacity.nap.time.sleep") as sleep,
+        ):
             # Budget is 2.5 × 0.05s; the 120s hint cannot fit inside it.
             with pytest.raises(litellm.RateLimitError) as caught:
                 LiteLLMProvider(timeout=0.05).complete(
                     [{"role": "user", "content": "hi"}], "openrouter/m"
                 )
 
+        sleep.assert_not_called()
         assert attempts_of(caught.value) == 1
         assert time.perf_counter() - started < 60
 


### PR DESCRIPTION
## What changed

The retry-budget regression test now patches Tenacity's sleeper and asserts it is never called when a 120-second `Retry-After` cannot fit inside a 0.05-second request budget.

## Why

This addresses the valid CodeRabbit finding left on #395. Attempt count and elapsed time were useful indirect checks, but neither directly proved that the retry loop skipped sleeping.

## Impact

No runtime behavior changes. The test now fails immediately if the budget guard permits an over-budget sleep.

## Validation

- `uv run pytest tests/providers/test_retry.py -q` — 72 passed
- `uv run pytest -q` — 1974 passed, 3 skipped, 19 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest tests/specs -q`
- `openspec validate --specs`