### PR TITLE
test(github): prove the count overlaps by handshake, not by sleep

### DIFF
--- a/tests/github/test_rest_gateway.py
+++ b/tests/github/test_rest_gateway.py
@@ -280,7 +280,16 @@ def test_base_checkout_root_returns_none_when_ref_unavailable(monkeypatch) -> No
 def test_open_thread_count_overlaps_the_file_fetches() -> None:
     """The count is disclosure metadata, so it must not sit in FRONT of the
     content fetches — it shares nothing with them and rides the same pool. Run
-    serially it would add a round trip to every review's startup."""
+    serially it would add a round trip to every review's startup.
+
+    Each handler waits for the OTHER to be in flight rather than sleeping a fixed
+    span. A sleep only asserts overlap if the scheduler happens to start the
+    second request inside it, which a loaded CI runner does not guarantee — this
+    test failed exactly that way, on a diff that touched nothing near the
+    gateway. The handshake proves the same property with no clock in it: on
+    concurrent code both events are set immediately and neither side waits, and
+    on serial code the first handler waits out `_OVERLAP_TIMEOUT` and the
+    assertion below fails on the events, which is the real regression signal."""
     import threading
 
     respx.route(
@@ -298,12 +307,18 @@ def test_open_thread_count_overlaps_the_file_fetches() -> None:
 
     lock = threading.Lock()
     events: list[str] = []
+    # Long enough that a busy runner is never mistaken for serial execution,
+    # short enough that a genuine regression fails rather than hangs.
+    _OVERLAP_TIMEOUT = 10.0
+    in_flight = {"threads": threading.Event(), "content": threading.Event()}
 
     def slow(label: str):
         def handler(request: httpx.Request) -> httpx.Response:
             with lock:
                 events.append(f"start-{label}")
-            threading.Event().wait(0.05)
+            in_flight[label].set()
+            other = "content" if label == "threads" else "threads"
+            in_flight[other].wait(_OVERLAP_TIMEOUT)
             with lock:
                 events.append(f"end-{label}")
             if label == "threads":


### PR DESCRIPTION
`test_open_thread_count_overlaps_the_file_fetches` is timing-dependent and failed on `main`'s code from an unrelated PR ([#413](https://github.com/MattJColes/lgtmaybe/pull/413), which touches only the provider factory and the CLI):

```
AssertionError: the thread count did not overlap the content fetches:
['start-threads', 'end-threads', 'start-content', 'start-content', 'end-content', 'end-content']
```

## Why it flakes

Each mocked handler slept 0.05 s, and the test asserted a second request had started before the first finished. That only holds if the scheduler happens to dispatch the second request *inside* that sleep. On a loaded runner the count ran start-to-finish before the first content fetch was submitted — the sleep measured the runner's mood, not the gateway's concurrency.

## The fix

Each handler now waits for the **other** to be in flight rather than for a fixed span:

- **Concurrent code** (what's on `main`) sets both events immediately, neither side waits, and the overlap is proven with no clock in it — the test also gets faster, since nothing sleeps.
- **Serial code** makes the first handler wait out a 10 s bound and then fail the same assertion on the same evidence. Bounded rather than a bare `wait()` so a regression fails instead of hanging.

Verified in both directions: with `open_threads.result()` forced inside the pool (serialising the count), the test fails in 10 s; unmodified, it passes five runs in a row at 0.34 s.

The property under test is unchanged — the count must not sit in front of the content fetches — only how it's observed.

Full gate green locally: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest -q` (1991 passed, 3 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_018bDgLZVhed9mPr6CarmLBy)_