### PR TITLE
Step reasoning effort to floor when unconfigured

### DIFF
--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -280,11 +280,13 @@ A lens whose truncation was reasoning-bound SHALL be re-run once with its
 `reasoning_effort` stepped down one level, merging its findings with the cut
 call's salvage — the sibling of the split, changing the one variable that can
 move a thinking budget. Exactly one attempt: a retry that truncates the same way
-reports plain. The step is always downward, never offered on a payload-bound
-truncation, and a no-op when no effort is configured, so a review that never set
-one is byte-identical. The retry SHALL re-check the whole-review deadline, token
-budget and interrupt first, so it can never spend past a stop. A lens that only
-answered after stepping down SHALL be named in the summary.
+reports plain. The step is always downward and never offered on a payload-bound
+truncation. With no effort configured there is no rung to descend, so the step
+SHALL be to a named floor — the configuration a model reasoning at its own
+default arrives in, which must not be the one with no lever. The retry SHALL
+re-check the whole-review deadline, token budget and interrupt first, so it can
+never spend past a stop. A lens that only answered after stepping down SHALL be
+named in the summary.
 <!-- anchor: engine.reasoning-step-down -->
 
 #### Scenario: the lower effort fits
@@ -297,7 +299,14 @@ answered after stepping down SHALL be named in the summary.
 - **THEN** it reports and stops — one attempt, never a walk down the ladder
 
 #### Scenario: no effort was configured
-- **WHEN** the provider reports no reasoning effort to step down from
+- **WHEN** a reasoning-bound truncation comes from a run that set no effort
+- **THEN** the retry goes out at the floor, in whichever shape that provider
+  carries its effort — the model was thinking at its own default, which is why
+  the ceiling went
+
+#### Scenario: the effort is already at the bottom
+- **WHEN** the configured effort is the lowest rung, or names no position on the
+  ladder at all
 - **THEN** nothing is retried and nothing is spent
 
 #### Scenario: a ceiling was reached while the first call was finishing

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -41,6 +41,7 @@ from tenacity import (
 
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
+    Provider,
     ProviderResult,
     attempts_of,
     stamp_attempts,
@@ -51,7 +52,7 @@ from lgtmaybe.core.ports import (
     ProviderTruncated,
     ProviderWallTimeout,
 )
-from lgtmaybe.providers.factory import CLOUD_TIMEOUT
+from lgtmaybe.providers.factory import CLOUD_TIMEOUT, litellm_model_string
 
 _log = get_logger(__name__)
 
@@ -513,10 +514,7 @@ class LiteLLMProvider:
             lower = _one_level_lower(flat)
             return {"reasoning_effort": lower} if lower else None
         raw_extra = self.default_opts.get("extra_body")
-        if not isinstance(raw_extra, dict):
-            # No nested shape to read or answer in — the flat one it is.
-            return {"reasoning_effort": _EFFORT_FLOOR}
-        extra: dict[str, Any] = raw_extra
+        extra: dict[str, Any] = raw_extra if isinstance(raw_extra, dict) else {}
         nested = extra.get("reasoning")
         if isinstance(nested, dict) and isinstance(nested.get("effort"), str):
             lower = _one_level_lower(nested["effort"])
@@ -526,10 +524,19 @@ class LiteLLMProvider:
             # per-call opts over the defaults a key at a time, so a partial
             # extra_body here would drop every other key it carries.
             return {"extra_body": {**extra, "reasoning": {**nested, "effort": lower}}}
-        # Nothing configured in either shape. Answer in the shape this provider
-        # was BUILT with, so the floor reaches an OpenRouter route the same way a
-        # configured effort would have — that is where most of these models live.
-        return {"extra_body": {**extra, "reasoning": {"effort": _EFFORT_FLOOR}}}
+        # Nothing configured in either shape, so the floor picks its own shape —
+        # from the ROUTE, never from whether `extra_body` happens to exist, which
+        # a caller may set for any unrelated provider option.
+        #
+        # OpenRouter gets the nested object for the same reason the factory
+        # re-routes a configured effort into it: litellm forwards the flat param
+        # only for models its capability map flags reasoning-capable, and the
+        # newest models are not in that map — exactly the set that truncates this
+        # way. A flat param there would be dropped and the retry would fail
+        # identically. OpenRouter takes the nested object regardless of model.
+        if self.model.startswith(_OPENROUTER_PREFIX):
+            return {"extra_body": {**extra, "reasoning": {"effort": _EFFORT_FLOOR}}}
+        return {"reasoning_effort": _EFFORT_FLOOR}
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
@@ -845,6 +852,11 @@ _EFFORT_LADDER = ("none", "minimal", "low", "medium", "high", "xhigh")
 # review for a worse one. `low` is also the rung every reasoning route
 # understands, where the two below it are unevenly supported.
 _EFFORT_FLOOR = "low"
+
+# ``openrouter/`` — derived rather than spelled out, so it cannot drift from the
+# route prefix the factory builds model strings with. The one route that reads a
+# nested ``reasoning`` object.
+_OPENROUTER_PREFIX = litellm_model_string(Provider.openrouter, "")
 
 
 def _one_level_lower(effort: str) -> str | None:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -483,10 +483,18 @@ class LiteLLMProvider:
     def lower_reasoning_effort(self) -> dict[str, Any] | None:
         """Per-call opts that step this provider's reasoning effort down one level.
 
-        ``None`` when there is nothing to step: no effort configured (the library
-        default — a user who never set it must send byte-identical requests), a
-        value already at the floor, or ``default``, which names no position on the
-        ladder and so cannot be moved down from.
+        ``None`` when there is nothing to step: a value already at the bottom of
+        the ladder, or ``default``, which names no position on it and so cannot
+        be moved down from.
+
+        With NO effort configured the step is to ``_EFFORT_FLOOR`` rather than
+        nowhere. That case used to answer ``None`` — to keep a run that never set
+        an effort sending byte-identical requests — but it is the very
+        configuration that produces this failure: a model reasoning at its own
+        default is the one that spends a whole output ceiling thinking, and
+        answering ``None`` left it the only model with no lever at all. The
+        byte-identical guarantee is unaffected, because this is consulted ONLY
+        after a reasoning-bound truncation: a healthy call never reaches here.
 
         Adapter-only, beyond the frozen ``ProviderClient`` port, and deliberately
         so: the effort lives in one of two provider-shaped places — a flat
@@ -494,7 +502,7 @@ class LiteLLMProvider:
         re-routes it into for OpenRouter (see ``_honour_param_support``, where
         sending both is a 400). The engine asks for "one level less" and gets back
         opts in whichever shape this provider was built with; it never learns
-        which, and a provider that cannot answer simply never steps down.
+        which.
 
         Read off ``default_opts`` because that is where the configured value was
         resolved, and returned as an override rather than mutated in place: this
@@ -504,9 +512,11 @@ class LiteLLMProvider:
         if isinstance(flat, str):
             lower = _one_level_lower(flat)
             return {"reasoning_effort": lower} if lower else None
-        extra = self.default_opts.get("extra_body")
-        if not isinstance(extra, dict):
-            return None
+        raw_extra = self.default_opts.get("extra_body")
+        if not isinstance(raw_extra, dict):
+            # No nested shape to read or answer in — the flat one it is.
+            return {"reasoning_effort": _EFFORT_FLOOR}
+        extra: dict[str, Any] = raw_extra
         nested = extra.get("reasoning")
         if isinstance(nested, dict) and isinstance(nested.get("effort"), str):
             lower = _one_level_lower(nested["effort"])
@@ -516,7 +526,10 @@ class LiteLLMProvider:
             # per-call opts over the defaults a key at a time, so a partial
             # extra_body here would drop every other key it carries.
             return {"extra_body": {**extra, "reasoning": {**nested, "effort": lower}}}
-        return None
+        # Nothing configured in either shape. Answer in the shape this provider
+        # was BUILT with, so the floor reaches an OpenRouter route the same way a
+        # configured effort would have — that is where most of these models live.
+        return {"extra_body": {**extra, "reasoning": {"effort": _EFFORT_FLOOR}}}
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
         merged = {**self.default_opts, **opts}
@@ -822,6 +835,16 @@ class LiteLLMProvider:
 # which is a "let the route decide" sentinel rather than a rung — there is no
 # telling what it is one level below.
 _EFFORT_LADDER = ("none", "minimal", "low", "medium", "high", "xhigh")
+
+# Where a step-down lands when NOTHING was configured to step down from — the
+# case that produces this failure most often, since a model reasoning at its own
+# default is precisely the one that spends a whole output ceiling thinking.
+#
+# `low` rather than `none` or `minimal`: a model whose thinking overran is still
+# a reasoning model, and switching thought off entirely trades a truncated
+# review for a worse one. `low` is also the rung every reasoning route
+# understands, where the two below it are unevenly supported.
+_EFFORT_FLOOR = "low"
 
 
 def _one_level_lower(effort: str) -> str | None:

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -521,8 +521,15 @@ def test_a_model_reasoning_at_its_own_default_still_gets_the_retry() -> None:
     always told there was nothing to retry with."""
 
     class _UnconfiguredReasoner(_TruncatesUntilEffortDrops):
+        # An OpenRouter route with nothing configured — the shape all three
+        # models arrived in, and the one where the effort rides nested.
+        model = "openrouter/z-ai/glm-4.7-flash"
         default_opts: dict[str, Any] = {}
         lower_reasoning_effort = LiteLLMProvider.lower_reasoning_effort
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            nested = opts.get("extra_body", {}).get("reasoning", {})
+            return super().complete(messages, model, reasoning_effort=nested.get("effort"))
 
     provider = _UnconfiguredReasoner(effort=None, answers_at=_EFFORT_FLOOR)
 

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -36,6 +36,7 @@ from lgtmaybe.core.models import (
 from lgtmaybe.core.ports import Message, ProviderTruncated
 from lgtmaybe.engine import LLMReviewEngine, clear_interrupt, request_interrupt
 from lgtmaybe.engine.engine import ReviewIncompleteError
+from lgtmaybe.providers.litellm_provider import _EFFORT_FLOOR, LiteLLMProvider
 from tests.fakes import FakeProvider
 
 _TWO_FILE_DIFF = """diff --git a/one.py b/one.py
@@ -503,6 +504,34 @@ def test_a_reasoning_bound_truncation_retries_once_at_a_lower_effort() -> None:
     assert [f.title for f in findings] == ["unchecked value in one.py"]
     # Not silent: a lens that answered only after being told to think less is a
     # fact about this review, and the summary says so.
+    assert "reasoning_effort" in summary
+
+
+def test_a_model_reasoning_at_its_own_default_still_gets_the_retry() -> None:
+    """The configuration this failure actually arrives in, wired end to end.
+
+    A benchmark run lost 8 observations across three models (GLM 4.7 Flash,
+    Nemotron, Laguna) that exhausted a 16k output ceiling thinking. None had an
+    explicit `reasoning_effort`, and the adapter answered "nothing to step down
+    from" for exactly that case — so the one lever that can move a thinking
+    budget was unavailable to the only models that needed it.
+
+    Uses the REAL adapter method rather than a fake's, because the defect was in
+    the seam between the two: the engine was always willing to retry, and was
+    always told there was nothing to retry with."""
+
+    class _UnconfiguredReasoner(_TruncatesUntilEffortDrops):
+        default_opts: dict[str, Any] = {}
+        lower_reasoning_effort = LiteLLMProvider.lower_reasoning_effort
+
+    provider = _UnconfiguredReasoner(effort=None, answers_at=_EFFORT_FLOOR)
+
+    findings, summary = LLMReviewEngine(provider).review(
+        _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg()
+    )
+
+    assert provider.efforts == [None, _EFFORT_FLOOR]  # nothing, then the floor
+    assert [f.title for f in findings] == ["unchecked value in one.py"]
     assert "reasoning_effort" in summary
 
 

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -18,7 +18,12 @@ import pytest
 from lgtmaybe.core.models import attempts_of, is_unrecoverable
 from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.providers import litellm_provider as provider_module
-from lgtmaybe.providers.litellm_provider import _MAX_ATTEMPTS, LiteLLMProvider
+from lgtmaybe.providers.litellm_provider import (
+    _EFFORT_FLOOR,
+    _EFFORT_LADDER,
+    _MAX_ATTEMPTS,
+    LiteLLMProvider,
+)
 
 
 def _reasoning_response(reasoning: Any, content: str = "ok") -> Any:
@@ -1676,12 +1681,50 @@ class TestSteppingReasoningEffortDown:
 
         assert provider.lower_reasoning_effort() is None
 
-    def test_an_unset_effort_steps_nowhere(self) -> None:
-        """The library default. A user who never configured this must send
-        byte-identical requests, so there is nothing to retry with."""
+    def test_an_unset_effort_steps_to_the_floor(self) -> None:
+        """The case that matters most and used to have no answer.
+
+        A model that reasons by DEFAULT, run without an explicit effort, is
+        exactly the configuration that burns its whole output ceiling thinking —
+        and returning None here meant the one lever that can move a thinking
+        budget was unavailable to it. There is no configured rung to step down
+        from, so the step is to a named floor instead.
+
+        Safe because this is only ever consulted after a reasoning-bound
+        truncation: a healthy call still sends byte-identical requests."""
         provider = LiteLLMProvider(model="openai/gpt-5.5")
 
-        assert provider.lower_reasoning_effort() is None
+        assert provider.lower_reasoning_effort() == {"reasoning_effort": _EFFORT_FLOOR}
+
+    def test_the_floor_is_a_real_reduction_not_the_bottom(self) -> None:
+        """Not `none`: a model whose thinking overran is still a reasoning model,
+        and switching thought off entirely trades a truncated review for a worse
+        one. The floor bounds the thinking rather than removing it."""
+        assert _EFFORT_FLOOR in _EFFORT_LADDER
+        assert _EFFORT_LADDER.index(_EFFORT_FLOOR) > 0
+
+    def test_an_unset_nested_effort_also_steps_to_the_floor(self) -> None:
+        """OpenRouter carries the effort in a nested object, and the models that
+        truncate this way are mostly reached through it — so the floor has to be
+        available on that route too, without losing the rest of extra_body."""
+        provider = LiteLLMProvider(
+            model="openrouter/z-ai/glm-4.7-flash",
+            extra_body={"provider": {"sort": "latency"}},
+        )
+
+        assert provider.lower_reasoning_effort() == {
+            "extra_body": {
+                "provider": {"sort": "latency"},
+                "reasoning": {"effort": _EFFORT_FLOOR},
+            }
+        }
+
+    def test_stepping_to_the_floor_is_still_not_a_mutation(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        provider.lower_reasoning_effort()
+
+        assert "reasoning_effort" not in provider.default_opts
 
     def test_default_is_a_sentinel_not_a_rung(self) -> None:
         """`default` says "let the route decide" — there is no telling what sits

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1703,7 +1703,7 @@ class TestSteppingReasoningEffortDown:
         assert _EFFORT_FLOOR in _EFFORT_LADDER
         assert _EFFORT_LADDER.index(_EFFORT_FLOOR) > 0
 
-    def test_an_unset_nested_effort_also_steps_to_the_floor(self) -> None:
+    def test_the_floor_takes_openrouters_nested_shape(self) -> None:
         """OpenRouter carries the effort in a nested object, and the models that
         truncate this way are mostly reached through it — so the floor has to be
         available on that route too, without losing the rest of extra_body."""
@@ -1718,6 +1718,28 @@ class TestSteppingReasoningEffortDown:
                 "reasoning": {"effort": _EFFORT_FLOOR},
             }
         }
+
+    def test_the_floor_takes_the_nested_shape_with_no_extra_body_at_all(self) -> None:
+        """The shape follows the ROUTE, not whether extra_body happens to exist.
+
+        litellm forwards the flat param only for models its capability map flags
+        reasoning-capable, and the newest models are not in it — which is exactly
+        the set that truncates this way. A flat param here would be dropped and
+        the retry would fail identically. OpenRouter takes the nested object
+        regardless of model, so that is what the floor uses."""
+        provider = LiteLLMProvider(model="openrouter/nvidia/nemotron")
+
+        assert provider.lower_reasoning_effort() == {
+            "extra_body": {"reasoning": {"effort": _EFFORT_FLOOR}}
+        }
+
+    def test_an_unrelated_extra_body_does_not_make_a_route_nested(self) -> None:
+        """extra_body is not evidence of the nested shape — a caller can set it
+        for any provider option. Only OpenRouter reads a nested `reasoning`, so
+        anywhere else the floor must go out as the flat param the route wants."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5", extra_body={"service_tier": "priority"})
+
+        assert provider.lower_reasoning_effort() == {"reasoning_effort": _EFFORT_FLOOR}
 
     def test_stepping_to_the_floor_is_still_not_a_mutation(self) -> None:
         provider = LiteLLMProvider(model="openai/gpt-5.5")


### PR DESCRIPTION
## Summary

When a reasoning-bound truncation occurs on a model with no explicit `reasoning_effort` configured, the provider now steps down to a named floor (`"low"`) instead of returning `None`. This fixes a critical gap where models reasoning at their own default — the exact configuration that exhausts output ceilings — had no retry lever available.

## Changes

- **`litellm_provider.py`**: Modified `lower_reasoning_effort()` to return a floor effort when nothing is configured, rather than `None`. The floor is selected based on the provider route:
  - OpenRouter models get the nested shape: `{"extra_body": {"reasoning": {"effort": _EFFORT_FLOOR}}}`
  - Other models get the flat shape: `{"reasoning_effort": _EFFORT_FLOOR}`
  - Added `_EFFORT_FLOOR = "low"` constant — chosen because it's the lowest rung all reasoning routes understand, and switching thought off entirely trades a truncated review for a worse one
  - Added `_OPENROUTER_PREFIX` constant derived from the factory's route builder to detect OpenRouter models
  - Updated docstring to explain the new behavior and why it's safe (only consulted after reasoning-bound truncation, so healthy calls remain byte-identical)

- **Test coverage** (`test_retry.py`):
  - Renamed `test_an_unset_effort_steps_nowhere` → `test_an_unset_effort_steps_to_the_floor` with updated assertion
  - Added `test_the_floor_is_a_real_reduction_not_the_bottom` — validates floor is in the ladder and not at the bottom
  - Added `test_the_floor_takes_openrouters_nested_shape` — verifies nested shape for OpenRouter with existing `extra_body`
  - Added `test_the_floor_takes_the_nested_shape_with_no_extra_body_at_all` — verifies nested shape for OpenRouter without `extra_body`
  - Added `test_an_unrelated_extra_body_does_not_make_a_route_nested` — ensures `extra_body` presence doesn't force nested shape for non-OpenRouter models
  - Added `test_stepping_to_the_floor_is_still_not_a_mutation` — confirms the method doesn't mutate provider state

- **Integration test** (`test_truncation_split.py`):
  - Added `test_a_model_reasoning_at_its_own_default_still_gets_the_retry` — end-to-end test using the real adapter method, simulating the exact failure mode observed in benchmarks (GLM 4.7 Flash, Nemotron, Laguna models)

- **Specification** (`openspec/specs/review-pipeline/spec.md`):
  - Updated engine spec to document the floor behavior and clarify that it applies when no effort is configured
  - Separated the "no effort configured" scenario from "effort already at bottom" for clarity

## Implementation Details

The fix distinguishes between two cases:
1. **Effort explicitly configured** (flat or nested): step down the ladder as before, return `None` if already at bottom
2. **No effort configured** (the new case): return the floor in the appropriate shape for the route

The route detection uses `model.startswith(_OPENROUTER_PREFIX)` rather than checking for `extra_body` presence, because `extra_body` may be set for unrelated provider options. This ensures the shape follows the provider's actual capability, not incidental configuration.

The floor choice of `"low"` balances safety (still enables reasoning, doesn't disable thinking entirely) with effectiveness (lowest rung universally supported across routes).

https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh