### PR TITLE
test(evals): trap the same-file and test-elsewhere false positives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,6 +643,13 @@ Split by whether it can be deterministic, because that decides where it lives:
   example — one genuine in-diff catch (a logged secret) plus three forbidden
   cross-file traps (model_dump-vs-V2, idempotency re-run, tenant_id null) — and it
   measures the codebase-humility behavior the review prompt + reflection enforce.
-  Real-spend hosted-provider e2e remains label-gated in `action-e2e.yml`.
+  **`unshown-code-fp`** is its sibling for the two shapes cross-file-fp cannot
+  express (its changed file is new, so nothing of it is unshown): a short edit at
+  the bottom of a long existing module traps a claim about **what an unshown
+  constant in the SAME file contains** (an empty frozenset ~180 lines up, the
+  `_SINGLE_STREAM_PROVIDERS` shape) and a claim that the change is **untested**
+  when the test lives in a file the diff never touched — the shape reflection's
+  gap-finding carve-out currently protects. Real-spend hosted-provider e2e
+  remains label-gated in `action-e2e.yml`.
 
 [litellm]: https://github.com/BerriAI/litellm

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -358,6 +358,19 @@ typically cross-file false positives where the relevant guard lives in a file th
 reviewer can't see. The `cross-file-fp` fixture is the worked example: one genuine
 in-diff catch alongside three forbidden cross-file claims.
 
+`unshown-code-fp` is its sibling, for the two shapes cross-file-fp cannot express
+(its changed file is new, so nothing of it is unshown). Its diff is a short edit
+to the bottom of a long existing module, and both traps turn on what the reviewer
+was *not* shown:
+
+- **the value of a symbol in the same file** — `SINGLE_STREAM_PROVIDERS` is an
+  empty frozenset defined ~180 lines above the function that reads it, so a
+  finding asserting what it *contains* ("this pins ollama to one worker") is
+  false, and no amount of context padding reaches it;
+- **a test that exists elsewhere** — `worker_count` arrives with no test beside
+  it in the diff, while `tests/test_dispatch.py` covers it in a file the PR never
+  touched, so "this change is untested" is true of the diff and wrong as a defect.
+
 ### Measuring what the fast preset trades away
 
 The default `fast` preset covers the nine lenses in four grouped calls;

--- a/evals/fixtures/unshown-code-fp/diff.txt
+++ b/evals/fixtures/unshown-code-fp/diff.txt
@@ -1,0 +1,24 @@
+diff --git a/scheduler/dispatch.py b/scheduler/dispatch.py
+index ed83bce..00af502 100644
+--- a/scheduler/dispatch.py
++++ b/scheduler/dispatch.py
+@@ -203,3 +203,19 @@ def percentile(latencies: list[float], pct: float) -> float:
+     ordered = sorted(latencies)
+     rank = max(1, min(len(ordered), round(pct / 100 * len(ordered))))
+     return ordered[rank - 1]
++
++
++def worker_count(provider: str, configured: int) -> int:
++    """How many workers the fan-out may run against *provider*.
++
++    A provider that serves one stream at a time is pinned to a single worker
++    whatever the user configured; everybody else gets what they asked for.
++    """
++    if provider in SINGLE_STREAM_PROVIDERS:
++        return 1
++    return configured
++
++
++def average_latency(samples: list[float]) -> float:
++    """Mean latency across *samples*, in seconds."""
++    return sum(samples) / len(samples)

--- a/evals/fixtures/unshown-code-fp/expected.json
+++ b/evals/fixtures/unshown-code-fp/expected.json
@@ -1,0 +1,41 @@
+{
+  "name": "unshown-code-fp",
+  "changed_file": "scheduler/dispatch.py",
+  "expected": [
+    {
+      "label": "average_latency divides by len(samples) with no empty-list guard",
+      "line": 221,
+      "keywords": ["zerodivision", "division by zero", "divide by zero", "empty list", "empty"]
+    }
+  ],
+  "forbidden": [
+    {
+      "label": "FP: asserts what SINGLE_STREAM_PROVIDERS contains (it is empty, 180 lines up in the SAME file)",
+      "line": 214,
+      "keywords": [
+        "single_stream",
+        "single worker",
+        "one worker",
+        "returns 1",
+        "return 1",
+        "pinned to 1",
+        "serialis",
+        "serializ"
+      ]
+    },
+    {
+      "label": "FP: claims the new behaviour is untested (tests/test_dispatch.py covers it, untouched by the diff)",
+      "line": 208,
+      "keywords": [
+        "untested",
+        "no test",
+        "not tested",
+        "missing test",
+        "test coverage",
+        "lacks a test",
+        "without a test",
+        "no unit test"
+      ]
+    }
+  ]
+}

--- a/evals/fixtures/unshown-code-fp/repo/scheduler/dispatch.py
+++ b/evals/fixtures/unshown-code-fp/repo/scheduler/dispatch.py
@@ -1,0 +1,221 @@
+"""Job dispatch: worker sizing, backoff, and latency reporting.
+
+This file is the fixture's *unshown* corpus. The diff under review touches only
+``worker_count`` and ``average_latency`` at the bottom, so a reviewer sees two
+short hunks out of a two-hundred-line module.
+
+Two things it can therefore not see, and must not assert:
+
+- what ``SINGLE_STREAM_PROVIDERS`` (defined near the top) actually CONTAINS. Its
+  name reads like a policy list; its value is an empty frozenset, so the branch
+  the diff adds never fires. A finding claiming "this returns 1 for ollama" is
+  the trap.
+- whether the new behaviour is tested. It is — in ``tests/test_dispatch.py``,
+  which the diff does not touch.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+# Providers whose backend serves one stream at a time, so the fan-out has to be
+# pinned to a single worker for them.
+#
+# EMPTY, deliberately. Every backend we route to now multiplexes, so the policy
+# this set encoded no longer applies to anybody — the name survived a cleanup the
+# membership did not. A reviewer seeing only `worker_count` reads the name and
+# assumes ollama (or "local providers") is in here. Nothing is.
+SINGLE_STREAM_PROVIDERS: frozenset[str] = frozenset()
+
+# Backoff shape, in seconds. Doubling per attempt, capped so a long outage does
+# not park a job for an hour.
+BASE_DELAY = 0.5
+MAX_DELAY = 30.0
+
+# HTTP statuses worth another go: a capacity limit and the three transient
+# gateway failures. A 4xx that is not 429 is the caller's fault and never retried.
+RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})
+
+# How many times one job may be attempted before it lands on the dead-letter
+# queue. Four attempts spans roughly BASE_DELAY * (1 + 2 + 4) = 3.5s of backoff.
+MAX_ATTEMPTS = 4
+
+
+@dataclass
+class Job:
+    """One unit of dispatchable work."""
+
+    id: str
+    tenant_id: str
+    provider: str
+    payload: dict[str, str] = field(default_factory=dict)
+    attempts: int = 0
+
+
+@dataclass
+class Attempt:
+    """The outcome of one delivery attempt."""
+
+    job_id: str
+    status: int
+    latency_s: float
+
+
+class DeadLetter(Exception):
+    """A job that exhausted its attempts and will not be retried again."""
+
+
+def next_delay(attempt: int) -> float:
+    """Seconds to wait before *attempt* (1-based), with full jitter.
+
+    Doubling from :data:`BASE_DELAY`, clamped at :data:`MAX_DELAY`. Jitter is
+    applied over the whole interval rather than added to it, so a thundering herd
+    of retries spreads instead of arriving together one delay later.
+    """
+    ceiling = min(BASE_DELAY * 2 ** max(attempt - 1, 0), MAX_DELAY)
+    return random.uniform(0.0, ceiling)
+
+
+def should_retry(attempt: Attempt, job: Job) -> bool:
+    """Whether *job* gets another go after *attempt*.
+
+    Two independent gates: the status has to be one we consider transient, and
+    the job has to have attempts left. Either one closing ends the job.
+    """
+    if attempt.status not in RETRYABLE_STATUSES:
+        return False
+    return job.attempts < MAX_ATTEMPTS
+
+
+def record_attempt(job: Job, attempt: Attempt) -> Job:
+    """Fold *attempt* into *job*'s counter and hand the job back.
+
+    Returns a new Job rather than mutating in place: the dispatcher keeps the
+    pre-attempt copy for its audit trail, and a mutation would rewrite history
+    under it.
+    """
+    return Job(
+        id=job.id,
+        tenant_id=job.tenant_id,
+        provider=job.provider,
+        payload=dict(job.payload),
+        attempts=job.attempts + 1,
+    )
+
+
+def classify(attempt: Attempt) -> str:
+    """A coarse label for *attempt*, for the metrics tag."""
+    if attempt.status < 300:
+        return "ok"
+    if attempt.status < 500:
+        return "client"
+    return "server"
+
+
+def partition(attempts: list[Attempt]) -> dict[str, list[Attempt]]:
+    """Group *attempts* by :func:`classify` label."""
+    grouped: dict[str, list[Attempt]] = {"ok": [], "client": [], "server": []}
+    for attempt in attempts:
+        grouped[classify(attempt)].append(attempt)
+    return grouped
+
+
+def succeeded(attempts: list[Attempt]) -> list[Attempt]:
+    """Only the attempts that landed."""
+    return partition(attempts)["ok"]
+
+
+def failed(attempts: list[Attempt]) -> list[Attempt]:
+    """Everything that did not land, client and server faults alike."""
+    grouped = partition(attempts)
+    return grouped["client"] + grouped["server"]
+
+
+def dead_letter(job: Job) -> None:
+    """Refuse a job that has run out of attempts."""
+    if job.attempts >= MAX_ATTEMPTS:
+        raise DeadLetter(f"job {job.id} exhausted {MAX_ATTEMPTS} attempts")
+
+
+def tenants(jobs: list[Job]) -> list[str]:
+    """The distinct tenants represented in *jobs*, in a stable order."""
+    return sorted({job.tenant_id for job in jobs})
+
+
+def by_tenant(jobs: list[Job]) -> dict[str, list[Job]]:
+    """Bucket *jobs* by tenant so one noisy tenant can be throttled alone."""
+    buckets: dict[str, list[Job]] = {}
+    for job in jobs:
+        buckets.setdefault(job.tenant_id, []).append(job)
+    return buckets
+
+
+def fair_order(jobs: list[Job]) -> list[Job]:
+    """Round-robin *jobs* across tenants.
+
+    One tenant submitting a thousand jobs must not starve the others, so the
+    queue is drained a job per tenant per pass rather than in arrival order.
+    """
+    buckets = by_tenant(jobs)
+    ordered: list[Job] = []
+    while buckets:
+        for tenant in sorted(buckets):
+            ordered.append(buckets[tenant].pop(0))
+            if not buckets[tenant]:
+                del buckets[tenant]
+    return ordered
+
+
+def throttled(jobs: list[Job], limit: int) -> list[Job]:
+    """At most *limit* jobs per tenant, keeping the fair order."""
+    seen: dict[str, int] = {}
+    kept: list[Job] = []
+    for job in fair_order(jobs):
+        count = seen.get(job.tenant_id, 0)
+        if count >= limit:
+            continue
+        seen[job.tenant_id] = count + 1
+        kept.append(job)
+    return kept
+
+
+def describe(job: Job) -> str:
+    """A one-line, log-safe description of *job* (no payload, no credentials)."""
+    return f"job={job.id} tenant={job.tenant_id} provider={job.provider}"
+
+
+def summarise(attempts: list[Attempt]) -> str:
+    """A one-line roll-up of a dispatch round."""
+    grouped = partition(attempts)
+    return " ".join(f"{label}={len(items)}" for label, items in sorted(grouped.items()))
+
+
+def slowest(attempts: list[Attempt], count: int) -> list[Attempt]:
+    """The *count* slowest attempts, slowest first."""
+    return sorted(attempts, key=lambda a: a.latency_s, reverse=True)[:count]
+
+
+def percentile(latencies: list[float], pct: float) -> float:
+    """The *pct* percentile of *latencies* (nearest-rank), 0.0 when empty."""
+    if not latencies:
+        return 0.0
+    ordered = sorted(latencies)
+    rank = max(1, min(len(ordered), round(pct / 100 * len(ordered))))
+    return ordered[rank - 1]
+
+
+def worker_count(provider: str, configured: int) -> int:
+    """How many workers the fan-out may run against *provider*.
+
+    A provider that serves one stream at a time is pinned to a single worker
+    whatever the user configured; everybody else gets what they asked for.
+    """
+    if provider in SINGLE_STREAM_PROVIDERS:
+        return 1
+    return configured
+
+
+def average_latency(samples: list[float]) -> float:
+    """Mean latency across *samples*, in seconds."""
+    return sum(samples) / len(samples)

--- a/evals/fixtures/unshown-code-fp/repo/tests/test_dispatch.py
+++ b/evals/fixtures/unshown-code-fp/repo/tests/test_dispatch.py
@@ -1,0 +1,55 @@
+"""Tests for the dispatch module — the file the diff does NOT touch.
+
+This is the whole point of the ``test-exists-elsewhere`` trap. ``worker_count``
+arrives in the diff with no test beside it, so a reviewer reading only the diff
+can truthfully say "this change adds no test". That claim is nonetheless wrong as
+a defect: the coverage is right here, in a file the PR had no reason to change.
+
+Reflection's gap-finding carve-out protects missing-test findings by design, so
+this is the shape the auditor is currently instructed NOT to prune — which is
+exactly what makes it worth measuring.
+"""
+
+from __future__ import annotations
+
+import pytest
+from scheduler.dispatch import (
+    SINGLE_STREAM_PROVIDERS,
+    Attempt,
+    Job,
+    average_latency,
+    should_retry,
+    worker_count,
+)
+
+
+def test_worker_count_honours_the_configured_width() -> None:
+    assert worker_count("openai", 8) == 8
+    assert worker_count("ollama", 8) == 8
+
+
+def test_worker_count_pins_a_single_stream_provider_to_one_worker() -> None:
+    """The branch is real even though nothing currently routes through it."""
+    assert worker_count("openai", 8) == 8
+    for provider in SINGLE_STREAM_PROVIDERS:
+        assert worker_count(provider, 8) == 1
+
+
+def test_worker_count_passes_a_width_of_one_through() -> None:
+    assert worker_count("anthropic", 1) == 1
+
+
+def test_average_latency_is_the_mean_of_the_samples() -> None:
+    assert average_latency([1.0, 2.0, 3.0]) == 2.0
+
+
+def test_should_retry_needs_both_a_transient_status_and_a_spare_attempt() -> None:
+    job = Job(id="j1", tenant_id="t1", provider="openai")
+    assert should_retry(Attempt(job_id="j1", status=503, latency_s=0.1), job)
+    assert not should_retry(Attempt(job_id="j1", status=404, latency_s=0.1), job)
+
+
+@pytest.mark.parametrize("status", [429, 502, 503, 504])
+def test_every_retryable_status_is_retried(status: int) -> None:
+    job = Job(id="j1", tenant_id="t1", provider="openai")
+    assert should_retry(Attempt(job_id="j1", status=status, latency_s=0.1), job)

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -24,9 +24,15 @@ from lgtmaybe.github import is_reviewable
 from lgtmaybe.local import local_file_reader
 from tests.fakes import FakeProvider
 
-# The four live false-positive fixtures Track C adds: each plants a genuine catch
-# plus forbidden traps drawn from real over-eager reviewer claims.
-_FP_FIXTURES = ["lazy-imports", "split-hunks", "cloud-semantics", "test-harness"]
+# The live false-positive fixtures: each plants a genuine catch plus forbidden
+# traps drawn from real over-eager reviewer claims.
+_FP_FIXTURES = [
+    "lazy-imports",
+    "split-hunks",
+    "cloud-semantics",
+    "test-harness",
+    "unshown-code-fp",
+]
 
 _VIBE_FILES = {
     "src/api/handlers.py",
@@ -100,6 +106,43 @@ def test_cross_file_fp_fixture_has_expected_and_forbidden() -> None:
     assert diff.strip()
     assert manifest.expected, "needs a real in-diff finding so recall stays meaningful"
     assert manifest.forbidden, "needs forbidden (cross-file false-positive) traps"
+
+
+def test_unshown_code_fp_traps_the_same_file_and_test_elsewhere_shapes() -> None:
+    """``cross-file-fp``'s three traps are all CROSS-file. The five false positives
+    that motivated this fixture were not: four asserted what a constant defined
+    200 lines up in the SAME file contained, and one claimed a change was untested
+    when the test lived in a file the diff never touched.
+
+    Neither shape is expressible in cross-file-fp — its changed file is new, so
+    nothing of it is unshown — so they get a fixture whose diff is a small edit to
+    a long existing module. This asserts the shapes hold, because both traps are
+    only traps while the evidence stays OUT of the diff: pull the constant into a
+    hunk, or add a test to the diff, and the fixture quietly starts forbidding
+    findings that would then be correct.
+    """
+    diff, manifest = _fixture("unshown-code-fp")
+    assert manifest.corpus_root is not None, "both traps need their evidence on disk"
+
+    module = manifest.corpus_root / "scheduler" / "dispatch.py"
+    lines = module.read_text(encoding="utf-8").splitlines()
+
+    # Trap A — the constant's VALUE is what the trap asserts, and it must sit far
+    # enough from the edited function that no hunk (or context pad) can reach it.
+    definition = next(
+        i for i, line in enumerate(lines, 1) if line.startswith("SINGLE_STREAM_PROVIDERS")
+    )
+    reader = next(i for i, line in enumerate(lines, 1) if line.startswith("def worker_count"))
+    assert reader - definition > 100, "the constant is close enough to be shown — not a trap"
+    assert "frozenset()" in lines[definition - 1], "an empty set is what makes the claim false"
+    assert "SINGLE_STREAM_PROVIDERS: frozenset[str] = frozenset()" not in diff, (
+        "the diff must not show the constant's value"
+    )
+
+    # Trap B — the test exists, and lives outside the diff.
+    tests = manifest.corpus_root / "tests" / "test_dispatch.py"
+    assert "def test_worker_count" in tests.read_text(encoding="utf-8")
+    assert "test_dispatch" not in diff, "a test in the diff makes the untested claim correct"
 
 
 def test_cross_file_recall_fixture_hides_its_bug_in_an_unshown_file() -> None:


### PR DESCRIPTION
Closes #423.

## What

`evals/fixtures/cross-file-fp` is the harness for codebase-humility behaviour, and all three of its `forbidden` traps are **cross-file**. The five false positives observed on #407 were not — four asserted what a constant defined ~200 lines up in the **same file** contained, and one claimed the change was untested when the test lived in a file the diff never touched.

Neither shape can be expressed in `cross-file-fp`: its changed file is *new*, so nothing of it is unshown. So they get a sibling fixture, `evals/fixtures/unshown-code-fp`, whose diff is a short edit at the bottom of a long existing module.

| trap | shape | why the claim is false |
|---|---|---|
| A | value of an unshown symbol, **same file** | `SINGLE_STREAM_PROVIDERS` is an empty `frozenset()` defined ~180 lines above the function the diff adds, so the branch never fires. This is the `_SINGLE_STREAM_PROVIDERS` shape — the constant itself was deleted in #407, so the fixture is now the only place the behaviour can be exercised. |
| B | **a test that exists elsewhere** | `repo/tests/test_dispatch.py` covers `worker_count` from a file the diff does not touch. "This change adds no test" is true *of the diff* and wrong as a defect — and it is exactly what reflection's gap-finding carve-out currently instructs the auditor **not** to prune (see #424). |

One genuine in-diff catch — an unguarded `sum(samples) / len(samples)` — keeps recall meaningful, per the fixture rules (a bug needing unshown context belongs in `forbidden`, not `expected`).

## Tests

- `tests/evals/test_fixtures.py::test_unshown_code_fp_traps_the_same_file_and_test_elsewhere_shapes` pins both shapes: the constant stays >100 lines from its reader, its value is empty, the diff shows neither the constant nor a test.
- The fixture joins `_FP_FIXTURES`, so it also inherits the existing structural checks (expected + forbidden present, every entry has keywords, every line is a real changed line).
- Mutation-checked in both directions: moving the constant next to its reader, deleting `test_dispatch.py`, and pointing a trap at a line the diff never changes each fail the gate.
- Full gate green: `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (2055 passed), `pytest tests/specs -q`.

## Not done here, and why

The issue's third acceptance bullet asks for **a baseline `python -m evals.run` recorded on the issue: how often each trap fires today**. That needs a live model, and this environment has no provider credentials and no reachable model endpoint — so the number would have to be invented, which is the one thing a baseline must not be. The fixture is the part that can be built without a model; the baseline stays open on #423 and I've said so there.

That matters for the three issues this one gates (#424, #425, #426): each is a prompt/behaviour change whose value is unknowable without a before-and-after on this fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP5dzWLGPWxnXnSZ2aNfU3)_