### PR TITLE
fix(engine): don't re-ask a lens whose schema the adapter already stripped

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1816,6 +1816,23 @@ class LLMReviewEngine:
             self._drop_response_format(model)
         return findings, error
 
+    def _sends_response_format(self, model: str) -> bool:
+        """Whether the schema this call asked for actually reached the provider.
+
+        Passing ``response_format`` is not the same as sending it: the adapter
+        strips it for a model that has already refused it (a 400, or schema mode
+        decoding to nothing), and from here that call looks identical to one
+        made under enforcement. Re-running such a lens "without the schema"
+        would re-send the request that just failed, byte for byte — a wasted
+        full-diff call, and exactly what ``engine.rescue`` forbids.
+
+        Feature-detected and **fail-open**, like every other adapter probe: an
+        adapter that cannot answer is assumed to have sent what it was given, so
+        the recovery keeps working rather than silently switching itself off.
+        """
+        probe = getattr(self._provider, "sends_response_format", None)
+        return bool(probe(model)) if callable(probe) else True
+
     def _drop_response_format(self, model: str) -> None:
         """Tell the adapter this model's schema mode is not working.
 
@@ -1979,7 +1996,11 @@ class LLMReviewEngine:
                     # 2. The reformat could not do it either. If this call sent
                     #    the provider's schema, that enforcement is the remaining
                     #    suspect — re-run the lens once without it.
-                    if response_format is not None and run.cfg.retry_without_schema:
+                    if (
+                        response_format is not None
+                        and run.cfg.retry_without_schema
+                        and self._sends_response_format(model)
+                    ):
                         retried, retry_error = self._retry_without_schema(
                             messages, model, batch_num, lens, reason, run
                         )

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -499,6 +499,20 @@ class LiteLLMProvider:
         """
         self._disable_response_format(self.model or model, why)
 
+    def sends_response_format(self, model: str) -> bool:
+        """Whether a call for *model* would actually carry the schema.
+
+        The engine passes ``response_format`` on every lens call, but ``_call``
+        strips it for a model already known to refuse it — so "the engine asked
+        for a schema" and "a schema went out" are different facts. The
+        schema-less re-run turns on the second: blaming enforcement that was
+        never applied would re-send the request that just failed, byte for byte,
+        which is precisely what that retry exists to avoid.
+
+        Keyed as ``complete`` resolves the model, like ``drop_response_format``.
+        """
+        return (self.model or model) not in self._schema_dropped
+
     def schema_dropped(self) -> bool:
         """Whether any model lost ``response_format`` during this run.
 

--- a/tests/engine/test_schemaless_retry.py
+++ b/tests/engine/test_schemaless_retry.py
@@ -217,6 +217,60 @@ def test_it_is_off_when_disabled() -> None:
     assert len(_repair_calls(provider)) == 1
 
 
+def test_a_model_whose_schema_the_adapter_already_strips_is_not_re_asked() -> None:
+    """Passing `response_format` is not the same as sending it.
+
+    The adapter strips the schema for a model that already refused it, and from
+    the engine that call looks identical to one made under enforcement. Re-running
+    it "without the schema" would re-send the request that just failed, byte for
+    byte — the identical retry the rescue wave forbids, at full diff price.
+    """
+
+    class _SchemaAlreadyStripped(_NeverComplies):
+        def sends_response_format(self, model: str) -> bool:
+            return False
+
+    provider = _SchemaAlreadyStripped()
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_CTX, _cfg())
+
+    assert len(_lens_calls(provider)) == 1
+    assert len(_repair_calls(provider)) == 1
+
+
+def test_an_adapter_that_cannot_answer_still_gets_the_retry() -> None:
+    """Fail-open, like every other adapter probe: an adapter with no opinion is
+    assumed to have sent what it was given, so the recovery keeps working rather
+    than silently switching itself off."""
+    provider = _CompliesOnlyWithoutTheSchema()
+    assert not hasattr(provider, "sends_response_format")
+
+    findings, _summary = LLMReviewEngine(provider).review(_CTX, _cfg())
+
+    assert findings
+
+
+def test_a_ceiling_reached_by_the_repair_stops_the_retry() -> None:
+    """The re-run re-sends the whole diff, so it is the most expensive thing on
+    this path — a budget the first call and its reformat have already spent must
+    not be blown by it."""
+
+    class _ExpensiveRepair(_NeverComplies):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            result = super().complete(messages, model, **opts)
+            if _is_repair(messages):
+                # Push the running total past the budget mid-recovery.
+                return ProviderResult(text=result.text, input_tokens=10_000, output_tokens=10_000)
+            return result
+
+    provider = _ExpensiveRepair()
+    with pytest.raises(ReviewIncompleteError):
+        LLMReviewEngine(provider).review(_CTX, _cfg(max_review_tokens=5_000))
+
+    assert len(_repair_calls(provider)) == 1, "the reformat ran and spent the budget"
+    assert len(_lens_calls(provider)) == 1, "…so the full-diff re-run never started"
+
+
 def test_a_truncated_reply_stays_on_the_truncation_path() -> None:
     """Its complete findings are already salvaged and its batch is already
     re-split; the schema is not what cut it off."""
@@ -260,6 +314,47 @@ def test_a_successful_retry_tells_the_adapter_to_stop_sending_the_schema() -> No
 
     assert provider.dropped, "later calls must not repeat the schema-mode failure"
     assert provider.dropped[0][0] == "m", "keyed by the model the engine called"
+
+
+def test_a_later_lens_skips_the_schema_after_the_first_one_recovered() -> None:
+    """The point of remembering, asserted end to end.
+
+    Recording the `drop_response_format` call only proves the engine asked. What
+    the feature promises is that the NEXT lens stops paying the two wasted calls
+    — which a wrong model key, or options rebuilt from scratch per call, would
+    break while the recording assertion still passed.
+    """
+
+    class _AdapterLike(_CompliesOnlyWithoutTheSchema):
+        """Mirrors the real adapter: it strips the schema for a marked model."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._dropped: set[str] = set()
+
+        def drop_response_format(self, model: str, why: str) -> None:
+            self._dropped.add(model)
+
+        def sends_response_format(self, model: str) -> bool:
+            return model not in self._dropped
+
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            if model in self._dropped:
+                opts.pop("response_format", None)
+            return super().complete(messages, model, **opts)
+
+    provider = _AdapterLike()
+    findings, _summary = LLMReviewEngine(provider).review(
+        _CTX, _cfg(categories=[ReviewCategory.security, ReviewCategory.correctness])
+    )
+
+    assert findings
+    lens_calls = _lens_calls(provider)
+    # The first lens pays the full recovery: schema call, then the schema-less
+    # re-run. Every later call goes out schema-less from the start.
+    assert lens_calls[0]["opts"].get("response_format") is not None
+    assert all("response_format" not in c["opts"] for c in lens_calls[1:])
+    assert len(_repair_calls(provider)) == 1, "only the first lens needed a reformat"
 
 
 def test_a_failed_retry_remembers_nothing() -> None:

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -1884,6 +1884,42 @@ class TestSchemaDropIsVisibleAndScoped:
             provider.complete([{"role": "user", "content": "a"}], model, response_format={"x": 1})
             assert provider.schema_dropped() is True
 
+    def test_the_engine_can_ask_for_the_drop_and_later_calls_honour_it(self) -> None:
+        """The one trigger the adapter cannot see for itself: a reply that
+        arrives well-formed and turns out not to be findings. Only the engine
+        parses, so only the engine can ask — and the ask has to reach the same
+        keyed entry `_call` looks up, or every later call repeats the failure."""
+        model = "openai/gpt-4o"
+        seen: list[bool] = []
+
+        def side_effect(*_args: Any, **kwargs: Any) -> Any:
+            seen.append("response_format" in kwargs)
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            provider.complete([{"role": "user", "content": "a"}], model, response_format={"x": 1})
+            assert provider.sends_response_format(model) is True
+
+            provider.drop_response_format(model, "unparseable-output")
+            assert provider.sends_response_format(model) is False
+
+            provider.complete([{"role": "user", "content": "b"}], model, response_format={"x": 1})
+
+        assert seen == [True, False], "the schema must stop going out after the ask"
+
+    def test_the_ask_is_keyed_by_the_provider_s_own_model_string(self) -> None:
+        """A factory-built provider carries the resolved litellm model string
+        while the engine only knows `cfg.model`. Both name the same call, so both
+        must land on the same entry — else the drop is recorded against a model
+        nothing ever calls."""
+        provider = LiteLLMProvider(model="openrouter/anthropic/claude-haiku-4.5")
+
+        provider.drop_response_format("claude-haiku-4.5", "unparseable-output")
+
+        assert provider.sends_response_format("claude-haiku-4.5") is False
+        assert provider.schema_dropped() is True
+
 
 class TestTheFloorRespectsRouteCapability:
     """The floor is only worth sending if the route will actually carry it.


### PR DESCRIPTION
Follow-up to #454 (merged as #463), from that PR's own review. #463 merged
before these could land on it, so they come as a fresh change.

## The bug

Passing `response_format` is not the same as **sending** it.

The adapter strips the schema for a model that has already refused it — a 400
naming the field, or schema mode decoding to nothing — while `_complete_lens`
still holds the schema class it passed. From the engine that call looks
identical to one made under enforcement, so an unparseable reply from it got
re-run "without the schema" against a request **that was already schema-less**:
byte-identical, at full diff price. Exactly what `engine.rescue` forbids.

Narrow but real, and it costs one wasted full-diff call per (batch, lens) on
precisely the models most likely to be in this state.

## The fix

`sends_response_format(model)` answers the question the engine actually needs:
*would a call for this model carry the schema?* Keyed as `complete` resolves the
model, so the engine's `cfg.model` and a factory-built provider's prefixed
litellm string land on the same entry.

Feature-detected and **fail-open**, like every other adapter probe — an adapter
with no opinion is assumed to have sent what it was given, so the recovery keeps
working rather than silently switching itself off.

## Tests

Three the review asked for, each of which would have passed before while
covering nothing:

- **the already-stripped model** reports plain instead of paying a wasted
  re-run. Mutation-checked: dropping the guard fails it.
- **a ceiling reached by the reformat** stops the re-run before it starts. The
  full-diff call is the most expensive thing on this path, and a budget the
  first two calls already spent must not be blown by it.
- **a later lens goes out schema-less** after the first one recovered.
  Recording the `drop_response_format` call only proved the engine *asked*; this
  is the promise the feature rests on, and a wrong model key or per-call option
  rebuilding would break it while the recording assertion still passed.

Plus two adapter-level tests for the ask itself: later calls stop carrying the
schema, and the entry is keyed by the provider's own model string.

## Verification

`uv run pytest` (2222 passed) · `ruff check` · `ruff format` · `mypy src`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_