### PR TITLE
feat(cli): report the running version with --version

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -94,6 +94,13 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or -not ($reviewHelp | Select-String -Quiet "Usage")) {
             throw "lgtmaybe.exe review --help failed"
           }
+          # The version has to survive freezing: it comes from the distribution
+          # metadata the spec copies in, and "lgtmaybe unknown" means that copy
+          # was lost — which would ship an executable nobody can identify.
+          $version = & $exe --version
+          if ($LASTEXITCODE -ne 0 -or $version -ne "lgtmaybe ${{ steps.ver.outputs.version }}") {
+            throw "lgtmaybe.exe --version reported '$version'"
+          }
 
           $size = (Get-Item $exe).Length
           Write-Output "Executable size: $size bytes ($([math]::Round($size / 1MB, 1)) MiB)"

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -80,6 +80,12 @@ jobs:
         id: smoke
         if: steps.idem.outputs.skip != 'true'
         shell: pwsh
+        env:
+          # Read through the environment, never interpolated into the script:
+          # the version originates in a workflow_dispatch input, and a `"` or a
+          # backtick in a GitHub expression pasted into PowerShell source would
+          # break out of the string and run on the runner.
+          EXPECTED_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           $exe = Resolve-Path ".\dist\lgtmaybe.exe"
           $help = & $exe --help
@@ -98,7 +104,7 @@ jobs:
           # metadata the spec copies in, and "lgtmaybe unknown" means that copy
           # was lost — which would ship an executable nobody can identify.
           $version = & $exe --version
-          if ($LASTEXITCODE -ne 0 -or $version -ne "lgtmaybe ${{ steps.ver.outputs.version }}") {
+          if ($LASTEXITCODE -ne 0 -or $version -ne "lgtmaybe $env:EXPECTED_VERSION") {
             throw "lgtmaybe.exe --version reported '$version'"
           }
 

--- a/docs/how-to/install-the-cli.md
+++ b/docs/how-to/install-the-cli.md
@@ -26,6 +26,18 @@ lgtmaybe --help
 That prints the command list with usage examples; `<command> --help`
 (e.g. `lgtmaybe review --help`) shows the full option reference for one command.
 
+To record which build you are running — for a bug report, or to pin the
+executable a benchmark ran against — ask it:
+
+```bash
+lgtmaybe --version
+```
+
+It prints one parseable line, `lgtmaybe <version>`, and works the same for every
+install (pip, Homebrew, or the portable Windows executable). A source checkout
+that was never installed has no version metadata to read and says
+`lgtmaybe unknown`.
+
 Upgrade later with `pip install --upgrade lgtmaybe`.
 
 ## Install on Windows (WinGet)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -259,6 +259,18 @@ lgtmaybe --help
 That prints the command list with usage examples; `<command> --help`
 (e.g. `lgtmaybe review --help`) shows the full option reference for one command.
 
+To record which build you are running — for a bug report, or to pin the
+executable a benchmark ran against — ask it:
+
+```bash
+lgtmaybe --version
+```
+
+It prints one parseable line, `lgtmaybe <version>`, and works the same for every
+install (pip, Homebrew, or the portable Windows executable). A source checkout
+that was never installed has no version metadata to read and says
+`lgtmaybe unknown`.
+
 Upgrade later with `pip install --upgrade lgtmaybe`.
 
 ## Install on Windows (WinGet)

--- a/packaging/pyinstaller/lgtmaybe.spec
+++ b/packaging/pyinstaller/lgtmaybe.spec
@@ -3,12 +3,17 @@
 from pathlib import Path
 import shutil
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 project_root = Path(SPECPATH).parents[1]
 ast_grep = shutil.which("ast-grep")
 
-datas = collect_data_files("lgtmaybe") + collect_data_files("litellm")
+# copy_metadata ships the dist-info alongside the code. `lgtmaybe --version`
+# reads the installed distribution's metadata, and a frozen executable has none
+# of its own — so without this the portable exe, the one install a user cannot
+# identify any other way (no pip, no uv tool list), is the one that answers
+# "unknown".
+datas = collect_data_files("lgtmaybe") + collect_data_files("litellm") + copy_metadata("lgtmaybe")
 binaries = [(ast_grep, ".")] if ast_grep else []
 hiddenimports = ["tiktoken_ext", "tiktoken_ext.openai_public"]
 

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -969,7 +969,36 @@ def graceful_interrupt() -> Iterator[None]:
         _restore()
 
 
+def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
+    """Print `lgtmaybe <version>` and exit — the eager `--version` callback.
+
+    Written by hand rather than with ``click.version_option`` because both of
+    that helper's modes get an edge case wrong here. Passing a resolved version
+    would read the distribution metadata at import time, on every invocation
+    that never asks for it; passing ``package_name`` makes click do the read
+    itself and raise ``RuntimeError`` when there is no dist-info, so the flag
+    would CRASH in a source checkout. ``package_version`` already answers
+    "unknown" there, and a diagnostic that fails is worse than one that hedges.
+
+    The line is deliberately plain: a benchmark runner records the executable it
+    ran by parsing this, so it names the program (never click's ``main``) in one
+    stable shape.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(f"lgtmaybe {package_version()}")
+    ctx.exit()
+
+
 @click.group(epilog=_EPILOG)
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_print_version,
+    help="Show the lgtmaybe version and exit.",
+)
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """lgtmaybe — provider-agnostic PR reviewer."""

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+
 import click
 from click.testing import CliRunner
 
@@ -122,3 +124,33 @@ def test_unknown_provider_fails_with_a_usage_error() -> None:
     assert result.exit_code == 2
     assert "bogus" in result.output
     assert "openai-compatible" in result.output
+
+
+def test_version_flag_prints_a_machine_readable_line(monkeypatch) -> None:
+    """`lgtmaybe --version` is how a benchmark runner (or a support ticket)
+    records which executable it ran, so the line is `lgtmaybe <version>` — one
+    stable, parseable shape rather than click's default `main, version X`.
+
+    The version is stubbed so the assertion is about the FORMAT, not about this
+    test host happening to have distribution metadata installed.
+    """
+    import lgtmaybe.core.version as version_module
+
+    monkeypatch.setattr(version_module.metadata, "version", lambda _name: "1.2.3")
+    result = CliRunner().invoke(main, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "lgtmaybe 1.2.3"
+
+
+def test_version_flag_survives_an_uninstalled_checkout(monkeypatch) -> None:
+    """A source checkout with no dist-info still has to exit 0 — the flag is a
+    diagnostic, and one that fails is worse than one that says "unknown"."""
+    import lgtmaybe.core.version as version_module
+
+    def _fail(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError("lgtmaybe")
+
+    monkeypatch.setattr(version_module.metadata, "version", _fail)
+    result = CliRunner().invoke(main, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "lgtmaybe unknown"

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -29,13 +29,24 @@ def test_windows_exe_workflow_builds_smokes_and_uploads() -> None:
     assert "workflow_dispatch:" in text
     assert job["runs-on"] == "windows-latest"
     assert "uv run pyinstaller packaging/pyinstaller/lgtmaybe.spec" in runs
-    for command in ("--help", "config path", "review --help"):
+    for command in ("--help", "config path", "review --help", "--version"):
         assert command in runs
     assert "gh release upload" in runs
     assert runs.count('--repo "$env:GITHUB_REPOSITORY"') == 2
     assert "gh release upload failed with exit code $LASTEXITCODE" in runs
     assert "windows-x86_64.exe" in runs
     assert ".Length" in runs
+
+
+def test_pyinstaller_spec_ships_the_distribution_metadata() -> None:
+    """`lgtmaybe --version` reads the installed distribution's metadata, and a
+    frozen executable has none unless the spec copies it in — so without this the
+    winget build, the one install that cannot be identified any other way, is
+    exactly the one that answers "unknown"."""
+    spec = (_ROOT / "packaging" / "pyinstaller" / "lgtmaybe.spec").read_text(encoding="utf-8")
+
+    assert "copy_metadata" in spec
+    assert 'copy_metadata("lgtmaybe")' in spec
 
 
 def test_winget_workflow_updates_the_portable_package() -> None:


### PR DESCRIPTION
Closes #410.

`lgtmaybe --version` exits 0 and prints one stable, parseable line:

```text
lgtmaybe 1.14.1
```

so a benchmark runner (or a support ticket) can record which executable it actually ran. The fallback today is parsing `uv tool list`, which only sees uv-managed installs and cannot identify an arbitrary executable on PATH.

## What changed

- **`--version` on the `main` group** — an eager callback, not `click.version_option`. Both of that helper's modes get an edge case wrong here: passing a resolved version reads distribution metadata at import time on every invocation that never asks for it, and passing `package_name` makes click do the read itself and raise `RuntimeError` when there is no dist-info — so the flag would *crash* in a source checkout. `package_version()` already answers `unknown` there, and a diagnostic that fails is worse than one that hedges.
- **PyInstaller spec copies the dist-info** (`copy_metadata("lgtmaybe")`). The portable Windows executable is the install that most needs a version flag — no pip, no `uv tool list` — and was the one that would have answered `lgtmaybe unknown`, because a frozen build carries no distribution metadata unless the spec ships it.
- **Release smoke test asserts the exact version.** `windows-exe.yml` now checks the built exe reports `lgtmaybe <released version>`, so a lost metadata copy fails the build instead of shipping an unidentifiable binary.
- **Docs** — `docs/how-to/install-the-cli.md` documents the flag and the `unknown` case; `llms-full.txt` regenerated.

## Tests

Red-first, per the repo's TDD gate:

- `tests/cli/test_help.py::test_version_flag_prints_a_machine_readable_line` — asserts the exact `lgtmaybe <version>` shape (never click's default `main, version X`), with the version stubbed so the assertion is about the format.
- `tests/cli/test_help.py::test_version_flag_survives_an_uninstalled_checkout` — exit 0 and `lgtmaybe unknown` with no dist-info.
- `tests/test_windows_distribution.py::test_pyinstaller_spec_ships_the_distribution_metadata` and the extended workflow-contract test.

Full gate green locally: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest -q` (2000 passed, 3 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_018bDgLZVhed9mPr6CarmLBy)_