### PR TITLE
fix(cli): scale the local per-call timeout by the fan-out width

### DIFF
--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -218,9 +218,12 @@ artefacts           43.67s   |   so these overlapped
 security            43.30s   |
 ```
 
-**When to go the other way.** On a very slow model — a large one on CPU, minutes
-per call — six queued calls can each sit waiting long enough to run out the
-per-request timeout below. Pin it down:
+**Queue time is already paid for.** A queued call's timeout clock starts when the
+request is *sent*, not when your server gets to it, so on a single-slot box the
+last call in a six-wide fan-out would otherwise have to be served within the same
+budget as the first. lgtmaybe scales the local default by the fan-out width to
+cover that (see below), so you should not need to intervene. If you would rather
+not have the calls queue at all:
 
 ```yaml
 # .lgtmaybe.yml
@@ -233,8 +236,21 @@ Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama 
 long default per-request timeout (1800 seconds)** automatically — you don't need
 to set anything for a normal run. (Direct cloud providers default to 600 s.)
 
+**That default scales with the fan-out.** Because the calls queue, the budget has
+to cover the wait as well as the work: at the default width of six the resolved
+per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
+default) so no single call can outlive the review it belongs to. At
+`max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
+run logs which number it resolved, and why:
+
+```
+per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+```
+
+An explicit `timeout` is never scaled — `timeout: 600` means 600 at any width.
+
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 1800.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 3600.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
@@ -250,20 +266,16 @@ timeout: 1800
 ```
 
 The review fans out **four calls** under the default `fast` preset (nine under
-`--preset full`). lgtmaybe runs those **serially for
-ollama**: a single ollama instance serves one request at a time, so firing them
-concurrently would only make each wait and time out. The trade-off is
-wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — four serial calls instead of nine is the
-single biggest local speed-up.
+`--preset full`). On a default ollama those queue rather than overlap, so a slow
+model takes roughly `lens calls × per-call time` — which is exactly why `fast` is
+the default: four calls instead of nine is the single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
-`OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match — the same four calls then overlap instead of queueing, which is close to
-a 4× wall-clock win. By default lgtmaybe issues ollama calls one at a time. Add
-`--profile` to any run to see the per-call breakdown.
+`OLLAMA_NUM_PARALLEL` on the **ollama server** as described above — the same four
+calls then overlap instead of queueing, which is close to a 4× wall-clock win.
+Add `--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -158,7 +158,18 @@ lgtmaybe review --provider openai-compatible --model <model> \
   --api-base http://localhost:8000/v1 --max-concurrency 6
 ```
 
-For a single-slot server, say so and let lgtmaybe queue nothing:
+**Queueing does not cost you a timeout.** A queued request's clock starts when it
+is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
+per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
+bounded by `max_review_seconds` (3600 s) so no call outlives the review. An
+explicit `timeout` is honoured exactly as written, at any width. Each run logs the
+number it resolved and the width it assumed:
+
+```
+per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+```
+
+For a single-slot server, you can still say so and let lgtmaybe queue nothing:
 
 ```yaml
 # .lgtmaybe.yml

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1907,9 +1907,12 @@ artefacts           43.67s   |   so these overlapped
 security            43.30s   |
 ```
 
-**When to go the other way.** On a very slow model — a large one on CPU, minutes
-per call — six queued calls can each sit waiting long enough to run out the
-per-request timeout below. Pin it down:
+**Queue time is already paid for.** A queued call's timeout clock starts when the
+request is *sent*, not when your server gets to it, so on a single-slot box the
+last call in a six-wide fan-out would otherwise have to be served within the same
+budget as the first. lgtmaybe scales the local default by the fan-out width to
+cover that (see below), so you should not need to intervene. If you would rather
+not have the calls queue at all:
 
 ```yaml
 # .lgtmaybe.yml
@@ -1922,8 +1925,21 @@ Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama 
 long default per-request timeout (1800 seconds)** automatically — you don't need
 to set anything for a normal run. (Direct cloud providers default to 600 s.)
 
+**That default scales with the fan-out.** Because the calls queue, the budget has
+to cover the wait as well as the work: at the default width of six the resolved
+per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
+default) so no single call can outlive the review it belongs to. At
+`max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
+run logs which number it resolved, and why:
+
+```
+per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+```
+
+An explicit `timeout` is never scaled — `timeout: 600` means 600 at any width.
+
 If a big model still times out — you'll see
-`litellm.Timeout: Connection timed out after 1800.0 seconds` — raise it explicitly:
+`litellm.Timeout: Connection timed out after 3600.0 seconds` — raise it explicitly:
 
 ```bash
 # CLI flag (seconds):
@@ -1939,20 +1955,16 @@ timeout: 1800
 ```
 
 The review fans out **four calls** under the default `fast` preset (nine under
-`--preset full`). lgtmaybe runs those **serially for
-ollama**: a single ollama instance serves one request at a time, so firing them
-concurrently would only make each wait and time out. The trade-off is
-wall-clock time. A slow model takes roughly `lens calls × per-call time`, which
-is exactly why `fast` is the default — four serial calls instead of nine is the
-single biggest local speed-up.
+`--preset full`). On a default ollama those queue rather than overlap, so a slow
+model takes roughly `lens calls × per-call time` — which is exactly why `fast` is
+the default: four calls instead of nine is the single biggest local speed-up.
 
 To go faster still, narrow the lenses with `categories:` in `.lgtmaybe.yml`
 (e.g. just `security` and `correctness`), use a smaller model, or give ollama
 more GPU. If you have the VRAM to truly serve requests in parallel, raise
-`OLLAMA_NUM_PARALLEL` on the **ollama server** and raise `--max-concurrency` to
-match — the same four calls then overlap instead of queueing, which is close to
-a 4× wall-clock win. By default lgtmaybe issues ollama calls one at a time. Add
-`--profile` to any run to see the per-call breakdown.
+`OLLAMA_NUM_PARALLEL` on the **ollama server** as described above — the same four
+calls then overlap instead of queueing, which is close to a 4× wall-clock win.
+Add `--profile` to any run to see the per-call breakdown.
 
 ## Troubleshooting
 
@@ -2179,7 +2191,18 @@ lgtmaybe review --provider openai-compatible --model <model> \
   --api-base http://localhost:8000/v1 --max-concurrency 6
 ```
 
-For a single-slot server, say so and let lgtmaybe queue nothing:
+**Queueing does not cost you a timeout.** A queued request's clock starts when it
+is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
+per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
+bounded by `max_review_seconds` (3600 s) so no call outlives the review. An
+explicit `timeout` is honoured exactly as written, at any width. Each run logs the
+number it resolved and the width it assumed:
+
+```
+per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+```
+
+For a single-slot server, you can still say so and let lgtmaybe queue nothing:
 
 ```yaml
 # .lgtmaybe.yml

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -230,8 +230,10 @@ names a ceiling hit its own way is caught downstream by the parser instead.
 Timeouts SHALL default long for providers that may front a slow model —
 local-capable ones (ollama/openai-compatible) and openrouter, a gateway to
 arbitrary models including slow reasoning ones — and short for direct cloud
-providers; the litellm model string is derived per provider so users give bare
-model ids.
+providers; a local-capable default SHALL additionally scale with the fan-out
+width, bounded by the whole-review deadline, because a queued call spends that
+budget waiting rather than working; the litellm model string is derived per
+provider so users give bare model ids.
 <!-- anchor: provider.defaults -->
 
 #### Scenario: no timeout configured
@@ -241,6 +243,17 @@ model ids.
 #### Scenario: openrouter gets the generous default
 - **WHEN** `timeout` is unset and the provider is openrouter
 - **THEN** the generous (long) default applies, not the cloud one
+
+#### Scenario: a local fan-out queues behind one slot
+- **WHEN** `timeout` is unset, the provider is local-capable, and the fan-out is
+  wider than one
+- **THEN** the default is multiplied by that width, so a call whose wait is spent
+  in the server's queue still has a full budget for the work itself
+
+#### Scenario: the widened budget would outlive the run
+- **WHEN** that scaled default exceeds `max_review_seconds`
+- **THEN** it is clamped to the deadline — never below the provider's own default,
+  and never clamped at all when the deadline is disabled
 
 #### Scenario: the documented default and the resolved one disagree
 - **WHEN** a provider's resolved default stops matching the seconds the Action

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -45,6 +45,7 @@ from lgtmaybe.engine import (
     LLMReviewEngine,
     SymbolResolver,
     build_symbol_resolver,
+    concurrency_cap,
     request_interrupt,
 )
 from lgtmaybe.engine.profiling import profiler
@@ -170,6 +171,25 @@ def parse_pr_url(pr_url: str) -> tuple[str, int]:
     return f"{match['owner']}/{match['repo']}", int(match["number"])
 
 
+def _bounded_default(cfg: ReviewConfig, concurrency: int) -> int:
+    """The provider default, widened for queue time, then bounded by the run.
+
+    Six workers against the generous local default is three hours of per-call
+    budget, and the whole-review deadline cannot take it back: that deadline only
+    skips calls that have not *started*, and a fan-out narrower than the pool
+    starts all of its calls at once. So the clamp happens here instead — no
+    single call gets a budget outliving the review it belongs to.
+
+    Bounded in both directions. ``max_review_seconds: 0`` means "no deadline",
+    not "zero seconds"; and the clamp may only take back what the scaling added,
+    never drag a call below the provider default it would have had at width one.
+    """
+    scaled = default_timeout_for(cfg.provider, concurrency=concurrency)
+    if not cfg.max_review_seconds:
+        return scaled
+    return max(default_timeout_for(cfg.provider), min(scaled, cfg.max_review_seconds))
+
+
 def build_provider_engine(
     cfg: ReviewConfig,
     runtime: RuntimeOptions,
@@ -227,8 +247,15 @@ def build_provider_engine(
     # versioned independently: a budget that looks impossible against the
     # documented default is usually an older image, and the only way to tell from
     # a log is for the run to name its own build.
+    #
+    # The width is part of the budget on a local endpoint. lgtmaybe issues the
+    # whole fan-out at once, and a single-slot server (ollama's default) makes
+    # all but the first wait their turn with their timeout clocks already
+    # running — so the default is scaled by the width there, and only there.
+    # This is the one place that knows both numbers.
+    concurrency = concurrency_cap(cfg)
     effective_timeout = (
-        cfg.timeout if cfg.timeout is not None else default_timeout_for(cfg.provider)
+        cfg.timeout if cfg.timeout is not None else _bounded_default(cfg, concurrency)
     )
     _log.info(
         "per-call timeout resolved",
@@ -237,6 +264,7 @@ def build_provider_engine(
             "provider": cfg.provider.value,
             "timeout_s": effective_timeout,
             "timeout_source": "configured" if cfg.timeout is not None else "provider default",
+            "concurrency": concurrency,
         },
     )
     provider = build_provider(
@@ -246,7 +274,10 @@ def build_provider_engine(
         api_base=auth.api_base,
         azure_ad_token=auth.azure_ad_token,
         fallback_model=runtime.fallback_model,
-        timeout=cfg.timeout,
+        # The resolved value, not cfg.timeout — the widening and its bound are
+        # decided above, and passing the raw setting would have the factory
+        # resolve a second, unbounded number that the log above then misreports.
+        timeout=effective_timeout,
         temperature=cfg.temperature,
         **extra,
     )

--- a/src/lgtmaybe/engine/__init__.py
+++ b/src/lgtmaybe/engine/__init__.py
@@ -6,6 +6,7 @@ from .engine import (
     LLMReviewEngine,
     ReviewIncompleteError,
     clear_interrupt,
+    concurrency_cap,
     interrupt_requested,
     request_interrupt,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "LLMReviewEngine",
     "ReviewIncompleteError",
     "clear_interrupt",
+    "concurrency_cap",
     "interrupt_requested",
     "request_interrupt",
     "FileFetcher",

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -313,7 +313,7 @@ def _build_notices(state: _NoticeState) -> list[str]:
     return notices
 
 
-def _concurrency_cap(cfg: ReviewConfig) -> int:
+def concurrency_cap(cfg: ReviewConfig) -> int:
     """How many model calls this run may have in flight: the explicit cap, else
     the provider-aware default.
 
@@ -332,7 +332,7 @@ def _concurrency_cap(cfg: ReviewConfig) -> int:
 
 def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:
     """The fan-out pool size: the cap above, narrowed to the work there is."""
-    return max(1, min(_concurrency_cap(cfg), task_count))
+    return max(1, min(concurrency_cap(cfg), task_count))
 
 
 @dataclass(frozen=True)
@@ -542,7 +542,7 @@ class _Run:
     budget_at: int | None
     # Mid-review retrieval budget in tokens, or None when a lens may not defer.
     retrieval_budget: int | None
-    # How many calls this backend will serve at once (_concurrency_cap). Carried
+    # How many calls this backend will serve at once (concurrency_cap). Carried
     # for the oversized-batch split, which runs its pieces in a pool of its own
     # and must not out-run what the fan-out itself is allowed.
     concurrency: int
@@ -893,7 +893,7 @@ class LLMReviewEngine:
             deadline_at=deadline_at,
             budget_at=budget_at,
             retrieval_budget=retrieval_budget,
-            concurrency=_concurrency_cap(cfg),
+            concurrency=concurrency_cap(cfg),
         )
         workers = _resolve_workers(cfg, len(batches) * len(lenses))
         per_batch: list[tuple[bool, list[_PreparedCall]]] = []

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -63,6 +63,27 @@ _SLOW_TIMEOUT = 1800
 # Providers whose endpoint may be a slow model (local server or open gateway).
 _SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider.openrouter})
 
+# Providers whose endpoint may be ONE box that serves requests in turn.
+#
+# lgtmaybe issues its whole lens fan-out at once, so on a single-slot server
+# (ollama's OLLAMA_NUM_PARALLEL is 1 by default; llama.cpp without `-np`) five
+# of six requests sit in the server's queue. Their timeout clocks are already
+# running: the budget is measured from the moment the request is SENT, not from
+# the moment the server starts on it. Unscaled, the last call in a six-wide
+# fan-out has to be served within the same 1800s as the first, and on a slow
+# model it can blow its budget having never been looked at — which posts
+# "results may be incomplete" for a lens that was never actually slow.
+#
+# So the default is multiplied by the fan-out width for these two, and only
+# these two. A hosted endpoint (including openrouter, which is capacity rather
+# than a box) serves concurrently and has no queue to cover, and scaling there
+# would buy nothing but a longer wait before a genuinely stuck call is reported.
+#
+# This does not run unbounded: `max_review_seconds` (3600s by default) is a
+# whole-review deadline that stops queued work regardless of what any single
+# call's budget says, so the scaled number is a ceiling the run rarely reaches.
+_MAY_QUEUE = frozenset({Provider.ollama, Provider.openai_compatible})
+
 # Ollama context window. Big enough to hold a real review prompt + diff + the
 # emitted findings; ollama's own default (~4k) truncates the output to a stub.
 # Sized to hold a real multi-file diff review — 16k was tight enough that a real
@@ -70,9 +91,19 @@ _SLOW_CAPABLE = frozenset({Provider.ollama, Provider.openai_compatible, Provider
 _OLLAMA_NUM_CTX = 32768
 
 
-def default_timeout_for(provider: Provider) -> int:
-    """The auto timeout (seconds) for a provider when none is given explicitly."""
-    return _SLOW_TIMEOUT if provider in _SLOW_CAPABLE else CLOUD_TIMEOUT
+def default_timeout_for(provider: Provider, *, concurrency: int = 1) -> int:
+    """The auto timeout (seconds) for a provider when none is given explicitly.
+
+    ``concurrency`` is the fan-out width the run will use. For a provider that
+    may be a single-slot local server (:data:`_MAY_QUEUE`) the default is
+    multiplied by it, so a call that spends its wait in the server's queue is
+    still given a full budget for the work itself. Everywhere else it is
+    ignored — see the comment on :data:`_MAY_QUEUE`.
+    """
+    base = _SLOW_TIMEOUT if provider in _SLOW_CAPABLE else CLOUD_TIMEOUT
+    if provider in _MAY_QUEUE:
+        return base * max(1, concurrency)
+    return base
 
 
 def cheaper_reflect_sibling(provider: Provider, model: str) -> str | None:
@@ -195,13 +226,16 @@ def build_provider(
     azure_ad_token: str | None = None,
     fallback_model: str | None = None,
     timeout: int | None = None,
+    concurrency: int = 1,
     **extra_opts: Any,
 ) -> LiteLLMProvider:
     """Build a configured LiteLLMProvider for the given provider and model.
 
     ``timeout`` of ``None`` resolves to a provider-aware default
     (:func:`default_timeout_for`) — so ollama always gets a long timeout without
-    the caller having to ask. An explicit value is honoured as-is.
+    the caller having to ask, scaled by ``concurrency`` when the endpoint may be
+    a server that queues. An explicit value is honoured as-is: ``timeout: 600``
+    means 600, at any fan-out width.
     """
     # litellm's import is multi-second; deferring it here keeps `import
     # lgtmaybe.cli` fast for commands that never build a provider (config, help).
@@ -217,7 +251,9 @@ def build_provider(
     # map keys on comes into existence.
     _honour_param_support(provider, model, opts)
 
-    opts["timeout"] = timeout if timeout is not None else default_timeout_for(provider)
+    opts["timeout"] = (
+        timeout if timeout is not None else default_timeout_for(provider, concurrency=concurrency)
+    )
 
     if api_key is not None:
         opts["api_key"] = api_key

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -17,6 +17,7 @@ import pytest
 
 from lgtmaybe.cli import build_provider_engine
 from lgtmaybe.core.models import Provider, ReviewConfig
+from lgtmaybe.engine.engine import concurrency_cap
 from lgtmaybe.providers.factory import default_timeout_for
 
 
@@ -126,3 +127,75 @@ def test_the_two_sources_are_distinguishable_at_the_same_value(cli_logs) -> None
     record = _timeout_record(cli_logs)
     assert getattr(record, "timeout_s", None) == cloud_default
     assert getattr(record, "timeout_source", None) == "configured"
+
+
+def test_a_local_default_is_widened_for_the_fan_out_it_will_queue_behind(cli_logs) -> None:
+    """The CLI is the only place that knows both numbers — the provider and the
+    fan-out width — so it is where the scaling has to be applied. Getting this
+    wiring wrong is invisible: the unscaled budget still works on a fast box and
+    only fails on the slow one the scaling exists for.
+    """
+    cfg = ReviewConfig(provider=Provider.ollama, model="m")
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    unscaled = default_timeout_for(Provider.ollama)
+    expected = min(unscaled * concurrency_cap(cfg), cfg.max_review_seconds)
+    assert expected > unscaled, "the fixture must actually exercise a widening"
+    assert provider.default_opts["timeout"] == expected
+
+    record = _timeout_record(cli_logs)
+    assert getattr(record, "timeout_s", None) == expected
+    assert getattr(record, "concurrency", None) == concurrency_cap(cfg)
+
+
+def test_a_serial_local_run_gets_the_unscaled_budget(cli_logs) -> None:
+    """Width 1 has no queue, so the mitigation must cost it nothing."""
+    cfg = ReviewConfig(provider=Provider.ollama, model="m", max_concurrency=1)
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    assert provider.default_opts["timeout"] == default_timeout_for(Provider.ollama)
+
+
+def test_a_hosted_default_is_not_widened_by_the_fan_out(cli_logs) -> None:
+    cfg = ReviewConfig(provider=Provider.openai, model="m")
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    assert provider.default_opts["timeout"] == default_timeout_for(Provider.openai)
+
+
+def test_the_widened_budget_never_outlives_the_whole_review_deadline(cli_logs) -> None:
+    """Scaling by width is a mitigation, not a licence to run forever.
+
+    Six workers on the generous local default is 3 hours of per-call budget, and
+    the fan-out all starts at once — so the whole-review deadline, which only
+    skips calls that have not *started*, cannot cut it short. Clamping the scaled
+    value to that deadline restores the property the deadline exists for: no
+    single call outlives the run it belongs to.
+    """
+    cfg = ReviewConfig(provider=Provider.ollama, model="m")
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    resolved = provider.default_opts["timeout"]
+    assert resolved <= cfg.max_review_seconds
+    assert resolved > default_timeout_for(Provider.ollama), "still widened, just bounded"
+
+
+def test_a_disabled_deadline_leaves_the_scaling_unbounded(cli_logs) -> None:
+    """`max_review_seconds: 0` means "no deadline" — it must not read as a
+    zero-second ceiling that collapses every budget to nothing."""
+    cfg = ReviewConfig(provider=Provider.ollama, model="m", max_review_seconds=0)
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    assert provider.default_opts["timeout"] == default_timeout_for(
+        Provider.ollama, concurrency=concurrency_cap(cfg)
+    )
+
+
+def test_a_short_deadline_never_cuts_below_the_providers_own_default(cli_logs) -> None:
+    """The clamp may only take back what the scaling added. A tight deadline
+    must not drag a local call below the budget it would have had unscaled —
+    that would be a regression dressed up as a safety bound."""
+    cfg = ReviewConfig(provider=Provider.ollama, model="m", max_review_seconds=60)
+    provider = build_provider_engine(cfg, _runtime())[1]
+
+    assert provider.default_opts["timeout"] == default_timeout_for(Provider.ollama)

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -381,3 +381,66 @@ class TestOpenRouterReasoning:
         built = build_provider(Provider.openai, "gpt-4o", api_key="k", reasoning_effort="low")
 
         assert "extra_body" not in built.default_opts
+
+
+class TestQueuedTimeoutScaling:
+    """A local server may run one request at a time while lgtmaybe issues the
+    whole fan-out at once. Every queued call's timeout clock starts when the
+    request is *sent*, not when the server picks it up, so the last call in a
+    six-wide fan-out can burn its entire budget waiting its turn and time out
+    having never been served. Scaling the default by the fan-out width is what
+    keeps the budget a budget for *work* rather than for work-plus-queue.
+    """
+
+    def test_a_local_default_scales_with_the_fan_out_width(self) -> None:
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        one = default_timeout_for(Provider.ollama, concurrency=1)
+        six = default_timeout_for(Provider.ollama, concurrency=6)
+        assert six == one * 6
+
+    def test_openai_compatible_scales_too(self) -> None:
+        # llama.cpp and vLLM front the same single-box failure mode.
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert default_timeout_for(Provider.openai_compatible, concurrency=4) == (
+            default_timeout_for(Provider.openai_compatible, concurrency=1) * 4
+        )
+
+    def test_a_hosted_provider_does_not_scale(self) -> None:
+        """Hosted endpoints serve concurrent requests rather than queueing them,
+        so there is no queue time to cover — scaling there would only delay the
+        moment a genuinely stuck call is reported."""
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        for hosted in (Provider.openai, Provider.anthropic, Provider.bedrock):
+            assert default_timeout_for(hosted, concurrency=6) == default_timeout_for(hosted)
+
+    def test_openrouter_does_not_scale(self) -> None:
+        """A gateway is hosted capacity, not one box — it gets the generous
+        default for slow *models*, not for a queue it does not have."""
+        from lgtmaybe.providers.factory import default_timeout_for
+
+        assert default_timeout_for(Provider.openrouter, concurrency=6) == default_timeout_for(
+            Provider.openrouter
+        )
+
+    def test_serial_local_is_unchanged(self) -> None:
+        """The mitigation must be free when there is no queue: width 1 is the
+        pre-existing number, byte for byte."""
+        from lgtmaybe.providers.factory import _SLOW_TIMEOUT, default_timeout_for
+
+        assert default_timeout_for(Provider.ollama, concurrency=1) == _SLOW_TIMEOUT
+        assert default_timeout_for(Provider.ollama) == _SLOW_TIMEOUT
+
+    def test_an_explicit_timeout_is_never_scaled(self) -> None:
+        """`timeout: 600` means 600. Scaling a number the user chose would make
+        the setting mean something other than what it says."""
+        provider = build_provider(Provider.ollama, "qwen3.6:35b", timeout=600, concurrency=6)
+        assert provider.default_opts["timeout"] == 600
+
+    def test_build_provider_applies_the_scaled_default(self) -> None:
+        from lgtmaybe.providers.factory import _SLOW_TIMEOUT
+
+        provider = build_provider(Provider.ollama, "qwen3.6:35b", concurrency=6)
+        assert provider.default_opts["timeout"] == _SLOW_TIMEOUT * 6


### PR DESCRIPTION
Follow-up to #402, addressing the MEDIUM finding lgtmaybe raised on it.

## The problem #402 left behind

#402 gave local providers the same six-worker pool as everyone else. The review of that PR pointed out the cost, and it was right:

> Removing both local providers from the single-stream set makes the default pool six workers even for the common single-slot Ollama or llama.cpp deployment. Those requests do not overlap … The previous default of one avoided this queueing and reduced the chance that a slow local review exhausts its per-request timeout.

The mechanism is that **a queued request's timeout clock starts when the request is sent, not when the server picks it up**. On a default ollama (`OLLAMA_NUM_PARALLEL=1`) or a llama.cpp without `-np`, five of six requests sit in the server's queue burning budget. Unscaled, the last call has to be served within the same 1800 s as the first — so on a slow model it can blow its budget having never been looked at, and posts "results may be incomplete" for a lens that was never actually slow.

Concretely: 5 lens calls, 1800 s budget, one slot → the last call dies once per-call time exceeds ~360 s. Fine on a GPU, realistic on CPU.

## The fix

Multiply the default by the fan-out width, for `ollama` and `openai-compatible` **only**. A hosted endpoint — openrouter included, being capacity rather than a box — serves concurrently and has no queue to cover; scaling there would buy nothing but a longer wait before a genuinely stuck call is reported.

Rather than take the finding's suggested remedy (revert local to one worker), this addresses the mechanism, so a batching server (vLLM, a raised `OLLAMA_NUM_PARALLEL`) still gets real parallelism by default while a single-slot box stops being penalised for it.

### Bounded, or it trades one problem for a worse one

Six workers on the generous local default is three hours of per-call budget, and `max_review_seconds` **cannot** take that back on its own: it only skips calls that have not *started*, and a fan-out narrower than the pool starts all of its calls at once. So the clamp is applied in the CLI, where both numbers are known.

Bounded in both directions, each pinned by its own test:

- `max_review_seconds: 0` means *no deadline*, not a zero-second ceiling.
- The clamp may only take back what the scaling added — never drag a call below the provider default it would have had at width one.

An explicit `timeout` is never scaled: `timeout: 600` means 600 at any width.

### One correctness fix that came out of it

The resolved timeout now reaches the client directly instead of being recomputed by the factory from the raw setting. Previously the CLI's diagnostic log and the client it built could have resolved two different numbers — which would defeat the entire point of that log, whose job is to make "why did this time out?" answerable. Covered by a mutation-tested case.

## Testing

TDD throughout: every test below was written and watched fail before the code existed.

- `tests/providers/test_factory.py::TestQueuedTimeoutScaling` — 7 tests: local scales, hosted and openrouter do not, width 1 is byte-identical to today, explicit timeouts are untouched.
- `tests/cli/test_timeout_diagnostics.py` — 6 tests for the wiring, the clamp, and both of its bounds.

**Mutation-tested in eight directions**, after an earlier episode in this line of work where a guard I had vouched for turned out to be vacuous. Each of these was applied and confirmed to turn the suite red:

| mutation | caught by |
|---|---|
| scale for every provider (drop the gate) | 4 tests |
| never scale (ignore the width) | 4 tests |
| treat openrouter as a box | 2 tests |
| scale an explicit timeout too | 1 test |
| no clamp at all | 3 tests |
| read `max_review_seconds: 0` as a zero ceiling | 1 test |
| drop the lower bound of the clamp | 1 test |
| build the client from `cfg.timeout` again | 3 tests |

Full gate green: `pytest` (1987 passed, 3 skipped), `ruff`, `ruff format`, `mypy`, `pytest tests/specs`, `openspec validate --specs`, spec-drift.

## Docs and spec

- `openspec/specs/provider-gateway/spec.md` — the `provider.defaults` requirement now states the scaling and its bound, with two scenarios.
- `docs/how-to/run-locally-with-ollama.md` — documents the scaled default and the log line that reports it; also removes a stale paragraph #402 missed, still claiming lgtmaybe runs ollama calls serially.
- `docs/how-to/use-a-custom-openai-compatible-endpoint.md` — same, for llama.cpp/vLLM/LM Studio.
- `docs/llms.txt` / `llms-full.txt` regenerated.

## What is not verified here

**Neither local path can be exercised from this container** — there is no ollama available and the proxy blocks outbound model hosts. The suite proves the arithmetic and the wiring; it proves nothing about behaviour against a real server. A local `lgtmaybe review --provider ollama --model <local> --profile` would confirm the resolved budget in the log line and whether the six calls overlapped or queued.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dbQVinBgkosiR6rpZy4gP)_