### PR TITLE
feat(engine): retry a reasoning-bound truncation at a lower effort

### DIFF
--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -80,6 +80,16 @@ engine.reasoning-ceiling:
     has: { field: name, regex: '^_reasoning_exhausted_reason$' }
   files: [src/lgtmaybe/engine/**/*.py]
 
+engine.reasoning-step-down:
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^_retry_lower_effort$' }
+    files: [src/lgtmaybe/engine/**/*.py]
+  - rule:
+      kind: function_definition
+      has: { field: name, regex: '^lower_reasoning_effort$' }
+    files: [src/lgtmaybe/providers/**/*.py]
+
 engine.mid-review-retrieval:
   rule:
     kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -231,6 +231,19 @@ says nothing about size is not split at all.
 - **THEN** no pieces are reviewed, the salvage is kept, and the notice names both
   levers, since the counts alone cannot say which one is the fix
 
+#### Scenario: the ceiling went on the answer
+- **WHEN** a truncated call spent only a small share of the ceiling reasoning
+- **THEN** the batch is split as usual — that call really did have more to say
+  than one response could hold
+
+#### Scenario: the route reports no reasoning count
+- **WHEN** a truncation carries no reasoning breakdown at all
+- **THEN** the batch is split as usual, because silence is not evidence of thinking
+
+#### Scenario: the failure says nothing about size
+- **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)
+- **THEN** no split happens, because nothing suggests the payload was the problem
+
 ### Requirement: A reasoning-bound truncation is retried once at a lower effort
 
 A lens whose truncation was reasoning-bound SHALL be re-run once with its
@@ -239,8 +252,9 @@ call's salvage — the sibling of the split, changing the one variable that can
 move a thinking budget. Exactly one attempt: a retry that truncates the same way
 reports plain. The step is always downward, never offered on a payload-bound
 truncation, and a no-op when no effort is configured, so a review that never set
-one is byte-identical. A lens that only answered after stepping down SHALL be
-named in the summary.
+one is byte-identical. The retry SHALL re-check the whole-review deadline, token
+budget and interrupt first, so it can never spend past a stop. A lens that only
+answered after stepping down SHALL be named in the summary.
 <!-- anchor: engine.reasoning-step-down -->
 
 #### Scenario: the lower effort fits
@@ -256,18 +270,10 @@ named in the summary.
 - **WHEN** the provider reports no reasoning effort to step down from
 - **THEN** nothing is retried and nothing is spent
 
-#### Scenario: the ceiling went on the answer
-- **WHEN** a truncated call spent only a small share of the ceiling reasoning
-- **THEN** the batch is split as usual — that call really did have more to say
-  than one response could hold
-
-#### Scenario: the route reports no reasoning count
-- **WHEN** a truncation carries no reasoning breakdown at all
-- **THEN** the batch is split as usual, because silence is not evidence of thinking
-
-#### Scenario: the failure says nothing about size
-- **WHEN** a lens call fails for any other reason (quota, bad key, unparseable)
-- **THEN** no split happens, because nothing suggests the payload was the problem
+#### Scenario: a ceiling was reached while the first call was finishing
+- **WHEN** the deadline, the token budget or a termination signal lands before
+  the step-down begins
+- **THEN** the retry is not issued and the truncation is reported as it stands
 
 ### Requirement: A lens may defer once for bounded read-only context
 

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -231,6 +231,31 @@ says nothing about size is not split at all.
 - **THEN** no pieces are reviewed, the salvage is kept, and the notice names both
   levers, since the counts alone cannot say which one is the fix
 
+### Requirement: A reasoning-bound truncation is retried once at a lower effort
+
+A lens whose truncation was reasoning-bound SHALL be re-run once with its
+`reasoning_effort` stepped down one level, merging its findings with the cut
+call's salvage — the sibling of the split, changing the one variable that can
+move a thinking budget. Exactly one attempt: a retry that truncates the same way
+reports plain. The step is always downward, never offered on a payload-bound
+truncation, and a no-op when no effort is configured, so a review that never set
+one is byte-identical. A lens that only answered after stepping down SHALL be
+named in the summary.
+<!-- anchor: engine.reasoning-step-down -->
+
+#### Scenario: the lower effort fits
+- **WHEN** a reasoning-bound truncation is re-run one level down and answers
+- **THEN** its findings join the review and the summary names the lens that
+  needed the lower setting
+
+#### Scenario: the lower effort truncates too
+- **WHEN** the step-down retry is itself reasoning-bound
+- **THEN** it reports and stops — one attempt, never a walk down the ladder
+
+#### Scenario: no effort was configured
+- **WHEN** the provider reports no reasoning effort to step down from
+- **THEN** nothing is retried and nothing is spent
+
 #### Scenario: the ceiling went on the answer
 - **WHEN** a truncated call spent only a small share of the ceiling reasoning
 - **THEN** the batch is split as usual — that call really did have more to say

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.logging import get_logger
@@ -227,6 +228,7 @@ class _NoticeState:
     failed_calls: int
     failed_lenses: list[str]
     split_batches: int
+    stepped_down: list[str]
     reflection_skipped: str | None
     suppressed: int
     off_diff: int
@@ -282,6 +284,16 @@ def _build_notices(state: _NoticeState) -> list[str]:
             "(timed out, or ran past the `max_tokens` ceiling) and "
             f"{was} reviewed in smaller pieces instead. Consider a lower "
             "`max_input_tokens`, a higher `max_tokens`, or a faster model."
+        )
+    if state.stepped_down:
+        count = len(state.stepped_down)
+        listed = ", ".join(f"`{lens}`" for lens in state.stepped_down)
+        notices.append(
+            f"🧠 {count} lens{_plural(count, many='es')} spent its whole `max_tokens` "
+            f"ceiling on reasoning and was re-run once at a lower `reasoning_effort` "
+            f"({listed}). Those findings come from the lower setting — lower "
+            "`reasoning_effort` yourself, or raise `max_tokens`, to make that the "
+            "first attempt rather than the second."
         )
     if state.reflection_skipped:
         notices.append(
@@ -698,6 +710,11 @@ class LLMReviewEngine:
         # Per-review state (reset here, not in __init__, so a reused engine starts
         # clean); a set's add is atomic, which is all the fan-out threads need.
         self._split_batches: set[int] = set()
+        # Lenses that only answered after their reasoning effort was stepped down
+        # (see _retry_lower_effort). Keyed by lens so the notice counts lenses,
+        # not calls — the same lens stepping down in two batches is one fact
+        # about the review, not two.
+        self._stepped_down: set[str] = set()
 
         # 1. Redact secrets from the diff before it leaves this process.
         with profiler.stage("redact"):
@@ -1135,6 +1152,7 @@ class LLMReviewEngine:
                 failed_calls=failed_calls,
                 failed_lenses=failed_lenses,
                 split_batches=len(self._split_batches),
+                stepped_down=sorted(self._stepped_down),
                 reflection_skipped=reflection_skipped,
                 suppressed=suppressed,
                 off_diff=off_diff,
@@ -1542,6 +1560,61 @@ class LLMReviewEngine:
             return findings, _RetryableReason(last)
         return findings, str(last)
 
+    def _retry_lower_effort(
+        self,
+        messages: list[Message],
+        model: str,
+        response_format: type[ReviewResult] | None,
+        batch_num: int,
+        lens: _Lens,
+        reason: str,
+    ) -> _LensOutcome:
+        """Re-run one lens once with its reasoning effort stepped down a level.
+
+        The missing sibling of :meth:`_review_split`. Both start from the same
+        failure — the answer hit the output ceiling — and the diagnosis decides
+        which remedy applies: a payload-bound truncation shrinks the payload, a
+        reasoning-bound one cannot (halving the diff does not halve the thinking),
+        so it changes the only variable that does move a thinking budget.
+
+        Without this, the reasoning branch diagnosed correctly and then stopped,
+        losing the lens for that round — a real dogfood review reviewed its tests
+        and documentation with nothing at all, and the message it left named a
+        knob for the reader to turn by hand next time.
+
+        Bounded exactly like the split:
+
+        - **One attempt.** The retry runs with ``effort`` set, and that is the
+          same flag :meth:`_complete_lens` checks before offering a step-down —
+          so a retry that truncates the same way reports plain.
+        - **Down, never up**, one level, and only where
+          :func:`_reasoning_exhausted_reason` already fired.
+        - **No split, no deferral** on the retry (both callbacks are None): the
+          payload was never the problem.
+        - **Nothing when the effort is unset.** The adapter answers None for the
+          library default, so a user who never configured it pays nothing and
+          sends byte-identical requests.
+
+        Returns the retry's ``(findings, error)``. The cut call's salvage is
+        merged by the caller, exactly as the split's is.
+        """
+        # Adapter-only, like `post_issue_comment` on the GitHub side: the effort
+        # lives in provider-shaped opts (a flat `reasoning_effort`, or
+        # OpenRouter's nested `reasoning` object), and the engine has no business
+        # knowing which. A provider without it simply never steps down.
+        lower = getattr(self._provider, "lower_reasoning_effort", None)
+        step_down = lower() if callable(lower) else None
+        if not step_down:
+            return [], reason
+        _log.warning(
+            "retrying the lens once at a lower reasoning effort",
+            extra={"lens": lens.id, "batch": batch_num, "effort": step_down},
+        )
+        self._stepped_down.add(lens.id)
+        return self._complete_lens(
+            messages, model, response_format, batch_num, lens, None, None, effort=step_down
+        )
+
     def _complete_lens(
         self,
         messages: list[Message],
@@ -1551,6 +1624,8 @@ class LLMReviewEngine:
         lens: _Lens,
         on_oversized: Callable[[str], _LensOutcome] | None = None,
         on_needs: Callable[[list[str], list[ReviewFinding]], _LensOutcome] | None = None,
+        *,
+        effort: dict[str, Any] | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
         """The provider call + parse + stamp shared by both prompt shapes.
 
@@ -1567,8 +1642,15 @@ class LLMReviewEngine:
         returns the outcome to use instead. None (a re-run, or the feature off)
         means a ``needs`` in the response is simply ignored — nothing is parsed
         for it, so a review without the feature costs exactly what it did before.
+
+        ``effort`` carries the per-call reasoning override of a step-down retry
+        (see :meth:`_retry_lower_effort`). Not None also MARKS this call as that
+        retry, which is what bounds it to one: the step-down is only ever offered
+        to a call that has not already taken it.
         """
-        opts = {"response_format": response_format} if response_format is not None else {}
+        opts: dict[str, Any] = {"response_format": response_format} if response_format else {}
+        if effort is not None:
+            opts.update(effort)
         # Heartbeat: log the call going out and coming back so the Action shows
         # steady per-lens progress while the model runs, not a silent gap.
         _log.info("reviewing lens", extra={"lens": lens.id})
@@ -1616,7 +1698,16 @@ class LLMReviewEngine:
                         "truncation was reasoning-bound — not splitting",
                         extra={"lens": lens.id, "batch": batch_num},
                     )
-                    return completed, exhausted
+                    if effort is not None:
+                        # This IS the step-down retry, and it went the same way.
+                        # One attempt, not a cascade: the lower level did not fit
+                        # either, and grinding down the ladder spends the whole
+                        # review proving it.
+                        return completed, exhausted
+                    retried, retry_reason = self._retry_lower_effort(
+                        messages, model, response_format, batch_num, lens, exhausted
+                    )
+                    return completed + retried, retry_reason
                 if on_oversized is None:
                     # Already a piece: nothing smaller to try. Report the reason
                     # rather than recurse — an unbounded cascade would spend the

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1610,10 +1610,16 @@ class LLMReviewEngine:
             "retrying the lens once at a lower reasoning effort",
             extra={"lens": lens.id, "batch": batch_num, "effort": step_down},
         )
-        self._stepped_down.add(lens.id)
-        return self._complete_lens(
+        findings, error = self._complete_lens(
             messages, model, response_format, batch_num, lens, None, None, effort=step_down
         )
+        if error is None:
+            # Recorded on the way OUT, not the way in: the notice claims findings
+            # came from the lower setting, and a retry that truncated again
+            # produced no such findings. That run reports the failure it already
+            # had — claiming a recovery on top of it would be two wrong notices.
+            self._stepped_down.add(lens.id)
+        return findings, error
 
     def _complete_lens(
         self,

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1340,7 +1340,14 @@ class LLMReviewEngine:
             run, wrapped, intent_block, hint_block, dir_block, lens, spec_block=spec_block
         )
         return self._complete_lens(
-            messages, run.model, run.response_format, batch_num, lens, on_oversized, on_needs
+            messages,
+            run.model,
+            run.response_format,
+            batch_num,
+            lens,
+            on_oversized,
+            on_needs,
+            run=run,
         )
 
     def _review_with_context(
@@ -1420,7 +1427,7 @@ class LLMReviewEngine:
             context=wrap_context(fetched),
         )
         retry, error = self._complete_lens(
-            messages, run.model, run.response_format, batch_num, lens, None, None
+            messages, run.model, run.response_format, batch_num, lens, None, None, run=run
         )
         return findings + retry, error
 
@@ -1568,6 +1575,7 @@ class LLMReviewEngine:
         batch_num: int,
         lens: _Lens,
         reason: str,
+        run: _Run | None = None,
     ) -> _LensOutcome:
         """Re-run one lens once with its reasoning effort stepped down a level.
 
@@ -1594,6 +1602,12 @@ class LLMReviewEngine:
         - **Nothing when the effort is unset.** The adapter answers None for the
           library default, so a user who never configured it pays nothing and
           sends byte-identical requests.
+        - **Every whole-review ceiling still applies.** ``_skip_reason`` is
+          re-checked before the call, exactly as ``_review_split``'s pieces do by
+          re-entering ``_review_lens`` — this path reaches ``_complete_lens``
+          directly, so it has to make that check itself. A retry that would begin
+          past the deadline, the token budget or a termination signal reports the
+          truncation it already had instead of spending past a stop.
 
         Returns the retry's ``(findings, error)``. The cut call's salvage is
         merged by the caller, exactly as the split's is.
@@ -1602,6 +1616,10 @@ class LLMReviewEngine:
         # lives in provider-shaped opts (a flat `reasoning_effort`, or
         # OpenRouter's nested `reasoning` object), and the engine has no business
         # knowing which. A provider without it simply never steps down.
+        if run is not None and _skip_reason(run.deadline_at, run.budget_at, lens) is not None:
+            # Past a ceiling: the run is already stopping, and the notice it will
+            # carry is the truncation's, not a skip's — this call never happened.
+            return [], reason
         lower = getattr(self._provider, "lower_reasoning_effort", None)
         step_down = lower() if callable(lower) else None
         if not step_down:
@@ -1611,7 +1629,7 @@ class LLMReviewEngine:
             extra={"lens": lens.id, "batch": batch_num, "effort": step_down},
         )
         findings, error = self._complete_lens(
-            messages, model, response_format, batch_num, lens, None, None, effort=step_down
+            messages, model, response_format, batch_num, lens, None, None, effort=step_down, run=run
         )
         if error is None:
             # Recorded on the way OUT, not the way in: the notice claims findings
@@ -1632,6 +1650,7 @@ class LLMReviewEngine:
         on_needs: Callable[[list[str], list[ReviewFinding]], _LensOutcome] | None = None,
         *,
         effort: dict[str, Any] | None = None,
+        run: _Run | None = None,
     ) -> tuple[list[ReviewFinding], str | None]:
         """The provider call + parse + stamp shared by both prompt shapes.
 
@@ -1711,7 +1730,7 @@ class LLMReviewEngine:
                         # review proving it.
                         return completed, exhausted
                     retried, retry_reason = self._retry_lower_effort(
-                        messages, model, response_format, batch_num, lens, exhausted
+                        messages, model, response_format, batch_num, lens, exhausted, run
                     )
                     return completed + retried, retry_reason
                 if on_oversized is None:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -440,6 +440,44 @@ class LiteLLMProvider:
         # patch the litellm lookup stay isolated.
         self._cache_capable: dict[str, bool] = {}
 
+    def lower_reasoning_effort(self) -> dict[str, Any] | None:
+        """Per-call opts that step this provider's reasoning effort down one level.
+
+        ``None`` when there is nothing to step: no effort configured (the library
+        default — a user who never set it must send byte-identical requests), a
+        value already at the floor, or ``default``, which names no position on the
+        ladder and so cannot be moved down from.
+
+        Adapter-only, beyond the frozen ``ProviderClient`` port, and deliberately
+        so: the effort lives in one of two provider-shaped places — a flat
+        ``reasoning_effort``, or the nested ``reasoning`` object the factory
+        re-routes it into for OpenRouter (see ``_honour_param_support``, where
+        sending both is a 400). The engine asks for "one level less" and gets back
+        opts in whichever shape this provider was built with; it never learns
+        which, and a provider that cannot answer simply never steps down.
+
+        Read off ``default_opts`` because that is where the configured value was
+        resolved, and returned as an override rather than mutated in place: this
+        is one retry's request, not a new setting for the rest of the run.
+        """
+        flat = self.default_opts.get("reasoning_effort")
+        if isinstance(flat, str):
+            lower = _one_level_lower(flat)
+            return {"reasoning_effort": lower} if lower else None
+        extra = self.default_opts.get("extra_body")
+        if not isinstance(extra, dict):
+            return None
+        nested = extra.get("reasoning")
+        if isinstance(nested, dict) and isinstance(nested.get("effort"), str):
+            lower = _one_level_lower(nested["effort"])
+            if not lower:
+                return None
+            # The whole extra_body is replaced, not deep-merged: `complete` merges
+            # per-call opts over the defaults a key at a time, so a partial
+            # extra_body here would drop every other key it carries.
+            return {"extra_body": {**extra, "reasoning": {**nested, "effort": lower}}}
+        return None
+
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
         merged.setdefault("timeout", CLOUD_TIMEOUT)
@@ -733,6 +771,21 @@ class LiteLLMProvider:
             # thinking they did by two different readings of the same field.
             reasoning_tokens=_reasoning_tokens(usage),
         )
+
+
+# The reasoning ladder, lowest first. litellm's normalised set minus `default`,
+# which is a "let the route decide" sentinel rather than a rung — there is no
+# telling what it is one level below.
+_EFFORT_LADDER = ("none", "minimal", "low", "medium", "high", "xhigh")
+
+
+def _one_level_lower(effort: str) -> str | None:
+    """The rung below *effort*, or None at (or off) the bottom of the ladder."""
+    try:
+        index = _EFFORT_LADDER.index(effort)
+    except ValueError:
+        return None
+    return _EFFORT_LADDER[index - 1] if index else None
 
 
 def _configured_ceiling(kwargs: dict[str, Any]) -> int | None:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -50,6 +50,7 @@ def test_notice_builder_preserves_notice_order() -> None:
             failed_calls=0,
             failed_lenses=[],
             split_batches=0,
+            stepped_down=[],
             reflection_skipped=None,
             suppressed=1,
             off_diff=1,

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -501,6 +501,47 @@ def test_a_second_reasoning_bound_truncation_reports_and_stops() -> None:
     assert "reasoning_effort" in str(exc_info.value)
 
 
+def test_a_failed_step_down_is_not_reported_as_a_recovery() -> None:
+    """The notice says findings came from the lower setting. A retry that
+    truncated again produced none, so claiming it would be a second wrong notice
+    stacked on the failure the run already reports."""
+
+    class _TruncatesEverywhereButAnswersOneFile(_TruncatesUntilEffortDrops):
+        """two.py answers at any effort; one.py truncates at every effort.
+
+        Both lenses have to be in one run, or the review raises before a summary
+        is ever built.
+        """
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            diff = "\n".join(str(m.get("content", "")) for m in messages)
+            if "second_change" in diff and "first_change" not in diff:
+                return ProviderResult(
+                    text=_finding_json("two.py", "second_change = sys.maxsize"),
+                    input_tokens=5,
+                    output_tokens=5,
+                )
+            self.efforts.append(opts.get("reasoning_effort", self._effort))
+            raise ProviderTruncated(
+                _CEILING,
+                text="",
+                reasoning_tokens=_REASONING_SPENT,
+                output_tokens=_REASONING_CEILING,
+            )
+
+    provider = _TruncatesEverywhereButAnswersOneFile()
+    ctx = _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"])
+
+    _findings, summary = LLMReviewEngine(provider).review(
+        ctx,
+        _cfg(max_input_tokens=60),  # one batch per file, so one lens survives
+    )
+
+    assert provider.efforts == ["medium", "low"]  # it did step down, and failed
+    assert "re-run once at a lower" not in summary
+    assert "results may be incomplete" in summary
+
+
 def test_no_retry_when_reasoning_effort_is_unset() -> None:
     """Byte-identical behaviour for the users who never configured it: there is
     no lower level to step to, so nothing is retried and nothing is spent."""

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -21,6 +21,7 @@ Two wrinkles the timeout does not have:
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 import pytest
@@ -33,7 +34,7 @@ from lgtmaybe.core.models import (
     ReviewConfig,
 )
 from lgtmaybe.core.ports import Message, ProviderTruncated
-from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine import LLMReviewEngine, clear_interrupt, request_interrupt
 from lgtmaybe.engine.engine import ReviewIncompleteError
 from tests.fakes import FakeProvider
 
@@ -622,3 +623,45 @@ def test_the_step_down_does_not_spend_past_a_whole_review_ceiling() -> None:
         )
 
     assert provider.efforts == ["medium"]  # no step-down attempted
+
+
+def test_the_step_down_does_not_outlive_the_review_deadline() -> None:
+    """The budget is one of three stops `_skip_reason` enforces. This is the
+    second: a deadline already passed when the truncation lands must not buy a
+    second billed call."""
+
+    class _SlowTruncation(_TruncatesUntilEffortDrops):
+        """Overruns the 1s ceiling before it truncates, exactly as a real
+        reasoning runaway does — it is the slowest call in the run by far."""
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            time.sleep(1.2)
+            return super().complete(messages, model, **opts)
+
+    provider = _SlowTruncation(answers_at=_TruncatesUntilEffortDrops._NEVER)
+
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(
+            _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg(max_review_seconds=1)
+        )
+
+    assert provider.efforts == ["medium"]
+
+
+def test_the_step_down_respects_a_termination_signal() -> None:
+    """And the third: a cancelled or timed-out CI job. An interrupted run posts
+    what it has — it does not spend one more call on the way out."""
+
+    class _TruncatesThenAsksToStop(_TruncatesUntilEffortDrops):
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            request_interrupt()
+            return super().complete(messages, model, **opts)
+
+    provider = _TruncatesThenAsksToStop(answers_at=_TruncatesUntilEffortDrops._NEVER)
+    try:
+        with pytest.raises(ReviewIncompleteError):
+            LLMReviewEngine(provider).review(_ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg())
+    finally:
+        clear_interrupt()
+
+    assert provider.efforts == ["medium"]

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -602,3 +602,23 @@ def test_a_payload_bound_truncation_splits_and_does_not_step_down() -> None:
 
     assert sorted(f.path for f in findings) == ["one.py", "two.py"]  # the split still ran
     assert _SplitsAndCountsStepDowns.asked == 0
+
+
+def test_the_step_down_does_not_spend_past_a_whole_review_ceiling() -> None:
+    """This path reaches `_complete_lens` directly, so it does not get the
+    re-check the split's pieces inherit by re-entering `_review_lens`.
+
+    A retry that begins past the deadline, the token budget, or a termination
+    signal would spend after the review was told to stop — which is the guarantee
+    the partial-results notice rests on."""
+    provider = _TruncatesUntilEffortDrops(answers_at=_TruncatesUntilEffortDrops._NEVER)
+
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(
+            _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]),
+            # A budget of one token: the first call blows it, so the retry must
+            # not run — the truncation is reported, nothing more is spent.
+            _cfg(max_review_tokens=1),
+        )
+
+    assert provider.efforts == ["medium"]  # no step-down attempted

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -423,3 +423,141 @@ def test_a_piece_that_fails_is_still_reported() -> None:
     assert [f.path for f in findings] == ["one.py"]  # the half that answered
     assert "results may be incomplete" in summary
     assert "insufficient_quota" in summary  # naming the piece's real failure
+
+
+# ---------------------------------------------------------------------------
+# The reasoning-bound sibling of the split: one step down, then stop.
+# ---------------------------------------------------------------------------
+
+
+class _TruncatesUntilEffortDrops(FakeProvider):
+    """Spends the whole ceiling thinking until asked to think less.
+
+    The provider's own shape: it holds the configured effort and hands back the
+    per-call opts that step it down, exactly as the litellm adapter does — the
+    engine never knows whether that is a flat `reasoning_effort` or OpenRouter's
+    nested `reasoning` object.
+    """
+
+    _NEVER = object()  # distinct from every effort value, including None
+
+    def __init__(self, effort: str | None = "medium", answers_at: Any = "low") -> None:
+        super().__init__()
+        self.efforts: list[str | None] = []
+        self._effort = effort
+        self._answers_at = answers_at
+
+    def lower_reasoning_effort(self) -> dict[str, Any] | None:
+        if self._effort in (None, "none"):
+            return None
+        ladder = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        return {"reasoning_effort": ladder[ladder.index(self._effort) - 1]}
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        effort = opts.get("reasoning_effort", self._effort)
+        self.efforts.append(effort)
+        if effort == self._answers_at:
+            return ProviderResult(
+                text=_finding_json("one.py", "first_change = os.getcwd()"),
+                input_tokens=10,
+                output_tokens=10,
+            )
+        raise ProviderTruncated(
+            _CEILING,
+            text="",
+            reasoning_tokens=_REASONING_SPENT,
+            output_tokens=_REASONING_CEILING,
+        )
+
+
+def test_a_reasoning_bound_truncation_retries_once_at_a_lower_effort() -> None:
+    """The missing sibling of the split.
+
+    A payload-bound truncation shrinks the payload and re-reviews. A
+    reasoning-bound one was diagnosed correctly and then abandoned, losing the
+    lens for that round. It changes the one variable that can help instead.
+    """
+    provider = _TruncatesUntilEffortDrops()
+
+    findings, summary = LLMReviewEngine(provider).review(
+        _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg()
+    )
+
+    assert provider.efforts == ["medium", "low"]  # one step down, never up
+    assert [f.title for f in findings] == ["unchecked value in one.py"]
+    # Not silent: a lens that answered only after being told to think less is a
+    # fact about this review, and the summary says so.
+    assert "reasoning_effort" in summary
+
+
+def test_a_second_reasoning_bound_truncation_reports_and_stops() -> None:
+    """One attempt, not a cascade — the same posture as the split's one level."""
+    provider = _TruncatesUntilEffortDrops(answers_at=_TruncatesUntilEffortDrops._NEVER)
+
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(_ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg())
+
+    assert provider.efforts == ["medium", "low"]  # and no third
+    assert "reasoning_effort" in str(exc_info.value)
+
+
+def test_no_retry_when_reasoning_effort_is_unset() -> None:
+    """Byte-identical behaviour for the users who never configured it: there is
+    no lower level to step to, so nothing is retried and nothing is spent."""
+    provider = _TruncatesUntilEffortDrops(effort=None, answers_at=_TruncatesUntilEffortDrops._NEVER)
+
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg())
+
+    assert provider.efforts == [None]  # one call, no step-down
+
+
+def test_the_step_down_keeps_what_the_cut_call_completed() -> None:
+    """Salvage still applies: the findings finished before the cut are real work,
+    and they merge with the retry's rather than being replaced by them."""
+
+    class _SalvagesThenAnswers(_TruncatesUntilEffortDrops):
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            if opts.get("reasoning_effort", self._effort) == "low":
+                return ProviderResult(
+                    text=_finding_json("two.py", "second_change = sys.maxsize", "found at low"),
+                    input_tokens=10,
+                    output_tokens=10,
+                )
+            self.efforts.append("medium")
+            raise ProviderTruncated(
+                _CEILING,
+                text=_cut_off_json("one.py", "first_change = os.getcwd()", "found before the cut"),
+                reasoning_tokens=_REASONING_SPENT,
+                output_tokens=_REASONING_CEILING,
+            )
+
+    provider = _SalvagesThenAnswers()
+
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert {f.title for f in findings} == {"found before the cut", "found at low"}
+
+
+def test_a_payload_bound_truncation_splits_and_does_not_step_down() -> None:
+    """The two remedies stay disjoint. A payload-bound truncation says nothing
+    about the thinking budget, so lowering the effort there would pay for a fix
+    in review quality that the split provides for free."""
+
+    class _SplitsAndCountsStepDowns(_TruncatesUntilSmaller):
+        asked = 0
+
+        def lower_reasoning_effort(self) -> dict[str, Any] | None:
+            type(self).asked += 1
+            return {"reasoning_effort": "low"}
+
+    provider = _SplitsAndCountsStepDowns()
+
+    findings, _summary = LLMReviewEngine(provider).review(
+        _ctx(_TWO_FILE_DIFF, ["one.py", "two.py"]), _cfg()
+    )
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]  # the split still ran
+    assert _SplitsAndCountsStepDowns.asked == 0

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1568,3 +1568,62 @@ class TestTruncationAdviceMatchesTheMeasurement:
 
     def test_it_names_the_model_as_the_lever_that_actually_moves_this(self) -> None:
         assert "model" in self._message()
+
+
+class TestSteppingReasoningEffortDown:
+    """The lever the engine pulls when a truncation went on THOUGHT.
+
+    Splitting the payload cannot shrink a thinking budget, so the engine retries
+    the lens once at a lower effort instead — and the effort lives in one of two
+    provider-shaped places, which is why the adapter answers this rather than the
+    engine deriving it.
+    """
+
+    def test_a_flat_effort_steps_down_one_level(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5", reasoning_effort="medium")
+
+        assert provider.lower_reasoning_effort() == {"reasoning_effort": "low"}
+
+    def test_the_bottom_of_the_ladder_has_nowhere_to_go(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5", reasoning_effort="none")
+
+        assert provider.lower_reasoning_effort() is None
+
+    def test_an_unset_effort_steps_nowhere(self) -> None:
+        """The library default. A user who never configured this must send
+        byte-identical requests, so there is nothing to retry with."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        assert provider.lower_reasoning_effort() is None
+
+    def test_default_is_a_sentinel_not_a_rung(self) -> None:
+        """`default` says "let the route decide" — there is no telling what sits
+        one level below it, so it is left alone rather than guessed at."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5", reasoning_effort="default")
+
+        assert provider.lower_reasoning_effort() is None
+
+    def test_openrouters_nested_reasoning_object_steps_down_in_place(self) -> None:
+        """The factory re-routes `reasoning_effort` into a top-level `reasoning`
+        object for OpenRouter (sending both is a 400), so the step-down has to
+        find it there — and must not lose the rest of extra_body doing it."""
+        provider = LiteLLMProvider(
+            model="openrouter/openai/gpt-5.6-luna",
+            extra_body={"reasoning": {"effort": "high"}, "provider": {"sort": "latency"}},
+        )
+
+        assert provider.lower_reasoning_effort() == {
+            "extra_body": {
+                "reasoning": {"effort": "medium"},
+                "provider": {"sort": "latency"},
+            }
+        }
+
+    def test_the_step_down_is_an_override_not_a_mutation(self) -> None:
+        """One retry's request, not a new setting for the rest of the run: the
+        next lens must still go out at the effort the user configured."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5", reasoning_effort="high")
+
+        provider.lower_reasoning_effort()
+
+        assert provider.default_opts["reasoning_effort"] == "high"


### PR DESCRIPTION
Closes #420.

The engine tells the two truncation modes apart correctly and recovers from one:

| mode | diagnosis | recovery — before | after |
|---|---|---|---|
| payload-bound | `on_oversized` → `_review_split` | splits and re-reviews | unchanged |
| reasoning-bound | `_reasoning_exhausted_reason` | **none — reports and stops** | `_retry_lower_effort` |

The reasoning branch was right to refuse the split (*"a smaller payload cannot shrink a thinking budget"*) and right about the lever, and then gave up where its sibling recovers. On #415's own review that cost the whole `artefacts` lens — tests and documentation reviewed by nothing that run, after a call spent 8,192 of the 8,192-token ceiling on reasoning alone.

## The retry

One bounded attempt at the next lower effort, bounded on every axis the split is:

- **One attempt, not a cascade.** The retry runs with `effort` set, and that is the *same flag* `_complete_lens` checks before offering a step-down — so the bound is structural, not a counter that can drift.
- **Down one level, never up**, and only where `_reasoning_exhausted_reason` already fires. A payload-bound truncation never asks.
- **No split, no deferral on the retry** — the payload was never the problem.
- **Salvage still applies**: what the cut call completed merges with the retry's findings.
- **No-op when `reasoning_effort` is unset**, so a user who never configured it sends byte-identical requests.

## Why the step lives in the adapter

`LiteLLMProvider.lower_reasoning_effort()` is adapter-only, beyond the frozen `ProviderClient` port — the same precedent as `post_issue_comment` on the GitHub side. The effort sits in one of two provider-shaped places: the flat `reasoning_effort`, or the nested `reasoning` object the factory re-routes it into for OpenRouter, where sending both is `400 Only one of "reasoning" and "reasoning_effort" may be provided`. The engine asks for "one level less", gets opts back in whichever shape this provider was built with, and never learns which. A provider without the method simply never steps down (`getattr` + `callable`), so fakes and future adapters need no change.

`default` is deliberately not a rung: it names no position on the ladder, so there is nothing below it to step to.

## Not silent

A lens that only answered after being told to think less is a fact about the review, so the summary says so and points at making that the first attempt rather than the second — rather than quietly serving lower-effort findings as if they were the configured ones.

## Tests

Written first and watched fail. Engine level (`tests/engine/test_truncation_split.py`): the retry happens and its findings land; a second reasoning-bound truncation reports and stops (`["medium", "low"]` and no third); an unset effort retries nothing; the cut call's salvage survives and merges; and a payload-bound truncation still splits **and never asks for a step-down**. Adapter level (`tests/providers/test_retry.py`): both shapes step down, the ladder floor and `default` step nowhere, OpenRouter's nested object keeps the rest of `extra_body`, and the step-down is an override rather than a mutation of the run's settings.

Full gate green: `ruff`, `mypy`, `pytest -q` (2070 passed), `pytest tests/specs -q`, `openspec validate --specs`.

Specs: new requirement `engine.reasoning-step-down` in `openspec/specs/review-pipeline/spec.md` with three scenarios, anchored to both halves.

## Related

#421 is the observability that would price this — how often the step-down actually fires. #422 is the structural fix that would make it unnecessary, if the route supports separating the two budgets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP5dzWLGPWxnXnSZ2aNfU3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviews now retry once with reduced reasoning effort when reasoning limits cause truncation.
  * Partial findings are preserved and combined with results from the retry.
  * Review notices identify items rescued through the fallback.

* **Bug Fixes**
  * Payload-related truncations continue using the existing splitting behavior.
  * Reviews avoid retrying when reasoning settings are unavailable or already minimal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->