### PR TITLE
fix(providers): read a spent ceiling as a truncation

### DIFF
--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -46,6 +46,12 @@ provider.truncation:
     has: { field: name, regex: '^_finish_reason$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.ceiling-detection:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_spent_the_ceiling$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.output-ceiling:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -197,12 +197,9 @@ the user set, not the model's own — plus the reasoning-token count where the
 route reports it, and SHALL carry the cut-off body so the engine can salvage the
 findings finished before the cut, and both counts as data so a caller can tell a
 long answer from exhausted thinking without reading the message. It SHALL NOT be
-retried — at temperature 0 the
-identical request reaches the identical ceiling, and each attempt costs a full
-ceiling-length generation — while a configured fallback model is still tried.
-Detection reads the finish reason only where the route reports it plainly:
-litellm rewrites a reason it does not recognise to `stop`, so a route that
-names a ceiling hit its own way is caught downstream by the parser instead.
+retried — at temperature 0 the identical request reaches the identical ceiling,
+and each attempt costs a full ceiling-length generation — while a configured
+fallback model is still tried.
 <!-- anchor: provider.truncation -->
 
 #### Scenario: the model generates to its output limit
@@ -220,10 +217,30 @@ names a ceiling hit its own way is caught downstream by the parser instead.
 - **THEN** the failure carries none either, never zero — "it never said" must not
   read as "it thought nothing"
 
+### Requirement: A ceiling hit is detected even when the route will not say
+
+Detection SHALL read the finish reason where the route reports it plainly, and
+SHALL additionally treat a response that generated to a ceiling lgtmaybe itself
+configured as a ceiling hit. litellm rewrites a finish reason it does not
+recognise to `stop`, and ollama reports nothing useful, so on those routes
+spending the whole cap is the only evidence there is — and without this a cut-off
+call renders in the profile as a clean, cheap success, which is what had
+benchmark tooling counting zero truncations. Judged only against a ceiling
+lgtmaybe set: with none configured a long answer is just a long answer.
+<!-- anchor: provider.ceiling-detection -->
+
 #### Scenario: the route misreports why it stopped
 - **WHEN** a provider reports a ceiling hit under a name litellm maps to `stop`
-- **THEN** the response still reaches the parser, which reports the truncation
-  from the unclosed JSON itself
+- **THEN** spending the configured ceiling is itself read as the truncation, so
+  the profile marks the call rather than showing a clean row
+
+#### Scenario: the answer simply finished
+- **WHEN** a completion stops below the configured ceiling
+- **THEN** it is an ordinary success, never a truncation
+
+#### Scenario: nothing was capped
+- **WHEN** no ceiling was configured for the call
+- **THEN** no output length is read as a truncation
 
 ### Requirement: Defaults are provider-aware
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -559,7 +559,15 @@ class LiteLLMProvider:
             count_request()
             try:
                 return self._map_response(
-                    _completion_with_wall_timeout(model, messages, kwargs), model
+                    _completion_with_wall_timeout(model, messages, kwargs),
+                    model,
+                    # Read off the request that was actually sent, not off
+                    # `default_opts`: a per-call `max_tokens` overrides the one
+                    # this provider was built with, and judging a 256-token call
+                    # against a 4,096 default would miss every ceiling hit.
+                    # `max_completion_tokens` is the same ceiling under the newer
+                    # OpenAI spelling, which litellm accepts either way.
+                    kwargs.get("max_tokens") or kwargs.get("max_completion_tokens"),
                 )
             except Exception as exc:
                 if not self._drop_rejected_param(exc, kwargs):
@@ -645,7 +653,9 @@ class LiteLLMProvider:
             out[run_start:] = [{"role": "user", "content": merged}]
         return out
 
-    def _map_response(self, response: Any, model: str) -> ProviderResult:
+    def _map_response(
+        self, response: Any, model: str, ceiling: int | None = None
+    ) -> ProviderResult:
         # Some providers return null content (e.g. a model that answered only via
         # a reasoning channel under JSON mode); treat that as empty, not a crash.
         text: str = response.choices[0].message.content or ""
@@ -666,7 +676,19 @@ class LiteLLMProvider:
         # because it is the whole explanation for a fifteen-line diff truncating —
         # a reasoning model spends this same budget on thought before it writes a
         # single finding, so the cap, not the diff, is what needs raising.
-        if _finish_reason(response) == "length":
+        #
+        # Second test, for the routes that never say it. litellm maps an
+        # unrecognised finish reason to `stop`, and ollama's route reports
+        # nothing useful at all, so a call cut off at the cap arrives looking
+        # like a clean finish — measured on a local benchmark as two lens calls
+        # reporting exactly the configured 512 output tokens with an empty error
+        # column, which had the tooling downstream counting zero truncations.
+        # Spending the ceiling to the token is not a stopping point a model
+        # chooses; it is what being cut off looks like from the outside. Only
+        # ever applied against a ceiling WE set (`ceiling`) — with none
+        # configured there is nothing to compare against and a long answer is
+        # just a long answer.
+        if _finish_reason(response) == "length" or _spent_the_ceiling(output_tokens, ceiling):
             reasoning = _reasoning_tokens(usage)
             detail = f" ({reasoning} reasoning)" if reasoning else ""
             raise ProviderTruncated(
@@ -709,6 +731,17 @@ class LiteLLMProvider:
             # thinking they did by two different readings of the same field.
             reasoning_tokens=_reasoning_tokens(usage),
         )
+
+
+def _spent_the_ceiling(output_tokens: int, ceiling: int | None) -> bool:
+    """Whether this response generated all the way to the ceiling we configured.
+
+    ``>=`` rather than ``==``: some routes count a token or two past the cap, and
+    a ceiling hit reported as 513-of-512 is still a ceiling hit. A ``ceiling`` of
+    None (or 0, the uncapped escape hatch) means we set no cap, so there is
+    nothing to judge against and this never fires.
+    """
+    return ceiling is not None and ceiling > 0 and output_tokens >= ceiling
 
 
 def _finish_reason(response: Any) -> str | None:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -561,13 +561,7 @@ class LiteLLMProvider:
                 return self._map_response(
                     _completion_with_wall_timeout(model, messages, kwargs),
                     model,
-                    # Read off the request that was actually sent, not off
-                    # `default_opts`: a per-call `max_tokens` overrides the one
-                    # this provider was built with, and judging a 256-token call
-                    # against a 4,096 default would miss every ceiling hit.
-                    # `max_completion_tokens` is the same ceiling under the newer
-                    # OpenAI spelling, which litellm accepts either way.
-                    kwargs.get("max_tokens") or kwargs.get("max_completion_tokens"),
+                    _configured_ceiling(kwargs),
                 )
             except Exception as exc:
                 if not self._drop_rejected_param(exc, kwargs):
@@ -731,6 +725,26 @@ class LiteLLMProvider:
             # thinking they did by two different readings of the same field.
             reasoning_tokens=_reasoning_tokens(usage),
         )
+
+
+def _configured_ceiling(kwargs: dict[str, Any]) -> int | None:
+    """The output ceiling this request was actually sent with, if any.
+
+    Read off the request rather than off ``default_opts``: a per-call
+    ``max_tokens`` overrides the one the provider was built with, and judging a
+    256-token call against a 4,096 default would miss every ceiling hit.
+
+    ``max_completion_tokens`` is the same ceiling under the newer OpenAI
+    spelling, which litellm accepts either way — but it is only consulted when
+    ``max_tokens`` is ABSENT, never when it is merely falsy. ``max_tokens: 0`` is
+    the uncapped escape hatch, and falling through on it would re-impose a
+    ceiling the caller explicitly turned off, then report a truncation against
+    it.
+    """
+    if "max_tokens" in kwargs:
+        ceiling: int | None = kwargs["max_tokens"]
+        return ceiling
+    return kwargs.get("max_completion_tokens")
 
 
 def _spent_the_ceiling(output_tokens: int, ceiling: int | None) -> bool:

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -449,3 +449,96 @@ class TestEnginePipelineTiming:
         with pytest.raises(engine_mod.ReviewIncompleteError):
             LLMReviewEngine(_BurntBudget()).review(_CTX, cfg)
         assert profiler.calls[-1].attempts == 2
+
+
+class TestCeilingHitsReachTheProfile:
+    """The row for a call that spent its whole output ceiling must say so.
+
+    This is the seam the fix is for: the adapter classifies the ceiling hit, the
+    profiler renders it. A local benchmark saw two lens calls report exactly the
+    configured 512 output tokens with an empty error column, so the tooling
+    reading that column counted zero truncations and could not exclude the call
+    time — the row looked like a clean, cheap success.
+    """
+
+    @staticmethod
+    def _at_ceiling(completion_tokens: int) -> object:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"findings": [{"path": "a.py"'),
+                    # `stop`, not `length` — the case the profile used to miss.
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=900, completion_tokens=completion_tokens),
+        )
+
+    def test_a_ceiling_hit_without_a_finish_reason_is_marked(self) -> None:
+        from unittest.mock import patch
+
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        profiler.reset()
+        provider = LiteLLMProvider(max_tokens=512)
+        with (
+            patch("litellm.completion", return_value=self._at_ceiling(512)),
+            pytest.raises(ProviderTruncated),
+        ):
+            timed_complete(
+                provider,
+                [{"role": "user", "content": "hi"}],
+                model="ollama/qwen2.5-coder:3b",
+                label="ponytail",
+            )
+
+        call = profiler.calls[-1]
+        assert call.error is not None, "the profile row gave no truncation marker"
+        assert "Truncated" in call.error
+        # And it is charged for what it spent: the row a reader is looking at is
+        # routinely the most expensive call in the run.
+        assert (call.input_tokens, call.output_tokens) == (900, 512)
+
+    def test_the_rendered_error_column_is_not_a_dash(self) -> None:
+        """Asserted on the rendered table, because `-` in that column is exactly
+        what the benchmark tooling read as "no truncation here"."""
+        from unittest.mock import patch
+
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        profiler.reset()
+        provider = LiteLLMProvider(max_tokens=512)
+        with (
+            patch("litellm.completion", return_value=self._at_ceiling(512)),
+            pytest.raises(ProviderTruncated),
+        ):
+            timed_complete(
+                provider,
+                [{"role": "user", "content": "hi"}],
+                model="ollama/qwen2.5-coder:3b",
+                label="ponytail",
+            )
+
+        row = next(line for line in profiler.render().splitlines() if line.startswith("ponytail"))
+        assert not row.rstrip().endswith("-"), f"error column read as empty: {row!r}"
+        assert "Truncated" in row
+
+    def test_a_normal_answer_still_renders_clean(self) -> None:
+        """The guard must not paint every local call as truncated."""
+        from unittest.mock import patch
+
+        from lgtmaybe.providers.litellm_provider import LiteLLMProvider
+
+        profiler.reset()
+        provider = LiteLLMProvider(max_tokens=512)
+        with patch("litellm.completion", return_value=self._at_ceiling(200)):
+            timed_complete(
+                provider,
+                [{"role": "user", "content": "hi"}],
+                model="ollama/qwen2.5-coder:3b",
+                label="ponytail",
+            )
+
+        assert profiler.calls[-1].error is None

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1401,3 +1401,91 @@ class TestMalformedRetryAfter:
             wait = provider_module._retry_wait(state)
             assert wait == wait  # not NaN
             assert wait <= provider_module._RATE_LIMIT_BACKOFF_MAX
+
+
+class TestCeilingHitWithoutAFinishReason:
+    """A response that spent the whole configured ceiling IS a ceiling hit, even
+    when the route never says so.
+
+    litellm normalises `finish_reason` through a fixed map and rewrites anything
+    it doesn't recognise to `stop`, and ollama's route reports nothing useful at
+    all — so a call cut off at the cap arrives looking like a clean finish. In a
+    20-repository local benchmark two lens calls reported exactly the configured
+    512 output tokens with an empty error column, and the tooling downstream
+    counted zero truncations.
+
+    Spending the ceiling to the token is not something a model does by choosing
+    to stop there; it is what being cut off looks like. So it is treated as one.
+    """
+
+    @staticmethod
+    def _at_ceiling(completion_tokens: int, reason: str | None = "stop") -> Any:
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content='{"findings": [{"path": "a.py"'),
+                    finish_reason=reason,
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=900, completion_tokens=completion_tokens),
+        )
+
+    def test_output_at_the_configured_ceiling_is_truncated(self) -> None:
+        with patch("litellm.completion", return_value=self._at_ceiling(512)):
+            provider = LiteLLMProvider(max_tokens=512)
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "ollama/qwen2.5-coder:3b")
+
+        assert "512" in str(exc_info.value)
+        assert exc_info.value.output_tokens == 512
+
+    def test_a_per_call_ceiling_is_honoured_over_the_default(self) -> None:
+        """The engine may pass its own `max_tokens`; the check has to judge the
+        ceiling this call actually ran under, not the one it was built with."""
+        with patch("litellm.completion", return_value=self._at_ceiling(256)):
+            provider = LiteLLMProvider(max_tokens=4096)
+            with pytest.raises(ProviderTruncated):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    "ollama/qwen2.5-coder:3b",
+                    max_tokens=256,
+                )
+
+    def test_output_over_the_ceiling_is_truncated(self) -> None:
+        """Some routes count a token or two past the cap. Still a ceiling hit."""
+        with patch("litellm.completion", return_value=self._at_ceiling(513)):
+            provider = LiteLLMProvider(max_tokens=512)
+            with pytest.raises(ProviderTruncated):
+                provider.complete([{"role": "user", "content": "hi"}], "ollama/qwen2.5-coder:3b")
+
+    def test_output_below_the_ceiling_is_a_normal_answer(self) -> None:
+        """The guard must not fire on a model that simply finished. This is the
+        common case, and a false truncation would post an incomplete notice on a
+        review that was complete."""
+        with patch("litellm.completion", return_value=self._at_ceiling(511)):
+            provider = LiteLLMProvider(max_tokens=512)
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "ollama/qwen2.5-coder:3b"
+            )
+
+        assert result.output_tokens == 511
+
+    def test_an_uncapped_call_is_never_judged_against_a_ceiling(self) -> None:
+        """With no configured ceiling there is nothing to compare against, and a
+        long answer is just a long answer."""
+        with patch("litellm.completion", return_value=self._at_ceiling(65536)):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openrouter/deepseek")
+
+        assert result.output_tokens == 65536
+
+    def test_the_body_still_travels_for_salvage(self) -> None:
+        """Same contract as a reported truncation: the findings completed before
+        the cut are real, and the engine recovers them."""
+        with patch("litellm.completion", return_value=self._at_ceiling(512)):
+            provider = LiteLLMProvider(max_tokens=512)
+            with pytest.raises(ProviderTruncated) as exc_info:
+                provider.complete([{"role": "user", "content": "hi"}], "ollama/qwen2.5-coder:3b")
+
+        assert exc_info.value.text == '{"findings": [{"path": "a.py"'
+        assert exc_info.value.input_tokens == 900

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1479,6 +1479,34 @@ class TestCeilingHitWithoutAFinishReason:
 
         assert result.output_tokens == 65536
 
+    def test_the_newer_openai_spelling_is_the_same_ceiling(self) -> None:
+        """litellm accepts `max_completion_tokens` for the same cap, so a caller
+        that uses it must get the same detection."""
+        with patch("litellm.completion", return_value=self._at_ceiling(512)):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    "ollama/qwen2.5-coder:3b",
+                    max_completion_tokens=512,
+                )
+
+    def test_an_explicit_zero_wins_over_the_other_spelling(self) -> None:
+        """`max_tokens=0` is the uncapped escape hatch, and it is chosen by being
+        PRESENT, not by being truthy. Falling through to a second spelling would
+        re-impose a ceiling the caller explicitly turned off — and then report a
+        truncation against it."""
+        with patch("litellm.completion", return_value=self._at_ceiling(512)):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "ollama/qwen2.5-coder:3b",
+                max_tokens=0,
+                max_completion_tokens=512,
+            )
+
+        assert result.output_tokens == 512
+
     def test_the_body_still_travels_for_salvage(self) -> None:
         """Same contract as a reported truncation: the findings completed before
         the cut are real, and the engine recovers them."""


### PR DESCRIPTION
Closes #414.

A call that generated all the way to the configured `max_tokens` could render in `--profile` as a clean success:

```
ponytail   1   1   84.21s   4210   512   0   0   0   -
```

litellm normalises an unrecognised finish reason to `stop`, and ollama's route reports nothing useful, so on those routes a cut-off response arrives indistinguishable from a model that chose to stop. The benchmark's two `out_tok=512` rows against a configured 512 ceiling therefore showed `-`, the tooling counted zero truncations, and the costliest row in the table read as the cheapest kind of success.

## What changed

- **`_spent_the_ceiling`** — detection now fires on `finish_reason == "length"` **or** a response that generated to a ceiling lgtmaybe itself configured. Spending the cap to the token is not a stopping point a model chooses; it is what being cut off looks like from the outside. `>=` rather than `==`, since some routes count a token or two past the cap.
- **The ceiling is read off the request that was actually sent** (`kwargs`), not off `default_opts`: a per-call `max_tokens` has to be judged against itself, and a 256-token call measured against a 4096 default would miss every hit. `max_completion_tokens` is accepted as the same ceiling under the newer OpenAI spelling.
- **Nothing configured, nothing judged.** With no ceiling (including the `max_tokens: 0` escape hatch) a long answer stays a long answer — the guard cannot invent a truncation on an uncapped route.

Everything downstream already worked once the call is classified: the findings completed before the cut are salvaged, the call counts as failed so the incomplete notice fires, and the profile row carries the marker instead of a dash.

## Tests

Red-first:

- `tests/providers/test_retry.py::TestCeilingHitWithoutAFinishReason` — at the ceiling, past the ceiling, and a per-call ceiling overriding the built-in one all raise `ProviderTruncated` under a `stop` finish reason; **below** the ceiling and **uncapped** stay ordinary successes (a false truncation would post an incomplete notice on a complete review); the cut-off body still travels for salvage.
- `tests/engine/test_profiling.py::TestCeilingHitsReachTheProfile` — the seam the issue is actually about: the profile row is marked, is charged for the 900/512 it spent, and the rendered error column is no longer `-`. Plus the negative case, so the guard can't paint every local call as truncated.

Spec: the detection rule outgrew the "named, not retried" requirement's 40-line cap, so it is split into its own requirement — *"A ceiling hit is detected even when the route will not say"* — anchored to `_spent_the_ceiling`. `tests/specs` and `openspec validate --specs` green.

Full gate green locally: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest -q` (2013 passed, 3 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_018bDgLZVhed9mPr6CarmLBy)_