### PR TITLE
fix: give a reasoning-bound truncation both levers, and the dogfood cap the headroom

### DIFF
--- a/.lgtmaybe.yml
+++ b/.lgtmaybe.yml
@@ -11,43 +11,49 @@ exclude_paths:
 # Bound what one call may generate — and, more to the point, bound what a
 # RUNAWAY call may generate.
 #
-# History, because this value has moved three times and every move was upward.
-# The cap was raised to 16k, then to 32k, chasing lens calls that truncated; the
-# measurements behind those moves showed 25,963-35,463 reasoning tokens per
-# truncation and concluded that the cap was the wrong lever because raising it
-# only buys the model more room to think. That conclusion was drawn while
-# `reasoning_effort` was being silently dropped on OpenRouter, and this comment
-# asked the next person to re-measure before moving the value again.
+# History, because this value keeps moving and each move answered a different
+# failure. It was raised to 16k, then to 32k, chasing lens calls that truncated;
+# those measurements showed 25,963-35,463 reasoning tokens per truncation and
+# concluded the cap was the wrong lever, since raising it only bought the model
+# more room to think. That conclusion was drawn while `reasoning_effort` was
+# being silently dropped on OpenRouter, i.e. with thinking effectively unbounded.
 #
-# Re-measured, twice, on the same diff, with the budget actually enforced:
+# Re-measured at 32k, twice, on the same diff, with the budget enforced:
 #
 #   run          truncated lens   reasoning   output    that call   whole review
 #   low                code-health       516  ~32,250        380s           410s
 #   medium             security          961  ~32,700        288s           361s
 #
-# Three things follow. Thinking is bounded now (~500-1000, not ~30,000), so the
-# old diagnosis is spent. `reasoning_effort` is not the lever either — `medium`
-# truncated too, on a different lens. And the truncation is a CONTENT runaway,
-# not a thinking one: 961 tokens of thought against ~32,700 of output, salvaging
-# zero findings, where the same material split in half produced 1,122 tokens.
-# Roughly one lens call in five does this. It is model-level generation
-# instability, and no cap prevents it.
+# Those were a CONTENT runaway, not a thinking one: ~1k tokens of thought against
+# ~32k of output, salvaging zero findings, where the same material split in half
+# produced 1,122. Roughly one lens call in five. No cap prevents that, so the
+# cap's job was re-framed as blast radius — at 32k one runaway ate 93% and 80%
+# of those two runs' wall clock, at 8k it costs ~95s instead of ~380s. Hence
+# 8,192, against a largest-healthy-output of 937 at `low` and 3,986 at `medium`.
 #
-# So the cap's job is not prevention, it is blast radius — and at 32k the blast
-# radius was the entire review: 93% and 80% of those two runs' wall clock went on
-# one call that said nothing. At 8k a runaway costs ~95s instead of ~380s.
+# Then the model changed (openai/gpt-5.6-luna — see
+# .github/workflows/lgtmaybe.yml) and the failure inverted. A dogfood review lost
+# its whole `artefacts` lens — tests and documentation, reviewed by nothing that
+# run — to a truncation that spent 8,192 of the 8,192 ceiling on REASONING: zero
+# content tokens, zero findings salvaged, and no split, because splitting cannot
+# shrink a thinking budget. That is the ~2x headroom the note below already
+# flagged as thin, arriving.
 #
-# 8,192 against a largest-healthy-output of 937 tokens at `low` (~9x headroom)
-# and 3,986 at `medium` (~2x). A truncation is not fatal in any case: the engine
-# splits the batch and reviews the pieces, which is how both runs still produced
-# findings from the lens that ran away.
+# So: 16,384. It doubles the headroom over a model whose thinking alone reached
+# 8k, while keeping a runaway's blast radius at half of what 32k cost. Note it is
+# the opposite of what the runs above wanted — that is what makes this number
+# hard, because the two failures are indistinguishable from the outside (both are
+# "truncated at the ceiling") and want opposite moves. `reasoning_effort` is not
+# the alternative here: the note below measured `low` missing a real bug in both
+# runs and producing the only false positive across four.
 #
-# The coupling is what makes this number hard, so: the cap pays for THINKING as
-# well as output on this model. 8,192 is comfortable at `low` and `medium`. It
-# would need raising again at `high`/`xhigh`, where thinking alone can approach
-# it — and at that point re-measure rather than guessing, the same way this
-# number was arrived at.
-max_tokens: 8192
+# Honest about what this is: a directional response to ONE observed truncation,
+# not a re-measurement — every number above came from paired runs and this did
+# not. What to measure next, on the dogfood diff at `medium`: largest healthy
+# output, the reasoning share of it, and whether `artefacts` still truncates. If
+# thinking has simply grown past 16k too, the lever really is `reasoning_effort`
+# and this should come back down rather than climb to 32k a second time.
+max_tokens: 16384
 
 # Bound what the model spends THINKING, as opposed to answering.
 #
@@ -75,8 +81,9 @@ max_tokens: 8192
 # output's higher unit price is applied. Not the 3x the token counts suggest.
 #
 # Two things to watch. `max_tokens` above pays for thinking as well, and the
-# largest healthy output at `medium` was 3,986 tokens against that 8,192 cap —
-# roughly 2x headroom, where `low` had 9x. And `medium` truncated once in two
-# runs where `low` truncated twice, which is directionally interesting but n=2:
-# do not read it as a fix for the runaway.
+# largest healthy output at `medium` was 3,986 tokens — roughly 2x headroom
+# against the 8,192 cap those runs used, and ~4x against the 16,384 it now sits
+# at, which is the headroom that raise was buying back. And `medium` truncated
+# once in two runs where `low` truncated twice, which is directionally
+# interesting but n=2: do not read it as a fix for the runaway.
 reasoning_effort: medium

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -216,18 +216,20 @@ kept, and the lens SHALL still count as failed.
 ### Requirement: A split is only attempted when covering less can help
 
 A truncation that spent essentially the whole ceiling reasoning SHALL NOT be
-split, and SHALL name `reasoning_effort` as the lever instead: a smaller payload
-does not shrink a thinking budget, so the split would re-spend the whole
-`max_tokens` ceiling on every piece and fail identically. The
-decision reads the counts the failure carries, never its message. Findings
-completed before the cut are kept on this path too, and a failure that says
-nothing about size is not split at all.
+split, and SHALL name both a lower `reasoning_effort` and a higher `max_tokens`
+as the levers: a smaller payload does not shrink a thinking budget, so the split
+would re-spend the whole `max_tokens` ceiling on every piece and fail
+identically — but these counts cannot say whether the thinking expands to fill
+any ceiling given it or merely outgrew this one, and those two have opposite
+fixes. The decision reads the counts the failure carries, never its message.
+Findings completed before the cut are kept on this path too, and a failure that
+says nothing about size is not split at all.
 <!-- anchor: engine.reasoning-ceiling -->
 
 #### Scenario: the ceiling went on thinking
 - **WHEN** a lens call truncates having spent nearly the whole ceiling reasoning
-- **THEN** no pieces are reviewed, the salvage is kept, and the notice names
-  `reasoning_effort` rather than `max_tokens`
+- **THEN** no pieces are reviewed, the salvage is kept, and the notice names both
+  levers, since the counts alone cannot say which one is the fix
 
 #### Scenario: the ceiling went on the answer
 - **WHEN** a truncated call spent only a small share of the ceiling reasoning

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1689,9 +1689,16 @@ def _reasoning_exhausted_reason(exc: BaseException) -> str | None:
     meaningless without the ceiling it is a share of — so a route that reports
     neither keeps the split it has always had.
 
-    The returned reason replaces the adapter's, whose advice ("raise
-    `max_tokens`") is the one thing that provably does not work here: the cap
-    does not separate thinking from answering, so raising it buys more thinking.
+    The returned reason replaces the adapter's, which offers only "raise
+    `max_tokens`" and never mentions the thinking that actually spent it. Both
+    levers are named, because these numbers cannot say which one is the fix.
+    Thinking that *expands to fill* whatever ceiling it is given is immune to a
+    bigger cap — the case recorded above, where the effort is the only move.
+    Thinking with a bounded natural size that merely exceeds this ceiling looks
+    identical here and is the opposite case: the cap fixes it outright, and
+    lowering the effort pays for the fix in review quality instead. Only a
+    re-run at a higher cap separates them, so the reader is handed the choice
+    rather than one of the two asserted as proven.
     """
     if not isinstance(exc, ProviderTruncated):
         return None
@@ -1703,7 +1710,8 @@ def _reasoning_exhausted_reason(exc: BaseException) -> str | None:
     return (
         f"{type(exc).__name__}: spent {reasoning} of the {ceiling}-token `max_tokens` "
         "ceiling on reasoning, so the batch was not split — a smaller payload cannot "
-        "shrink a thinking budget; lower `reasoning_effort` instead"
+        "shrink a thinking budget. Lower `reasoning_effort`, or raise `max_tokens` if "
+        "this model simply thinks bigger than the ceiling"
     )
 
 

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1689,9 +1689,11 @@ def _reasoning_exhausted_reason(exc: BaseException) -> str | None:
     meaningless without the ceiling it is a share of — so a route that reports
     neither keeps the split it has always had.
 
-    The returned reason replaces the adapter's, which offers only "raise
-    `max_tokens`" and never mentions the thinking that actually spent it. Both
-    levers are named, because these numbers cannot say which one is the fix.
+    The returned reason replaces the adapter's, which promises a split this
+    failure is not going to get and warns that a higher ceiling makes things
+    worse — true of the content runaway it was written for, and the wrong half
+    of the advice here. Both levers are named instead, because these numbers
+    cannot say which one is the fix.
     Thinking that *expands to fill* whatever ceiling it is given is immune to a
     bigger cap — the case recorded above, where the effort is the only move.
     Thinking with a bounded natural size that merely exceeds this ceiling looks

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -297,6 +297,28 @@ def test_a_reasoning_dominated_truncation_keeps_its_salvage() -> None:
     assert "reasoning_effort" in summary
 
 
+def test_a_reasoning_dominated_truncation_offers_the_cap_as_well() -> None:
+    """Naming only `reasoning_effort` states the pessimistic case as fact.
+
+    Two different failures produce identical numbers. Thinking that *expands to
+    fill* whatever ceiling it is given is immune to a bigger cap — the case
+    issue #348 measured, and the one where lowering the effort is the only move.
+    Thinking with a bounded natural size that merely exceeds this ceiling is the
+    opposite: raising the cap fixes it outright, and lowering the effort buys
+    the fix in review quality instead. One truncation cannot tell the two apart
+    — only re-running at a higher cap can — so the reader is handed both levers
+    rather than the pessimistic one asserted as proven.
+    """
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(_TruncatesOnReasoning()).review(
+            _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+        )
+
+    reason = str(exc_info.value)
+    assert "reasoning_effort" in reason
+    assert "raise `max_tokens`" in reason
+
+
 def test_a_truncation_that_spent_its_ceiling_on_findings_is_still_split() -> None:
     """The output-length truncation the split was built for is untouched.
 


### PR DESCRIPTION
A dogfood review on this repo posted:

> ⚠️ 1 of 5 review calls failed (artefacts — ProviderTruncated: spent 8192 of the 8192-token `max_tokens` ceiling on reasoning, so the batch was not split — a smaller payload cannot shrink a thinking budget; lower `reasoning_effort` instead)

The `artefacts` lens is the merged tests + documentation lens, so that run reviewed neither. Two things were wrong, and they are separate commits.

## 1. The notice named one lever and asserted the other was proven useless

`_reasoning_exhausted_reason` is right not to split — halving the diff does not halve the thinking — but its advice over-claimed. Two different failures produce identical counts:

- Thinking that **expands to fill** whatever ceiling it is given. Immune to a bigger cap; the effort is the only move. This is what the 32k measurement recorded, and what the docstring generalised from.
- Thinking with a **bounded natural size** that merely outgrew this ceiling. The cap fixes it outright, and lowering the effort pays for the fix in review quality instead.

Only a re-run at a higher cap separates them, so the notice now hands over both levers rather than stating the pessimistic one as fact. The no-split behaviour is unchanged — only what the reader is told about it. The spec section (`engine.reasoning-ceiling`) and its scenario are updated to match.

## 2. 8,192 was sized for a different model

`.lgtmaybe.yml` set the cap against a largest-healthy-output of 3,986 at `medium` — roughly 2x headroom, which the comment itself flagged as thin and predicted would need raising. The model has since moved to `openai/gpt-5.6-luna`, whose thinking alone now reaches the whole ceiling.

Raised to 16,384: double the headroom, while keeping a runaway's blast radius at half of what 32k cost. Deliberately **not** `reasoning_effort` — the same file records `low` missing a real bug in both measured runs and producing the only false positive across four.

Worth flagging: this is the opposite of what the runs recorded in that file wanted (they were content runaways, where a bigger cap is more expensive). That is precisely what makes the number hard — both failures read as "truncated at the ceiling" from outside and want opposite moves, which is also why commit 1 exists.

## Honesty about the evidence

The cap raise is a **directional response to one observed truncation, not a re-measurement**. Every other number in that comment block came from paired runs; this one did not — I have no provider key here to re-measure with. The comment block says so, and names what to measure next on the dogfood diff at `medium`: largest healthy output, the reasoning share of it, and whether `artefacts` still truncates. If thinking has simply grown past 16k too, the lever really is `reasoning_effort` and this should come back down rather than climb to 32k a second time.

## Testing

Red-first: `test_a_reasoning_dominated_truncation_offers_the_cap_as_well` asserts the notice offers to raise `max_tokens` as well as lower `reasoning_effort`; it failed against the old wording.

Full gate green locally — `ruff check`, `ruff format --check`, `mypy` (52 files), `pytest` (2017 passed, 3 skipped), `pytest tests/specs`, and `openspec validate --specs` (10 passed).

Both fixes are on the one branch I am scoped to, so this is a single PR rather than two.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VY6pebX2dzMHjjBUCfoMS)_