### PR TITLE
fix: make follow-up thread resolution fail safe

### DIFF
--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -120,7 +120,7 @@ A follow-up run with a completed-head watermark SHALL review only the compare-AP
 
 ### Requirement: Resolving threads is best-effort GraphQL
 
-A follow-up run SHALL classify each earlier active finding as `fixed`, `still_open`, or `uncertain` from structured model output. A finding SHALL be resolved via GraphQL only when the model returns `fixed` and GitHub independently marks its anchored thread outdated; every other or invalid verdict SHALL remain open without repetitive replies. After resolve, the opening comment's fingerprint and identity markers SHALL be rewritten into disjoint resolved families before one cosmetic reply is attempted. Threads remain independently best-effort and identity-wide permission refusal SHALL stop that wave without failing the review.
+A follow-up run SHALL classify each earlier active finding as `fixed`, `still_open`, or `uncertain` from structured model output. A finding SHALL be resolved via GraphQL only when the model returns `fixed` and GitHub independently marks its anchored thread outdated; every other or invalid verdict SHALL remain open without repetitive replies. Before resolve, the opening comment's fingerprint and identity markers SHALL be rewritten into disjoint resolved families; a failed resolve SHALL restore the active body, and only a successful resolve may receive one cosmetic reply. Threads remain independently best-effort and identity-wide permission refusal SHALL stop that wave without failing the review.
 <!-- anchor: github.resolve-fixed -->
 
 #### Scenario: a prior finding is explicitly fixed
@@ -132,8 +132,8 @@ A follow-up run SHALL classify each earlier active finding as `fixed`, `still_op
 - **THEN** the thread remains open and receives no repetitive reply
 
 #### Scenario: GraphQL call errors
-- **WHEN** `resolveReviewThread` fails
-- **THEN** the review still completes and posts normally
+- **WHEN** the marker rewrite or `resolveReviewThread` fails
+- **THEN** the thread stays open with active markers retained or restored, receives no reply, and the review still completes
 
 #### Scenario: one thread of several fails
 - **WHEN** several threads are fixed and one errors mid-resolve
@@ -151,9 +151,6 @@ A follow-up run SHALL classify each earlier active finding as `fixed`, `still_op
 - **THEN** the fingerprint marker is still rewritten — a resolved thread is never
   revisited, so leaving an active marker would suppress the finding forever
 
-#### Scenario: the marker rewrite fails after resolve
-- **WHEN** the thread resolves but its active-marker rewrite fails
-- **THEN** the thread is reopened and receives no fixed reply, preserving retryable state
 
 ### Requirement: Downvoted findings are read from 👎 reactions
 

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -1098,31 +1098,40 @@ class RestGitHubGateway:
         refused = threading.Event()
 
         def resolve_one(thread: tuple[str, int | None, str]) -> None:
-            """Resolve one thread, then record it — in that order, deliberately.
+            """Retire one finding marker, resolve its thread, then reply.
 
             Three steps with three different consequences, so they are sequenced
-            by how much a failure costs:
+            so the unsafe failure state — a resolved thread with active markers —
+            is impossible:
 
-            1. **Resolve** — the gate. Until it succeeds nothing else should
-               happen: a reply on a thread that stays open re-qualifies as fixed
-               on every later run and collects another reply each time.
-            2. **Rewrite the marker** — correctness-critical, and this is the
-               only chance. A resolved thread is skipped by `_fixed_threads`
-               forever, so an active fingerprint left behind would let re-run
-               dedupe suppress the finding permanently if it came back.
+            1. **Rewrite the marker** — correctness-critical. If this fails the
+               thread stays open and retryable.
+            2. **Resolve** — if this fails, restore the active body. A failed
+               restore may cause a duplicate later, but can never suppress a
+               reintroduced finding.
             3. **Reply** — cosmetic audit trail. Last, because a failure here
-               must not skip step 2.
+               must not affect either durable state transition.
             """
             if refused.is_set():
                 return
             thread_id, comment_id, first_body = thread
             try:
+                self._mark_comment_resolved(comment_id, first_body)
+            except Exception as exc:  # noqa: BLE001 — one thread never blocks the rest
+                _log.warning("resolved-marker rewrite on %s failed: %s", thread_id, exc)
+                return
+            try:
                 self._resolve_thread(thread_id)
             except Exception as exc:  # noqa: BLE001 — one thread never blocks the rest
+                try:
+                    self._restore_comment_active(comment_id, first_body)
+                except Exception as restore_exc:  # noqa: BLE001 — safe duplicate failure mode
+                    _log.warning(
+                        "restoring active markers on thread %s failed: %s",
+                        thread_id,
+                        restore_exc,
+                    )
                 if "FORBIDDEN" in str(exc) or "not accessible by integration" in str(exc):
-                    # Not transient: the identity simply cannot resolve threads,
-                    # so this recurs every run until someone changes the setup.
-                    # Say what to do about it rather than repeating a bare error.
                     if not refused.is_set():
                         refused.set()
                         _log.warning(
@@ -1134,19 +1143,6 @@ class RestGitHubGateway:
                         )
                 else:
                     _log.warning("auto-resolve of thread %s failed: %s", thread_id, exc)
-                return
-            try:
-                self._mark_comment_resolved(comment_id, first_body)
-            except Exception as exc:  # noqa: BLE001 — restore retryable state below
-                _log.warning("resolved-marker rewrite on %s failed: %s", thread_id, exc)
-                try:
-                    self._unresolve_thread(thread_id)
-                except Exception as reopen_exc:  # noqa: BLE001 — best-effort repair
-                    _log.warning(
-                        "reopening thread %s after marker failure failed: %s",
-                        thread_id,
-                        reopen_exc,
-                    )
                 return
             try:
                 self.reply_in_thread(thread_id, "✅ Looks resolved.")
@@ -1244,15 +1240,6 @@ class RestGitHubGateway:
         """
         self._graphql(resolve, {"threadId": thread_id})
 
-    def _unresolve_thread(self, thread_id: str) -> None:
-        """Reopen a thread whose resolved-marker rewrite failed so it can retry."""
-        unresolve = """
-        mutation($threadId:ID!){
-          unresolveReviewThread(input:{threadId:$threadId}){ thread{ id isResolved } }
-        }
-        """
-        self._graphql(unresolve, {"threadId": thread_id})
-
     def _mark_comment_resolved(self, comment_id: int | None, body: str) -> None:
         """Rewrite a resolved comment's fingerprint marker into the "resolved" family.
 
@@ -1268,11 +1255,21 @@ class RestGitHubGateway:
         rewritten = body.replace(_ACTIVE_MARKER_PREFIX, _RESOLVED_MARKER_PREFIX).replace(
             _ACTIVE_IDENTITY_PREFIX, _RESOLVED_IDENTITY_PREFIX
         )
+        self._update_review_comment(comment_id, rewritten)
+
+    def _restore_comment_active(self, comment_id: int | None, body: str) -> None:
+        """Restore the original active marker body after resolution fails."""
+        if comment_id is None:
+            return
+        self._update_review_comment(comment_id, body)
+
+    def _update_review_comment(self, comment_id: int, body: str) -> None:
+        """Replace one review comment body, raising on any GitHub failure."""
         url = f"{self._api}/pulls/comments/{comment_id}"
         resp = self._client.patch(
             url,
             headers=self._json_headers,
-            json={"body": rewritten},
+            json={"body": body},
             timeout=_TIMEOUT,
         )
         resp.raise_for_status()

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -600,7 +600,7 @@ def test_resolve_fixed_rewrites_fingerprint_to_resolved_marker() -> None:
 
 @respx.mock
 def test_resolve_fixed_marker_rewrite_failure_never_fails_review() -> None:
-    """A failed marker rewrite reopens the thread for a later retry."""
+    """A failed marker rewrite leaves the thread open for a later retry."""
     _mark_existing_review()
     gone_fp = finding_fingerprint("src/old.py", "Removed bug")
     graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1", comment_id=555)])
@@ -610,11 +610,11 @@ def test_resolve_fixed_marker_rewrite_failure_never_fails_review() -> None:
     )
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
-    # Must not raise, but the thread cannot stay resolved with active markers.
+    # Must not raise, and resolution is never attempted without retired markers.
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
 
-    assert graphql.resolved == ["THREAD1"]
-    assert graphql.unresolved == ["THREAD1"]
+    assert graphql.resolved == []
+    assert graphql.unresolved == []
     assert graphql.replies == []
 
 
@@ -1175,7 +1175,48 @@ def test_failed_resolve_posts_no_reply() -> None:
 
     assert graphql.replies == [], "replied on a thread that was never resolved"
     assert graphql.resolved == []
-    assert patched == [], "rewrote the fingerprint marker of an unresolved thread"
+    assert len(patched) == 2
+    assert "lgtmaybe-resolved-fingerprint" in json.loads(patched[0].content)["body"]
+    assert json.loads(patched[1].content)["body"].endswith(
+        f"<!-- lgtmaybe-finding:{gone_fp} -->"
+    )
+
+
+@respx.mock
+def test_missing_comment_id_never_attempts_resolution() -> None:
+    _mark_existing_review()
+    gone_fp = finding_fingerprint("src/old.py", "Removed bug")
+    graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1", comment_id=None)])
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=graphql)
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert graphql.resolved == []
+    assert graphql.replies == []
+
+
+@respx.mock
+def test_failed_resolve_and_marker_restore_never_fail_the_review() -> None:
+    _mark_existing_review()
+    gone_fp = finding_fingerprint("src/old.py", "Removed bug")
+    graphql = _GraphQL([_thread(gone_fp, outdated=True, tid="THREAD1")])
+
+    def forbid_resolve(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        if "resolveReviewThread" in payload.get("query", ""):
+            return httpx.Response(200, json={"data": None, "errors": [{"message": "denied"}]})
+        return graphql(request)
+
+    respx.route(method="POST", url=GRAPHQL_URL).mock(side_effect=forbid_resolve)
+    patches = iter([httpx.Response(200, json={}), httpx.Response(500)])
+    respx.route(method="PATCH").mock(side_effect=lambda request: next(patches))
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+    gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
+
+    assert graphql.resolved == []
+    assert graphql.replies == []
 
 
 @respx.mock

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1177,9 +1177,7 @@ def test_failed_resolve_posts_no_reply() -> None:
     assert graphql.resolved == []
     assert len(patched) == 2
     assert "lgtmaybe-resolved-fingerprint" in json.loads(patched[0].content)["body"]
-    assert json.loads(patched[1].content)["body"].endswith(
-        f"<!-- lgtmaybe-finding:{gone_fp} -->"
-    )
+    assert json.loads(patched[1].content)["body"].endswith(f"<!-- lgtmaybe-finding:{gone_fp} -->")
 
 
 @respx.mock


### PR DESCRIPTION
## What changed

- retire active finding markers before resolving a validated fixed thread
- leave the thread open when marker retirement fails
- restore the original active-marker body when GraphQL resolution fails
- post the cosmetic fixed reply only after both durable state transitions succeed
- align the living posting spec with the fail-safe ordering

## Why

PR #412 was merged while its final review feedback was still being addressed. Its resolve-then-rewrite sequence could strand a resolved thread with active markers if both the marker rewrite and compensating reopen failed. Later deduplication could then suppress a reintroduced finding permanently.

This follow-up makes the failure direction safe: a failed restore may cause a duplicate finding, but it cannot hide one.

## Validation

- `uv run pytest -q` — 2043 passed, 3 skipped, 19 deselected
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest tests/specs -q` — 17 passed
- `npx -y @fission-ai/openspec@latest validate --specs --strict` — 10 specs passed