### PR TITLE
feat(profiling): report the reasoning share of every call, not just failed ones

### DIFF
--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -243,6 +243,22 @@ total), which is the comparison a truncated call cannot give you: a call that
 hit the ceiling spent reasoning + findings ≥ `max_tokens` by definition, so it
 tells you nothing about the healthy calls sitting beside it.
 
+Two more numbers answer the headroom question directly, so you do not have to
+work the ratio out per row:
+
+- the **`think_%`** column — that call's thinking as a share of the `max_tokens`
+  ceiling it came out of;
+- a **`largest reasoning share:`** line under the table, naming the single
+  closest call to the ceiling and which lens it was.
+
+An 8,192-token cap whose worst lens reports 50% has real headroom. One reporting
+95% is a truncation that has not happened yet — and the aggregate `reasoning:`
+line will not show you that, because one runaway hides inside an average.
+
+A route that reports no breakdown renders as `-` in both columns and prints no
+`largest` line. That is not zero: it means the route never said, and there is
+nothing to conclude either way.
+
 ### When the cap is not the lever
 
 If `think_tok` is most of `out_tok`, raising `max_tokens` will not fix the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3903,6 +3903,22 @@ total), which is the comparison a truncated call cannot give you: a call that
 hit the ceiling spent reasoning + findings ≥ `max_tokens` by definition, so it
 tells you nothing about the healthy calls sitting beside it.
 
+Two more numbers answer the headroom question directly, so you do not have to
+work the ratio out per row:
+
+- the **`think_%`** column — that call's thinking as a share of the `max_tokens`
+  ceiling it came out of;
+- a **`largest reasoning share:`** line under the table, naming the single
+  closest call to the ceiling and which lens it was.
+
+An 8,192-token cap whose worst lens reports 50% has real headroom. One reporting
+95% is a truncation that has not happened yet — and the aggregate `reasoning:`
+line will not show you that, because one runaway hides inside an average.
+
+A route that reports no breakdown renders as `-` in both columns and prints no
+`largest` line. That is not zero: it means the route never said, and there is
+nothing to conclude either way.
+
 ### When the cap is not the lever
 
 If `think_tok` is most of `out_tok`, raising `max_tokens` will not fix the
@@ -4305,8 +4321,9 @@ The normalised return value of one LLM completion, including token usage.
 | `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
+| `output_ceiling` | integer / null | No | `null` | Output Ceiling |
 | `output_tokens` | integer | Yes | — | Output Tokens |
-| `reasoning_tokens` | integer | No | `0` | Reasoning Tokens |
+| `reasoning_tokens` | integer / null | No | `null` | Reasoning Tokens |
 | `text` | string | Yes | — | Text |
 
 ## PRContext
@@ -5331,14 +5348,33 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "Input Tokens",
       "type": "integer"
     },
+    "output_ceiling": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Output Ceiling"
+    },
     "output_tokens": {
       "title": "Output Tokens",
       "type": "integer"
     },
     "reasoning_tokens": {
-      "default": 0,
-      "title": "Reasoning Tokens",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Reasoning Tokens"
     },
     "text": {
       "title": "Text",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -119,8 +119,9 @@ The normalised return value of one LLM completion, including token usage.
 | `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
 | `input_tokens` | integer | Yes | — | Input Tokens |
+| `output_ceiling` | integer / null | No | `null` | Output Ceiling |
 | `output_tokens` | integer | Yes | — | Output Tokens |
-| `reasoning_tokens` | integer | No | `0` | Reasoning Tokens |
+| `reasoning_tokens` | integer / null | No | `null` | Reasoning Tokens |
 | `text` | string | Yes | — | Text |
 
 ## PRContext
@@ -1145,14 +1146,33 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "title": "Input Tokens",
       "type": "integer"
     },
+    "output_ceiling": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Output Ceiling"
+    },
     "output_tokens": {
       "title": "Output Tokens",
       "type": "integer"
     },
     "reasoning_tokens": {
-      "default": 0,
-      "title": "Reasoning Tokens",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Reasoning Tokens"
     },
     "text": {
       "title": "Text",

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -12,6 +12,12 @@ provider.credentials:
     has: { field: name, regex: '^resolve_credentials$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.reasoning-accounting:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_reasoning_tokens$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.complete:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -97,6 +97,24 @@ cause, since a ceiling-hitting call offers no healthy call to compare against.
 - **WHEN** retries on the primary model are exhausted and a fallback is set
 - **THEN** the call completes on the fallback model instead of failing the review
 
+### Requirement: The reasoning spend is reported against what it was drawn from
+
+A response's reasoning-token count SHALL be reported as **unknown** when the
+route gives no breakdown — never as zero, which asserts the model did no
+thinking. The `max_tokens` ceiling the request actually carried SHALL ride the
+result alongside it, so the spend can be read as a SHARE of its own budget: the
+two settings are coupled (one ceiling pays for thought and answer alike), and
+neither raw count says whether the pair has headroom left.
+<!-- anchor: provider.reasoning-accounting -->
+
+#### Scenario: the route reports no breakdown
+- **WHEN** a successful response carries no `completion_tokens_details`
+- **THEN** the count is unknown, and nothing is claimed about the thinking done
+
+#### Scenario: no ceiling was configured
+- **WHEN** a request goes out with no `max_tokens`
+- **THEN** no ceiling rides the result, and no share is computed from one
+
 ### Requirement: Backoff matches what failed
 
 Retry backoff SHALL be chosen by the failure. A capacity rate limit SHALL back

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -588,8 +588,7 @@ class ProviderResult(_Strict):
     cache_creation_tokens: int = 0
     # Tokens the model spent thinking before it wrote a word of the answer, when
     # the route reports them. A SUBSET of `output_tokens`, never an addition to
-    # it — the two are added nowhere, or the budget double-counts. Zero on routes
-    # that report no breakdown, which means "not reported", NOT "did no thinking".
+    # it — the two are added nowhere, or the budget double-counts.
     #
     # It is on the success path for a reason: read only off truncated calls (where
     # it was first surfaced, to name the cause) the number cannot answer the

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -595,7 +595,17 @@ class ProviderResult(_Strict):
     # it was first surfaced, to name the cause) the number cannot answer the
     # question it exists for, because such a call has reasoning + findings >=
     # max_tokens by definition and so offers no healthy call to compare against.
-    reasoning_tokens: int = 0
+    # None, not 0: "the route reported no breakdown" and "the model did no
+    # thinking" are different claims, and a 0 in the profile table asserts the
+    # second one. ProviderTruncated has always drawn that line; the success path
+    # drew it as a zero, which is the path a healthy run is judged from.
+    reasoning_tokens: int | None = None
+    # The output ceiling this request actually carried (`max_tokens`), or None
+    # when none was configured. Stamped here because only the adapter knows it —
+    # it is resolved per provider and overridable per call — and because the
+    # reasoning SHARE, not either raw count, is what says whether the ceiling has
+    # headroom. A share needs a denominator that was really sent.
+    output_ceiling: int | None = None
     # Completion attempts the adapter made to produce this result (1 = first try).
     # Feeds the timing instrumentation so a call that burned its retry budget is
     # distinguishable from one that was merely slow.

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -42,9 +42,22 @@ class CallRecord:
     cache_read_tokens: int
     cache_creation_tokens: int
     error: str | None = None  # None on success; the concise failure reason otherwise
-    # Thinking tokens inside `output_tokens` (0 = the route reported no breakdown).
+    # Thinking tokens inside `output_tokens`. None = the route reported no
+    # breakdown, which is NOT the same as zero and must not render as one.
     # Keyword-defaulted so every existing caller keeps working unchanged.
-    reasoning_tokens: int = 0
+    reasoning_tokens: int | None = None
+    # The `max_tokens` ceiling this call was sent with (None = uncapped). The
+    # denominator of the reasoning share — the figure that answers "does this
+    # pair of settings have headroom on the real workload?", which before this
+    # only became visible when a call FAILED, in the truncation message.
+    output_ceiling: int | None = None
+
+    @property
+    def reasoning_share(self) -> float | None:
+        """Reasoning as a fraction of the ceiling, or None when either is unknown."""
+        if not self.reasoning_tokens or not self.output_ceiling:
+            return None
+        return self.reasoning_tokens / self.output_ceiling
 
 
 @dataclass(frozen=True)
@@ -82,7 +95,8 @@ class Profiler:
         output_tokens: int,
         cache_read_tokens: int,
         cache_creation_tokens: int,
-        reasoning_tokens: int = 0,
+        reasoning_tokens: int | None = None,
+        output_ceiling: int | None = None,
         error: str | None = None,
     ) -> None:
         """Record one provider call and log it as a structured line."""
@@ -96,6 +110,7 @@ class Profiler:
             cache_read_tokens=cache_read_tokens,
             cache_creation_tokens=cache_creation_tokens,
             reasoning_tokens=reasoning_tokens,
+            output_ceiling=output_ceiling,
             error=error,
         )
         with self._lock:
@@ -106,6 +121,8 @@ class Profiler:
         # model did no thinking, which is not what it means.
         if not reasoning_tokens:
             del extra["reasoning_tokens"]
+        if output_ceiling is None:
+            del extra["output_ceiling"]
         if not error:
             del extra["error"]
         _log.info("provider call", extra=extra)
@@ -122,6 +139,7 @@ class Profiler:
             cache_read_tokens=result.cache_read_tokens,
             cache_creation_tokens=result.cache_creation_tokens,
             reasoning_tokens=result.reasoning_tokens,
+            output_ceiling=result.output_ceiling,
         )
 
     def record_error(
@@ -149,7 +167,11 @@ class Profiler:
             attempts=attempts_of(exc),
             input_tokens=getattr(exc, "input_tokens", None) or 0,
             output_tokens=getattr(exc, "output_tokens", None) or 0,
-            reasoning_tokens=getattr(exc, "reasoning_tokens", None) or 0,
+            reasoning_tokens=getattr(exc, "reasoning_tokens", None),
+            # A truncation's ceiling IS its output_tokens — it generated all the
+            # way to it — so the share it reports is 100% by construction, which
+            # is exactly the diagnosis.
+            output_ceiling=getattr(exc, "output_tokens", None),
             # A truncation is billed as ordinary input; the route reports no cache
             # breakdown alongside the ceiling error, so claiming one would be
             # invention rather than accounting.
@@ -202,14 +224,24 @@ class Profiler:
 
         # `think_tok` sits next to `out_tok` deliberately: side by side they are
         # the whole story of a lens that ran for a minute and wrote 50 tokens.
+        # `think_%` is that count against the `max_tokens` ceiling it came out
+        # of — the ratio, not either raw number, is what says whether this pair
+        # of settings still has headroom on the real workload.
         lines.append(
             f"{'call':<16} {'batch':>5} {'tries':>5} {'elapsed':>9} "
-            f"{'in_tok':>8} {'out_tok':>8} {'think_tok':>9} {'cache_rd':>8} {'cache_wr':>8}  error"
+            f"{'in_tok':>8} {'out_tok':>8} {'think_tok':>9} {'think_%':>8} "
+            f"{'cache_rd':>8} {'cache_wr':>8}  error"
         )
         for call in sorted(calls, key=lambda c: c.elapsed, reverse=True):
+            # A dash, never a zero, on both: a route that reported no breakdown
+            # did not tell us the model thought nothing, and an uncapped call has
+            # no denominator to be a share of.
+            thinking = "-" if call.reasoning_tokens is None else f"{call.reasoning_tokens}"
+            share = call.reasoning_share
+            percent = "-" if share is None else f"{round(100 * share)}%"
             lines.append(
                 f"{call.label:<16} {call.batch:>5} {call.attempts:>5} {call.elapsed:>8.2f}s "
-                f"{call.input_tokens:>8} {call.output_tokens:>8} {call.reasoning_tokens:>9} "
+                f"{call.input_tokens:>8} {call.output_tokens:>8} {thinking:>9} {percent:>8} "
                 f"{call.cache_read_tokens:>8} {call.cache_creation_tokens:>8}  "
                 f"{call.error or '-'}"
             )
@@ -218,9 +250,9 @@ class Profiler:
         read = sum(c.cache_read_tokens for c in calls)
         created = sum(c.cache_creation_tokens for c in calls)
         lines.append(f"cache: {read} tokens read / {created} created across {len(calls)} calls")
-        reasoning_line = self._render_reasoning(calls)
-        if reasoning_line:
-            lines.append(reasoning_line)
+        for extra_line in (self._render_reasoning(calls), self._render_headroom(calls)):
+            if extra_line:
+                lines.append(extra_line)
         lines.append(self.render_total())
         return "\n".join(lines)
 
@@ -234,12 +266,36 @@ class Profiler:
         it is the ratio — not either raw count — that says whether the output
         ceiling is being spent on findings or on reasoning.
         """
-        reasoning = sum(c.reasoning_tokens for c in calls)
+        reasoning = sum(c.reasoning_tokens or 0 for c in calls)
         if not reasoning:
             return ""
         output = sum(c.output_tokens for c in calls)
         share = round(100 * reasoning / output) if output else 0
         return f"reasoning: {reasoning:,} of {output:,} output tokens ({share}%)"
+
+    @staticmethod
+    def _render_headroom(calls: list[CallRecord]) -> str:
+        """The largest reasoning share any single call reached — "" when unknown.
+
+        The one line that answers the question the raw counts do not: is the
+        configured `max_tokens` / `reasoning_effort` pair close to the edge on
+        this workload? An aggregate share hides it — a run whose lenses average
+        20% can still contain the call that spent the whole ceiling thinking and
+        wrote nothing, which is exactly the failure this exists to make visible
+        before it happens rather than after.
+
+        The call is named, because "which lens" is the next question and the
+        table is long.
+        """
+        scored = [(c.reasoning_share, c) for c in calls if c.reasoning_share is not None]
+        if not scored:
+            return ""
+        share, call = max(scored, key=lambda pair: pair[0] or 0.0)
+        return (
+            f"largest reasoning share: {round(100 * (share or 0))}% of the "
+            f"{call.output_ceiling:,}-token ceiling ({call.reasoning_tokens:,} tokens, "
+            f"{call.label}, batch {call.batch})"
+        )
 
     def render_total(self) -> str:
         """One line: what this run spent, formatted for a human.

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -273,9 +273,13 @@ class Profiler:
         counted is said out loud rather than left for the reader to assume.
         """
         measured = [c for c in calls if c.reasoning_tokens is not None]
-        reasoning = sum(c.reasoning_tokens or 0 for c in measured)
-        if not reasoning:
+        if not measured:
+            # Nothing REPORTED — the only case with nothing to say. A run whose
+            # routes all reported 0 has measured something (a model that did no
+            # thinking), and suppressing it here would put it back in the same
+            # bucket as silence, which is the distinction this line exists for.
             return ""
+        reasoning = sum(c.reasoning_tokens or 0 for c in measured)
         output = sum(c.output_tokens for c in measured)
         share = round(100 * reasoning / output) if output else 0
         line = f"reasoning: {reasoning:,} of {output:,} output tokens ({share}%)"

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -265,13 +265,23 @@ class Profiler:
         that. The share is computed here rather than left to the reader, because
         it is the ratio — not either raw count — that says whether the output
         ceiling is being spent on findings or on reasoning.
+
+        Both sums are restricted to the calls that REPORTED a breakdown. Dividing
+        known reasoning by every call's output mixes a measurement with a silence
+        and understates the share by however much the unreporting calls
+        generated — badly, when they generated most of it. Whether every call is
+        counted is said out loud rather than left for the reader to assume.
         """
-        reasoning = sum(c.reasoning_tokens or 0 for c in calls)
+        measured = [c for c in calls if c.reasoning_tokens is not None]
+        reasoning = sum(c.reasoning_tokens or 0 for c in measured)
         if not reasoning:
             return ""
-        output = sum(c.output_tokens for c in calls)
+        output = sum(c.output_tokens for c in measured)
         share = round(100 * reasoning / output) if output else 0
-        return f"reasoning: {reasoning:,} of {output:,} output tokens ({share}%)"
+        line = f"reasoning: {reasoning:,} of {output:,} output tokens ({share}%)"
+        if len(measured) == len(calls):
+            return line
+        return f"{line[:-1]}, across {len(measured)} of {len(calls)} calls reporting it)"
 
     @staticmethod
     def _render_headroom(calls: list[CallRecord]) -> str:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -909,10 +909,18 @@ def _reasoning_tokens(usage: Any) -> int | None:
     None rather than 0, because they are different claims: "it never said" and
     "it did no thinking" send a reader to different conclusions about whether the
     ceiling has headroom, and only one of them is knowable here.
+
+    A route that DOES report the breakdown and puts 0 in it has said the second
+    one, and that is kept: it is a measurement, and a non-reasoning model landing
+    at 0% belongs in the table beside the ones that did not. Booleans are
+    excluded explicitly — `True` is an `int` in Python, and a route filling the
+    field with a flag would otherwise be read as "one reasoning token".
     """
     details = getattr(usage, "completion_tokens_details", None)
     value = getattr(details, "reasoning_tokens", None)
-    return value if isinstance(value, int) and value > 0 else None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
 
 
 def _cache_usage(usage: Any) -> tuple[int, int]:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -703,7 +703,7 @@ class LiteLLMProvider:
                 # between them, and re-reading them out of the prose above would be
                 # parsing our own sentence. None, not 0, when the route reported no
                 # breakdown — "it never said" must not read as "it thought nothing".
-                reasoning_tokens=reasoning or None,
+                reasoning_tokens=reasoning,
                 output_tokens=output_tokens,
                 # Not diagnosis but accounting: the prompt was sent and billed,
                 # so the spend ceiling must see it (see profiling.record_error).
@@ -732,6 +732,11 @@ class LiteLLMProvider:
             # succeeded and a call that hit the ceiling can never report the
             # thinking they did by two different readings of the same field.
             reasoning_tokens=_reasoning_tokens(usage),
+            # The denominator for that count. Carried from the request rather
+            # than looked up later: a per-call `max_tokens` overrides the
+            # provider's, and a share against the wrong ceiling is worse than no
+            # share at all.
+            output_ceiling=ceiling,
         )
 
 
@@ -893,17 +898,21 @@ def _supports_cache_control(model: str) -> bool:
         return False
 
 
-def _reasoning_tokens(usage: Any) -> int:
-    """Output tokens the model spent thinking, or 0 when the route doesn't say.
+def _reasoning_tokens(usage: Any) -> int | None:
+    """Output tokens the model spent thinking, or None when the route doesn't say.
 
     litellm normalises this onto ``completion_tokens_details.reasoning_tokens``
     for the routes that report it. Read defensively — a route that omits the
     wrapper, or fills it with a non-number, must not turn a truncation report
-    into a crash — and 0 simply means "no breakdown to show".
+    into a crash.
+
+    None rather than 0, because they are different claims: "it never said" and
+    "it did no thinking" send a reader to different conclusions about whether the
+    ceiling has headroom, and only one of them is knowable here.
     """
     details = getattr(usage, "completion_tokens_details", None)
     value = getattr(details, "reasoning_tokens", None)
-    return value if isinstance(value, int) and value > 0 else 0
+    return value if isinstance(value, int) and value > 0 else None
 
 
 def _cache_usage(usage: Any) -> tuple[int, int]:

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -85,8 +85,10 @@ class TestProfiler:
         )
         assert p.calls[0].reasoning_tokens == 1100
 
-    def test_reasoning_tokens_default_to_zero(self) -> None:
-        """Non-reasoning routes report nothing, and callers may omit it."""
+    def test_reasoning_tokens_default_to_unknown(self) -> None:
+        """Non-reasoning routes report nothing, and callers may omit it — which
+        records as None. A 0 would claim the model did no thinking; nobody said
+        that, and the profile table would print it as if somebody had."""
         p = Profiler()
         p.record_call(
             label="security",
@@ -98,7 +100,7 @@ class TestProfiler:
             cache_read_tokens=0,
             cache_creation_tokens=0,
         )
-        assert p.calls[0].reasoning_tokens == 0
+        assert p.calls[0].reasoning_tokens is None
 
     def test_reset_clears_prior_records(self) -> None:
         p = Profiler()
@@ -542,3 +544,94 @@ class TestCeilingHitsReachTheProfile:
             )
 
         assert profiler.calls[-1].error is None
+
+
+class TestReasoningShareIsLegibleFromAnyRun:
+    """`max_tokens` pays for thinking AND answering, so the two settings are
+    coupled — but the split only became visible when a call FAILED, in the
+    truncation message. A healthy call that came within a few hundred tokens of
+    the ceiling looked identical to one that used a fifth of it, which is why
+    settling `reasoning_effort` needed a bespoke four-run experiment.
+    """
+
+    def test_a_route_that_reports_no_breakdown_renders_as_unknown_not_zero(self) -> None:
+        """A zero would claim the model did no thinking. It said nothing."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.5,
+            attempts=1,
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+
+        assert p.calls[0].reasoning_tokens is None
+        row = next(line for line in p.render().splitlines() if line.startswith("security"))
+        assert " 0 " not in row.split("20", 1)[1][:12]
+        assert "-" in row
+
+    def test_a_call_reports_its_reasoning_as_a_share_of_the_ceiling(self) -> None:
+        """The ratio is the number that answers "is there headroom?" — neither
+        raw count says it, and computing it by hand is what this replaces."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.5,
+            attempts=1,
+            input_tokens=100,
+            output_tokens=4000,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=4096,
+            output_ceiling=8192,
+        )
+
+        row = next(line for line in p.render().splitlines() if line.startswith("security"))
+        assert "4096" in row
+        assert "50%" in row
+
+    def test_the_summary_names_the_largest_share_seen(self) -> None:
+        """So the headroom question is answered without reading every row."""
+        p = Profiler()
+        for label, reasoning in (("security", 800), ("artefacts", 7000)):
+            p.record_call(
+                label=label,
+                batch=1,
+                elapsed=1.0,
+                attempts=1,
+                input_tokens=10,
+                output_tokens=reasoning + 100,
+                cache_read_tokens=0,
+                cache_creation_tokens=0,
+                reasoning_tokens=reasoning,
+                output_ceiling=8192,
+            )
+
+        rendered = p.render()
+        assert "largest" in rendered
+        assert "85%" in rendered  # 7000 / 8192
+        assert "artefacts" in rendered.split("largest", 1)[1]
+
+    def test_no_share_is_claimed_when_no_ceiling_was_configured(self) -> None:
+        """`max_tokens` unset means there is no denominator — a share against a
+        number nobody chose would be invention, not accounting."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=10,
+            output_tokens=900,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=800,
+        )
+
+        rendered = p.render()
+        assert "800" in rendered
+        assert "largest" not in rendered

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -616,6 +616,40 @@ class TestReasoningShareIsLegibleFromAnyRun:
         assert "85%" in rendered  # 7000 / 8192
         assert "artefacts" in rendered.split("largest", 1)[1]
 
+    def test_the_aggregate_does_not_divide_by_unreported_calls(self) -> None:
+        """Dividing known reasoning by EVERY call's output mixes a measurement
+        with a silence, and understates the share by however much the
+        unreporting calls generated — badly, when they generated most of it.
+
+        The line says what it covered rather than leaving the reader to assume
+        it covered everything."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=10,
+            output_tokens=1000,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=900,
+        )
+        p.record_call(  # a route that reports no breakdown, and generated a lot
+            label="artefacts",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=10,
+            output_tokens=9000,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        )
+
+        rendered = p.render()
+        assert "reasoning: 900 of 1,000 output tokens (90%" in rendered  # not 9%
+        assert "1 of 2 calls reporting it" in rendered
+
     def test_no_share_is_claimed_when_no_ceiling_was_configured(self) -> None:
         """`max_tokens` unset means there is no denominator — a share against a
         number nobody chose would be invention, not accounting."""

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -650,6 +650,24 @@ class TestReasoningShareIsLegibleFromAnyRun:
         assert "reasoning: 900 of 1,000 output tokens (90%" in rendered  # not 9%
         assert "1 of 2 calls reporting it" in rendered
 
+    def test_a_run_that_measured_zero_still_says_so(self) -> None:
+        """A route that reported the breakdown and put 0 in it measured something.
+        Suppressing the line puts that back in the same bucket as silence."""
+        p = Profiler()
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=10,
+            output_tokens=500,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            reasoning_tokens=0,
+        )
+
+        assert "reasoning: 0 of 500 output tokens (0%)" in p.render()
+
     def test_no_share_is_claimed_when_no_ceiling_was_configured(self) -> None:
         """`max_tokens` unset means there is no denominator — a share against a
         number nobody chose would be invention, not accounting."""

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -82,13 +82,15 @@ class TestLiteLLMProvider:
         # adding it to `output_tokens` would double-count against the budget.
         assert result.output_tokens == 1200
 
-    def test_a_route_without_reasoning_detail_reports_zero(self) -> None:
-        """No detail is not an error — a non-reasoning route simply reports 0."""
+    def test_a_route_without_reasoning_detail_reports_unknown(self) -> None:
+        """No detail is not an error, and it is not a zero either: "the route
+        never said" and "the model thought nothing" send a reader to opposite
+        conclusions about whether the ceiling has headroom."""
         with patch("litellm.completion", return_value=_fake_response()):
             provider = LiteLLMProvider()
             result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-4o")
 
-        assert result.reasoning_tokens == 0
+        assert result.reasoning_tokens is None
 
     def test_complete_passes_messages_and_model_to_litellm(self) -> None:
         response = _fake_response()

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1597,6 +1597,31 @@ class TestTheCeilingRidesTheResult:
         assert result.output_ceiling == 8192
         assert result.reasoning_tokens == 1200
 
+    def test_a_per_call_ceiling_overrides_the_provider_default(self) -> None:
+        """`complete` merges per-call opts over the provider's, so the ceiling a
+        request carried is not always the one it was built with. A share against
+        the wrong denominator is worse than no share, and this is the only place
+        the right one is knowable."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5", max_tokens=8192)
+
+        with patch("litellm.completion", return_value=_reasoning_response(1200)):
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], model="openai/gpt-5.5", max_tokens=2048
+            )
+
+        assert result.output_ceiling == 2048
+
+    def test_an_explicitly_reported_zero_is_kept_as_a_measurement(self) -> None:
+        """A route that reports the breakdown and puts 0 in it HAS said the model
+        did no thinking. That belongs in the table at 0%, beside the calls that
+        did — conflating it with silence loses a real reading."""
+        provider = LiteLLMProvider(model="openai/gpt-4o")
+
+        with patch("litellm.completion", return_value=_reasoning_response(0)):
+            result = provider.complete([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
+
+        assert result.reasoning_tokens == 0
+
     def test_no_ceiling_configured_reports_none(self) -> None:
         provider = LiteLLMProvider(model="openai/gpt-5.5")
 

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -20,7 +20,7 @@ from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
 
 
-def _reasoning_response(reasoning: int, content: str = "ok") -> Any:
+def _reasoning_response(reasoning: Any, content: str = "ok") -> Any:
     """A response whose route DOES report the thinking/answer breakdown."""
     return SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
@@ -1621,6 +1621,20 @@ class TestTheCeilingRidesTheResult:
             result = provider.complete([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
 
         assert result.reasoning_tokens == 0
+
+    def test_a_malformed_breakdown_is_read_as_unknown(self) -> None:
+        """A flag, a negative count, or a string is not a measurement. `True` is
+        the one that would slip through a plain `isinstance(int)` — it would read
+        as one reasoning token, which is a number the table would then print."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        for value in (True, -1, "900", None, 3.5):
+            with patch("litellm.completion", return_value=_reasoning_response(value)):
+                result = provider.complete(
+                    [{"role": "user", "content": "hi"}], model="openai/gpt-5.5"
+                )
+
+            assert result.reasoning_tokens is None, value
 
     def test_no_ceiling_configured_reports_none(self) -> None:
         provider = LiteLLMProvider(model="openai/gpt-5.5")

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -20,6 +20,18 @@ from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
 
 
+def _reasoning_response(reasoning: int, content: str = "ok") -> Any:
+    """A response whose route DOES report the thinking/answer breakdown."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(
+            prompt_tokens=5,
+            completion_tokens=10,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning),
+        ),
+    )
+
+
 def _fake_response(content: str = "ok") -> Any:
     return SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
@@ -1568,3 +1580,38 @@ class TestTruncationAdviceMatchesTheMeasurement:
 
     def test_it_names_the_model_as_the_lever_that_actually_moves_this(self) -> None:
         assert "model" in self._message()
+
+
+class TestTheCeilingRidesTheResult:
+    """The reasoning share needs a denominator, and only the adapter knows it —
+    `max_tokens` is resolved per provider and can be overridden per call, so the
+    ceiling this request actually carried is stamped on the result rather than
+    re-derived downstream from a setting that may not be the one sent."""
+
+    def test_a_successful_call_reports_the_ceiling_it_was_sent_with(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5", max_tokens=8192)
+
+        with patch("litellm.completion", return_value=_reasoning_response(1200)):
+            result = provider.complete([{"role": "user", "content": "hi"}], model="openai/gpt-5.5")
+
+        assert result.output_ceiling == 8192
+        assert result.reasoning_tokens == 1200
+
+    def test_no_ceiling_configured_reports_none(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        with patch("litellm.completion", return_value=_fake_response("{}")):
+            result = provider.complete([{"role": "user", "content": "hi"}], model="openai/gpt-5.5")
+
+        assert result.output_ceiling is None
+
+    def test_a_route_with_no_breakdown_reports_unknown_not_zero(self) -> None:
+        """`None` and `0` are different claims: "it never said" versus "it did no
+        thinking". `ProviderTruncated` already draws that line; the success path
+        drew it as a zero."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        with patch("litellm.completion", return_value=_fake_response("{}")):
+            result = provider.complete([{"role": "user", "content": "hi"}], model="openai/gpt-5.5")
+
+        assert result.reasoning_tokens is None

--- a/tests/snapshots/ProviderResult.json
+++ b/tests/snapshots/ProviderResult.json
@@ -22,14 +22,33 @@
       "title": "Input Tokens",
       "type": "integer"
     },
+    "output_ceiling": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Output Ceiling"
+    },
     "output_tokens": {
       "title": "Output Tokens",
       "type": "integer"
     },
     "reasoning_tokens": {
-      "default": 0,
-      "title": "Reasoning Tokens",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Reasoning Tokens"
     },
     "text": {
       "title": "Text",


### PR DESCRIPTION
Closes #421.

`max_tokens` pays for thinking **and** answering, so the two settings are coupled — but nothing reported how the budget was actually spent. The split only became visible when a call *failed*, in the truncation message. A healthy call that came within a few hundred tokens of the ceiling looked identical to one that used a fifth of it.

That is why settling `reasoning_effort` needed a bespoke four-run experiment, and why #415's review spending **8,192 of 8,192 on reasoning alone** was discovered by accident — it happened to fail.

## What changes

All three are on data the run was already measuring:

| change | why |
|---|---|
| `ProviderResult.reasoning_tokens` → `int \| None` | A route with no breakdown said `0`, which asserts the model did no thinking and prints in the table as if someone had measured it. `ProviderTruncated` has always drawn this line; the success path — the one a *healthy* run is judged from — drew it as a zero. |
| `ProviderResult.output_ceiling` | The denominator. Only the adapter knows it: `max_tokens` is resolved per provider and overridable per call, and a share against a ceiling that wasn't sent is worse than no share. |
| `--profile`: a `think_%` column + a `largest reasoning share:` line | The ratio is what answers "does this pair of settings have headroom?". The line names the closest single call **and its lens**, because the aggregate `reasoning:` line cannot show it — one runaway hides inside an average, and the runaway is the thing that becomes a truncation. |

```
call             batch tries   elapsed   in_tok  out_tok think_tok  think_%  cache_rd  cache_wr  error
artefacts            1     1    41.20s    18402     7100      7000      85%      1024         0  -
security             1     1    22.10s    18402      950       800      10%     18402         0  -

cache: 19,426 tokens read / 0 created across 2 calls
reasoning: 7,800 of 8,050 output tokens (97%)
largest reasoning share: 85% of the 8,192-token ceiling (7,000 tokens, artefacts, batch 1)
```

A route that reports no breakdown renders `-` in both columns and prints no `largest` line — silence, not a zero, exactly as `ProviderTruncated` already treats it.

## Tests

Written first and watched fail. Profiler: unknown renders as a dash rather than a zero; a call reports its share of the ceiling; the summary names the largest share and its lens; **no** share is claimed when no ceiling was configured (a share against a number nobody chose is invention). Adapter: the ceiling rides the result, `None` when uncapped, and a route with no breakdown reports unknown.

Two pre-existing tests encoded the old zero-means-nothing contract and now assert `None` — renamed to say so.

Full gate green: `ruff`, `mypy`, `pytest -q` (2066 passed), `pytest tests/specs -q`, `openspec validate --specs`. Regenerated `docs/reference/config.md`, `docs/llms*.txt` and `tests/snapshots/ProviderResult.json` (the schema snapshot is a contract, so its drift is the point).

## Docs and specs

- `docs/how-to/reduce-review-cost.md` gains the two new readings next to the existing `think_tok` guidance, with the rule of thumb: worst lens at 50% has headroom; at 95% it is a truncation that has not happened yet.
- New requirement `provider.reasoning-accounting` in `provider-gateway/spec.md` rather than growing `provider.complete`, which was already near the 40-line section cap.

## What this prices

#420's step-down retry — whether it fires often enough to matter — and the open question on `.lgtmaybe.yml`'s `max_tokens`, which is currently answered by a hand-written note listing numbers somebody measured once. Both become a glance at any `--profile` run on the real workload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP5dzWLGPWxnXnSZ2aNfU3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-call reasoning headroom and reasoning-share reporting.
  - Profile summaries now show the largest reasoning share and ceiling usage.
  - Added output-ceiling metadata to provider results.

- **Bug Fixes**
  - Reasoning usage is now distinguished between unavailable data and an explicit zero.
  - Uncapped requests omit ceiling and derived-share information.

- **Documentation**
  - Added guidance for interpreting reasoning metrics and unavailable breakdowns.
  - Updated provider result schemas and reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->