### PR TITLE
fix(github): post re-run inline findings when the run was incomplete

### DIFF
--- a/openspec/specs/github-posting/spec.md
+++ b/openspec/specs/github-posting/spec.md
@@ -40,6 +40,13 @@ posting failures SHALL remain fatal.
 - **THEN** the notice also posts as a PR comment, so a partial review is never
   indistinguishable from a clean one
 
+#### Scenario: an incomplete re-run computed findings
+- **WHEN** a re-run stamps no completion watermark but its calls produced new
+  findings
+- **THEN** those findings still post inline, anchored to the PR's current head
+  — or, when no head can be resolved, are demoted into the review body — never
+  silently dropped between the summary count and GitHub
+
 #### Scenario: GitHub rejects one rerun comment position
 - **WHEN** one new inline comment returns 422 and later comments remain valid
 - **THEN** later comments still post and the rejected finding appears in the

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -512,7 +512,13 @@ class RestGitHubGateway:
             # NEW findings (fingerprints not already on the PR) as individual
             # review comments — otherwise a re-run's fresh findings would only
             # ever appear in the summary body, silently losing their line.
-            rejected = self._post_new_inline_comments(inline, self._reviewed_sha)
+            # Anchored to the completion watermark when there is one, else the
+            # PR's current head: an incomplete run stamps no watermark, but the
+            # findings its successful calls produced are real and still belong
+            # inline — anchoring them to nothing silently dropped them (#443).
+            rejected = self._post_new_inline_comments(
+                inline, self._reviewed_sha or self._anchor_sha()
+            )
             if rejected:
                 body = (
                     f"{summary}{_render_demoted([*demoted, *rejected])}"
@@ -871,6 +877,24 @@ class RestGitHubGateway:
         """
         self._reviewed_sha = head_sha
 
+    def _anchor_sha(self) -> str | None:
+        """The PR's current head SHA, for anchoring re-run inline comments.
+
+        The fallback when the completion watermark is absent — i.e. an
+        incomplete run, whose ``mark_reviewed(None)`` correctly suppresses the
+        watermark stamp but must not also suppress the findings the run did
+        compute. The head cached by ``get_pr_context``, with the same lazy
+        metadata fetch ``get_file_contents`` uses when no context was fetched;
+        None when even that fails, in which case the caller demotes rather than
+        drops.
+        """
+        if self._head_sha is None:
+            try:
+                self._head_sha = self._pr_meta()["head"]["sha"]
+            except (httpx.HTTPError, KeyError, TypeError):
+                return None
+        return self._head_sha
+
     def _post_new_inline_comments(
         self,
         inline: list[tuple[dict[str, Any], ReviewFinding]],
@@ -896,10 +920,11 @@ class RestGitHubGateway:
 
         A comment GitHub rejects with 422 is returned to the caller for demotion
         into the review body; later comments still post. Other errors remain
-        fatal. Without a head SHA there is nothing to anchor to, so nothing
-        posts.
+        fatal. Without a head SHA there is nothing to anchor to, so unmatched
+        candidates are demoted into the review body the same way — never
+        dropped silently.
         """
-        if not inline or head_sha is None:
+        if not inline:
             return []
         unmatched = self._existing_finding_keys()
         url = f"{self._pr_api}/comments"
@@ -909,6 +934,16 @@ class RestGitHubGateway:
             already = next((i for i, e in enumerate(unmatched) if e & keys), None)
             if already is not None:
                 unmatched.pop(already)  # consumed — it can't absorb a second candidate
+                continue
+            if head_sha is None:
+                _log.warning(
+                    "no head SHA to anchor a new inline comment at %s:%s:%s — "
+                    "demoting to review body",
+                    finding.path,
+                    finding.line,
+                    finding.side,
+                )
+                rejected.append(finding)
                 continue
             resp = self._client.post(
                 url,

--- a/tests/github/test_incremental.py
+++ b/tests/github/test_incremental.py
@@ -546,6 +546,58 @@ def test_rerun_reposts_finding_whose_thread_was_resolved_as_fixed() -> None:
     assert posted[0]["path"] == "src/app.py"
 
 
+@respx.mock
+def test_incomplete_rerun_still_posts_new_inline_findings() -> None:
+    """#443: an incomplete re-run carries no completion watermark
+    (``mark_reviewed(None)``), but its successful calls still computed findings
+    and the summary still counts them — they must reach GitHub inline, anchored
+    to the PR's current head, rather than vanish between count and post."""
+    posted, put_route = _mock_update_flow(existing_comment_fps=[])
+    respx.route(method="GET", url=PR_URL).mock(
+        return_value=httpx.Response(200, json={"head": {"sha": "headsha999"}})
+    )
+
+    gateway = _gateway()
+    gateway.mark_reviewed(None)
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert put_route.called  # summary still updated in place
+    assert len(posted) == 1
+    assert posted[0]["commit_id"] == "headsha999"
+    assert posted[0]["path"] == "src/app.py"
+
+
+@respx.mock
+def test_rerun_without_any_resolvable_head_demotes_new_findings_to_the_body(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The anchor-less fallback must never silently drop findings (#443): when
+    no head SHA can be resolved at all, the unmatched candidates demote into
+    the review body — the same recovery as a 422 — with a warning."""
+    existing = [{"id": 99, "body": f"Old summary {MARKER}"}]
+    respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=existing))
+    updated_bodies: list[str] = []
+
+    def capture_update(request: httpx.Request) -> httpx.Response:
+        updated_bodies.append(json.loads(request.content)["body"])
+        return httpx.Response(200, json={"id": 99})
+
+    respx.route(method="PUT", url=f"{REVIEWS_URL}/99").mock(side_effect=capture_update)
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(503))
+
+    gateway = _gateway()
+    gateway.mark_reviewed(None)
+    gateway.post_review([FINDING], "1 finding", diff=SAMPLE_DIFF)
+
+    assert len(updated_bodies) == 2  # recovery body re-PUT with the demoted finding
+    assert "### Additional findings" in updated_bodies[-1]
+    assert "Import order" in updated_bodies[-1]
+    assert "demoting" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # incremental scope on resolve-on-fix
 # ---------------------------------------------------------------------------
@@ -604,6 +656,9 @@ def test_incremental_scope_never_resolves_thread_outside_reviewed_paths() -> Non
     """A finding on an un-re-reviewed file is absent from this run's findings
     only because its hunk wasn't in the increment — its thread must stay open."""
     posted, _put = _mock_update_flow(existing_comment_fps=[])
+    respx.route(method="GET", url=PR_URL).mock(
+        return_value=httpx.Response(200, json={"head": {"sha": "headsha999"}})
+    )
     graphql = _GraphQL(
         threads=[
             _thread(finding_fingerprint("other.py", "old bug"), path="other.py", tid="OUT"),
@@ -624,6 +679,9 @@ def test_incremental_scope_never_resolves_thread_outside_reviewed_paths() -> Non
 @respx.mock
 def test_no_scope_keeps_full_resolve_behaviour() -> None:
     posted, _put = _mock_update_flow(existing_comment_fps=[])
+    respx.route(method="GET", url=PR_URL).mock(
+        return_value=httpx.Response(200, json={"head": {"sha": "headsha999"}})
+    )
     graphql = _GraphQL(
         threads=[_thread(finding_fingerprint("other.py", "old bug"), path="other.py", tid="T1")]
     )

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -24,6 +24,7 @@ TOKEN = "ghp_test"
 BASE_URL = "https://api.github.com"
 PR_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}"
 REVIEWS_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}/reviews"
+REVIEW_COMMENTS_URL = f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}/comments"
 COMMENTS_URL = f"{BASE_URL}/repos/{REPO}/issues/{PR_NUMBER}/comments"
 GRAPHQL_URL = f"{BASE_URL}/graphql"
 
@@ -118,6 +119,15 @@ def test_post_review_updates_existing_review_on_second_call() -> None:
 
     respx.route(method="PUT", url=update_url).mock(side_effect=capture_update)
     respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+    # Re-run posting (#443): the finding posts individually, anchored to the
+    # lazily-fetched PR head.
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(200, json=_pr_detail()))
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="POST", url=REVIEW_COMMENTS_URL).mock(
+        return_value=httpx.Response(201, json={"id": 1000})
+    )
 
     client = httpx.Client()
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=client)
@@ -164,6 +174,14 @@ def test_post_review_finds_existing_review_past_first_page() -> None:
 
     respx.route(method="PUT", url=update_url).mock(side_effect=capture_update)
     respx.route(method="POST", url=REVIEWS_URL).mock(side_effect=capture_create)
+    # Re-run posting (#443): see the second-call test above.
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(200, json=_pr_detail()))
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="POST", url=REVIEW_COMMENTS_URL).mock(
+        return_value=httpx.Response(201, json={"id": 1000})
+    )
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
@@ -458,12 +476,22 @@ def test_post_review_with_distinct_marker_keys_coexist() -> None:
 
 def _mark_existing_review() -> None:
     """Route the reviews GET so an existing lgtmaybe review is found (a re-run)
-    and the PUT that updates its summary succeeds."""
+    and the PUT that updates its summary succeeds. Also routes the calls a
+    re-run's individual inline posting now makes (#443): the posted-comments
+    listing (dedupe), the comment POST, and the lazy PR-head fetch that anchors
+    a run with no completion watermark."""
     existing = [{"id": 99, "body": f"Old summary {MARKER}"}]
     respx.route(method="GET", url=REVIEWS_URL).mock(return_value=httpx.Response(200, json=existing))
     respx.route(method="PUT", url=f"{REVIEWS_URL}/99").mock(
         return_value=httpx.Response(200, json={"id": 99})
     )
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="POST", url=REVIEW_COMMENTS_URL).mock(
+        return_value=httpx.Response(201, json={"id": 1000})
+    )
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(200, json=_pr_detail()))
 
 
 class _GraphQL:
@@ -1064,6 +1092,15 @@ def test_reviews_list_fetched_once_per_run() -> None:
     respx.route(method="PUT", url=f"{REVIEWS_URL}/{existing_review_id}").mock(
         return_value=httpx.Response(200, json={"id": existing_review_id})
     )
+    # Re-run posting (#443): the finding posts individually; neither call
+    # touches the reviews list, which is what this test counts.
+    respx.route(method="GET", url=PR_URL).mock(return_value=httpx.Response(200, json=_pr_detail()))
+    respx.route(method="GET", url=REVIEW_COMMENTS_URL + "?per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="POST", url=REVIEW_COMMENTS_URL).mock(
+        return_value=httpx.Response(201, json={"id": 1000})
+    )
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     assert gw.last_reviewed_sha() == "def5678"
@@ -1560,7 +1597,6 @@ def test_badge_leaves_the_hidden_markers_byte_identical() -> None:
 def test_pre_badge_comment_still_dedupes_against_a_badged_finding() -> None:
     """A comment posted before badges existed (an unbadged title line) is still
     recognised on the next run, so upgrading causes no re-post storm."""
-    _mark_existing_review()
     respx.route(method="POST", url=GRAPHQL_URL).mock(
         side_effect=_GraphQL([])  # no prior threads to resolve
     )
@@ -1572,6 +1608,8 @@ def test_pre_badge_comment_still_dedupes_against_a_badged_finding() -> None:
         f"<!-- lgtmaybe-finding:{finding_fingerprint(finding.path, finding.title)} -->\n"
         f"<!-- lgtmaybe-identity:{finding_identity(finding)} -->"
     )
+    # Registered BEFORE _mark_existing_review so this legacy listing wins over
+    # the helper's empty one (first matching route wins in respx).
     respx.route(method="GET", url__startswith=f"{PR_URL}/comments").mock(
         return_value=httpx.Response(200, json=[{"id": 1, "body": legacy_body}])
     )
@@ -1582,6 +1620,7 @@ def test_pre_badge_comment_still_dedupes_against_a_badged_finding() -> None:
         return httpx.Response(201, json={"id": 2})
 
     respx.route(method="POST", url=f"{PR_URL}/comments").mock(side_effect=capture_post)
+    _mark_existing_review()
 
     gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
     gw.mark_reviewed("deadbee")

--- a/tests/test_incomplete_visibility.py
+++ b/tests/test_incomplete_visibility.py
@@ -274,11 +274,22 @@ def test_notice_is_visible_on_a_re_run() -> None:
         )[1]
     )
     # No inline comments already on the PR, and posting one succeeds.
+    inline_posts: list[dict[str, object]] = []
+
+    def capture_inline(request: httpx.Request) -> httpx.Response:
+        inline_posts.append(json.loads(request.content))
+        return httpx.Response(201, json={"id": 1})
+
     respx.route(method="GET", url__startswith=f"{_BASE}/repos/{_REPO}/pulls/{_PR}/comments").mock(
         return_value=httpx.Response(200, json=[])
     )
     respx.route(method="POST", url=f"{_BASE}/repos/{_REPO}/pulls/{_PR}/comments").mock(
-        return_value=httpx.Response(201, json={"id": 1})
+        side_effect=capture_inline
+    )
+    # An incomplete run stamps no watermark, so the re-run's inline finding
+    # anchors to the lazily-fetched PR head instead (#443).
+    respx.route(method="GET", url=f"{_BASE}/repos/{_REPO}/pulls/{_PR}").mock(
+        return_value=httpx.Response(200, json={"head": {"sha": "headsha999"}})
     )
     posted_comments: list[str] = []
     respx.route(method="POST", url=_ISSUE_COMMENTS_URL).mock(
@@ -308,6 +319,11 @@ def test_notice_is_visible_on_a_re_run() -> None:
         "post as new PR activity"
     )
     assert "results may be incomplete" in posted_comments[0]
+    # #443: the incomplete run's finding must still reach GitHub inline — the
+    # summary counted it, so silently dropping it between count and post is a
+    # green run that delivered nothing.
+    assert len(inline_posts) == 1, "the finding an incomplete re-run computed must still post"
+    assert inline_posts[0]["commit_id"] == "headsha999"
 
 
 def test_incomplete_marker_cannot_be_mistaken_for_another_marker_family() -> None:


### PR DESCRIPTION
Fixes #443.

## What was happening

On a re-run, `post_review` anchored new inline comments to the **completion watermark** (`self._reviewed_sha`). An incomplete run — any round where some review calls failed — stamps no watermark (`mark_reviewed(None)`, correctly, so the incremental scope isn't advanced). `_post_new_inline_comments` then hit `if head_sha is None: return []` and **silently dropped every new inline finding**: the summary counted them, the run stayed green, and nothing reached GitHub. Exactly the failure mode #443 describes — distinct from #438, which was about 422-rejected comments, not comments never attempted.

This is why it clustered on the consumer repo: a model prone to truncation/timeout failures produces incomplete rounds, and every incomplete *re*-run hit the bug. (The first-review path posts through the review-create endpoint and was never affected — which is also why the inconsistency went unnoticed.)

## The fix

- Re-run inline comments now anchor to the completion watermark when set, else the **PR's current head** (`_anchor_sha`: the context fetch's cached head, with the same lazy metadata fetch `get_file_contents` already uses). The watermark keeps gating only the `<!-- lgtmaybe-reviewed:… -->` stamp — the two concerns are no longer conflated.
- If no head can be resolved at all, unmatched candidates take the 422 recovery path — demoted into the review body with a warning — never dropped silently.

## Tests

- `tests/github/test_incremental.py`: an incomplete re-run (`mark_reviewed(None)`) still posts inline, anchored to the PR head; an unresolvable head demotes to the body with a warning (both were red before the fix).
- `tests/test_incomplete_visibility.py`: the end-to-end re-run now asserts the finding actually posts with `commit_id` — this test already mocked the posting routes; the finding just never got there.
- Living spec: one scenario added to `github-posting` (anchoring on watermark-less re-runs).