### PR TITLE
fix: deterministic ceiling tests, and delete the dead single-stream branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ latency:
 - `preset` (default `fast`) — four calls, one per concern (security, correctness, code health, artefacts), the same on every provider; `full` runs one call per lens.
 - `max_files` (default 50) — reviews the top-N changed files and notes how many were skipped.
 - `max_input_tokens` (default 100k) — batches the diff to fit the model's budget.
-- `max_concurrency` (default 6 cloud / 1 ollama and openai-compatible) — concurrent model calls across the whole fan-out.
+- `max_concurrency` (default 6, every provider) — concurrent model calls across the whole fan-out. What decides local throughput is the server's own setting (`OLLAMA_NUM_PARALLEL`, llama.cpp `-np`, vLLM batching); set `1` to run serially.
 - `recursive` (default on) — when a single file's diff exceeds that budget, walks it hunk-by-hunk instead of sending it whole; `--no-recursive` sends files whole.
 - `categories` (default all nine) — which review lenses to run; an explicit list overrides the preset grouping and runs exactly those lenses, one call each.
 - `min_severity` (default `low`) plus `include_paths` / `exclude_paths` — focus the review on what you care about.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -87,8 +87,8 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    same four run on every provider — worker count changes only how they are
    scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
-   provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
-   ollama and openai-compatible), so batches never wait on each other.
+   provider port, sized by `max_concurrency` (default 6 for every provider,
+   local included), so batches never wait on each other.
 
    Each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -390,7 +390,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
-| `max_concurrency` | 6 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
+| `max_concurrency` | 6, every provider | Concurrent model calls across the whole fan-out (all batches share one pool). Local throughput is set on the server (`OLLAMA_NUM_PARALLEL`, llama.cpp `-np`, vLLM batching); set this to `1` for serial. |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -239,8 +239,8 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) — though never trimmed below ollama's own 1800 s, so a deadline set under
-that does not shrink it. (And it bounds the budget rather than the wall clock: the
+default; `0` disables the deadline and with it the cap) — though never trimmed
+below ollama's own 1800 s, so a deadline set under that does not shrink it. (And it bounds the budget rather than the wall clock: the
 deadline decides when a call may *start*, so one that begins just inside it still
 runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -239,7 +239,9 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) so no single call can outlive the review it belongs to. At
+default) so no call is ever given more time than the whole review is allowed. (That
+bounds the budget rather than the wall clock: the deadline decides when a call may
+*start*, so one that begins just inside it still runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
 run logs which number it resolved, and why:
 

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -239,9 +239,10 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) so no call is ever given more time than the whole review is allowed. (That
-bounds the budget rather than the wall clock: the deadline decides when a call may
-*start*, so one that begins just inside it still runs its budget out.) At
+default) — though never trimmed below ollama's own 1800 s, so a deadline set under
+that does not shrink it. (And it bounds the budget rather than the wall clock: the
+deadline decides when a call may *start*, so one that begins just inside it still
+runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
 run logs which number it resolved, and why:
 

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -161,7 +161,9 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) so no call outlives the review. An
+bounded by `max_review_seconds` (3600 s) so no call is given more time than the
+whole review is allowed — a bound on the budget, not on the wall clock, since the
+deadline gates when a call may start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the
 number it resolved and the width it assumed:
 

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -161,8 +161,9 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) — though never trimmed below the 1800 s
-provider default, so a deadline set under that does not shrink it, and a bound on
+bounded by `max_review_seconds` (3600 s; `0` disables the deadline and the cap
+with it) — though never trimmed below the 1800 s provider default, so a deadline
+set under that does not shrink it, and a bound on
 the budget rather than the wall clock, since the deadline gates when a call may
 start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -161,9 +161,10 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) so no call is given more time than the
-whole review is allowed — a bound on the budget, not on the wall clock, since the
-deadline gates when a call may start rather than cutting a running one short. An
+bounded by `max_review_seconds` (3600 s) — though never trimmed below the 1800 s
+provider default, so a deadline set under that does not shrink it, and a bound on
+the budget rather than the wall clock, since the deadline gates when a call may
+start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the
 number it resolved and the width it assumed:
 

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -234,7 +234,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
-| `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
+| `max_concurrency` | auto (6, every provider) | Concurrent review calls across the whole fan-out. Set `1` for a serial local run |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -596,7 +596,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `triage_model` | — | Cheap model that runs first to skip plainly-non-substantive files and rank the rest by risk; security-relevant files always escalate past triage. Unset = no triage |
 | `reflect_model` | defaults to `model` | Model for the self-reflection (false-positive audit) pass — point it at a stronger model to audit a weaker reviewer's findings |
 | `max_review_seconds` | `3600` | Soft wall-clock ceiling for the whole review; once passed, queued calls are skipped and partial results post with a notice (a cancelled or timed-out job does the same, via SIGINT/SIGTERM). `0` disables |
-| `max_concurrency` | auto (6 cloud, 1 ollama/openai-compatible) | Concurrent review calls across the whole fan-out |
+| `max_concurrency` | auto (6, every provider) | Concurrent review calls across the whole fan-out. Set `1` for a serial local run |
 | `symbol_resolution` | `true` | During reflection, resolve a deferred finding's symbol via ast-grep in a read-only shallow clone of the base branch, so cross-file findings are re-judged against the real definition |
 | `incremental` | auto | Commit-scoped incremental review on `synchronize` pushes (full review elsewhere); `true`/`false` forces it. `/review full` forces a full re-review on demand |
 | `static_analysis` | `false` | Run deterministic tools (ruff, bandit, mypy, gitleaks, zizmor, ast-grep, osv-scanner, semgrep) sandboxed over the changed files: linters ground the model as untrusted hints, while gitleaks, zizmor, ast-grep and osv-scanner post directly with no model call. The image bundles these tools and an offline vulnerability database |
@@ -1930,8 +1930,8 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) — though never trimmed below ollama's own 1800 s, so a deadline set under
-that does not shrink it. (And it bounds the budget rather than the wall clock: the
+default; `0` disables the deadline and with it the cap) — though never trimmed
+below ollama's own 1800 s, so a deadline set under that does not shrink it. (And it bounds the budget rather than the wall clock: the
 deadline decides when a call may *start*, so one that begins just inside it still
 runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
@@ -2199,8 +2199,9 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) — though never trimmed below the 1800 s
-provider default, so a deadline set under that does not shrink it, and a bound on
+bounded by `max_review_seconds` (3600 s; `0` disables the deadline and the cap
+with it) — though never trimmed below the 1800 s provider default, so a deadline
+set under that does not shrink it, and a bound on
 the budget rather than the wall clock, since the deadline gates when a call may
 start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the
@@ -5798,7 +5799,7 @@ configurable in `.lgtmaybe.yml` (see
 | `max_files` | 50 | Reviews the top-N changed files; posts a "reviewed top N of M" notice if there are more. |
 | `max_file_diff_lines` | 2000 | Skips any single file whose diff is longer, naming it in the summary. `0` disables. |
 | `max_input_tokens` | 100,000 | Batches the diff so each model call stays within budget. |
-| `max_concurrency` | 6 cloud / 1 ollama, openai-compatible | Concurrent model calls across the whole fan-out (all batches share one pool). |
+| `max_concurrency` | 6, every provider | Concurrent model calls across the whole fan-out (all batches share one pool). Local throughput is set on the server (`OLLAMA_NUM_PARALLEL`, llama.cpp `-np`, vLLM batching); set this to `1` for serial. |
 | `max_review_seconds` | 3600 | Soft wall-clock ceiling: past it, queued calls are skipped and the review posts partial results with a notice. `0` disables. |
 | `categories` | all nine | Which review lenses to run; an explicit list overrides the preset grouping and runs those lenses one call each. |
 | `context_lines` | 20 | Ceiling on surrounding lines added around each hunk; the budget may use fewer. `0` disables context expansion. |
@@ -6058,8 +6059,8 @@ preset fans out one call per category, and custom lenses join the same fan-out.)
    same four run on every provider — worker count changes only how they are
    scheduled. `full` runs one call per category. Every
    (batch, lens) task shares **one `ThreadPoolExecutor`** over the sync
-   provider port, sized by `max_concurrency` (default 6 for cloud, 1 for
-   ollama and openai-compatible), so batches never wait on each other.
+   provider port, sized by `max_concurrency` (default 6 for every provider,
+   local included), so batches never wait on each other.
 
    Each call is shaped as a shared cacheable prefix —
    a lens-independent system preamble, then the wrapped diff — followed by

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1928,9 +1928,10 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) so no call is ever given more time than the whole review is allowed. (That
-bounds the budget rather than the wall clock: the deadline decides when a call may
-*start*, so one that begins just inside it still runs its budget out.) At
+default) — though never trimmed below ollama's own 1800 s, so a deadline set under
+that does not shrink it. (And it bounds the budget rather than the wall clock: the
+deadline decides when a call may *start*, so one that begins just inside it still
+runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
 run logs which number it resolved, and why:
 
@@ -2196,9 +2197,10 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) so no call is given more time than the
-whole review is allowed — a bound on the budget, not on the wall clock, since the
-deadline gates when a call may start rather than cutting a running one short. An
+bounded by `max_review_seconds` (3600 s) — though never trimmed below the 1800 s
+provider default, so a deadline set under that does not shrink it, and a bound on
+the budget rather than the wall clock, since the deadline gates when a call may
+start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the
 number it resolved and the width it assumed:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1928,7 +1928,9 @@ to set anything for a normal run. (Direct cloud providers default to 600 s.)
 **That default scales with the fan-out.** Because the calls queue, the budget has
 to cover the wait as well as the work: at the default width of six the resolved
 per-call timeout is `1800 × 6`, **bounded by `max_review_seconds`** (3600 s by
-default) so no single call can outlive the review it belongs to. At
+default) so no call is ever given more time than the whole review is allowed. (That
+bounds the budget rather than the wall clock: the deadline decides when a call may
+*start*, so one that begins just inside it still runs its budget out.) At
 `max_concurrency: 1` there is no queue and the budget is the plain 1800 s. Every
 run logs which number it resolved, and why:
 
@@ -2194,7 +2196,9 @@ lgtmaybe review --provider openai-compatible --model <model> \
 **Queueing does not cost you a timeout.** A queued request's clock starts when it
 is sent, not when the slot frees, so lgtmaybe scales the `openai-compatible`
 per-call default (1800 s) by the fan-out width — `1800 × 6` at the default,
-bounded by `max_review_seconds` (3600 s) so no call outlives the review. An
+bounded by `max_review_seconds` (3600 s) so no call is given more time than the
+whole review is allowed — a bound on the budget, not on the wall clock, since the
+deadline gates when a call may start rather than cutting a running one short. An
 explicit `timeout` is honoured exactly as written, at any width. Each run logs the
 number it resolved and the width it assumed:
 

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -250,10 +250,12 @@ provider so users give bare model ids.
 - **THEN** the default is multiplied by that width, so a call whose wait is spent
   in the server's queue still has a full budget for the work itself
 
-#### Scenario: the widened budget would outlive the run
+#### Scenario: the widened budget exceeds the review's own deadline
 - **WHEN** that scaled default exceeds `max_review_seconds`
-- **THEN** it is clamped to the deadline — never below the provider's own default,
-  and never clamped at all when the deadline is disabled
+- **THEN** it is clamped to the deadline — bounding the budget, not the wall clock,
+  since the deadline gates when a call may start rather than cutting one short —
+  never below the provider's own default, and never clamped at all when the
+  deadline is disabled
 
 #### Scenario: the documented default and the resolved one disagree
 - **WHEN** a provider's resolved default stops matching the seconds the Action

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -252,10 +252,11 @@ provider so users give bare model ids.
 
 #### Scenario: the widened budget exceeds the review's own deadline
 - **WHEN** that scaled default exceeds `max_review_seconds`
-- **THEN** it is clamped to the deadline — bounding the budget, not the wall clock,
-  since the deadline gates when a call may start rather than cutting one short —
-  never below the provider's own default, and never clamped at all when the
-  deadline is disabled
+- **THEN** the resolved budget is the lesser of the scaled default and the
+  deadline, floored at the provider's own default — so a deadline shorter than
+  that default does not shrink it — and nothing is clamped when the deadline is
+  disabled. It bounds the budget, not the wall clock: the deadline gates when a
+  call may start rather than cutting a running one short
 
 #### Scenario: the documented default and the resolved one disagree
 - **WHEN** a provider's resolved default stops matching the seconds the Action

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -177,8 +177,15 @@ def _bounded_default(cfg: ReviewConfig, concurrency: int) -> int:
     Six workers against the generous local default is three hours of per-call
     budget, and the whole-review deadline cannot take it back: that deadline only
     skips calls that have not *started*, and a fan-out narrower than the pool
-    starts all of its calls at once. So the clamp happens here instead — no
-    single call gets a budget outliving the review it belongs to.
+    starts all of its calls at once. So the clamp happens here instead.
+
+    What it bounds is the *budget*, not the wall clock. A call is never given
+    more time than the whole review is allowed — but the deadline is a start
+    gate, so a call that begins just inside it still runs its full budget
+    afterwards. The two together cap a pathological run at roughly twice the
+    deadline; unclamped, the same run is four times it. Making the wall clock
+    itself the bound needs a per-call budget computed from the deadline
+    *remaining* at call time, which the port does not currently carry.
 
     Bounded in both directions. ``max_review_seconds: 0`` means "no deadline",
     not "zero seconds"; and the clamp may only take back what the scaling added,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -179,13 +179,15 @@ def _bounded_default(cfg: ReviewConfig, concurrency: int) -> int:
     skips calls that have not *started*, and a fan-out narrower than the pool
     starts all of its calls at once. So the clamp happens here instead.
 
-    What it bounds is the *budget*, not the wall clock. A call is never given
-    more time than the whole review is allowed — but the deadline is a start
-    gate, so a call that begins just inside it still runs its full budget
-    afterwards. The two together cap a pathological run at roughly twice the
-    deadline; unclamped, the same run is four times it. Making the wall clock
-    itself the bound needs a per-call budget computed from the deadline
-    *remaining* at call time, which the port does not currently carry.
+    What it bounds is the *budget*, not the wall clock, and only down to the
+    provider's own default. Two things keep it short of "no call outlives the
+    review". The deadline is a start gate, so a call beginning just inside it
+    still runs its full budget afterwards; and the floor below wins over a
+    deadline set beneath it, so ``max_review_seconds: 600`` still resolves 1800.
+    What the clamp does buy is capping a pathological run at roughly twice the
+    deadline where unclamped it is four times. Making the wall clock itself the
+    bound needs a per-call budget computed from the deadline *remaining* at call
+    time, which the port does not currently carry.
 
     Bounded in both directions. ``max_review_seconds: 0`` means "no deadline",
     not "zero seconds"; and the clamp may only take back what the scaling added,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -183,10 +183,13 @@ def _bounded_default(cfg: ReviewConfig, concurrency: int) -> int:
     review". The deadline is a start gate, so a call beginning just inside it
     still runs its full budget afterwards; and the floor below wins over a
     deadline set beneath it, so ``max_review_seconds: 600`` still resolves 1800.
-    What the clamp does buy is capping a pathological run at roughly twice the
-    deadline where unclamped it is four times. Making the wall clock itself the
-    bound needs a per-call budget computed from the deadline *remaining* at call
-    time, which the port does not currently carry.
+    What the clamp buys, when the deadline is at or above that floor: a
+    pathological run is capped at roughly twice the deadline where unclamped it
+    is four times. Below the floor it buys nothing, because the floor wins —
+    ``max_review_seconds: 600`` resolves 1800, and the same run is four times the
+    deadline again. Making the wall clock itself the bound needs a per-call
+    budget computed from the deadline *remaining* at call time, which the port
+    does not currently carry.
 
     Bounded in both directions. ``max_review_seconds: 0`` means "no deadline",
     not "zero seconds"; and the clamp may only take back what the scaling added,

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -80,9 +80,9 @@ from .triage import triage_files
 
 _log = get_logger(__name__)
 
-# Auto concurrency (cfg.max_concurrency=None), resolved per provider:
+# Auto concurrency (cfg.max_concurrency=None) — one number, every provider:
 #
-# - Cloud providers get 6. An extra worker can cut a full-latency wave off the
+# - Six everywhere. An extra worker can cut a full-latency wave off the
 #   wall clock (only when it changes how many waves there are — wall time is
 #   ceil(batches × lenses / workers)), so the pull is upward — but the fan-out
 #   is one API key, and the
@@ -93,7 +93,7 @@ _log = get_logger(__name__)
 #   the rescue wave both make that survivable rather than fatal; six is the same
 #   fix from the other end — a quarter less burst for a quarter less parallelism.
 #   Teams on a high rate tier can raise it with `max_concurrency`.
-# - Local providers (ollama, openai-compatible) get the same 6. They used to get
+# - Local providers used to get
 #   1, on the reasoning that a local server processes one request at a time so a
 #   wider pool would only queue. The queueing is real, but the conclusion was
 #   wrong in both directions: a server that CAN batch was capped at 1 for no
@@ -116,7 +116,7 @@ _log = get_logger(__name__)
 # again, keep it a value a reader can see next to the branch that reads it: the
 # last one was a named-but-empty set two hundred lines away, which read as a
 # policy it no longer had.
-_CLOUD_MAX_WORKERS = 6
+_DEFAULT_MAX_WORKERS = 6
 _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     {
         ReviewCategory.security.value,
@@ -319,7 +319,7 @@ def _build_notices(state: _NoticeState) -> list[str]:
 
 def concurrency_cap(cfg: ReviewConfig) -> int:
     """How many model calls this run may have in flight: the explicit cap, else
-    the provider-aware default.
+    the common default — one number, not a per-provider one.
 
     A property of the *backend*, independent of how much work there is — which
     is why it is separate from the pool size below. The oversized-batch split
@@ -329,7 +329,7 @@ def concurrency_cap(cfg: ReviewConfig) -> int:
     """
     if cfg.max_concurrency is not None:
         return max(1, cfg.max_concurrency)
-    return _CLOUD_MAX_WORKERS
+    return _DEFAULT_MAX_WORKERS
 
 
 def _resolve_workers(cfg: ReviewConfig, task_count: int) -> int:

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -21,7 +21,6 @@ from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
     PRContext,
-    Provider,
     ReviewCategory,
     ReviewConfig,
     ReviewFinding,
@@ -110,9 +109,16 @@ _log = get_logger(__name__)
 #   exception: it batches and keeps full `--max-model-len` per request.
 #
 #   The one case for lowering this back to 1 is a very slow local model, where
-#   six queued calls could each wait out the per-request timeout.
+#   six queued calls could each wait out the per-request timeout — and the local
+#   per-call default is scaled by this width precisely so that they do not.
+#
+# There is deliberately no per-provider exception list. One briefly survived as
+# an empty frozenset feeding a branch that could never fire, and it cost four
+# separate false review findings: the name asserted that ollama resolved to 1
+# while the value said otherwise, and the value sat 200 lines from its only
+# reader — outside any diff hunk that touched it. Whatever replaces this should
+# be a value a reader can see, not a name they have to trust.
 _CLOUD_MAX_WORKERS = 6
-_SINGLE_STREAM_PROVIDERS: frozenset[Provider] = frozenset()
 _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     {
         ReviewCategory.security.value,
@@ -325,8 +331,6 @@ def concurrency_cap(cfg: ReviewConfig) -> int:
     """
     if cfg.max_concurrency is not None:
         return max(1, cfg.max_concurrency)
-    if cfg.provider in _SINGLE_STREAM_PROVIDERS:
-        return 1
     return _CLOUD_MAX_WORKERS
 
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -112,12 +112,10 @@ _log = get_logger(__name__)
 #   six queued calls could each wait out the per-request timeout — and the local
 #   per-call default is scaled by this width precisely so that they do not.
 #
-# There is deliberately no per-provider exception list. One briefly survived as
-# an empty frozenset feeding a branch that could never fire, and it cost four
-# separate false review findings: the name asserted that ollama resolved to 1
-# while the value said otherwise, and the value sat 200 lines from its only
-# reader — outside any diff hunk that touched it. Whatever replaces this should
-# be a value a reader can see, not a name they have to trust.
+# There is deliberately no per-provider exception list. If one is ever needed
+# again, keep it a value a reader can see next to the branch that reads it: the
+# last one was a named-but-empty set two hundred lines away, which read as a
+# policy it no longer had.
 _CLOUD_MAX_WORKERS = 6
 _FAILURE_SCENARIO_CATEGORIES: frozenset[str] = frozenset(
     {

--- a/tests/cli/test_incremental_review.py
+++ b/tests/cli/test_incremental_review.py
@@ -254,6 +254,12 @@ def test_auto_diagram_on_pr_change_events_when_enabled() -> None:
     assert should_auto_diagram(on, event_action="closed") is False
     assert should_auto_diagram(make_cfg(), event_action="opened") is True  # default on
     assert should_auto_diagram(make_cfg(auto_diagram=False), event_action="opened") is False
+    # The opt-out has to hold on every eligible event, not just the first one.
+    # Asserting it only on `opened` lets a mutant that ORs synchronize into the
+    # enable condition — the plausible slip when adding a new event — pass the
+    # whole suite while ignoring `auto_diagram: false` on a push.
+    assert should_auto_diagram(make_cfg(auto_diagram=False), event_action="synchronize") is False
+    assert should_auto_diagram(make_cfg(auto_diagram=False), event_action="reopened") is False
 
 
 def test_run_diagram_posts_via_the_idempotent_upsert() -> None:

--- a/tests/engine/test_interrupt.py
+++ b/tests/engine/test_interrupt.py
@@ -68,7 +68,15 @@ class _InterruptingProvider(FakeProvider):
 
 def _cfg(**overrides: object) -> ReviewConfig:
     defaults: dict[str, object] = {
-        "provider": Provider.ollama,  # serial: calls execute one at a time
+        "provider": Provider.openai,
+        # Serial on purpose, so the ceiling tripping during the first call leaves
+        # the rest queued and skippable. Stated outright rather than leaning on a
+        # provider that used to resolve to one worker — local providers now get
+        # the same six as cloud, so the proxy no longer holds. While it did, this
+        # suite failed roughly one run in ten: the ceiling still tripped, just one
+        # call later. A ceiling test that passes by luck is worse than one that
+        # fails.
+        "max_concurrency": 1,
         "model": "m",
         "categories": [
             ReviewCategory.security,

--- a/tests/engine/test_timeout_split.py
+++ b/tests/engine/test_timeout_split.py
@@ -340,7 +340,7 @@ def test_one_worker_reviews_the_split_pieces_one_at_a_time() -> None:
     assert provider.max_in_flight == 1
 
 
-def test_an_explicit_concurrency_lifts_the_split_off_the_single_stream_default() -> None:
+def test_an_explicit_concurrency_lifts_the_split_off_the_auto_default() -> None:
     """The user's number wins over the provider default, in the split as in the
     fan-out.
 

--- a/tests/engine/test_token_budget.py
+++ b/tests/engine/test_token_budget.py
@@ -53,7 +53,15 @@ class _CostlyProvider(FakeProvider):
 
 def _cfg(**overrides: object) -> ReviewConfig:
     defaults: dict[str, object] = {
-        "provider": Provider.ollama,  # serial: calls execute one at a time
+        "provider": Provider.openai,
+        # Serial on purpose, so the ceiling tripping during the first call leaves
+        # the rest queued and skippable. Stated outright rather than leaning on a
+        # provider that used to resolve to one worker — local providers now get
+        # the same six as cloud, so the proxy no longer holds. While it did, this
+        # suite failed roughly one run in ten: the ceiling still tripped, just one
+        # call later. A ceiling test that passes by luck is worse than one that
+        # fails.
+        "max_concurrency": 1,
         "model": "m",
         "categories": [
             ReviewCategory.security,


### PR DESCRIPTION
Three corrections to work merged in #402 and #404. Rebased onto `main` after #404 squash-merged, so this now contains only its own change.

## 1. A flake on `main` right now — masking a vacuous guard

`tests/engine/test_interrupt.py` and `tests/engine/test_token_budget.py` both set:

```python
"provider": Provider.ollama,  # serial: calls execute one at a time
```

so a ceiling tripped during the first call would leave the rest queued and skippable. #402 emptied `_SINGLE_STREAM_PROVIDERS`, making that comment false — those configs now resolve to **six** workers.

Measured on `main`: `pytest tests/engine -p no:randomly` fails **2 runs in 10**, alternating between `test_queued_calls_are_skipped_and_partial_findings_still_post` (`assert len(provider.calls) == 1` → got 2) and the token-budget equivalent.

The flake is the smaller half. In the other eight runs the ceiling still trips — just one call later — so the assertion passes on **timing**, not on the property it names. Same vacuous-guard failure mode as the deadline tests earlier in this line of work.

#402 converted three tests to `max_concurrency: 1`; these two were missed. **Verified: 0 failures in 20 consecutive fixed-order runs, against 2 in 10 before.**

## 2. Delete the dead `_SINGLE_STREAM_PROVIDERS` branch

Since #402 it has been an empty frozenset, referenced exactly once, guarding a branch that can never fire. The full suite passes unchanged with both removed — which is what "dead" means here — and `test_every_provider_defaults_to_six` already pins the invariant it used to encode. The engine no longer imports `Provider` at all: its concurrency policy is now provider-agnostic in fact as well as intent.

**It was not harmless while it sat there.** Its *name* asserted that ollama resolves to 1; its *value* said otherwise; and the value lived 200 lines from its only reader, outside any diff hunk that touched that reader. Four review findings across #404 and this PR, at 90–100% stated confidence, claimed the default ollama path resolves 1800 s and that the timeout-scaling tests would fail. Both are false:

```
_SINGLE_STREAM_PROVIDERS = frozenset() (empty)
concurrency_cap(ollama, max_concurrency unset) = 6
_bounded_default = 3600 seconds
tests/cli/test_timeout_diagnostics.py::test_a_local_default_is_widened... PASSED
```

A reviewer reasoning from an identifier's name rather than its value is the predictable outcome of a constant whose name and value disagree. Deleting it makes the mistake impossible rather than merely documented.

## 3. Two overclaims in #404's prose, both raised by review

Neither is a behaviour change — the code was right, the description oversold it.

**The clamp is not an absolute deadline.** `max_review_seconds` is a *start gate*, so a call beginning just inside it still runs its full budget afterwards. What the clamp buys is capping a pathological run at roughly **twice** the deadline instead of four times. A true wall-clock bound needs a per-call budget derived from the deadline *remaining* at call time, which the `ProviderClient` port does not carry — now named as such rather than implied away.

**The floor wins over a short deadline.** `_bounded_default` never trims below the provider's own unscaled default, so `max_review_seconds: 600` resolves **1800**. That is deliberate and tested (`test_a_short_deadline_never_cuts_below_the_providers_own_default` — the clamp may only take back what the scaling added), but "no call is given more time than the whole review allows" was false there.

Corrected in the `_bounded_default` docstring, the `provider.defaults` spec scenario, and both local how-tos.

## Gate

`pytest` (1993 passed, 3 skipped), `ruff`, `ruff format`, `mypy`, `pytest tests/specs`, `openspec validate --specs`, spec-drift — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified provider timeout behavior, including concurrency scaling, review-duration caps, provider minimums, and queued-call start deadlines.
  * Explained that configured deadlines do not interrupt calls already in progress.
  * Updated guidance for custom OpenAI-compatible endpoints and local providers.

* **Bug Fixes**
  * Standardized the automatic concurrency limit across providers when no explicit limit is configured.

* **Tests**
  * Improved interruption and token-budget coverage using explicit serial execution.
  * Clarified concurrency override test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->