### PR TITLE
feat(evals): run each fixture N times so flaky and reproducible failures separate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -371,6 +371,29 @@ was *not* shown:
   it in the diff, while `tests/test_dispatch.py` covers it in a file the PR never
   touched, so "this change is untested" is true of the diff and wrong as a defect.
 
+### Separating a reproducible failure from an intermittent one
+
+A single pass says a fixture passed or failed; it cannot say whether the model
+*reliably* passes it. `--repeats N` runs every selected fixture N times and adds
+a spread line per fixture — mean/min/max recall plus `parsed=n/N`:
+
+```bash
+uv run python -m evals.run --provider ollama --model qwen3.6:35b \
+  --api-base http://localhost:11434 --repeats 5
+```
+
+That distinction is the one a structured-output audit turns on: a model that
+fails to produce parseable output on *every* repeat of a case has a reproducible
+defect worth reporting upstream, while one that fails on some repeats has a
+flakiness problem you handle with the repair pass instead.
+
+The per-fixture rows stay flat (N entries per fixture), so pooled recall and
+precision keep their meaning and `evals/ab.py` is unaffected. Two bars do get
+strictly harsher, because they are all-quantified over the rows: one parse
+failure or one forbidden finding in **any** repeat fails the run. That is what
+you want from a false-positive gate, but it means a `--repeats 5` run is not
+comparable to a single pass at the same `--min-recall`.
+
 ### Measuring what the fast preset trades away
 
 The default `fast` preset covers the nine lenses in four grouped calls;

--- a/evals/run.py
+++ b/evals/run.py
@@ -15,7 +15,9 @@ import argparse
 import json
 import os
 import sys
+from collections import defaultdict
 from pathlib import Path
+from statistics import fmean
 
 from lgtmaybe.core.models import Provider, ReviewCategory, ReviewConfig, StaticAnalysisConfig
 from lgtmaybe.engine import LLMReviewEngine, ReviewIncompleteError, build_symbol_resolver
@@ -245,6 +247,32 @@ def _print(score: FixtureScore) -> None:
         print(f"    FALSE POSITIVE: {fp}")
 
 
+def _print_spread(scores: list[FixtureScore]) -> None:
+    """Report the recall spread of every fixture run more than once.
+
+    A mean on its own cannot say whether a model is reliable: 50% recall is a
+    fixture half-caught every time, or fully caught half the time, and those are
+    different defects. The min/max is what separates them — and `parsed=n/N` is
+    the same distinction for the failure the structured-output audit turned on,
+    where one model failed a case on every repeat and another failed it on some.
+    """
+    by_name: dict[str, list[FixtureScore]] = defaultdict(list)
+    for score in scores:
+        by_name[score.name].append(score)
+    repeated = {name: runs for name, runs in by_name.items() if len(runs) > 1}
+    if not repeated:
+        return
+    print()
+    for name, runs in repeated.items():
+        recalls = [s.recall for s in runs]
+        parsed = sum(1 for s in runs if s.parsed_ok)
+        print(
+            f"{name:14} over {len(runs):2} runs  recall "
+            f"mean={fmean(recalls):5.0%} min={min(recalls):5.0%} max={max(recalls):5.0%}  "
+            f"parsed={parsed}/{len(runs)}"
+        )
+
+
 def _gate(scores: list[FixtureScore], min_recall: float) -> tuple[bool, float]:
     """Decide pass/fail for a run and report the aggregate recall.
 
@@ -260,6 +288,13 @@ def _gate(scores: list[FixtureScore], min_recall: float) -> tuple[bool, float]:
     - Every fixture must be *clean*: a forbidden (cross-file false-positive)
       finding firing is a humility regression, so any one fails the run. Only
       fixtures that declare `forbidden` can trip this — the rest are always clean.
+
+    Under `--repeats N` the scores list carries N entries per fixture, so both
+    all-quantified bars get strictly harsher: one parse failure or one forbidden
+    hit in ANY repeat fails the run. That is deliberate for a false-positive
+    gate — an intermittent humility regression is still a regression — but it
+    does mean a repeated run is not comparable to a single-pass one at the same
+    --min-recall. Recall pools over the repeats and stays comparable.
     """
     total_expected = sum(s.expected_count for s in scores)
     total_matched = sum(s.matched_count for s in scores)
@@ -371,6 +406,14 @@ def main(argv: list[str] | None = None) -> int:
         "measure what two-stage routing costs in recall on the fixture set",
     )
     ap.add_argument(
+        "--repeats",
+        type=int,
+        default=1,
+        help="run every selected fixture N times (default 1) — a single pass cannot "
+        "tell a model that fails a case reproducibly from one that fails it "
+        "intermittently, and that distinction is what a compliance audit turns on",
+    )
+    ap.add_argument(
         "--json",
         dest="json_out",
         action="store_true",
@@ -406,7 +449,13 @@ def main(argv: list[str] | None = None) -> int:
             triage_model=args.triage_model,
             preset=args.preset,
         )
+        # FLAT, deliberately: `evals.ab` parses `fixtures` as a plain list of
+        # FixtureScore and pools raw counts, so N entries per fixture pool
+        # correctly with no change there. Nesting would break it, and ab's
+        # parsing has no test to catch that. Repeats are the INNER loop so a
+        # fixture's runs print adjacent, under its own spread line.
         for diff, m in fixtures
+        for _ in range(max(1, args.repeats))
     ]
 
     ok, aggregate = _gate(scores, args.min_recall)
@@ -424,6 +473,7 @@ def main(argv: list[str] | None = None) -> int:
                     # model produced which row.
                     "provider": args.provider,
                     "model": args.model,
+                    "repeats": args.repeats,
                     "aggregate_recall": aggregate,
                     **pooled,
                 }
@@ -433,6 +483,7 @@ def main(argv: list[str] | None = None) -> int:
 
     for score in scores:
         _print(score)
+    _print_spread(scores)
     print(
         f"\naggregate recall {aggregate:.0%} — "
         + ("PASS" if ok else "FAIL")

--- a/tests/evals/test_run.py
+++ b/tests/evals/test_run.py
@@ -639,3 +639,123 @@ def test_a_failed_call_is_printed_before_the_misses_it_explains(
     out = capsys.readouterr().out
     assert "CALL FAILED" in out
     assert "(prose)" in out, "the operator reads this line, so it names the shape"
+
+
+# ---------------------------------------------------------------------------
+# repeats
+#
+# Without a repeat axis a fixture either passed or failed, and nothing separated
+# "this model can't do it" from "this model does it four times in five". That
+# distinction is what the structured-output audit turned on: one model failed a
+# case consistently across three repeats (a reproducible defect), another failed
+# intermittently. Neither was expressible here.
+# ---------------------------------------------------------------------------
+
+
+def test_repeats_run_each_fixture_more_than_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        seen.append(manifest.name)
+        return FixtureScore(
+            name=manifest.name,
+            parsed_ok=True,
+            expected_count=1,
+            matched_count=1,
+            findings_count=1,
+            missed=[],
+        )
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "m",
+            "--min-recall",
+            "0.0",
+            "--fixture",
+            "badcode",
+            "--repeats",
+            "3",
+        ]
+    )
+
+    assert seen == ["badcode", "badcode", "badcode"]
+
+
+def test_one_repeat_is_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing invocations must cost exactly what they cost before."""
+    seen: list[str] = []
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        seen.append(manifest.name)
+        return FixtureScore(
+            name=manifest.name,
+            parsed_ok=True,
+            expected_count=1,
+            matched_count=1,
+            findings_count=1,
+            missed=[],
+        )
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+    run_mod.main(
+        ["--provider", "ollama", "--model", "m", "--min-recall", "0.0", "--fixture", "badcode"]
+    )
+
+    assert seen == ["badcode"]
+
+
+def test_the_payload_stays_a_flat_list_so_the_ab_harness_still_parses_it(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """evals.ab does `FixtureScore.model_validate(f) for f in payload["fixtures"]`
+    and pools raw counts. A flat list of N entries per fixture keeps that working
+    and pools correctly; nesting would break it, and ab's parsing has no test to
+    catch that."""
+    monkeypatch.setattr(run_mod, "build_provider", lambda *a, **k: _ShellInjectionProvider())
+    payload = _run_json(capsys, ["--fixture", "badcode", "--repeats", "2"])
+
+    assert payload["repeats"] == 2
+    assert [f["name"] for f in payload["fixtures"]] == ["badcode", "badcode"]
+    assert [FixtureScore.model_validate(f).name for f in payload["fixtures"]]
+
+
+def test_repeated_runs_report_their_spread(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A single number cannot say whether a model is reliable. The point of
+    repeats is the spread, so it has to reach the operator."""
+    recalls = iter([1.0, 0.0])
+
+    def fake_review(_diff, manifest, *_a, **_k):  # type: ignore[no-untyped-def]
+        matched = int(next(recalls))
+        return FixtureScore(
+            name=manifest.name,
+            parsed_ok=True,
+            expected_count=1,
+            matched_count=matched,
+            findings_count=matched,
+            missed=[],
+        )
+
+    monkeypatch.setattr(run_mod, "_review", fake_review)
+    run_mod.main(
+        [
+            "--provider",
+            "ollama",
+            "--model",
+            "m",
+            "--min-recall",
+            "0.0",
+            "--fixture",
+            "badcode",
+            "--repeats",
+            "2",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert "min" in out and "max" in out


### PR DESCRIPTION
Closes #458.

## The gap

A single eval pass says a fixture passed or failed. It cannot say whether the
model *reliably* passes it — and that distinction is exactly what the
structured-output audit turned on:

- one model returned unparseable output on **every** repeat of the same case — a
  reproducible defect worth reporting upstream;
- another failed **intermittently** — flakiness the repair pass handles.

`evals.run` could express neither.

## The change

`--repeats N` (default `1`, so existing invocations cost exactly what they did)
runs every selected fixture N times and prints a spread line per fixture:

```
badcode         over  5 runs  recall mean= 80% min= 60% max=100%  parsed=4/5
```

`parsed=n/N` is the reproducible-vs-intermittent signal directly; mean/min/max
is the same question for recall, where a mean alone cannot distinguish "half
caught every time" from "fully caught half the time".

## Three decisions made deliberately, not by accident

**The payload stays flat.** N entries per fixture in one list, repeats as the
*inner* loop so a fixture's runs print adjacent. `evals/ab.py` does
`FixtureScore.model_validate(f) for f in payload["fixtures"]` and pools raw
counts, so a flat list pools correctly with no change there. Nesting would break
it — and `_run_json`'s parsing has no test, so the break would surface only on a
live run. Covered now by
`test_the_payload_stays_a_flat_list_so_the_ab_harness_still_parses_it`.

**`--repeats` stays out of ab's passthrough allowlist.** In `--baseline-ref` mode
`ab.py` runs the *worktree's own* `evals/run.py`, so passing the flag through
would crash any ref predating it — the same hazard `ab.py:276-282` already
documents for `--preset`.

**Two gate bars get strictly harsher, and it is stated rather than left to be
discovered.** `parsed` and `clean` are all-quantified over the rows, so one parse
failure or one forbidden finding in *any* repeat now fails the run. That is what
a false-positive gate should do with an intermittent humility regression, but it
means a `--repeats 5` run is not comparable to a single pass at the same
`--min-recall`. Recall pools over the repeats and stays comparable. Written into
`_gate`'s docstring and DEVELOPMENT.md.

## Tests (red first)

Four in `tests/evals/test_run.py`: N calls per fixture, `1` is the default, the
payload stays flat and `FixtureScore`-parseable, and the spread reaches the
operator.

## Verification

`uv run pytest` · `ruff check` · `ruff format` · `mypy src` · `tests/specs` ·
`tests/docs` — all green. No spec change: `evals/` carries no anchors, and this
adds no `ReviewConfig` field, so `docs/reference/config.md` is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_