### PR TITLE
test(evals): derive the assignment-shape check from the fixtures

### DIFF
--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -9,6 +9,7 @@ ollama e2e run.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 
 import pytest
@@ -435,10 +436,10 @@ def test_spec_delivery_corpus_refutes_its_forbidden_traps() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _redacted_lines(diff: str) -> set[int]:
-    """RIGHT line numbers redaction blanked a value on.
+def _redacted_lines(diff: str) -> dict[int, str]:
+    """RIGHT line number → text, for every changed line redaction blanked a value on.
 
-    Line-only, no path — mirroring ``scorer._matches``, which compares
+    Keyed by line only, no path — mirroring ``scorer._matches``, which compares
     ``finding.line`` alone because an ``ExpectedFinding`` names no file. On a
     multi-file fixture two files can therefore share a line number, and this
     inherits that ambiguity rather than inventing a stricter rule the scorer
@@ -446,12 +447,19 @@ def _redacted_lines(diff: str) -> set[int]:
     """
     index = changed_line_index(redact(diff))
     return {
-        line
+        line: text
         for (_path, side), entries in index.items()
         if side == "RIGHT"
         for line, text in entries
         if "[REDACTED]" in text
     }
+
+
+# A NAME, an assignment, then the marker — `API_TOKEN = "[REDACTED]"`,
+# `const apiToken = "[REDACTED]"`, `"api_token": "[REDACTED]"`,
+# `const API_TOKEN: &str = "[REDACTED]"`. What survives redaction is exactly
+# what the finding is left to key on.
+_NAMED_ASSIGNMENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*[\"']?\s*[:=][^\[]*\[REDACTED\]")
 
 
 def test_no_expectation_is_graded_on_a_value_the_model_never_saw() -> None:
@@ -482,16 +490,29 @@ def test_no_expectation_is_graded_on_a_value_the_model_never_saw() -> None:
 
 def test_the_secret_fixtures_still_show_the_credential_assignment() -> None:
     """The other half of the same invariant: redaction must leave enough for the
-    finding to be *possible*. It replaces only the value, so the key name and the
-    inline literal survive — if that ever changes, these expectations become
-    unreachable rather than merely harder, and the test above cannot see it."""
-    for name in ("badcode", "vibe-multifile", "rust-safety", "go-concurrency", "typescript-web"):
-        diff, _manifest = _fixture(name)
-        redacted = redact(diff)
-        assert '"[REDACTED]"' in redacted, f"{name}: the assignment shape is gone"
-        assert any(token in redacted for token in ("API_TOKEN", "apiToken", "API_KEY")), (
-            f"{name}: the credential's NAME is what the finding is left to key on"
-        )
+    finding to be *possible*. It replaces only the value, so the name and the
+    assignment survive — if that ever changes, these expectations become
+    unreachable rather than merely harder, and the test above cannot see it.
+
+    Derived from the fixtures, never a hand-kept list: a named list would have to
+    be updated by whoever adds the next secret fixture, and the one that shipped
+    with this check already omitted two of the seven it claimed to cover.
+    """
+    covered: list[str] = []
+    for diff, manifest in run_mod._load_fixtures():
+        redacted = _redacted_lines(diff)
+        for exp in manifest.expected:
+            if exp.line not in redacted:
+                continue
+            covered.append(f"{manifest.name}:{exp.line}")
+            assert _NAMED_ASSIGNMENT.search(redacted[exp.line]), (
+                f"{manifest.name}: line {exp.line} is {redacted[exp.line]!r} — redaction took "
+                f"the name or the assignment with the value, so {exp.label!r} is now unreachable"
+            )
+
+    # A guard that silently checked nothing would pass forever. Every fixture
+    # planting a credential is expected to reach here.
+    assert len(covered) >= 8, f"only {covered} reached the check — has the redactor stopped firing?"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #466 (merged as #467), from that PR's own review. #467 merged
before this could land on it, so it comes as a fresh change.

## The problem

`test_the_secret_fixtures_still_show_the_credential_assignment` listed its
fixtures by hand:

```python
for name in ("badcode", "vibe-multifile", "rust-safety", "go-concurrency", "typescript-web"):
```

The list that shipped with the check **already omitted two of the seven** it
claimed to cover — `rlm-bigfile` and `test-harness` — both of which had their
manifests rewritten in the very same commit. A hand-kept list has to be updated
by whoever adds the next secret fixture, which is exactly the drift its sibling
severity check was made mechanical to avoid.

## The fix

Walk the fixtures instead. Every expectation sitting on a redacted line must
still show a **name** and an **assignment** before the marker. One regex covers
the four shapes the corpus actually contains:

| Fixture | Line as the model sees it |
|---|---|
| `badcode`, `vibe-multifile` | `API_TOKEN = "[REDACTED]"` |
| `go-concurrency`, `typescript-web` | `const apiToken = "[REDACTED]"` |
| `rlm-bigfile` | `"api_token": "[REDACTED]",` |
| `rust-safety` | `const API_TOKEN: &str = "[REDACTED]";` |
| `test-harness` | `SECRET_KEY = "[REDACTED][REDACTED]KEY…"` |

The failure message quotes the offending line verbatim, since *"the redactor
took the name with the value"* is the failure it exists to catch.

A floor of 8 covered lines guards the guard — a check that silently stopped
matching anything would otherwise pass forever, which is the failure mode the
original hand-list had in miniature.

## Verification

Mutation-checked: a redactor that swallows the whole line fails it.
`uv run pytest` (2231 passed) · `ruff check` · `ruff format`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk646yW4kGReFXsZSQXVeh)_