### PR TITLE
feat(provider): keep structured output on routes that reject response_format

### DIFF
--- a/docs/how-to/review-with-bedrock-oidc.md
+++ b/docs/how-to/review-with-bedrock-oidc.md
@@ -171,11 +171,15 @@ the policy must also allow the `inference-profile/*` ARN, not just
 
 **`output_config.format: Extra inputs are not permitted`** — the model's Converse
 route doesn't accept the structured-output field lgtmaybe asks for, and Bedrock
-rejects the whole request with a 400. lgtmaybe detects that rejection, re-sends
-without the field, and remembers the drop for the rest of the run, so no action
-is needed — the prompt asks for JSON anyway and the parser is lenient. If you're
-on a build from before that (the symptom is every lens failing at once, and the
-review reporting `every review call failed`), upgrade, or pass
+rejects the whole request with a 400. No action is needed: lgtmaybe detects the
+rejection and re-sends the *same* schema through the mechanism Converse does
+implement — a forced tool call, whose arguments are the findings — so output
+stays schema-enforced. It remembers that for the rest of the run, so the rest of
+the lens fan-out uses that shape straight away. Only if the route refuses the
+tool schema too does it fall back to prompt-instructed JSON (the prompt asks for
+JSON anyway and the parser is lenient); that fallback is logged as a warning. If
+you're on a build from before this (the symptom is every lens failing at once,
+and the review reporting `every review call failed`), upgrade, or pass
 `--no-structured-output` / set `structured_output: false` as a stopgap.
 
 **`The provided model identifier is invalid`** — the `model` is not a Bedrock

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1367,11 +1367,15 @@ the policy must also allow the `inference-profile/*` ARN, not just
 
 **`output_config.format: Extra inputs are not permitted`** — the model's Converse
 route doesn't accept the structured-output field lgtmaybe asks for, and Bedrock
-rejects the whole request with a 400. lgtmaybe detects that rejection, re-sends
-without the field, and remembers the drop for the rest of the run, so no action
-is needed — the prompt asks for JSON anyway and the parser is lenient. If you're
-on a build from before that (the symptom is every lens failing at once, and the
-review reporting `every review call failed`), upgrade, or pass
+rejects the whole request with a 400. No action is needed: lgtmaybe detects the
+rejection and re-sends the *same* schema through the mechanism Converse does
+implement — a forced tool call, whose arguments are the findings — so output
+stays schema-enforced. It remembers that for the rest of the run, so the rest of
+the lens fan-out uses that shape straight away. Only if the route refuses the
+tool schema too does it fall back to prompt-instructed JSON (the prompt asks for
+JSON anyway and the parser is lenient); that fallback is logged as a warning. If
+you're on a build from before this (the symptom is every lens failing at once,
+and the review reporting `every review call failed`), upgrade, or pass
 `--no-structured-output` / set `structured_output: false` as a stopgap.
 
 **`The provided model identifier is invalid`** — the `model` is not a Bedrock

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -150,26 +150,28 @@ slept past it.
 
 ### Requirement: A rejected request param degrades, it does not fail the review
 
-The adapter SHALL drop a request param the model refuses and re-send once
+The adapter SHALL degrade a request param the model refuses and re-send once
 rather than fail — `temperature` when only the default value is accepted, and
 the structured-output `response_format` when the route rejects the field it
 becomes (Bedrock Converse answers `output_config.format: Extra inputs are not
 permitted`). `drop_params` cannot cover these: the capability map reports the
-param supported, and the refusal is only visible in the error. A dropped
-`response_format` SHALL be remembered for THAT MODEL's later calls, never for
-every model the provider serves, and SHALL be announced once — a silent
-downgrade to prompt-instructed JSON is indistinguishable from a model that
-simply stopped honouring the schema. litellm's stdout banner SHALL be
-suppressed, since stdout carries machine-readable output. The engine MAY ask for
-the same drop, on the one trigger the adapter cannot see: a reply that arrives
-well-formed and turns out not to be findings.
+param supported, and the refusal is only visible in the error. A rejected
+`response_format` SHALL first be re-sent as the SAME schema in the mechanism the
+route does implement — a forced tool call, read back from its arguments — and
+only a route refusing that too SHALL fall back to prompt-instructed JSON. Each
+outcome SHALL be remembered for THAT MODEL's later calls, never for every model
+the provider serves, and losing the schema SHALL be announced once: silently, it
+is indistinguishable from a model that stopped honouring it. litellm's stdout
+banner SHALL be suppressed, since stdout carries machine-readable output. The
+engine MAY ask for the same drop, on the one trigger the adapter cannot see: a
+reply that arrives well-formed and turns out not to be findings.
 <!-- anchor: provider.param-drop -->
 
 #### Scenario: the route rejects the structured-output field
 - **WHEN** a Bedrock model 400s on the `output_config.format` field litellm
   derived from `response_format`
-- **THEN** the call is re-sent without it and the rest of the lens fan-out skips
-  it up front, instead of every lens failing on a permanent 400
+- **THEN** the same schema is re-sent as a forced tool call and the rest of the
+  fan-out uses that shape up front, keeping enforcement instead of losing it
 
 #### Scenario: another model shares the provider
 - **WHEN** one model rejects the schema while a second model — a fallback, or

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -30,6 +30,7 @@ from litellm.exceptions import (
     RateLimitError,
 )
 from litellm.utils import supports_prompt_caching
+from pydantic import BaseModel
 from tenacity import (
     RetryCallState,
     retry,
@@ -355,6 +356,17 @@ def _retry_wait(retry_state: RetryCallState) -> float:
     return _generic_wait(retry_state)
 
 
+# Phrases a backend uses to say "I do not know this request field". Matched
+# loosely because the wording is the backend's, not litellm's.
+_REJECTION_PHRASES = ("not permitted", "not supported", "unsupported", "unknown", "unexpected")
+
+
+def _rejects_field(exc: Exception, *names: str) -> bool:
+    """True when *exc* reads as "this route does not take <one of names>"."""
+    msg = str(exc).lower()
+    return any(name in msg for name in names) and any(p in msg for p in _REJECTION_PHRASES)
+
+
 def _rejects_response_format(exc: Exception) -> bool:
     """True when an API error means the model won't take our structured-output param.
 
@@ -370,18 +382,96 @@ def _rejects_response_format(exc: Exception) -> bool:
     ``drop_params`` cannot help here: it drops params litellm's capability map
     says a model lacks, and for these models the map says the param is supported.
     So the rejection is read off the error instead: the field name plus a
-    rejection phrase, matched loosely because the wording is the backend's, not
-    litellm's. A false positive costs one re-send without the param (the prompt
-    still asks for JSON and the parser is lenient); a false negative costs the
-    whole review.
+    rejection phrase. A false positive costs one re-send in tool mode (see
+    :func:`_schema_tool_kwargs`); a false negative costs the whole review.
     """
-    msg = str(exc).lower()
-    if not any(field in msg for field in ("response_format", "output_config", "responseformat")):
-        return False
-    return any(
-        phrase in msg
-        for phrase in ("not permitted", "not supported", "unsupported", "unknown", "unexpected")
-    )
+    return _rejects_field(exc, "response_format", "output_config", "responseformat")
+
+
+def _rejects_tool_config(exc: Exception) -> bool:
+    """True when an API error means the route won't take the tool schema either.
+
+    The second half of :func:`_rejects_response_format`: a route that refuses
+    ``response_format`` is asked for the same schema as a forced tool call
+    instead, and a route that refuses *that* has genuinely no structured-output
+    mechanism left. Bedrock names the Converse field (``toolConfig``); the
+    OpenAI-shaped routes name ``tools`` / ``tool_choice``.
+    """
+    return _rejects_field(exc, "toolconfig", "tool_choice", "toolchoice", "tools")
+
+
+# The one tool we ever offer. Named, not anonymous, because ``tool_choice`` has
+# to point at it by name to make the call forced rather than optional — an
+# optional tool lets the model answer in prose and enforces nothing.
+_SCHEMA_TOOL_NAME = "lgtmaybe_structured_output"
+
+
+def _json_schema_of(response_format: Any) -> dict[str, Any] | None:
+    """The JSON Schema inside a ``response_format``, or None if there isn't one.
+
+    Two shapes reach here: the pydantic model the engine passes (litellm derives
+    the schema from it) and litellm's own ``{"type": "json_schema",
+    "json_schema": {"schema": …}}`` dict. Anything else — ``{"type":
+    "json_object"}``, say — constrains nothing we could put in a tool's
+    parameters, so there is no tool call worth making.
+    """
+    if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+        return response_format.model_json_schema()
+    if isinstance(response_format, Mapping):
+        nested = response_format.get("json_schema")
+        schema = nested.get("schema") if isinstance(nested, Mapping) else None
+        if isinstance(schema, Mapping):
+            return dict(schema)
+    return None
+
+
+def _schema_tool_kwargs(response_format: Any) -> dict[str, Any] | None:
+    """The same schema expressed as a forced tool call, or None if it can't be.
+
+    A route refusing ``response_format`` has not necessarily refused *structured
+    output*. Bedrock's Converse endpoint implements it as tool use — a
+    ``toolConfig`` whose ``inputSchema`` is the shape you want back, plus a
+    ``toolChoice`` naming that tool — which is exactly what litellm's
+    OpenAI-shaped ``tools`` / ``tool_choice`` translate into. So the recovery
+    from a rejected ``response_format`` is to ask for the same schema through
+    the mechanism the route does implement, before giving up on enforcement and
+    falling back to prompt-instructed JSON.
+
+    That matters most on the newest models — the ones litellm's capability map
+    doesn't know yet, so ``drop_params`` leaves the unsupported field on and the
+    service 400s the whole review.
+    """
+    schema = _json_schema_of(response_format)
+    if schema is None:
+        return None
+    return {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": _SCHEMA_TOOL_NAME,
+                    "description": "Return the result. Call this exactly once, with the "
+                    "whole answer as its arguments.",
+                    "parameters": schema,
+                },
+            }
+        ],
+        "tool_choice": {"type": "function", "function": {"name": _SCHEMA_TOOL_NAME}},
+    }
+
+
+def _tool_call_arguments(message: Any) -> str:
+    """The first tool call's arguments, or "" when the reply used none.
+
+    Under a forced tool call the answer rides in the arguments and ``content`` is
+    empty, so a reader that only ever looks at ``content`` reports every lens as
+    having returned nothing.
+    """
+    for call in getattr(message, "tool_calls", None) or []:
+        arguments = getattr(getattr(call, "function", None), "arguments", None)
+        if isinstance(arguments, str) and arguments.strip():
+            return arguments
+    return ""
 
 
 def _rejects_temperature(exc: Exception) -> bool:
@@ -449,6 +539,11 @@ class LiteLLMProvider:
         # a quality regression on the strong model triggered by a model it
         # never ran.
         self._schema_dropped: set[str] = set()
+        # Models whose schema now travels as a forced tool call instead (see
+        # `_schema_tool_kwargs`). Disjoint from `_schema_dropped`: this set is
+        # enforcement preserved by another mechanism, that one is enforcement
+        # given up. Keyed by MODEL for the same reason.
+        self._schema_tool: set[str] = set()
         # Memoized supports-cache-control answers: the review fans out many
         # completions on the same model string, and the capability lookup is a
         # pure function of it. Instance-scoped (not lru_cache) so tests that
@@ -472,11 +567,46 @@ class LiteLLMProvider:
         if model in self._schema_dropped:
             return
         self._schema_dropped.add(model)
+        # Tool mode was enforcement; giving up on the schema retires it too.
+        self._schema_tool.discard(model)
         _log.warning(
             "structured output disabled for this model — later calls send "
             "prompt-instructed JSON only, which a weaker model may not honour",
             extra={"model": model, "reason": why},
         )
+
+    def _use_schema_tool(self, model: str, kwargs: dict[str, Any]) -> bool:
+        """Swap this request's ``response_format`` for the equivalent tool call.
+
+        Returns False when there is nothing to swap — no schema in the
+        ``response_format`` (so the tool would enforce nothing), or the request
+        is already in tool mode. False means the caller should fall through to
+        the real downgrade.
+
+        Announced at info, not warning, precisely because it is *not* the
+        downgrade ``_disable_response_format`` announces: the model is still held
+        to the schema, just through the mechanism its route implements. Once per
+        model, like that warning — the lens fan-out sends the same shape N times.
+        """
+        tool_kwargs = _schema_tool_kwargs(kwargs.get("response_format"))
+        if tool_kwargs is None:
+            return False
+        kwargs.pop("response_format", None)
+        kwargs.update(tool_kwargs)
+        if model not in self._schema_tool:
+            self._schema_tool.add(model)
+            _log.info(
+                "structured output sent as a forced tool call for this model — "
+                "the schema is still enforced",
+                extra={"model": model},
+            )
+        return True
+
+    @staticmethod
+    def _strip_schema(kwargs: dict[str, Any]) -> None:
+        """Remove every structured-output mechanism from this request."""
+        for key in ("response_format", "tools", "tool_choice"):
+            kwargs.pop(key, None)
 
     def drop_response_format(self, model: str, why: str) -> None:
         """Stop sending the schema for *model* — asked by the engine, not inferred.
@@ -658,20 +788,26 @@ class LiteLLMProvider:
             reraise=True,
         )
         def _call() -> ProviderResult:
-            # A prior call already proved this model's JSON-schema mode returns
-            # empty, so don't pay the wasted round-trip again — drop it up front.
+            # A prior call already settled how this model takes (or refuses) the
+            # schema, so don't pay the wasted round-trip again — apply it up front.
             if model in self._schema_dropped:
-                kwargs.pop("response_format", None)
+                self._strip_schema(kwargs)
+            elif model in self._schema_tool:
+                self._use_schema_tool(model, kwargs)
             result = self._raw_completion(model, messages, kwargs, count_request)
             # Some grammar-constrained backends (notably LM Studio fronting a
             # "thinking" model like qwen3.x) return EMPTY content under a
-            # response_format JSON schema — the schema decoder yields nothing. The
+            # response_format JSON schema — the schema decoder yields nothing. A
+            # route that accepts `tools` and then ignores them is the same dead
+            # end (nothing in the content, no tool call to read instead). The
             # prompt already asks for JSON and the parser is lenient, so drop the
             # schema and retry once: the model then emits the findings as normal
             # (fenced) text we can parse. Remember it so later calls skip it too.
-            if not result.text.strip() and kwargs.get("response_format") is not None:
+            if not result.text.strip() and (
+                kwargs.get("response_format") is not None or kwargs.get("tools")
+            ):
                 self._disable_response_format(model, "empty-response")
-                kwargs.pop("response_format")
+                self._strip_schema(kwargs)
                 result = self._raw_completion(model, messages, kwargs, count_request)
             return result
 
@@ -724,6 +860,11 @@ class LiteLLMProvider:
         to drop the param and re-send; ``kwargs`` is the dict every later retry
         of this call reuses, so the drop sticks for them too.
 
+        Structured output gets two recoveries rather than one, in order of how
+        much they keep: a rejected ``response_format`` becomes the same schema as
+        a forced tool call, and only a route that refuses *that* too falls back
+        to prompt-instructed JSON.
+
         Returns True when something was dropped and the call is worth re-sending.
         """
         if "temperature" in kwargs and _rejects_temperature(exc):
@@ -731,12 +872,17 @@ class LiteLLMProvider:
             # own default.
             kwargs.pop("temperature")
             return True
+        # Both branches remember the outcome for this model's later calls, not
+        # just this one: the lens fan-out sends the same shape N times, and
+        # without that every one of them pays its own rejected round-trip first.
         if kwargs.get("response_format") is not None and _rejects_response_format(exc):
-            # Remembered for this model's later calls, not just this one: the
-            # lens fan-out sends the same shape N times, and without this every
-            # one of them pays its own rejected round-trip first.
-            self._disable_response_format(model, "rejected")
-            kwargs.pop("response_format")
+            if not self._use_schema_tool(model, kwargs):
+                self._disable_response_format(model, "rejected")
+                kwargs.pop("response_format")
+            return True
+        if kwargs.get("tools") and _rejects_tool_config(exc):
+            self._disable_response_format(model, "tool-rejected")
+            self._strip_schema(kwargs)
             return True
         return False
 
@@ -799,7 +945,13 @@ class LiteLLMProvider:
     ) -> ProviderResult:
         # Some providers return null content (e.g. a model that answered only via
         # a reasoning channel under JSON mode); treat that as empty, not a crash.
-        text: str = response.choices[0].message.content or ""
+        message = response.choices[0].message
+        text: str = message.content or ""
+        # In tool mode the answer IS the tool call's arguments and `content` holds
+        # nothing (or a preamble). Prefer the arguments wherever a call came back:
+        # they are the schema-enforced payload, where the content is whatever the
+        # model said around it.
+        text = _tool_call_arguments(message) or text
         usage = response.usage
         input_tokens: int = usage.prompt_tokens
         output_tokens: int = usage.completion_tokens

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -460,15 +460,35 @@ def _schema_tool_kwargs(response_format: Any) -> dict[str, Any] | None:
     }
 
 
+def _is_schema_tool(tools: Any) -> bool:
+    """Whether *tools* is the one tool :func:`_schema_tool_kwargs` builds.
+
+    The adapter owns only the tool it added. Everything that reacts to tool mode
+    — stripping it, re-sending without it, reading the answer out of it — asks
+    this first, so a caller's own ``tools`` are never retired, overwritten, or
+    mistaken for our schema. Nothing in lgtmaybe passes tools today; this keeps
+    the adapter honest for anything that later does.
+    """
+    if not isinstance(tools, list) or len(tools) != 1 or not isinstance(tools[0], Mapping):
+        return False
+    function = tools[0].get("function")
+    return isinstance(function, Mapping) and function.get("name") == _SCHEMA_TOOL_NAME
+
+
 def _tool_call_arguments(message: Any) -> str:
-    """The first tool call's arguments, or "" when the reply used none.
+    """Our schema tool's arguments, or "" when the reply didn't call it.
 
     Under a forced tool call the answer rides in the arguments and ``content`` is
     empty, so a reader that only ever looks at ``content`` reports every lens as
-    having returned nothing.
+    having returned nothing. Matched by name rather than taking the first call of
+    any kind: a reply that answered in ``content`` and called something else on
+    the side must not have that call read as its answer.
     """
     for call in getattr(message, "tool_calls", None) or []:
-        arguments = getattr(getattr(call, "function", None), "arguments", None)
+        function = getattr(call, "function", None)
+        if getattr(function, "name", None) != _SCHEMA_TOOL_NAME:
+            continue
+        arguments = getattr(function, "arguments", None)
         if isinstance(arguments, str) and arguments.strip():
             return arguments
     return ""
@@ -588,6 +608,11 @@ class LiteLLMProvider:
         to the schema, just through the mechanism its route implements. Once per
         model, like that warning — the lens fan-out sends the same shape N times.
         """
+        tools = kwargs.get("tools")
+        if tools is not None and not _is_schema_tool(tools):
+            # The caller brought their own tools; swapping ours in would drop
+            # them. Their request shape wins — fall through to the plain drop.
+            return False
         tool_kwargs = _schema_tool_kwargs(kwargs.get("response_format"))
         if tool_kwargs is None:
             return False
@@ -604,9 +629,16 @@ class LiteLLMProvider:
 
     @staticmethod
     def _strip_schema(kwargs: dict[str, Any]) -> None:
-        """Remove every structured-output mechanism from this request."""
-        for key in ("response_format", "tools", "tool_choice"):
-            kwargs.pop(key, None)
+        """Remove every structured-output mechanism THIS ADAPTER added.
+
+        The tool half is conditional: a caller's own ``tools`` are not ours to
+        retire, so giving up on the schema must not disable unrelated tool use
+        for the model for the rest of the run.
+        """
+        kwargs.pop("response_format", None)
+        if _is_schema_tool(kwargs.get("tools")):
+            kwargs.pop("tools", None)
+            kwargs.pop("tool_choice", None)
 
     def drop_response_format(self, model: str, why: str) -> None:
         """Stop sending the schema for *model* — asked by the engine, not inferred.
@@ -804,7 +836,7 @@ class LiteLLMProvider:
             # schema and retry once: the model then emits the findings as normal
             # (fenced) text we can parse. Remember it so later calls skip it too.
             if not result.text.strip() and (
-                kwargs.get("response_format") is not None or kwargs.get("tools")
+                kwargs.get("response_format") is not None or _is_schema_tool(kwargs.get("tools"))
             ):
                 self._disable_response_format(model, "empty-response")
                 self._strip_schema(kwargs)
@@ -880,7 +912,7 @@ class LiteLLMProvider:
                 self._disable_response_format(model, "rejected")
                 kwargs.pop("response_format")
             return True
-        if kwargs.get("tools") and _rejects_tool_config(exc):
+        if _is_schema_tool(kwargs.get("tools")) and _rejects_tool_config(exc):
             self._disable_response_format(model, "tool-rejected")
             self._strip_schema(kwargs)
             return True

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -866,6 +866,82 @@ class TestSchemaAsToolFallback:
 
         assert seen == ["rf", "plain"]
 
+    def test_a_callers_own_tools_survive_the_downgrade(self) -> None:
+        """The adapter removes only the tool IT added. A caller's tools are not
+        ours to retire, so a `response_format` this route never accepted must not
+        permanently disable unrelated tool use for the model."""
+        caller_tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        seen: list[Any] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs.get("tools"))
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            # A schema we cannot express as a tool, so enforcement is given up
+            # outright and the caller's tools are the only ones in play.
+            for _ in range(2):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    self.MODEL,
+                    response_format={"type": "json_object"},
+                    tools=caller_tools,
+                )
+
+        assert seen == [caller_tools, caller_tools, caller_tools]
+
+    def test_a_callers_own_tools_are_never_overwritten(self) -> None:
+        """With tools already on the request, the schema swap would clobber them
+        — so the rejection degrades straight to prompt-instructed JSON instead."""
+        caller_tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        seen: list[Any] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs.get("tools"))
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}],
+                self.MODEL,
+                response_format=ReviewResult,
+                tools=caller_tools,
+            )
+
+        assert seen == [caller_tools, caller_tools]
+        assert provider.schema_dropped() is True
+
+    def test_a_callers_tool_call_does_not_become_the_answer(self) -> None:
+        """Reading arguments off any tool call would hijack a reply that answered
+        in `content` and called a caller's tool on the side."""
+        call = SimpleNamespace(
+            function=SimpleNamespace(name="get_weather", arguments='{"city": "London"}')
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="the real answer", tool_calls=[call])
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=10),
+        )
+
+        with patch("litellm.completion", return_value=response):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], self.MODEL)
+
+        assert result.text == "the real answer"
+
     def test_the_engine_can_still_turn_enforcement_off(self) -> None:
         """``drop_response_format`` is the engine saying a reply parsed to
         nothing useful. Tool mode is enforcement, so it has to go too — else the

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -15,7 +15,7 @@ import httpx
 import litellm
 import pytest
 
-from lgtmaybe.core.models import attempts_of, is_unrecoverable
+from lgtmaybe.core.models import ReviewResult, attempts_of, is_unrecoverable
 from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.providers import litellm_provider as provider_module
 from lgtmaybe.providers.litellm_provider import (
@@ -41,6 +41,18 @@ def _reasoning_response(reasoning: Any, content: str = "ok") -> Any:
 def _fake_response(content: str = "ok") -> Any:
     return SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=10),
+    )
+
+
+def _tool_call_response(arguments: str, content: str = "") -> Any:
+    """A reply that answered through a forced tool call, as Bedrock's Converse
+    endpoint does — the payload is in the arguments, the content is empty."""
+    call = SimpleNamespace(
+        function=SimpleNamespace(name="lgtmaybe_structured_output", arguments=arguments)
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=[call]))],
         usage=SimpleNamespace(prompt_tokens=5, completion_tokens=10),
     )
 
@@ -682,6 +694,202 @@ class TestRejectedStructuredOutputParam:
                 )
 
         assert calls == 1
+
+
+class TestSchemaAsToolFallback:
+    """A route that refuses ``response_format`` has not necessarily refused
+    *structured output* — Bedrock's Converse endpoint implements it as a forced
+    tool call instead. Giving up on the schema at the first 400 downgrades the
+    whole review to prompt-instructed JSON when enforcement was available all
+    along, one request shape away."""
+
+    BEDROCK_400 = TestRejectedStructuredOutputParam.BEDROCK_400
+    MODEL = "bedrock/us.anthropic.claude-opus-5"
+
+    def _rejects_response_format(self, arguments: str = '{"findings": []}') -> Any:
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            if "tools" in kwargs:
+                return _tool_call_response(arguments)
+            return _fake_response("prose, not findings")
+
+        return side_effect
+
+    def test_rejection_re_sends_the_schema_as_a_forced_tool_call(self) -> None:
+        seen: list[dict[str, Any]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            return self._rejects_response_format()(*args, **kwargs)
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert "response_format" not in seen[1]
+        tool = seen[1]["tools"][0]["function"]
+        assert tool["parameters"]["properties"]["findings"]
+        # Forced, not offered: an optional tool lets the model answer in prose
+        # and the enforcement is worth nothing.
+        assert seen[1]["tool_choice"]["function"]["name"] == tool["name"]
+
+    def test_the_answer_comes_from_the_tool_call_arguments(self) -> None:
+        """Under a forced tool call the findings ride in the arguments, and the
+        message content is empty — reading only content reports every lens as
+        having returned nothing."""
+        payload = '{"findings": [{"path": "a.py", "line": 1, "severity": "low", "title": "t"}]}'
+        with patch("litellm.completion", side_effect=self._rejects_response_format(payload)):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == payload
+
+    def test_later_calls_go_straight_to_tool_mode(self) -> None:
+        """Sticky like the plain drop: the lens fan-out sends the same shape N
+        times and must not each pay its own rejected round-trip."""
+        seen: list[str] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                seen.append("rf")
+            else:
+                seen.append("tools" if "tools" in kwargs else "plain")
+            return self._rejects_response_format()(*args, **kwargs)
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            for _ in range(3):
+                provider.complete(
+                    [{"role": "user", "content": "a"}], self.MODEL, response_format=ReviewResult
+                )
+
+        assert seen == ["rf", "tools", "tools", "tools"]
+
+    def test_tool_mode_is_not_a_downgrade(self) -> None:
+        """The schema is still enforced, so the review must not carry a notice
+        telling the user structured output was lost."""
+        with patch("litellm.completion", side_effect=self._rejects_response_format()):
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert provider.schema_dropped() is False
+        assert provider.sends_response_format(self.MODEL) is True
+
+    def test_a_route_that_refuses_tools_too_falls_back_to_plain(self) -> None:
+        """Two recoveries, in order of how much they preserve: schema → tool →
+        prompt-instructed JSON. The last one is the real downgrade."""
+        seen: list[str] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                seen.append("rf")
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            if "tools" in kwargs:
+                seen.append("tools")
+                raise litellm.BadRequestError(
+                    message="BedrockException - toolConfig: Extra inputs are not permitted",
+                    model=kwargs["model"],
+                    llm_provider="bedrock",
+                )
+            seen.append("plain")
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert seen == ["rf", "tools", "plain"]
+        assert provider.schema_dropped() is True
+
+    def test_a_tool_mode_reply_with_no_tool_call_falls_back_to_plain(self) -> None:
+        """A route can accept ``tools`` and ignore them. An empty content with no
+        tool call is the same dead end as an empty schema-mode reply."""
+        seen: list[str] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                seen.append("rf")
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            if "tools" in kwargs:
+                seen.append("tools")
+                return _fake_response("")
+            seen.append("plain")
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert seen == ["rf", "tools", "plain"]
+
+    def test_a_schema_we_cannot_express_as_a_tool_drops_straight_to_plain(self) -> None:
+        """No schema to put in the tool's parameters means a tool call would
+        enforce nothing — skip the wasted round-trip."""
+        seen: list[str] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                seen.append("rf")
+                raise litellm.BadRequestError(
+                    message=self.BEDROCK_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            seen.append("tools" if "tools" in kwargs else "plain")
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}],
+                self.MODEL,
+                response_format={"type": "json_object"},
+            )
+
+        assert seen == ["rf", "plain"]
+
+    def test_the_engine_can_still_turn_enforcement_off(self) -> None:
+        """``drop_response_format`` is the engine saying a reply parsed to
+        nothing useful. Tool mode is enforcement, so it has to go too — else the
+        re-run re-sends the request that just failed."""
+        with patch("litellm.completion", side_effect=self._rejects_response_format()):
+            provider = LiteLLMProvider(model=self.MODEL)
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+            provider.drop_response_format(self.MODEL, "unparseable")
+            assert provider.sends_response_format(self.MODEL) is False
+
+        seen: list[str] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append("tools" if "tools" in kwargs else "plain")
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert seen == ["plain"]
 
 
 class TestEmptyStructuredOutputFallback:


### PR DESCRIPTION
Closes #469.

## The problem

Bedrock's Converse endpoint 400s the whole request when litellm translates `response_format` into an `output_config.format` field the model's route doesn't implement:

```
BedrockException - {"message":"The model returned the following errors:
output_config.format: Extra inputs are not permitted"}
```

The adapter already recovered from that — it read the rejection off the error and re-sent without the param. But that recovery gave up structured output *entirely*: every later call for that model fell back to prompt-instructed JSON, which is exactly the "re-running with `--no-structured-output`" the issue reports.

`drop_params` can't help, because litellm's capability map says the param *is* supported — the newest models are precisely the ones the map hasn't caught up with.

## The fix

Converse does implement structured output. It just calls it tool use.

So a rejected `response_format` is now re-sent as the **same schema expressed as a forced single-tool call** — litellm's OpenAI-shaped `tools` / `tool_choice`, which become Converse's `toolConfig` / `toolChoice` — and the reply is read back from the tool call's `arguments` rather than from `content` (which is empty under a forced tool call).

Two recoveries now, in order of how much they preserve:

1. `response_format` — the schema as the route's own JSON mode
2. **forced tool call** — the same schema, through the mechanism Converse implements *(new)*
3. prompt-instructed JSON — the real downgrade, and the only one that warns

The swap is remembered per model (not per provider instance, matching the existing drop), so the rest of the lens fan-out sends the working shape up front instead of each paying its own rejected round-trip. `schema_dropped()` stays `False` in tool mode, so the review no longer carries a "structured output was lost" notice when it wasn't.

Nothing about this is user-facing: no new flag, no new config field, no new Action input. `structured_output: false` still turns the whole thing off if you want it off.

### Edge cases handled

- A route that refuses `tools` too → falls back to plain, warns (`reason=tool-rejected`)
- A route that accepts `tools` and ignores them (empty content, no tool call) → same fallback as an empty schema-mode reply
- A `response_format` with no schema in it (`{"type": "json_object"}`) → skipped straight to plain; a tool with no parameters enforces nothing, so the round-trip would be wasted
- The engine's `retry_without_schema` (`drop_response_format`) retires tool mode too — otherwise the "re-run without the schema" would re-send the request that just failed

## Tests

TDD, red first. New `TestSchemaAsToolFallback` in `tests/providers/test_retry.py` covers all eight behaviours above. Existing `TestRejectedStructuredOutputParam` / `TestSchemaDropIsVisibleAndScoped` pass unchanged (they use a schema-less `response_format` dict, so they still exercise the plain-drop path).

```
2239 passed, 3 skipped
ruff check / ruff format / mypy: clean
```

## Specs

`provider.param-drop` in `openspec/specs/provider-gateway/spec.md` is anchored to `_drop_rejected_param`, which this changes — the requirement and its first scenario are updated to describe the two-step degrade. `uv run pytest tests/specs` and `openspec validate --specs` are green.

## Docs

The Bedrock how-to's `output_config.format` troubleshooting entry now says enforcement is kept rather than dropped; `docs/llms-full.txt` regenerated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y86cHGmYEAtiX6WHrSrv3T)_