### PR TITLE
chore: point the Action refs at v2 after the 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai
           model: gpt-5.5
@@ -281,7 +281,7 @@ author identity. See
   ([details](docs/how-to/install-the-cli.md) — the `brew trust` step is required for third-party taps)
 - **CLI (WinGet, Windows x64)** — `winget install --id MattJColes.lgtmaybe --exact`
   ([details](docs/how-to/install-the-cli.md#install-on-windows-winget))
-- **GitHub Action** — `uses: MattJColes/lgtmaybe@v1`
+- **GitHub Action** — `uses: MattJColes/lgtmaybe@v2`
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -165,7 +165,7 @@ inputs:
   image:
     description: "Override the container image (advanced; defaults to the released GHCR image)."
     required: false
-    default: "ghcr.io/mattjcoles/lgtmaybe:v1"
+    default: "ghcr.io/mattjcoles/lgtmaybe:v2"
   github_token:
     description: "Token used to fetch the diff and post the review. Defaults to the workflow token."
     required: false

--- a/docs/how-to/generate-a-change-diagram.md
+++ b/docs/how-to/generate-a-change-diagram.md
@@ -147,7 +147,7 @@ needed — so a diagram posts automatically when a PR is opened or reopened and
 refreshes after later pushes. To opt out, set it in your workflow:
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/docs/how-to/post-as-a-github-app.md
+++ b/docs/how-to/post-as-a-github-app.md
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repository only
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           github_identity: lgtmaybe
           provider: openai
@@ -106,7 +106,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v7
-  - uses: MattJColes/lgtmaybe@v1
+  - uses: MattJColes/lgtmaybe@v2
     with:
       provider: openai
       model: gpt-5.5

--- a/docs/how-to/review-with-anthropic.md
+++ b/docs/how-to/review-with-anthropic.md
@@ -28,7 +28,7 @@ Copy [`examples/workflows/review-anthropic.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: anthropic
     model: claude-sonnet-4-6

--- a/docs/how-to/review-with-azure.md
+++ b/docs/how-to/review-with-azure.md
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: azure
           model: my-gpt-4o-deployment            # your deployment name
@@ -128,7 +128,7 @@ If you would rather use a resource key, set `AZURE_API_KEY` and `AZURE_API_BASE`
 extra is not required in this mode.
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: azure
           model: my-gpt-4o-deployment

--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: bedrock
           model: us.anthropic.claude-sonnet-4-6

--- a/docs/how-to/review-with-openai.md
+++ b/docs/how-to/review-with-openai.md
@@ -27,7 +27,7 @@ Copy [`examples/workflows/review-openai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openai
     model: gpt-5.5

--- a/docs/how-to/review-with-openrouter.md
+++ b/docs/how-to/review-with-openrouter.md
@@ -29,7 +29,7 @@ Copy [`examples/workflows/review-openrouter.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6

--- a/docs/how-to/review-with-vertex-wif.md
+++ b/docs/how-to/review-with-vertex-wif.md
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: vertex
           model: gemini-3-pro

--- a/docs/how-to/review-with-zai.md
+++ b/docs/how-to/review-with-zai.md
@@ -31,7 +31,7 @@ Copy [`examples/workflows/review-zai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: zai
     model: glm-4.6

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai
           model: gpt-5.5
@@ -169,21 +169,21 @@ Swap the `provider`, `model`, and `api_key` inputs:
 
 ```yaml
 # anthropic
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: anthropic
     model: claude-sonnet-4-6
     api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # openrouter
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
     api_key: ${{ secrets.OPENROUTER_API_KEY }}
 
 # zai (GLM / Zhipu AI)
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: zai
     model: glm-4.6
@@ -248,7 +248,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `app_private_key` | — | Advanced: private key of your own App named by `app_id` |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
-| `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
+| `image` | `ghcr.io/mattjcoles/lgtmaybe:v2` | Override the container image (advanced) |
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
@@ -262,7 +262,7 @@ otherwise. Enforcement rides the Check Run — lgtmaybe never sets PR approval
 state, so a clean review stays comment-only.
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openai
     model: gpt-4o
@@ -312,9 +312,9 @@ filters, and cost caps. See
 
 ## Pin to a specific version
 
-`@v1` is a floating tag that tracks the latest `v1.x.x` release. To pin exactly,
+`@v2` is a floating tag that tracks the latest `v2.x.x` release. To pin exactly,
 use a full version tag:
 
 ```yaml
-uses: MattJColes/lgtmaybe@v1.0.0
+uses: MattJColes/lgtmaybe@v2.0.0
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -514,7 +514,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai
           model: gpt-5.5
@@ -543,21 +543,21 @@ Swap the `provider`, `model`, and `api_key` inputs:
 
 ```yaml
 # anthropic
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: anthropic
     model: claude-sonnet-4-6
     api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # openrouter
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
     api_key: ${{ secrets.OPENROUTER_API_KEY }}
 
 # zai (GLM / Zhipu AI)
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: zai
     model: glm-4.6
@@ -622,7 +622,7 @@ pass `aws_role_arn`, `gcp_wif_provider`, or `azure_client_id`. All require
 | `app_private_key` | — | Advanced: private key of your own App named by `app_id` |
 | `app_owner` | — | Owner for a cross-repo App token (defaults to the current repo's owner) |
 | `app_repositories` | — | Repositories the App token may access, newline/comma-separated (defaults to the current repo); use with `app_owner` |
-| `image` | `ghcr.io/mattjcoles/lgtmaybe:v1` | Override the container image (advanced) |
+| `image` | `ghcr.io/mattjcoles/lgtmaybe:v2` | Override the container image (advanced) |
 
 The action sets the `GITHUB_TOKEN` and provider credentials for the container
 itself — you do not pass them as `env`.
@@ -636,7 +636,7 @@ otherwise. Enforcement rides the Check Run — lgtmaybe never sets PR approval
 state, so a clean review stays comment-only.
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openai
     model: gpt-4o
@@ -686,11 +686,11 @@ filters, and cost caps. See
 
 ## Pin to a specific version
 
-`@v1` is a floating tag that tracks the latest `v1.x.x` release. To pin exactly,
+`@v2` is a floating tag that tracks the latest `v2.x.x` release. To pin exactly,
 use a full version tag:
 
 ```yaml
-uses: MattJColes/lgtmaybe@v1.0.0
+uses: MattJColes/lgtmaybe@v2.0.0
 ```
 
 ---
@@ -739,7 +739,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repository only
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           github_identity: lgtmaybe
           provider: openai
@@ -801,7 +801,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v7
-  - uses: MattJColes/lgtmaybe@v1
+  - uses: MattJColes/lgtmaybe@v2
     with:
       provider: openai
       model: gpt-5.5
@@ -842,7 +842,7 @@ Copy [`examples/workflows/review-openai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openai
     model: gpt-5.5
@@ -917,7 +917,7 @@ Copy [`examples/workflows/review-anthropic.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: anthropic
     model: claude-sonnet-4-6
@@ -999,7 +999,7 @@ Copy [`examples/workflows/review-openrouter.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: openrouter
     model: anthropic/claude-sonnet-4-6
@@ -1140,7 +1140,7 @@ Copy [`examples/workflows/review-zai.yml`][wf] to
 `.github/workflows/lgtmaybe.yml`. The core step is:
 
 ```yaml
-- uses: MattJColes/lgtmaybe@v1
+- uses: MattJColes/lgtmaybe@v2
   with:
     provider: zai
     model: glm-4.6
@@ -1299,7 +1299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: bedrock
           model: us.anthropic.claude-sonnet-4-6
@@ -1458,7 +1458,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: vertex
           model: gemini-3-pro
@@ -1607,7 +1607,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: azure
           model: my-gpt-4o-deployment            # your deployment name
@@ -1649,7 +1649,7 @@ If you would rather use a resource key, set `AZURE_API_KEY` and `AZURE_API_BASE`
 extra is not required in this mode.
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: azure
           model: my-gpt-4o-deployment
@@ -3483,7 +3483,7 @@ needed — so a diagram posts automatically when a PR is opened or reopened and
 refreshes after later pushes. To opt out, set it in your workflow:
 
 ```yaml
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/examples/workflows/review-anthropic.yml
+++ b/examples/workflows/review-anthropic.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/examples/workflows/review-azure.yml
+++ b/examples/workflows/review-azure.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: azure
           model: my-gpt-4o-deployment      # your Azure deployment name

--- a/examples/workflows/review-bedrock.yml
+++ b/examples/workflows/review-bedrock.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: bedrock
           # Bedrock needs a Bedrock model id (Claude/Nova/Llama/…), not an

--- a/examples/workflows/review-github-app.yml
+++ b/examples/workflows/review-github-app.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repository only
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           github_identity: lgtmaybe
           provider: openai

--- a/examples/workflows/review-openai-compatible.yml
+++ b/examples/workflows/review-openai-compatible.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai-compatible
           model: deepseek-chat

--- a/examples/workflows/review-openai.yml
+++ b/examples/workflows/review-openai.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repo only — for .lgtmaybe.yml config
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai
           model: gpt-5.5

--- a/examples/workflows/review-openrouter.yml
+++ b/examples/workflows/review-openrouter.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openrouter
           model: anthropic/claude-sonnet-4-6

--- a/examples/workflows/review-self-managed-github-app.yml
+++ b/examples/workflows/review-self-managed-github-app.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7 # base repository only
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: openai
           model: gpt-5.5

--- a/examples/workflows/review-vertex.yml
+++ b/examples/workflows/review-vertex.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: vertex
           model: gemini-3-pro

--- a/examples/workflows/review-zai.yml
+++ b/examples/workflows/review-zai.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: MattJColes/lgtmaybe@v1
+      - uses: MattJColes/lgtmaybe@v2
         with:
           provider: zai
           model: glm-4.6


### PR DESCRIPTION
**main is red, and has been since the 2.0.0 release merged.** This is the fix. It is not one of the open issues — I hit it because every PR I opened inherited two failures that have nothing to do with its own diff.

## What happened

Release-please bumped `project.version` to `2.0.0` and `release.yml` cut the `v2` / `v2.0.0` tags and pushed the `:v2` image. Nothing moves the references that name the major **by hand**, so `action.yml`, the ten starter workflows, and the docs all still said v1.

Two tests exist for precisely this drift, and both fail on `main` at `e696f7c`:

```
FAILED tests/test_action_yml.py::test_default_container_image_tracks_package_major
  assert 'ghcr.io/mattjcoles/lgtmaybe:v1' == 'ghcr.io/mattjcoles/lgtmaybe:v2'
FAILED tests/test_workflow_examples.py::test_supplied_workflows_rely_on_the_auto_diagram_default
  examples/workflows/review-openai.yml has no lgtmaybe Action step
```

The second one reads oddly but is the same cause: it looks for a step whose `uses` equals `MattJColes/lgtmaybe@v{major}`, and every example still pins `@v1`.

This is also a **real user-facing bug**, not just a red gate — anyone copying a starter workflow or the README today wires up the v1 action against a v2 release.

## Changes

- `action.yml` `image` default → `ghcr.io/mattjcoles/lgtmaybe:v2`
- `examples/workflows/*.yml` (ten files) → `uses: MattJColes/lgtmaybe@v2`
- README + `docs/how-to/*` usage snippets, including the "Pin to a specific version" section — the floating tag now tracks `v2.x.x`
- regenerated `docs/llms.txt`, `docs/llms-full.txt`, `docs/reference/config.md` (freshness-gated)

Historical prose is deliberately left alone: the comments in `release.yml` and `.github/workflows/lgtmaybe.yml` describe what happened under v1, and rewriting them to v2 would make them false.

## Verification

`ruff check`, `ruff format --check`, `mypy`, `pytest -q` → **2057 passed, 3 skipped**. The two failures above are the ones that flip.

## Worth a follow-up

Nothing keeps these in step automatically, so the next major will break the same two tests the same way. `release-please-config.json` supports `extra-files` with generic version replacements, which would cover `action.yml` and the starter workflows. Out of scope here — happy to open an issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP5dzWLGPWxnXnSZ2aNfU3)_