### PR TITLE
fix(provider): don't step down an effort the route would discard

### DIFF
--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -278,15 +278,14 @@ says nothing about size is not split at all.
 
 A lens whose truncation was reasoning-bound SHALL be re-run once with its
 `reasoning_effort` stepped down one level, merging its findings with the cut
-call's salvage — the sibling of the split, changing the one variable that can
-move a thinking budget. Exactly one attempt: a retry that truncates the same way
-reports plain. The step is always downward and never offered on a payload-bound
-truncation. With no effort configured there is no rung to descend, so the step
-SHALL be to a named floor — the configuration a model reasoning at its own
-default arrives in, which must not be the one with no lever. The retry SHALL
-re-check the whole-review deadline, token budget and interrupt first, so it can
-never spend past a stop. A lens that only answered after stepping down SHALL be
-named in the summary.
+call's salvage — changing the one variable that can move a thinking budget.
+Exactly one attempt, always downward, never on a payload-bound truncation. With
+no effort configured the step SHALL be to a named floor, so a model reasoning at
+its own default is not the one with no lever; where the route would discard the
+override the original failure SHALL be reported instead of an identical request,
+and that judgement SHALL fail open. The retry SHALL re-check the deadline, token
+budget and interrupt first, and a lens that only answered after stepping down
+SHALL be named in the summary.
 <!-- anchor: engine.reasoning-step-down -->
 
 #### Scenario: the lower effort fits
@@ -297,21 +296,22 @@ named in the summary.
 #### Scenario: the lower effort truncates too
 - **WHEN** the step-down retry is itself reasoning-bound
 - **THEN** it reports and stops — one attempt, never a walk down the ladder
-
 #### Scenario: no effort was configured
 - **WHEN** a reasoning-bound truncation comes from a run that set no effort
-- **THEN** the retry goes out at the floor, in whichever shape that provider
-  carries its effort — the model was thinking at its own default, which is why
-  the ceiling went
+- **THEN** the retry goes out at the floor, in that provider's own effort shape
 
-#### Scenario: the effort is already at the bottom
+#### Scenario: the route would discard the override
+- **WHEN** a floor would be sent to a route whose capability map omits the param
+- **THEN** nothing is retried — the request would go out identical to the one
+  that just failed, billed twice for one answer
+
+#### Scenario: there is no step to take
 - **WHEN** the configured effort is the lowest rung, or names no position on the
   ladder at all
 - **THEN** nothing is retried and nothing is spent
 
 #### Scenario: a ceiling was reached while the first call was finishing
-- **WHEN** the deadline, the token budget or a termination signal lands before
-  the step-down begins
+- **WHEN** the deadline, token budget or a termination signal lands first
 - **THEN** the retry is not issued and the truncation is reported as it stands
 
 ### Requirement: A lens may defer once for bounded read-only context

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -340,8 +340,19 @@ def build_provider(
         # supplies an explicit base (e.g. a proxy) is honoured too.
         opts["api_base"] = api_base
 
+    # Answered here because this is where both halves live: `dropped_params`
+    # needs the Provider enum and the RAW model name, and the adapter holds
+    # neither — only the already-prefixed litellm string. Fails open by
+    # construction: `dropped_params` returns [] both when the param is supported
+    # and when the lookup fails, so only a map that positively omits it marks the
+    # route incapable.
+    effort_supported = "reasoning_effort" not in dropped_params(
+        provider, model, ["reasoning_effort"]
+    )
+
     return LiteLLMProvider(
         model=resolved_model,
         fallback_model=resolved_fallback,
+        effort_override_supported=effort_supported,
         **opts,
     )

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -423,12 +423,20 @@ class LiteLLMProvider:
         *,
         model: str = "",
         fallback_model: str | None = None,
+        effort_override_supported: bool = True,
         **default_opts: Any,
     ) -> None:
         if "prompt_cache" in default_opts:
             raise TypeError("prompt_cache was removed; prompt caching is always enabled")
         self.model = model
         self.fallback_model = fallback_model
+        # Whether this model's capability entry will actually carry a
+        # `reasoning_effort` we invent for a step-down retry. Defaults True and
+        # is only ever set False when litellm's map POSITIVELY omits the param:
+        # the map does not know the newest models, which are exactly the ones
+        # that truncate on reasoning, so silence has to mean "try it" or the
+        # retry would be withheld from the models it exists for.
+        self._effort_override_supported = effort_override_supported
         self.default_opts: dict[str, Any] = default_opts
         # Models that have proved they won't take response_format — either by
         # 400ing on it or by decoding it to nothing (see _call). Their later
@@ -536,6 +544,12 @@ class LiteLLMProvider:
         # identically. OpenRouter takes the nested object regardless of model.
         if self.model.startswith(_OPENROUTER_PREFIX):
             return {"extra_body": {**extra, "reasoning": {"effort": _EFFORT_FLOOR}}}
+        # Flat param, so `drop_params` gets a say. A route whose capability entry
+        # omits it would have the floor stripped and re-send the request that
+        # just failed — billed twice for one answer. Report the original failure
+        # instead; the engine already stops when this answers None.
+        if not self._effort_override_supported:
+            return None
         return {"reasoning_effort": _EFFORT_FLOOR}
 
     def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -594,15 +594,42 @@ def test_a_failed_step_down_is_not_reported_as_a_recovery() -> None:
     assert "results may be incomplete" in summary
 
 
-def test_no_retry_when_reasoning_effort_is_unset() -> None:
-    """Byte-identical behaviour for the users who never configured it: there is
-    no lower level to step to, so nothing is retried and nothing is spent."""
+def test_no_retry_when_the_adapter_has_no_step_to_offer() -> None:
+    """The engine's half of the contract: when the adapter answers None, the
+    original failure is reported and nothing more is spent.
+
+    Renamed from `test_no_retry_when_reasoning_effort_is_unset`, which no longer
+    described production: since #452 an unset effort steps to a floor rather than
+    nowhere, so the old name asserted the opposite of what the adapter does. The
+    fake still answers None, which is now the *incapable-route* case — a route
+    whose capability entry omits `reasoning_effort`, where sending it would be
+    stripped and re-send the request that just failed."""
     provider = _TruncatesUntilEffortDrops(effort=None, answers_at=_TruncatesUntilEffortDrops._NEVER)
 
     with pytest.raises(ReviewIncompleteError):
         LLMReviewEngine(provider).review(_ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg())
 
     assert provider.efforts == [None]  # one call, no step-down
+
+
+def test_an_incapable_route_reports_rather_than_re_sending_the_same_request() -> None:
+    """End to end through the REAL adapter method, which is where the decision
+    lives. A route litellm's map says cannot take `reasoning_effort` gets no
+    retry: the floor would be stripped by drop_params and the second call would
+    be byte-identical to the first, billed twice for one answer."""
+
+    class _IncapableRoute(_TruncatesUntilEffortDrops):
+        model = "openai/gpt-5.5"
+        default_opts: dict[str, Any] = {}
+        _effort_override_supported = False
+        lower_reasoning_effort = LiteLLMProvider.lower_reasoning_effort
+
+    provider = _IncapableRoute(effort=None, answers_at=_EFFORT_FLOOR)
+
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg())
+
+    assert provider.efforts == [None]  # never a second, identical request
 
 
 def test_the_step_down_keeps_what_the_cut_call_completed() -> None:

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -507,3 +507,34 @@ class TestOutputCeiling:
         empty answer rather than an unbounded one."""
         provider = build_provider(Provider.ollama, "qwen3.5:4b", max_tokens=0)
         assert "max_tokens" not in provider.default_opts
+
+
+def test_build_provider_tells_the_adapter_whether_the_route_takes_an_effort() -> None:
+    """The capability answer lives in the factory — it holds the Provider enum and
+    the raw model name that `dropped_params` needs, and the adapter holds neither.
+
+    Fails OPEN: only a map that POSITIVELY omits the param marks a route
+    incapable, because litellm's map does not know the newest models."""
+    from lgtmaybe.providers import factory as factory_mod
+
+    seen: dict[str, object] = {}
+
+    def fake_dropped(_provider: object, _model: str, params: object) -> list[str]:
+        seen["params"] = list(params)  # type: ignore[arg-type]
+        return ["reasoning_effort"]
+
+    original = factory_mod.dropped_params
+    factory_mod.dropped_params = fake_dropped  # type: ignore[assignment]
+    try:
+        provider = build_provider(Provider.openai, "gpt-5.5", api_key="k")
+    finally:
+        factory_mod.dropped_params = original  # type: ignore[assignment]
+
+    assert "reasoning_effort" in seen["params"]  # type: ignore[operator]
+    assert provider._effort_override_supported is False
+
+
+def test_build_provider_defaults_to_capable_when_the_map_is_silent() -> None:
+    provider = build_provider(Provider.openai, "gpt-5.5", api_key="k")
+
+    assert provider._effort_override_supported is True

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1883,3 +1883,53 @@ class TestSchemaDropIsVisibleAndScoped:
             assert provider.schema_dropped() is False
             provider.complete([{"role": "user", "content": "a"}], model, response_format={"x": 1})
             assert provider.schema_dropped() is True
+
+
+class TestTheFloorRespectsRouteCapability:
+    """The floor is only worth sending if the route will actually carry it.
+
+    litellm runs with `drop_params=True`, so a `reasoning_effort` a model's
+    capability entry omits is stripped silently — and the retry then goes out
+    byte-identical to the request that just failed, which is exactly what
+    `engine.rescue` forbids: "the identical request is not re-issued: it fails
+    the same way, at cost."
+
+    Narrow but reachable: it needs a route that REPORTS reasoning tokens (or
+    `_reasoning_exhausted_reason` never fires) while not ACCEPTING the param.
+    Those come from different places — `completion_tokens_details` versus
+    litellm's capability map — so they can disagree.
+    """
+
+    def test_a_route_that_cannot_take_the_param_steps_nowhere(self) -> None:
+        provider = LiteLLMProvider(model="openai/gpt-5.5", effort_override_supported=False)
+
+        assert provider.lower_reasoning_effort() is None
+
+    def test_an_unknown_route_still_gets_the_floor(self) -> None:
+        """Fail OPEN. litellm's map does not know the newest models — precisely
+        the set that truncates this way — so treating silence as "cannot" would
+        withhold the retry from the models it was built for."""
+        provider = LiteLLMProvider(model="openai/gpt-5.5")
+
+        assert provider.lower_reasoning_effort() == {"reasoning_effort": _EFFORT_FLOOR}
+
+    def test_openrouter_ignores_the_capability_answer(self) -> None:
+        """The nested object never passes through litellm's param mapping, so
+        drop_params cannot strip it — OpenRouter takes it regardless of model."""
+        provider = LiteLLMProvider(
+            model="openrouter/z-ai/glm-4.7-flash", effort_override_supported=False
+        )
+
+        assert provider.lower_reasoning_effort() == {
+            "extra_body": {"reasoning": {"effort": _EFFORT_FLOOR}}
+        }
+
+    def test_a_configured_effort_still_steps_down_regardless(self) -> None:
+        """The user asked for this param by name. If the route drops it, that was
+        already true of every healthy call — the step-down is not the place to
+        start second-guessing a configured setting."""
+        provider = LiteLLMProvider(
+            model="openai/gpt-5.5", reasoning_effort="high", effort_override_supported=False
+        )
+
+        assert provider.lower_reasoning_effort() == {"reasoning_effort": "medium"}


### PR DESCRIPTION
Closes #453.

## What was left after #452

#452 delivered the issue's headline — a reasoning-bound truncation with no configured `reasoning_effort` now steps to a named floor instead of having no lever — and meets every acceptance criterion except one:

> if the route cannot accept the override, report the original failure without sending an identical retry … Tests cover capable and **incapable** provider routes.

The floor was being sent unconditionally on the flat path. litellm runs with `drop_params=True`, so a `reasoning_effort` a model's capability entry omits is stripped silently, and the retry goes out **byte-identical** to the request that just failed — billed twice for one answer. `engine.rescue` forbids exactly that: *"the identical request is not re-issued: it fails the same way, at cost."*

## How narrow the window actually is

Worth being precise, because it decides how much this is worth.

`_reasoning_exhausted_reason` bails unless the route **reported** a reasoning count:

```python
reasoning, ceiling = exc.reasoning_tokens, exc.output_tokens
if not reasoning or not ceiling:
    return None
```

So a model with no reasoning channel can never be classified reasoning-bound and never reaches the step-down — `test_a_truncation_with_no_reasoning_breakdown_is_still_split` already locks that.

What's left is a route that **reports** reasoning tokens yet doesn't **accept** the param. Not a contradiction: the two come from different places — `completion_tokens_details.reasoning_tokens` versus litellm's capability map. OpenRouter was already immune, since the nested `reasoning` object never passes through litellm's param mapping, which is why the benchmark's models were never affected.

## The check fails open — that's the hard part

`_honour_param_support`'s own docstring says litellm's map doesn't know the newest models, *"which is exactly the set a reasoning budget gets configured for"*. Treating silence as "cannot" would withhold the retry from the models #452 was written for.

`dropped_params` already returns `[]` both when a param is supported **and** when the lookup fails, so `"reasoning_effort" not in dropped_params(...)` is fail-open by construction — only a map that *positively* omits it marks a route incapable.

The answer is computed in the factory because that's where both halves live: `dropped_params` needs the `Provider` enum and the **raw** model name, and the adapter holds neither — only the already-prefixed litellm string.

## A stale test, which may be the more valuable half

`test_no_retry_when_reasoning_effort_is_unset` still passed, but only because its *fake* returns `None` for an unset effort — the real adapter hasn't done that since #452. The name asserted the opposite of production behaviour.

Renamed to `test_no_retry_when_the_adapter_has_no_step_to_offer` (the engine's half of the contract: when the adapter says no, report and spend nothing), and repointed — that fake is now the *incapable-route* case. Added `test_an_incapable_route_reports_rather_than_re_sending_the_same_request`, which drives the **real** `LiteLLMProvider.lower_reasoning_effort` end to end, since the defect lived in the seam between engine and adapter.

## Tests

- `tests/providers/test_retry.py` — new `TestTheFloorRespectsRouteCapability`: incapable route steps nowhere; unknown route still gets the floor (fail-open); OpenRouter ignores the capability answer; a *configured* effort still steps down regardless, since the user asked for that param by name.
- `tests/providers/test_factory.py` — the capability answer reaches the adapter, and defaults to capable when the map is silent.
- `tests/engine/test_truncation_split.py` — as above.

Note the previous 11 tests in `TestSteppingReasoningEffortDown` covered "capable vs incapable" only in the *shape* sense (nested vs flat); none patched `litellm.get_supported_openai_params`.

## Spec

`engine.reasoning-step-down` gains the discard case and the fail-open rule, with its own scenario. Prose tightened to stay under the 40-line section cap.

## Verification

`uv run pytest` — 2182 passed, 3 skipped. `ruff check`, `ruff format`, `mypy src`, `tests/specs`, `tests/docs` green; `openspec validate --specs` 10/10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_