### PR TITLE
test(evals): stop grading secret findings on a value redaction removed

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -371,6 +371,28 @@ was *not* shown:
   it in the diff, while `tests/test_dispatch.py` covers it in a file the PR never
   touched, so "this change is untested" is true of the diff and wrong as a defect.
 
+### Secret findings are scored after redaction
+
+Redaction is the **first** pipeline stage, so it runs on the fixtures too. A
+fixture that plants `API_TOKEN = "ghp_…"` shows the model:
+
+```
++API_TOKEN = "[REDACTED]"
+```
+
+The constant name and the inline assignment survive; the value does not. So the
+finding those fixtures actually measure is *"a credential is held in a source
+constant instead of configuration"* — a fair catch, graded `medium` — and **not**
+*"a live token is committed"*, which the input cannot support and which would
+penalise a model right to decline. Their labels say so, and
+`test_no_expectation_is_graded_on_a_value_the_model_never_saw` enforces it
+mechanically across every fixture, because the bar moves whenever
+`engine/redact.py` does.
+
+If you want a finding scored against a real value, don't bypass the redactor —
+the harness exists to exercise the pipeline. Plant something it doesn't match,
+and say in the label that that is what you did.
+
 ### Separating a reproducible failure from an intermittent one
 
 A single pass says a fixture passed or failed; it cannot say whether the model

--- a/evals/fixtures/badcode/expected.json
+++ b/evals/fixtures/badcode/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "badcode.py",
   "expected": [
     {
-      "label": "hardcoded GitHub token (API_TOKEN)",
+      "label": "credential in a source constant (API_TOKEN) — value redacted before review",
       "line": 5,
       "keywords": ["secret", "token", "hardcoded", "credential", "api key"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "insecure HTTP / missing timeout in fetch_user",

--- a/evals/fixtures/go-concurrency/expected.json
+++ b/evals/fixtures/go-concurrency/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "report/report.go",
   "expected": [
     {
-      "label": "hardcoded GitHub token (apiToken)",
+      "label": "credential in a source constant (apiToken) — value redacted before review",
       "line": 12,
       "keywords": ["secret", "token", "hardcoded", "credential", "api key"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "SQL injection via fmt.Sprintf in FindUser",

--- a/evals/fixtures/rlm-bigfile/expected.json
+++ b/evals/fixtures/rlm-bigfile/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "service.py",
   "expected": [
     {
-      "label": "hardcoded GitHub token in load_config (hunk 1)",
+      "label": "credential in a source constant in load_config (hunk 1) — value redacted before review",
       "line": 17,
       "keywords": ["secret", "token", "hardcoded", "credential", "api key"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "SQL injection in find_by_email (hunk 2)",

--- a/evals/fixtures/rust-safety/expected.json
+++ b/evals/fixtures/rust-safety/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "src/billing.rs",
   "expected": [
     {
-      "label": "hardcoded GitHub token (API_TOKEN)",
+      "label": "credential in a source constant (API_TOKEN) — value redacted before review",
       "line": 4,
       "keywords": ["secret", "token", "hardcoded", "credential", "api key"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "unsigned subtraction in charge() underflows when amount > balance",

--- a/evals/fixtures/test-harness/expected.json
+++ b/evals/fixtures/test-harness/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "tests/integration/test_s3_roundtrip.py",
   "expected": [
     {
-      "label": "hardcoded AWS secret key in the test module",
+      "label": "credential in a source constant in the test module — value redacted before review",
       "line": 4,
       "keywords": ["secret", "hardcoded", "credential", "aws_secret", "key"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "assertion-free test: test_put_and_get_roundtrip makes no assertions",

--- a/evals/fixtures/typescript-web/expected.json
+++ b/evals/fixtures/typescript-web/expected.json
@@ -3,10 +3,10 @@
   "changed_file": "src/orders.ts",
   "expected": [
     {
-      "label": "hardcoded API key shipped in client code (API_KEY)",
+      "label": "credential in a source constant shipped to the client (API_KEY) — value redacted before review",
       "line": 3,
       "keywords": ["secret", "key", "hardcoded", "credential", "client", "exposed"],
-      "severity_at_least": "high"
+      "severity_at_least": "medium"
     },
     {
       "label": "XSS via innerHTML in renderComment",

--- a/evals/fixtures/vibe-multifile/expected.json
+++ b/evals/fixtures/vibe-multifile/expected.json
@@ -3,7 +3,7 @@
   "changed_file": "src/api/handlers.py",
   "expected": [
     {
-      "label": "hardcoded API token in handlers.py (API_TOKEN)",
+      "label": "credential in a source constant in handlers.py (API_TOKEN) — value redacted before review",
       "line": 6,
       "keywords": ["secret", "token", "hardcoded", "credential", "api key", "api_token"],
       "severity_at_least": "low"
@@ -42,7 +42,7 @@
       "severity_at_least": "medium"
     },
     {
-      "label": "hardcoded database password in settings.py",
+      "label": "credential in a source constant in settings.py — value redacted before review",
       "line": 5,
       "keywords": ["password", "hardcoded", "secret", "credential"],
       "severity_at_least": "low"

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -15,10 +15,18 @@ import pytest
 
 from evals import run as run_mod
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
-from lgtmaybe.core.models import PRContext, Provider, ProviderResult, ReviewConfig, ReviewFinding
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewConfig,
+    ReviewFinding,
+    Severity,
+)
 from lgtmaybe.engine import LLMReviewEngine
 from lgtmaybe.engine.astgrep import build_symbol_resolver
 from lgtmaybe.engine.compress import split_patch_into_hunks
+from lgtmaybe.engine.redact import redact
 from lgtmaybe.engine.reflect import reflect_findings
 from lgtmaybe.github import is_reviewable
 from lgtmaybe.local import local_file_reader
@@ -420,6 +428,70 @@ def test_spec_delivery_corpus_refutes_its_forbidden_traps() -> None:
 
     assert "expires_at" in models, "the column trap needs the field to already exist"
     assert "redeemed_at IS NULL" in repo, "the idempotency trap needs a conditional update"
+
+
+# ---------------------------------------------------------------------------
+# redaction runs on the fixtures too
+# ---------------------------------------------------------------------------
+
+
+def _redacted_lines(diff: str) -> set[int]:
+    """RIGHT line numbers redaction blanked a value on.
+
+    Line-only, no path — mirroring ``scorer._matches``, which compares
+    ``finding.line`` alone because an ``ExpectedFinding`` names no file. On a
+    multi-file fixture two files can therefore share a line number, and this
+    inherits that ambiguity rather than inventing a stricter rule the scorer
+    does not apply.
+    """
+    index = changed_line_index(redact(diff))
+    return {
+        line
+        for (_path, side), entries in index.items()
+        if side == "RIGHT"
+        for line, text in entries
+        if "[REDACTED]" in text
+    }
+
+
+def test_no_expectation_is_graded_on_a_value_the_model_never_saw() -> None:
+    """Redaction is the FIRST pipeline stage, so it runs on the fixtures too.
+
+    A fixture that plants ``API_TOKEN = "ghp_…"`` shows the model
+    ``API_TOKEN = "[REDACTED]"``: the constant name and the inline assignment
+    survive, the secret does not. "A credential is held in a source constant"
+    is still a fair catch there; "a live token is committed", graded `high`,
+    is not — the input cannot support it, and a model right to decline would
+    lose recall for being right.
+
+    So: an expectation sitting on a redacted line may not demand a severity
+    only a live secret could justify. Mechanical rather than per-fixture,
+    because the bar moves whenever ``engine/redact.py`` does — five fixtures
+    drifted this way unnoticed before anyone looked.
+    """
+    for diff, manifest in run_mod._load_fixtures():
+        redacted = _redacted_lines(diff)
+        for exp in manifest.expected:
+            if exp.line not in redacted or exp.severity_at_least is None:
+                continue
+            assert exp.severity_at_least <= Severity.medium, (
+                f"{manifest.name}: {exp.label!r} demands {exp.severity_at_least} on line "
+                f"{exp.line}, which the model sees as [REDACTED]"
+            )
+
+
+def test_the_secret_fixtures_still_show_the_credential_assignment() -> None:
+    """The other half of the same invariant: redaction must leave enough for the
+    finding to be *possible*. It replaces only the value, so the key name and the
+    inline literal survive — if that ever changes, these expectations become
+    unreachable rather than merely harder, and the test above cannot see it."""
+    for name in ("badcode", "vibe-multifile", "rust-safety", "go-concurrency", "typescript-web"):
+        diff, _manifest = _fixture(name)
+        redacted = redact(diff)
+        assert '"[REDACTED]"' in redacted, f"{name}: the assignment shape is gone"
+        assert any(token in redacted for token in ("API_TOKEN", "apiToken", "API_KEY")), (
+            f"{name}: the credential's NAME is what the finding is left to key on"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #466.

## The problem

Redaction is the **first** pipeline stage, so it runs on the fixtures too. A
fixture planting `API_TOKEN = "ghp_…"` shows the model:

```
+API_TOKEN = "[REDACTED]"
```

Seven fixtures carried an expectation labelled "hardcoded GitHub token", six of
them graded `high`, all scored against input the secret had already been
stripped from:

| Fixture | Line | Was |
|---|---:|---|
| `badcode` | 5 | `high` |
| `vibe-multifile` | 6, 5 | `low`, `low` |
| `rlm-bigfile` | 17 | `high` |
| `test-harness` | 4 | `high` |
| `rust-safety` | 4 | `high` |
| `go-concurrency` | 12 | `high` |
| `typescript-web` | 3 | `high` |

Not *unreachable* — the constant name and the inline assignment survive, so a
model can still fairly report a credential held in source, and the existing
keywords match such a finding. But **harder than the manifest claimed**, with
nothing recording that. Two concrete costs:

- a model right to decline to call `"[REDACTED]"` a leaked secret loses recall
  for being right;
- the finding's difficulty is set by the redactor, so a change to
  `engine/redact.py` silently moves the recall bar on seven fixtures.

Pre-existing since `badcode`; it surfaced because lgtmaybe reviewed its own new
fixtures in #464 and flagged it three times.

## The change

The expectations now describe what the model is actually shown — *a credential
held in a source constant rather than configuration* — and are graded `medium`,
which that input supports. **Keywords are unchanged**: they already matched.

Applied to all seven, not just the three new ones. Fixing a subset would have
made them incomparable to the rest, which is precisely what the cross-language
fixtures exist to allow.

## Enforced mechanically, not fixture by fixture

Because the bar moves with the redactor, the invariant is a test rather than a
one-time cleanup:

- **`test_no_expectation_is_graded_on_a_value_the_model_never_saw`** — an
  expectation sitting on a redacted line may not demand a severity above
  `medium`. Red before this change (`badcode` fails first); mutation-checked by
  re-grading one back to `critical`.
- **`test_the_secret_fixtures_still_show_the_credential_assignment`** — the other
  direction, which the severity check cannot see: redaction must keep leaving
  the key name and the assignment shape, or these expectations become
  *unreachable* rather than merely harder.

The line check is path-blind, mirroring `scorer._matches`, which compares
`finding.line` alone because an `ExpectedFinding` names no file — inheriting that
ambiguity rather than inventing a stricter rule the scorer does not apply.

## Docs

A `DEVELOPMENT.md` section states what is measured, and what to do if you want a
finding scored against a real value: don't bypass the redactor (the harness
exists to exercise the pipeline) — plant something it doesn't match, and say so
in the label.

## Verification

`uv run pytest` (2231 passed) · `ruff check` · `ruff format`. No `ReviewConfig`
change, so no reference regeneration; no spec anchors cover `evals/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_