### PR TITLE
feat(cli): give the profile a machine-readable form, and stop it corrupting stdout

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5498,6 +5498,109 @@ The canonical machine-readable schemas. These are the source of truth for provid
 
 ---
 
+<!-- Source: https://lgtmaybe.coles.codes/reference/profile/ -->
+
+# Profile Reference
+
+`--profile` prints a per-call breakdown of a review: where the time went, what
+each lens spent, and what it produced. `--profile-json PATH` writes the same
+data as JSON.
+
+**Parse the JSON, not the table.** The table's layout is not a contract and may
+be restyled; the JSON payload carries a `schema_version` precisely so it can be
+pinned against.
+
+## Which stream the table uses
+
+The table goes to **stdout** for a human-format review, and to **stderr** when
+the findings themselves are machine-readable (`--format json`, `--format agent`,
+`--json`). stdout carries the deliverable, so it stays parseable — the same rule
+the billable-token footer follows.
+
+`--profile-json` writes to a **file**, so it never collides with either stream
+whatever the output format is. An unwritable path is logged and skipped: a
+review that produced findings is not lost to a diagnostic file.
+
+## The table's columns
+
+| column | meaning |
+|---|---|
+| `call` | the lens id, or a stage label like `reflect`, `triage`, `repair:<lens>` |
+| `batch` | which batch of files the call covered |
+| `tries` | requests actually issued, including adapter retries |
+| `elapsed` | wall time for the call |
+| `in_tok` | prompt tokens |
+| `out_tok` | completion tokens |
+| `think_tok` | reasoning tokens, when the route reports them |
+| `think_%` | reasoning tokens as a share of the `max_tokens` ceiling |
+| `cache_rd` | prompt-cache tokens read |
+| `cache_wr` | prompt-cache tokens written |
+| `findings` | findings parsed from this call |
+| `error` | the failure reason, when the call failed |
+
+### What `-` means
+
+A dash is **unknown**, never zero.
+
+`think_tok` is a dash when the route reported no reasoning breakdown. That is
+deliberate: `0` would assert the model did no thinking, and nobody said that.
+`think_%` is a dash when there is no ceiling to be a share of, and `findings` is
+a dash for a call that does not produce review findings at all — distinct from a
+call that produced none, which shows `0`.
+
+This is the distinction that breaks naive parsers: `int(row["think_tok"])`
+raises on a dash. In the JSON payload the same value is `null`.
+
+## The JSON payload
+
+```json
+{
+  "schema_version": 1,
+  "wall_seconds": 12.4,
+  "total_tokens": 41231,
+  "returned_findings": 3,
+  "stages": [{"name": "redact", "elapsed": 0.01}],
+  "calls": [
+    {
+      "label": "security",
+      "batch": 1,
+      "attempts": 1,
+      "elapsed": 8.2,
+      "input_tokens": 36918,
+      "output_tokens": 1286,
+      "reasoning_tokens": null,
+      "reasoning_share": null,
+      "output_ceiling": null,
+      "cache_read_tokens": 0,
+      "cache_creation_tokens": 0,
+      "findings": 2,
+      "error": null
+    }
+  ]
+}
+```
+
+Notes:
+
+- `reasoning_tokens`, `reasoning_share`, `output_ceiling`, `findings` and
+  `error` are `null` when unknown or absent — the JSON counterpart of the
+  table's `-`.
+- `reasoning_share` is the raw ratio the table rounds into `think_%`.
+- `total_tokens` is `input + output` across all calls. Cache counters are
+  deliberately excluded: routes disagree on whether a cached read is already
+  inside the prompt count, so adding them would double-count on some and not
+  others.
+- `returned_findings` is the count after the whole pipeline, which may be lower
+  than the calls' parsed total once dedupe, reflection and filtering have run.
+
+## Stability
+
+`schema_version` is bumped when the payload's shape changes in a way a pinned
+consumer would notice. Adding a field is not such a change; removing one or
+altering what it means is.
+
+---
+
 <!-- Source: https://lgtmaybe.coles.codes/explanation/what-gets-reviewed/ -->
 
 # What gets reviewed

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,6 +31,7 @@
 ## Reference
 
 - [Configuration](https://lgtmaybe.coles.codes/reference/config/): Complete lgtmaybe configuration reference — every ReviewConfig field, enum, and JSON schema, generated from the pydantic models.
+- [Profile output](https://lgtmaybe.coles.codes/reference/profile/): The --profile table and --profile-json payload — every column, what a dash means, and the machine-readable shape to parse instead.
 
 ## Explanation
 

--- a/docs/reference/profile.md
+++ b/docs/reference/profile.md
@@ -1,0 +1,102 @@
+---
+description: The --profile table and --profile-json payload — every column, what a dash means, and the machine-readable shape to parse instead.
+---
+
+# Profile Reference
+
+`--profile` prints a per-call breakdown of a review: where the time went, what
+each lens spent, and what it produced. `--profile-json PATH` writes the same
+data as JSON.
+
+**Parse the JSON, not the table.** The table's layout is not a contract and may
+be restyled; the JSON payload carries a `schema_version` precisely so it can be
+pinned against.
+
+## Which stream the table uses
+
+The table goes to **stdout** for a human-format review, and to **stderr** when
+the findings themselves are machine-readable (`--format json`, `--format agent`,
+`--json`). stdout carries the deliverable, so it stays parseable — the same rule
+the billable-token footer follows.
+
+`--profile-json` writes to a **file**, so it never collides with either stream
+whatever the output format is. An unwritable path is logged and skipped: a
+review that produced findings is not lost to a diagnostic file.
+
+## The table's columns
+
+| column | meaning |
+|---|---|
+| `call` | the lens id, or a stage label like `reflect`, `triage`, `repair:<lens>` |
+| `batch` | which batch of files the call covered |
+| `tries` | requests actually issued, including adapter retries |
+| `elapsed` | wall time for the call |
+| `in_tok` | prompt tokens |
+| `out_tok` | completion tokens |
+| `think_tok` | reasoning tokens, when the route reports them |
+| `think_%` | reasoning tokens as a share of the `max_tokens` ceiling |
+| `cache_rd` | prompt-cache tokens read |
+| `cache_wr` | prompt-cache tokens written |
+| `findings` | findings parsed from this call |
+| `error` | the failure reason, when the call failed |
+
+### What `-` means
+
+A dash is **unknown**, never zero.
+
+`think_tok` is a dash when the route reported no reasoning breakdown. That is
+deliberate: `0` would assert the model did no thinking, and nobody said that.
+`think_%` is a dash when there is no ceiling to be a share of, and `findings` is
+a dash for a call that does not produce review findings at all — distinct from a
+call that produced none, which shows `0`.
+
+This is the distinction that breaks naive parsers: `int(row["think_tok"])`
+raises on a dash. In the JSON payload the same value is `null`.
+
+## The JSON payload
+
+```json
+{
+  "schema_version": 1,
+  "wall_seconds": 12.4,
+  "total_tokens": 41231,
+  "returned_findings": 3,
+  "stages": [{"name": "redact", "elapsed": 0.01}],
+  "calls": [
+    {
+      "label": "security",
+      "batch": 1,
+      "attempts": 1,
+      "elapsed": 8.2,
+      "input_tokens": 36918,
+      "output_tokens": 1286,
+      "reasoning_tokens": null,
+      "reasoning_share": null,
+      "output_ceiling": null,
+      "cache_read_tokens": 0,
+      "cache_creation_tokens": 0,
+      "findings": 2,
+      "error": null
+    }
+  ]
+}
+```
+
+Notes:
+
+- `reasoning_tokens`, `reasoning_share`, `output_ceiling`, `findings` and
+  `error` are `null` when unknown or absent — the JSON counterpart of the
+  table's `-`.
+- `reasoning_share` is the raw ratio the table rounds into `think_%`.
+- `total_tokens` is `input + output` across all calls. Cache counters are
+  deliberately excluded: routes disagree on whether a cached read is already
+  inside the prompt count, so adding them would double-count on some and not
+  others.
+- `returned_findings` is the count after the whole pipeline, which may be lower
+  than the calls' parsed total once dedupe, reflection and filtering have run.
+
+## Stability
+
+`schema_version` is bumped when the payload's shape changes in a way a pinned
+consumer would notice. Adding a field is not such a change; removing one or
+altering what it means is.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
           - Releasing: how-to/releasing.md
   - Reference:
       - Configuration: reference/config.md
+      - Profile output: reference/profile.md
   - Explanation:
       - What gets reviewed: explanation/what-gets-reviewed.md
       - Architecture: explanation/architecture.md

--- a/openspec/specs/cli-and-local/anchors.yml
+++ b/openspec/specs/cli-and-local/anchors.yml
@@ -46,6 +46,12 @@ cli.response-style:
     has: { field: name, regex: '^_answer_question$' }
   files: [src/lgtmaybe/cli/slash.py]
 
+cli.profile-output:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_write_profile_json$' }
+  files: [src/lgtmaybe/cli/**/*.py]
+
 cli.local-context:
   rule:
     kind: function_definition

--- a/openspec/specs/cli-and-local/spec.md
+++ b/openspec/specs/cli-and-local/spec.md
@@ -182,6 +182,30 @@ against the worktree's top level, not the caller's directory.
 - **WHEN** `lgtmaybe review` runs from a package directory, not the repo root
 - **THEN** it sees the whole worktree, with each file's head text loaded
 
+### Requirement: Diagnostics never corrupt machine output
+
+stdout SHALL carry only the review's deliverable. The opt-in profile table is a
+human artefact, so it SHALL move to stderr whenever the findings themselves are
+machine-readable — otherwise a run asking for both emits neither cleanly. The
+profile SHALL also be available as data, written to a path rather than a stream
+so it collides with no output format, carrying a schema version so a consumer
+can pin against it, and reporting an unknown count as null rather than a
+sentinel a parser must string-match. A diagnostic that cannot be written SHALL
+NOT fail a review that produced findings.
+<!-- anchor: cli.profile-output -->
+
+#### Scenario: machine-readable findings with the profile enabled
+- **WHEN** a review is asked for JSON findings and the profile together
+- **THEN** stdout parses as the findings alone, and the table is on stderr
+
+#### Scenario: a consumer wants the profile as data
+- **WHEN** a profile path is given
+- **THEN** the file holds a versioned payload whose unknown counts are null
+
+#### Scenario: the profile path cannot be written
+- **WHEN** writing the profile file fails
+- **THEN** the review still reports its findings
+
 ### Requirement: Config layers merge, secrets never persist
 
 Config SHALL merge user-level file → repo `.lgtmaybe.yml` → CLI flags (most

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -13,6 +13,7 @@ This package is split into three layers:
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import signal
@@ -69,6 +70,10 @@ class RuntimeOptions:
     fallback_model: str | None = None
     pr_url: str | None = None
     profile: bool = False
+    # Where to write the machine-readable profile, if anywhere. A PATH rather
+    # than a stream: stdout already carries the findings under --json/--agent,
+    # and a file collides with nothing whatever the output format is.
+    profile_json: Path | None = None
 
 
 _log = get_logger(__name__)
@@ -708,14 +713,33 @@ def execute_local_review(
         raise click.ClickException(str(exc)) from exc
 
     click.echo(render_findings(findings, summary, fmt=fmt))
+    _write_profile_json(runtime)
     if runtime.profile:
-        click.echo(profiler.render())
+        # stdout carries the deliverable, so the table only shares it when the
+        # deliverable is for a human. Under --json/--agent stdout is a machine
+        # channel and the table made it unparseable — `--json --profile | jq`
+        # simply failed. Same rule the footer below already follows.
+        click.echo(profiler.render(), err=fmt != "human")
     elif profiler.total_tokens():
         # The meter. A local review is the one that runs dozens of times a day
         # against a metered API, so what it spent is reported by default rather
         # than only under --profile (whose table already ends with this line —
         # hence the elif). stderr keeps --json / --agent output pipeable.
         click.echo(profiler.render_total(), err=True)
+
+
+def _write_profile_json(runtime: RuntimeOptions) -> None:
+    """Write the structured profile, when one was asked for.
+
+    Best-effort by design: a review that produced findings must not fail because
+    a diagnostic file could not be written.
+    """
+    if runtime.profile_json is None:
+        return
+    try:
+        runtime.profile_json.write_text(json.dumps(profiler.as_dict(), indent=2), encoding="utf-8")
+    except OSError as exc:
+        _log.warning("could not write the profile json", extra={"error": str(exc)})
 
 
 def execute_local_diagram(

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -92,11 +92,19 @@ def _check_diff_mode(working: bool, uncommitted: bool) -> None:
 
 
 def _runtime(
-    api_key: str | None, api_base: str | None, fallback_model: str | None, profile: bool = False
+    api_key: str | None,
+    api_base: str | None,
+    fallback_model: str | None,
+    profile: bool = False,
+    profile_json: Path | None = None,
 ) -> RuntimeOptions:
     """The RuntimeOptions every ``model_options`` command builds from its flags."""
     return RuntimeOptions(
-        api_key=api_key, api_base=api_base, fallback_model=fallback_model, profile=profile
+        api_key=api_key,
+        api_base=api_base,
+        fallback_model=fallback_model,
+        profile=profile,
+        profile_json=profile_json,
     )
 
 
@@ -424,6 +432,15 @@ local_diff_options = _stack(
     "pip install lgtmaybe[static-analysis])",
 )
 @click.option(
+    "--profile-json",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write the profile as JSON to PATH — per-call tokens, timings, findings "
+    "and errors, with an unknown reasoning count as null rather than a `-` a "
+    "parser has to string-match. A file, not a stream, so it never collides with "
+    "--json or --agent output",
+)
+@click.option(
     "--profile",
     is_flag=True,
     default=False,
@@ -446,6 +463,7 @@ def review(**inputs: Any) -> None:
         inputs.pop("api_base"),
         inputs.pop("fallback_model"),
         profile=inputs.pop("profile"),
+        profile_json=inputs.pop("profile_json"),
     )
     static_analysis = inputs.pop("static_analysis")
     base = inputs.pop("base")

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -28,6 +28,12 @@ from lgtmaybe.core.ports import Message, ProviderClient
 
 _log = get_logger(__name__)
 
+# Bumped when `Profiler.as_dict`'s shape changes in a way a pinned consumer
+# would notice. Adding a field is not such a change; removing or re-meaning one
+# is. Nothing else in the repo emits a versioned payload — this output exists to
+# be pinned against, which is why it starts one.
+_PROFILE_SCHEMA_VERSION = 1
+
 
 @dataclass(frozen=True)
 class CallRecord:
@@ -232,6 +238,36 @@ class Profiler:
             with self._lock:
                 self.stages.append(StageRecord(name=name, elapsed=elapsed))
             _log.info("stage completed", extra={"stage": name, "elapsed_s": round(elapsed, 3)})
+
+    def as_dict(self) -> dict[str, Any]:
+        """The profile as data, for a consumer that should not parse the table.
+
+        The table is a human artefact, and its one correctness decision — `-` for
+        an unknown reasoning count, never `0`, because 0 asserts the model did no
+        thinking — is exactly what breaks a naive `int()` on the column. A
+        downstream harness lost roughly a tenth of every call row it recorded to
+        that. So unknown stays ``None`` here and serialises to JSON `null`: still
+        not zero, but no longer something to string-match.
+
+        ``reasoning_share`` is the ratio the table rounds into an integer percent;
+        a consumer wants the number it was rounded from.
+
+        ``schema_version`` is a new convention rather than an existing one —
+        nothing else in the repo emits a versioned payload — and it is here
+        because the whole point of this output is that it can be pinned against.
+        """
+        with self._lock:
+            calls, stages = list(self.calls), list(self.stages)
+            returned = self.returned_findings
+            wall = time.perf_counter() - self._started
+        return {
+            "schema_version": _PROFILE_SCHEMA_VERSION,
+            "wall_seconds": wall,
+            "total_tokens": sum(c.input_tokens + c.output_tokens for c in calls),
+            "returned_findings": returned,
+            "stages": [{"name": s.name, "elapsed": s.elapsed} for s in stages],
+            "calls": [{**asdict(call), "reasoning_share": call.reasoning_share} for call in calls],
+        }
 
     def render(self) -> str:
         """The ``--profile`` summary as plain text (reads well in an Action log)."""

--- a/tests/cli/test_token_footer.py
+++ b/tests/cli/test_token_footer.py
@@ -7,6 +7,8 @@ The footer goes to stderr so machine-readable formats stay pipeable.
 
 from __future__ import annotations
 
+import json
+
 import click
 import pytest
 
@@ -53,10 +55,10 @@ def _local_run(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
     monkeypatch.setattr(cli, "build_provider_engine", lambda *a, **k: (_StubEngine(), object()))
     monkeypatch.setattr(cli, "local_pr_context", lambda **k: _CTX)
 
-    def run(fmt: str = "human", profile: bool = False) -> None:
+    def run(fmt: str = "human", profile: bool = False, profile_json=None) -> None:  # type: ignore[no-untyped-def]
         cli.execute_local_review(
             ReviewConfig(provider=Provider.openai, model="m"),
-            cli.RuntimeOptions(profile=profile),
+            cli.RuntimeOptions(profile=profile, profile_json=profile_json),
             base=None,
             working=False,
             fmt=fmt,
@@ -130,3 +132,70 @@ class TestLocalTokenFooter:
                 fmt="human",
             )
         assert "billable" not in capsys.readouterr().err
+
+
+class TestProfileDoesNotBreakMachineOutput:
+    """`--json --profile` was unpipeable: the findings array and the human table
+    went to the same stream, so `lgtmaybe review --json --profile | jq` failed.
+
+    The convention already existed — the token footer is routed to stderr with
+    the comment "stderr keeps --json / --agent output pipeable" — and the profile
+    table was the one output ignoring it.
+    """
+
+    def test_json_output_stays_parseable_under_profile(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        _local_run(profile=True, fmt="json")
+        captured = capsys.readouterr()
+
+        json.loads(captured.out)
+        assert "lgtmaybe profile" in captured.err
+
+    def test_agent_output_stays_clean_under_profile(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        _local_run(profile=True, fmt="agent")
+        captured = capsys.readouterr()
+
+        assert "lgtmaybe profile" not in captured.out
+        assert "lgtmaybe profile" in captured.err
+
+    def test_a_human_run_keeps_the_table_on_stdout(self, _local_run, capsys) -> None:  # type: ignore[no-untyped-def]
+        """Nothing changes for a human reader: stdout is not a machine channel
+        there, so moving it would be churn for its own sake."""
+        _local_run(profile=True)
+
+        assert "lgtmaybe profile" in capsys.readouterr().out
+
+
+class TestProfileJsonFile:
+    """A file rather than a stream. stdout already carries the findings under
+    --json/--agent, and stderr carries the structured logs — a path collides with
+    neither, whatever the output format is."""
+
+    def test_it_writes_the_structured_profile(self, _local_run, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        target = tmp_path / "profile.json"
+
+        _local_run(profile_json=target)
+
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        assert payload["schema_version"] >= 1
+        assert payload["calls"], "the run made calls; they belong in the payload"
+
+    def test_it_coexists_with_json_findings_on_stdout(self, _local_run, tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+        target = tmp_path / "profile.json"
+
+        _local_run(fmt="json", profile_json=target)
+
+        json.loads(capsys.readouterr().out)
+        assert json.loads(target.read_text(encoding="utf-8"))["calls"]
+
+    def test_an_unwritable_path_does_not_fail_the_review(
+        self, _local_run, tmp_path, capsys
+    ) -> None:  # type: ignore[no-untyped-def]
+        """A review that produced findings must not be lost to a diagnostic file."""
+        _local_run(profile_json=tmp_path / "nope" / "profile.json")
+
+        assert capsys.readouterr().out, "the findings still printed"
+
+    def test_nothing_is_written_when_not_asked(self, _local_run, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        _local_run()
+
+        assert list(tmp_path.iterdir()) == []

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -742,3 +742,94 @@ class TestReasoningShareIsLegibleFromAnyRun:
         rendered = p.render()
         assert "800" in rendered
         assert "largest" not in rendered
+
+
+class TestProfileAsData:
+    """The table is a human artefact that consumers were parsing anyway.
+
+    A downstream harness screen-scraped it column-by-column and lost ~10% of
+    every call row to one sentinel: `-` for an unknown reasoning count, which
+    `int()` refuses. The structured form exists so nobody has to do that, and its
+    one hard rule is that unknown stays `null` — never `0`, which would assert
+    the model did no thinking, and never `"-"`, which has to be string-matched.
+    """
+
+    def _record(self, **overrides: object) -> None:
+        defaults: dict[str, object] = {
+            "label": "security",
+            "batch": 1,
+            "elapsed": 1.5,
+            "attempts": 1,
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+        }
+        defaults.update(overrides)
+        profiler.record_call(**defaults)  # type: ignore[arg-type]
+
+    def test_an_unknown_reasoning_count_is_null_not_zero(self) -> None:
+        self._record(reasoning_tokens=None)
+
+        payload = profiler.as_dict()
+
+        assert payload["calls"][0]["reasoning_tokens"] is None
+
+    def test_a_known_reasoning_count_survives_as_a_number(self) -> None:
+        self._record(reasoning_tokens=1234, output_ceiling=16384)
+
+        call = profiler.as_dict()["calls"][0]
+
+        assert call["reasoning_tokens"] == 1234
+        assert call["output_ceiling"] == 16384
+
+    def test_the_reasoning_share_is_a_ratio_not_a_rendered_percent(self) -> None:
+        """The table rounds it to an integer percent with a `%` suffix. A
+        consumer wants the number it was rounded from."""
+        self._record(reasoning_tokens=8192, output_ceiling=16384)
+
+        assert profiler.as_dict()["calls"][0]["reasoning_share"] == pytest.approx(0.5)
+
+    def test_a_clean_call_reports_no_error(self) -> None:
+        self._record()
+
+        assert profiler.as_dict()["calls"][0]["error"] is None
+
+    def test_stages_and_totals_ride_along(self) -> None:
+        with profiler.stage("redact"):
+            pass
+        self._record()
+
+        payload = profiler.as_dict()
+
+        assert [s["name"] for s in payload["stages"]] == ["redact"]
+        assert payload["total_tokens"] == 300
+        assert payload["wall_seconds"] >= 0
+
+    def test_it_carries_a_schema_version(self) -> None:
+        """The whole point is something consumers can pin against, so the shape
+        has to be able to say when it changed."""
+        assert isinstance(profiler.as_dict()["schema_version"], int)
+
+    def test_every_table_column_has_a_field(self) -> None:
+        """Parity with the human table: anyone migrating off screen-scraping must
+        not have to keep the table for one missing column."""
+        self._record(reasoning_tokens=10, output_ceiling=100, findings=2, error=None)
+
+        call = profiler.as_dict()["calls"][0]
+
+        for field in (
+            "label",
+            "batch",
+            "attempts",
+            "elapsed",
+            "input_tokens",
+            "output_tokens",
+            "reasoning_tokens",
+            "reasoning_share",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "findings",
+            "error",
+        ):
+            assert field in call, f"{field} is in the table but not the payload"


### PR DESCRIPTION
Closes #456.

Two things — and the bug is the one worth leading with, because it wasn't in the issue.

## `--json --profile` was unpipeable

`render_findings` writes the findings array to stdout, and the profile table was appended to **the same stream**. So `lgtmaybe review --json --profile | jq` simply failed.

The convention already existed — the billable-token footer is routed to stderr with the comment *"stderr keeps --json / --agent output pipeable"* — and the profile table was the one output ignoring it. Nothing tested the combination.

The table now goes to **stderr when the findings themselves are machine-readable** (`--format json`, `--format agent`, `--json`), and stays on **stdout for a human run**, where stdout isn't a machine channel and moving it would be churn for its own sake. The e2e test that pins the table on stdout for a default run keeps passing unchanged.

## Consumers were screen-scraping, and the table broke them

There was no alternative, and the table's one correctness decision is exactly what breaks a naive parser.

`-` for an unknown reasoning count is deliberate: `provider.reasoning-accounting` requires unknown never to be reported as zero, *"which asserts the model did no thinking"*. But `int(row["think_tok"])` raises on it, and in a downstream harness that sat inside a broad `except (KeyError, ValueError): continue` which discarded **the entire row** — tokens, error and failure with it.

Measured against that harness's stored results: **832 call rows lost across 127 of 1,610 observations** — about a tenth of every call it ever recorded — concentrated in exactly the models whose routes report no reasoning breakdown.

So `Profiler.as_dict()` emits the same data with unknown as `null`, plus the raw `reasoning_share` ratio that the table rounds into `think_%`. `CallRecord` is already a frozen dataclass and `asdict()` was already used for the structured log line, so the serialisation is thin.

## Why a file, not a stream

`--profile-json PATH` writes to a **file**. stdout carries the findings under `--json`/`--agent` and stderr carries the structured JSON logs; a path collides with neither, whatever the output format is — no mode-dependent rule for a consumer to get wrong.

Best-effort by design: an unwritable path is logged and skipped, because a review that produced findings must not be lost to a diagnostic file.

## `schema_version` is precedent-setting, not house style

Nothing else in the repo emits a versioned payload — `evals/run.py`'s `--json` and the findings array are both unversioned. It's here because the entire point of this output is that it can be pinned against, and it's flagged as a new convention rather than presented as conformance to an existing one.

## Docs

`docs/reference/profile.md` — hand-authored, documenting both forms, every column, which stream carries what, and what a dash means and why. Only `reference/config.md` is generated, so this is safe to write by hand; added to the mkdocs nav with front-matter `description:` (the llms.txt generator reads it) and `docs/llms.txt`/`llms-full.txt` regenerated.

## Spec

New requirement `cli.profile-output` in `cli-and-local`: stdout carries only the deliverable, the profile is available as data at a path, unknown reports as null, and a diagnostic that cannot be written doesn't fail a review. The stream change is the stronger reason for a spec amendment than the flag — it alters existing documented behaviour.

Note adding `as_dict` does **not** disturb the `engine.profile-findings` anchor, whose rule is regexed `^render$`.

## Verification

`uv run pytest` — 2189 passed, 3 skipped. `ruff check`, `ruff format`, `mypy src`, `tests/specs`, `tests/docs` green; `openspec validate --specs` 10/10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_