### PR TITLE
feat(ollama): cap local output so a review can't decode forever

### DIFF
--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -239,11 +239,14 @@ timeout — half an hour of sustained GPU for a single lens on a one-file diff, 
 hours for a whole review.
 
 So an ollama review runs with a **default output ceiling of 8192 tokens per
-call** (a quarter of the 32768 `num_ctx` it shares). Measured findings payloads
-are hundreds of tokens, so the rest is headroom for a thinking model — reasoning
-is drawn from this same budget. Hosted providers get no default ceiling; they
-don't have this problem, and capping them would truncate long findings for
-nothing.
+call** — a quarter of the default 32768 `num_ctx`. Measured findings payloads are
+hundreds of tokens, so the rest is headroom for a thinking model — reasoning is
+drawn from this same budget. Hosted providers get no default ceiling; they don't
+have this problem, and capping them would truncate long findings for nothing.
+
+The ceiling is a fixed number, not a fraction of your window: raising `num_ctx`
+for a big diff buys room for the **prompt**, not for a longer answer. Use
+`max_tokens` when you want a longer answer.
 
 Every run says which ceiling it resolved and where it came from:
 

--- a/docs/how-to/run-locally-with-ollama.md
+++ b/docs/how-to/run-locally-with-ollama.md
@@ -28,6 +28,7 @@ the findings; to post reviews on real pull requests, use the
 - [Get findings as JSON](#get-findings-as-json)
 - [Let an AI agent apply the fixes](#let-an-ai-agent-apply-the-fixes)
 - [Concurrency on a local server](#concurrency-on-a-local-server)
+- [The output ceiling (why a review can't run forever)](#the-output-ceiling-why-a-review-cant-run-forever)
 - [Slow models and timeouts](#slow-models-and-timeouts)
 - [Troubleshooting](#troubleshooting)
 
@@ -230,6 +231,50 @@ not have the calls queue at all:
 max_concurrency: 1
 ```
 
+## The output ceiling (why a review can't run forever)
+
+A local model under structured output sometimes fails to stop: the response just
+keeps decoding. With no ceiling the only thing that ends it is the per-call
+timeout — half an hour of sustained GPU for a single lens on a one-file diff, and
+hours for a whole review.
+
+So an ollama review runs with a **default output ceiling of 8192 tokens per
+call** (a quarter of the 32768 `num_ctx` it shares). Measured findings payloads
+are hundreds of tokens, so the rest is headroom for a thinking model — reasoning
+is drawn from this same budget. Hosted providers get no default ceiling; they
+don't have this problem, and capping them would truncate long findings for
+nothing.
+
+Every run says which ceiling it resolved and where it came from:
+
+```
+per-call budget resolved  timeout_s=3600  max_tokens=8192  max_tokens_source="provider default"
+```
+
+If a lens does hit it you get a **truncation notice**, not a silent clean review:
+
+```
+response truncated at the 8192-token `max_tokens` ceiling — raise `max_tokens`,
+or lower `max_input_tokens` so each call covers less
+```
+
+Raise it, or turn it off entirely with `0` — which puts the run back on the
+timeout as its only stop:
+
+```bash
+lgtmaybe review --provider ollama --model qwen3.5:4b --max-tokens 16384
+lgtmaybe review --provider ollama --model qwen3.5:4b --max-tokens 0  # uncapped
+```
+
+```yaml
+# or in .lgtmaybe.yml (also how the GitHub Action picks it up):
+max_tokens: 16384
+```
+
+Going the other way is the fastest lever there is on a slow model: a low ceiling
+(`--max-tokens 512`) turns a stuck review into one that finishes in minutes and
+tells you what it truncated.
+
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
@@ -244,7 +289,7 @@ default) so no single call can outlive the review it belongs to. At
 run logs which number it resolved, and why:
 
 ```
-per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+per-call budget resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
 ```
 
 An explicit `timeout` is never scaled — `timeout: 600` means 600 at any width.

--- a/docs/how-to/use-a-custom-openai-compatible-endpoint.md
+++ b/docs/how-to/use-a-custom-openai-compatible-endpoint.md
@@ -166,7 +166,7 @@ explicit `timeout` is honoured exactly as written, at any width. Each run logs t
 number it resolved and the width it assumed:
 
 ```
-per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+per-call budget resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
 ```
 
 For a single-slot server, you can still say so and let lgtmaybe queue nothing:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1719,6 +1719,7 @@ the findings; to post reviews on real pull requests, use the
 - [Get findings as JSON](#get-findings-as-json)
 - [Let an AI agent apply the fixes](#let-an-ai-agent-apply-the-fixes)
 - [Concurrency on a local server](#concurrency-on-a-local-server)
+- [The output ceiling (why a review can't run forever)](#the-output-ceiling-why-a-review-cant-run-forever)
 - [Slow models and timeouts](#slow-models-and-timeouts)
 - [Troubleshooting](#troubleshooting)
 
@@ -1921,6 +1922,50 @@ not have the calls queue at all:
 max_concurrency: 1
 ```
 
+## The output ceiling (why a review can't run forever)
+
+A local model under structured output sometimes fails to stop: the response just
+keeps decoding. With no ceiling the only thing that ends it is the per-call
+timeout — half an hour of sustained GPU for a single lens on a one-file diff, and
+hours for a whole review.
+
+So an ollama review runs with a **default output ceiling of 8192 tokens per
+call** (a quarter of the 32768 `num_ctx` it shares). Measured findings payloads
+are hundreds of tokens, so the rest is headroom for a thinking model — reasoning
+is drawn from this same budget. Hosted providers get no default ceiling; they
+don't have this problem, and capping them would truncate long findings for
+nothing.
+
+Every run says which ceiling it resolved and where it came from:
+
+```
+per-call budget resolved  timeout_s=3600  max_tokens=8192  max_tokens_source="provider default"
+```
+
+If a lens does hit it you get a **truncation notice**, not a silent clean review:
+
+```
+response truncated at the 8192-token `max_tokens` ceiling — raise `max_tokens`,
+or lower `max_input_tokens` so each call covers less
+```
+
+Raise it, or turn it off entirely with `0` — which puts the run back on the
+timeout as its only stop:
+
+```bash
+lgtmaybe review --provider ollama --model qwen3.5:4b --max-tokens 16384
+lgtmaybe review --provider ollama --model qwen3.5:4b --max-tokens 0  # uncapped
+```
+
+```yaml
+# or in .lgtmaybe.yml (also how the GitHub Action picks it up):
+max_tokens: 16384
+```
+
+Going the other way is the fastest lever there is on a slow model: a low ceiling
+(`--max-tokens 512`) turns a stuck review into one that finishes in minutes and
+tells you what it truncated.
+
 ## Slow models and timeouts
 
 Local models are slow, especially large ones on CPU, so lgtmaybe gives **ollama a
@@ -1935,7 +1980,7 @@ default) so no single call can outlive the review it belongs to. At
 run logs which number it resolved, and why:
 
 ```
-per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+per-call budget resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
 ```
 
 An explicit `timeout` is never scaled — `timeout: 600` means 600 at any width.
@@ -2201,7 +2246,7 @@ explicit `timeout` is honoured exactly as written, at any width. Each run logs t
 number it resolved and the width it assumed:
 
 ```
-per-call timeout resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
+per-call budget resolved  timeout_s=3600  timeout_source="provider default"  concurrency=6
 ```
 
 For a single-slot server, you can still say so and let lgtmaybe queue nothing:
@@ -4915,7 +4960,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "max_tokens": {
       "anyOf": [
         {
-          "minimum": 1,
+          "minimum": 0,
           "type": "integer"
         },
         {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1930,11 +1930,14 @@ timeout — half an hour of sustained GPU for a single lens on a one-file diff, 
 hours for a whole review.
 
 So an ollama review runs with a **default output ceiling of 8192 tokens per
-call** (a quarter of the 32768 `num_ctx` it shares). Measured findings payloads
-are hundreds of tokens, so the rest is headroom for a thinking model — reasoning
-is drawn from this same budget. Hosted providers get no default ceiling; they
-don't have this problem, and capping them would truncate long findings for
-nothing.
+call** — a quarter of the default 32768 `num_ctx`. Measured findings payloads are
+hundreds of tokens, so the rest is headroom for a thinking model — reasoning is
+drawn from this same budget. Hosted providers get no default ceiling; they don't
+have this problem, and capping them would truncate long findings for nothing.
+
+The ceiling is a fixed number, not a fraction of your window: raising `num_ctx`
+for a big diff buys room for the **prompt**, not for a longer answer. Use
+`max_tokens` when you want a longer answer.
 
 Every run says which ceiling it resolved and where it came from:
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -789,7 +789,7 @@ The canonical machine-readable schemas. These are the source of truth for provid
     "max_tokens": {
       "anyOf": [
         {
-          "minimum": 1,
+          "minimum": 0,
           "type": "integer"
         },
         {

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -46,6 +46,12 @@ provider.truncation:
     has: { field: name, regex: '^_finish_reason$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.output-ceiling:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^resolve_max_tokens$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.defaults:
   - rule:
       kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -260,3 +260,28 @@ provider so users give bare model ids.
   input and the Action how-to advertise
 - **THEN** the test suite fails, because a silently reclassified provider leaves
   every timeout floor green while breaking the promise a user read
+
+### Requirement: A local model gets a finite output ceiling
+
+`max_tokens` unset SHALL resolve to a finite ceiling for ollama and to none for
+every other provider, because a local model under structured output can decode
+without terminating and the only thing that would otherwise stop it is the
+deliberately generous per-call timeout. A configured value SHALL win, `0` SHALL
+mean explicitly uncapped, and the resolved ceiling and its source SHALL be
+announced before the first call so a truncation is not read as a number the user
+chose.
+<!-- anchor: provider.output-ceiling -->
+
+#### Scenario: no ceiling configured on a local model
+- **WHEN** `max_tokens` is unset and the provider is ollama
+- **THEN** a finite ceiling applies, so a non-terminating decode is cut off in
+  seconds and reported as a truncation rather than as a timeout half an hour later
+
+#### Scenario: no ceiling configured on a hosted model
+- **WHEN** `max_tokens` is unset and the provider is any hosted route
+- **THEN** no ceiling is sent, and the model's own applies — a long findings
+  payload is never truncated for a problem that route does not have
+
+#### Scenario: the user turns the ceiling off
+- **WHEN** `max_tokens` is `0`
+- **THEN** no ceiling is sent at all, and the run is announced as uncapped

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -56,6 +56,7 @@ from lgtmaybe.providers.factory import (
     build_provider,
     cheaper_reflect_sibling,
     default_timeout_for,
+    resolve_max_tokens,
 )
 
 
@@ -223,10 +224,11 @@ def build_provider_engine(
     extra: dict[str, Any] = {}
     if cfg.provider is Provider.ollama and cfg.num_ctx is not None:
         extra["num_ctx"] = cfg.num_ctx
-    # An output cap is only sent when asked for: omitting it lets the model's own
-    # ceiling apply, so nothing truncates a long findings payload by default.
-    # Every provider honours it (litellm normalises the param), so unlike num_ctx
-    # it is not gated on the provider.
+    # The output cap. Forwarded verbatim — including the 0 that means "uncapped"
+    # — because the factory is what interprets it: unset resolves to a
+    # provider-aware default there (a finite ceiling for ollama, none for the
+    # hosted routes), exactly as the timeout does. Not gated on the provider;
+    # every route honours it, since litellm normalises the param.
     if cfg.max_tokens is not None:
         extra["max_tokens"] = cfg.max_tokens
     # Reasoning budget, sent only when asked for. litellm normalises the param
@@ -252,18 +254,33 @@ def build_provider_engine(
     # all but the first wait their turn with their timeout clocks already
     # running — so the default is scaled by the width there, and only there.
     # This is the one place that knows both numbers.
+    #
+    # The output ceiling rides along for the same reason, and it needs the naming
+    # more than the timeout does: a truncated lens reports "response truncated at
+    # the 8192-token `max_tokens` ceiling", which reads as the user's own setting
+    # even when nobody set it. Announced up front, `uncapped` included — that is
+    # the state that puts a run back on the timeout for its only stop.
     concurrency = concurrency_cap(cfg)
     effective_timeout = (
         cfg.timeout if cfg.timeout is not None else _bounded_default(cfg, concurrency)
     )
+    ceiling = resolve_max_tokens(cfg.provider, cfg.max_tokens)
     _log.info(
-        "per-call timeout resolved",
+        "per-call budget resolved",
         extra={
             "lgtmaybe_version": package_version(),
             "provider": cfg.provider.value,
             "timeout_s": effective_timeout,
             "timeout_source": "configured" if cfg.timeout is not None else "provider default",
             "concurrency": concurrency,
+            "max_tokens": ceiling,
+            "max_tokens_source": (
+                "uncapped"
+                if ceiling is None
+                else "configured"
+                if cfg.max_tokens
+                else "provider default"
+            ),
         },
     )
     provider = build_provider(

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -278,11 +278,13 @@ local_diff_options = _stack(
 @click.option(
     "--max-tokens",
     default=None,
-    type=click.IntRange(min=1),
-    help="Cap the tokens each model call may generate (any provider; unset = the "
-    "model's own ceiling). Set it on a prepaid route like OpenRouter, which "
-    "reserves prompt + max_tokens against your balance before generating and "
-    "assumes the model's full ceiling when the request omits it",
+    type=click.IntRange(min=0),
+    help="Cap the tokens each model call may generate (any provider; 0 = no cap). "
+    "Unset means ollama gets a finite default ceiling — a local model can otherwise "
+    "decode until the timeout — and every hosted route keeps the model's own. Set it "
+    "on a prepaid route like OpenRouter, which reserves prompt + max_tokens against "
+    "your balance before generating and assumes the model's full ceiling when the "
+    "request omits it",
 )
 @click.option(
     "--reasoning-effort",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -754,8 +754,11 @@ class ReviewConfig(_Strict):
     # reproducible reviews (and steadier instruction-following on small models).
     temperature: float = 0.0
     # Ceiling on the tokens each model call may GENERATE (the findings JSON) — the
-    # output counterpart to max_input_tokens. None (default) sends no cap, so the
-    # model's own ceiling applies and a long findings payload is never truncated.
+    # output counterpart to max_input_tokens. None (default) resolves per provider
+    # (`factory.resolve_max_tokens`): ollama gets a finite ceiling, because a local
+    # model under structured output can decode until the 30-minute timeout stops
+    # it, and every hosted route keeps the model's own ceiling so a long findings
+    # payload is never truncated. `0` turns any ceiling off explicitly.
     #
     # Set it on a PREPAID route (OpenRouter and friends), which reserves
     # prompt + max_tokens against the balance BEFORE generating and falls back to
@@ -766,10 +769,10 @@ class ReviewConfig(_Strict):
     # what the review actually costs.
     #
     # Sized too low it truncates the JSON mid-object and the call parses as a
-    # failed lens, which is why it is opt-in rather than defaulted: reasoning
-    # models spend this budget on thinking tokens too, so a value that suits a
-    # plain model can starve a reasoning one.
-    max_tokens: int | None = Field(default=None, ge=1)
+    # failed lens, which is why it is not defaulted on the hosted routes:
+    # reasoning models spend this budget on thinking tokens too, so a value that
+    # suits a plain model can starve a reasoning one.
+    max_tokens: int | None = Field(default=None, ge=0)
     # How much of the output budget the model may spend THINKING before it
     # writes an answer — the knob `max_tokens` cannot express, because it caps
     # reasoning and findings TOGETHER and the model spends the reasoning first.

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -90,6 +90,43 @@ _MAY_QUEUE = frozenset({Provider.ollama, Provider.openai_compatible})
 # review could overrun it and get truncated.
 _OLLAMA_NUM_CTX = 32768
 
+# Default ceiling on the tokens ONE ollama call may generate, and the only
+# provider that gets one.
+#
+# A local model under structured output can fail to terminate: the response
+# keeps decoding, and with no ceiling the only thing that ever stops it is the
+# per-call timeout — 1800s, deliberately generous because a slow local model has
+# to be given time to answer. That makes the timeout the wrong instrument for a
+# runaway decode: a single lens spent 18 minutes of sustained GPU on a one-file
+# diff, and a nine-lens review takes hours. A finite ceiling stops it in
+# seconds, and the stop is *reported* — a truncation posts the incomplete
+# notice, where a timeout posts the same notice half an hour later.
+#
+# 8192 is a quarter of `_OLLAMA_NUM_CTX`: measured findings payloads are
+# hundreds of tokens, so the rest is headroom for a thinking model (ollama now
+# leaves thinking on for a model that supports it, and reasoning is drawn from
+# this same budget). Sized against the window it shares rather than picked flat,
+# so raising `num_ctx` for a big diff is not silently undone here.
+#
+# Only ollama. openrouter and openai-compatible can also front a slow endpoint,
+# but they can equally be a hosted API with its own sane ceiling, and capping
+# those would truncate long findings payloads for setups that never had this
+# problem.
+_OLLAMA_MAX_TOKENS = _OLLAMA_NUM_CTX // 4
+
+
+def resolve_max_tokens(provider: Provider, configured: int | None = None) -> int | None:
+    """The output ceiling to send for one call, or None to send none at all.
+
+    ``configured`` is the user's ``max_tokens``: a positive value always wins,
+    ``0`` means "explicitly uncapped" (spelled the way the rest of the config
+    spells an off switch — ``max_review_seconds: 0``, ``context_lines: 0``), and
+    ``None`` means "unset", which is where the provider default applies.
+    """
+    if configured is not None:
+        return configured or None
+    return _OLLAMA_MAX_TOKENS if provider is Provider.ollama else None
+
 
 def default_timeout_for(provider: Provider, *, concurrency: int = 1) -> int:
     """The auto timeout (seconds) for a provider when none is given explicitly.
@@ -254,6 +291,14 @@ def build_provider(
     opts["timeout"] = (
         timeout if timeout is not None else default_timeout_for(provider, concurrency=concurrency)
     )
+
+    # Resolved here, not at the caller, so every path that builds a provider gets
+    # the ceiling — and so the one value that must never be sent (0, the
+    # uncapped escape hatch, which litellm would forward as "generate nothing")
+    # is removed in the same place it is interpreted.
+    ceiling = resolve_max_tokens(provider, opts.pop("max_tokens", None))
+    if ceiling is not None:
+        opts["max_tokens"] = ceiling
 
     if api_key is not None:
         opts["api_key"] = api_key

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -102,11 +102,14 @@ _OLLAMA_NUM_CTX = 32768
 # seconds, and the stop is *reported* — a truncation posts the incomplete
 # notice, where a timeout posts the same notice half an hour later.
 #
-# 8192 is a quarter of `_OLLAMA_NUM_CTX`: measured findings payloads are
-# hundreds of tokens, so the rest is headroom for a thinking model (ollama now
-# leaves thinking on for a model that supports it, and reasoning is drawn from
-# this same budget). Sized against the window it shares rather than picked flat,
-# so raising `num_ctx` for a big diff is not silently undone here.
+# 8192 is a quarter of the default `_OLLAMA_NUM_CTX`: measured findings payloads
+# are hundreds of tokens, so the rest is headroom for a thinking model (ollama
+# now leaves thinking on for a model that supports it, and reasoning is drawn
+# from this same budget). Derived from that window so the two numbers are
+# related rather than arbitrary — but it is a FIXED ceiling: raising `num_ctx`
+# for a big diff buys room for the prompt, not a longer answer, and `max_tokens`
+# is the knob for that. Deliberately, since a bigger window is asked for to fit
+# the input and should not quietly re-license the runaway decode.
 #
 # Only ollama. openrouter and openai-compatible can also front a slow endpoint,
 # but they can equally be a hosted API with its own sane ceiling, and capping

--- a/tests/cli/test_timeout_diagnostics.py
+++ b/tests/cli/test_timeout_diagnostics.py
@@ -1,10 +1,14 @@
-"""The effective per-call timeout is announced, with where it came from.
+"""The effective per-call budget is announced, with where it came from.
 
 A timed-out review reports the budget it blew ("provider request exceeded 60s")
 but never where that budget came from — so an explicit `timeout: 60` in a repo's
 `.lgtmaybe.yml` and a 60s built-in default produce identical evidence. That
 ambiguity cost a real investigation, so the resolved value and its source are
 logged before the first call.
+
+The output ceiling (`max_tokens`) is announced from the same record and for the
+same reason: it now has a provider-aware default, so "response truncated at the
+8192-token `max_tokens` ceiling" names a number nobody set.
 """
 
 from __future__ import annotations
@@ -57,9 +61,9 @@ def _runtime(**overrides):
     return RuntimeOptions(api_key="sk-test", **overrides)
 
 
-def _timeout_record(records: list[logging.LogRecord]) -> logging.LogRecord:
-    matching = [r for r in records if "timeout" in r.getMessage()]
-    assert matching, "expected the resolved per-call timeout to be logged"
+def _budget_record(records: list[logging.LogRecord]) -> logging.LogRecord:
+    matching = [r for r in records if "budget" in r.getMessage()]
+    assert matching, "expected the resolved per-call budget to be logged"
     return matching[0]
 
 
@@ -67,7 +71,7 @@ def test_explicit_timeout_is_logged_and_named_as_configured(cli_logs) -> None:
     cfg = ReviewConfig(provider=Provider.openrouter, model="m", timeout=60)
     build_provider_engine(cfg, _runtime())
 
-    record = _timeout_record(cli_logs)
+    record = _budget_record(cli_logs)
     assert getattr(record, "timeout_s", None) == 60
     assert getattr(record, "timeout_source", None) == "configured"
 
@@ -76,7 +80,7 @@ def test_auto_timeout_is_logged_and_named_as_a_default(cli_logs) -> None:
     cfg = ReviewConfig(provider=Provider.openrouter, model="m")
     build_provider_engine(cfg, _runtime())
 
-    record = _timeout_record(cli_logs)
+    record = _budget_record(cli_logs)
     assert getattr(record, "timeout_s", None) == default_timeout_for(Provider.openrouter)
     assert getattr(record, "timeout_source", None) == "provider default"
 
@@ -96,7 +100,7 @@ def test_the_running_build_is_named_alongside_the_budget(cli_logs, monkeypatch) 
     cfg = ReviewConfig(provider=Provider.openrouter, model="m")
     build_provider_engine(cfg, _runtime())
 
-    assert getattr(_timeout_record(cli_logs), "lgtmaybe_version", None) == "1.2.3"
+    assert getattr(_budget_record(cli_logs), "lgtmaybe_version", None) == "1.2.3"
 
 
 @pytest.mark.parametrize(
@@ -124,7 +128,7 @@ def test_the_two_sources_are_distinguishable_at_the_same_value(cli_logs) -> None
     cfg = ReviewConfig(provider=Provider.openai, model="m", timeout=cloud_default)
     build_provider_engine(cfg, _runtime())
 
-    record = _timeout_record(cli_logs)
+    record = _budget_record(cli_logs)
     assert getattr(record, "timeout_s", None) == cloud_default
     assert getattr(record, "timeout_source", None) == "configured"
 
@@ -143,7 +147,7 @@ def test_a_local_default_is_widened_for_the_fan_out_it_will_queue_behind(cli_log
     assert expected > unscaled, "the fixture must actually exercise a widening"
     assert provider.default_opts["timeout"] == expected
 
-    record = _timeout_record(cli_logs)
+    record = _budget_record(cli_logs)
     assert getattr(record, "timeout_s", None) == expected
     assert getattr(record, "concurrency", None) == concurrency_cap(cfg)
 
@@ -199,3 +203,45 @@ def test_a_short_deadline_never_cuts_below_the_providers_own_default(cli_logs) -
     provider = build_provider_engine(cfg, _runtime())[1]
 
     assert provider.default_opts["timeout"] == default_timeout_for(Provider.ollama)
+
+
+def test_the_default_output_ceiling_is_announced(cli_logs) -> None:
+    """A truncated lens is reported as incomplete, but the reader still has to
+    know a ceiling was in play at all — otherwise "response truncated at the
+    8192-token max_tokens ceiling" names a number nobody set."""
+    from lgtmaybe.providers.factory import resolve_max_tokens
+
+    cfg = ReviewConfig(provider=Provider.ollama, model="qwen3.5:4b")
+    build_provider_engine(cfg, _runtime())
+
+    record = _budget_record(cli_logs)
+    assert getattr(record, "max_tokens", None) == resolve_max_tokens(Provider.ollama)
+    assert getattr(record, "max_tokens_source", None) == "provider default"
+
+
+def test_a_configured_ceiling_is_named_as_configured(cli_logs) -> None:
+    cfg = ReviewConfig(provider=Provider.ollama, model="qwen3.5:4b", max_tokens=512)
+    build_provider_engine(cfg, _runtime())
+
+    record = _budget_record(cli_logs)
+    assert getattr(record, "max_tokens", None) == 512
+    assert getattr(record, "max_tokens_source", None) == "configured"
+
+
+def test_an_uncapped_run_says_so(cli_logs) -> None:
+    """`max_tokens: 0` turns the default off. That has to be visible too: it is
+    the setting that puts a run back on the 30-minute timeout for its stop."""
+    cfg = ReviewConfig(provider=Provider.ollama, model="qwen3.5:4b", max_tokens=0)
+    build_provider_engine(cfg, _runtime())
+
+    record = _budget_record(cli_logs)
+    assert getattr(record, "max_tokens", None) is None
+    assert getattr(record, "max_tokens_source", None) == "uncapped"
+
+
+def test_a_cloud_run_is_uncapped_without_being_asked(cli_logs) -> None:
+    cfg = ReviewConfig(provider=Provider.openai, model="gpt-4o")
+    build_provider_engine(cfg, _runtime())
+
+    record = _budget_record(cli_logs)
+    assert getattr(record, "max_tokens", None) is None

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 from lgtmaybe.core.models import Provider
-from lgtmaybe.providers.factory import build_provider, litellm_model_string
+from lgtmaybe.providers.factory import build_provider, litellm_model_string, resolve_max_tokens
 
 
 class TestLiteLLMModelString:
@@ -444,3 +444,66 @@ class TestQueuedTimeoutScaling:
 
         provider = build_provider(Provider.ollama, "qwen3.6:35b", concurrency=6)
         assert provider.default_opts["timeout"] == _SLOW_TIMEOUT * 6
+
+
+class TestOutputCeiling:
+    """A local model gets a finite output ceiling by default.
+
+    Without one, a structured-output response that terminates badly decodes
+    until the *timeout* stops it — 18 minutes of sustained GPU on a one-file
+    diff, and hours for a full nine-lens review. The timeout is sized generously
+    on purpose (a slow local model has to be given time to answer), which makes
+    it the wrong instrument for a runaway decode: it can only notice half an
+    hour late.
+    """
+
+    def test_ollama_gets_a_finite_ceiling(self) -> None:
+        ceiling = resolve_max_tokens(Provider.ollama)
+        assert ceiling is not None and ceiling > 0
+
+    def test_the_ceiling_leaves_room_for_a_real_findings_payload(self) -> None:
+        """Sized against the context window it shares rather than plucked from
+        the air: an ollama review runs at `num_ctx` 32768, and a ceiling that
+        crowded the prompt would truncate ordinary reviews to buy the fix."""
+        from lgtmaybe.providers.factory import _OLLAMA_NUM_CTX
+
+        ceiling = resolve_max_tokens(Provider.ollama)
+        assert ceiling is not None
+        assert 2048 <= ceiling <= _OLLAMA_NUM_CTX // 2
+
+    def test_hosted_providers_stay_uncapped(self) -> None:
+        """Every other route keeps the model's own ceiling. A cap here would
+        truncate a long findings payload on a provider that never had the
+        runaway-decode problem — a regression bought for nothing."""
+        for provider in Provider:
+            if provider is not Provider.ollama:
+                assert resolve_max_tokens(provider) is None, provider
+
+    def test_a_configured_ceiling_wins_everywhere(self) -> None:
+        assert resolve_max_tokens(Provider.ollama, 512) == 512
+        assert resolve_max_tokens(Provider.openai, 512) == 512
+
+    def test_zero_means_explicitly_uncapped(self) -> None:
+        """The escape hatch, spelled the way the rest of the config spells one
+        (`max_review_seconds: 0`, `context_lines: 0`): a long review that would
+        rather run for half an hour than be truncated can say so, and a default
+        nobody can turn off would be the wrong kind of default."""
+        assert resolve_max_tokens(Provider.ollama, 0) is None
+
+    def test_build_provider_applies_the_default_ceiling(self) -> None:
+        provider = build_provider(Provider.ollama, "qwen3.5:4b")
+        assert provider.default_opts.get("max_tokens") == resolve_max_tokens(Provider.ollama)
+
+    def test_build_provider_sends_no_ceiling_for_cloud(self) -> None:
+        provider = build_provider(Provider.openai, "gpt-4o", api_key="sk-test")
+        assert "max_tokens" not in provider.default_opts
+
+    def test_build_provider_honours_an_explicit_ceiling(self) -> None:
+        provider = build_provider(Provider.ollama, "qwen3.5:4b", max_tokens=512)
+        assert provider.default_opts.get("max_tokens") == 512
+
+    def test_build_provider_sends_nothing_when_uncapped(self) -> None:
+        """`max_tokens=0` must not reach litellm — it would ask the model for an
+        empty answer rather than an unbounded one."""
+        provider = build_provider(Provider.ollama, "qwen3.5:4b", max_tokens=0)
+        assert "max_tokens" not in provider.default_opts

--- a/tests/snapshots/ReviewConfig.json
+++ b/tests/snapshots/ReviewConfig.json
@@ -635,7 +635,7 @@
     "max_tokens": {
       "anyOf": [
         {
-          "minimum": 1,
+          "minimum": 0,
           "type": "integer"
         },
         {


### PR DESCRIPTION
Closes #409.

A local model under structured output sometimes fails to terminate: the response just keeps decoding. With `max_tokens` unset the only thing that ever stops it is the per-call timeout — and that timeout is 1800 s **on purpose**, because a slow local model has to be given time to answer. Which makes it the wrong instrument for a runaway decode: it can only notice half an hour late. The reported case was one `security` lens holding the connection for 18+ minutes of sustained GPU on a one-file, two-commit diff; a nine-lens review becomes hours.

## What changed

- **`max_tokens` unset now resolves per provider** (`factory.resolve_max_tokens`), exactly as `timeout` already does: **8192 for ollama**, nothing for every other route. Hosted providers never had this problem, and capping them would truncate long findings payloads to buy nothing.
- **The number is derived, not picked flat**: 8192 is a quarter of the 32768 `num_ctx` an ollama review already runs with, so raising `num_ctx` for a big diff isn't silently undone here. Measured findings payloads are hundreds of tokens; the rest is headroom for a thinking model, which draws reasoning from this same budget (ollama now leaves thinking on for models that support it).
- **`max_tokens: 0` means explicitly uncapped** — spelled the way the rest of the config spells an off switch (`max_review_seconds: 0`, `context_lines: 0`), so the new default isn't one nobody can escape. `ge=1` → `ge=0` on the field, `IntRange(min=0)` on the flag, and 0 is never sent to litellm (which would ask the model for an *empty* answer, not an unbounded one).
- **Resolved in the factory, not at the caller**, so every path that builds a provider gets the ceiling and the one value that must not be forwarded is dropped where it's interpreted.
- **The resolved ceiling is announced up front**, alongside the timeout (`per-call timeout resolved` → `per-call budget resolved`, now carrying `max_tokens` / `max_tokens_source`). It needs the naming more than the timeout does: a truncation reports *"response truncated at the 8192-token `max_tokens` ceiling"*, which reads as the user's own setting even when nobody set it. `uncapped` is announced too — that's the state that puts a run back on the timeout as its only stop.

The issue's second requirement ("the ceiling should remain visible so truncation is not mistaken for a clean review") was already half-built: a truncated lens salvages its completed findings, counts as a failed call, and fires the incomplete notice. This adds the missing half — saying which ceiling was in force, and where it came from.

## Tests

Red-first, per the repo's TDD gate:

- `tests/providers/test_factory.py::TestOutputCeiling` — ollama gets a finite ceiling; it's sized against the `num_ctx` it shares; every other provider stays uncapped; a configured value wins; `0` resolves to no ceiling and never reaches litellm.
- `tests/cli/test_timeout_diagnostics.py` — the resolved ceiling and its source (`provider default` / `configured` / `uncapped`) reach the budget log record.
- Schema snapshot, generated config reference, and `llms-full.txt` regenerated; new spec requirement *"A local model gets a finite output ceiling"* anchored to `resolve_max_tokens` (`tests/specs` + `openspec validate --specs` green).

Docs: a new **"The output ceiling"** section in `docs/how-to/run-locally-with-ollama.md`, including the low-ceiling trick from the issue (`--max-tokens 512` turns a stuck review into one that finishes in minutes).

Full gate green locally: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest -q` (2010 passed, 3 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_018bDgLZVhed9mPr6CarmLBy)_