### PR TITLE
docs: add benchmark model selection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,13 @@ the
 [GitHub Action](#use-as-a-github-action). See
 [Getting Started](docs/tutorial/getting-started.md) for the full walkthrough.
 
-> **Picking a model:** use a **coding** model, and **bigger/newer is more
-> accurate**. Our benchmark numbers are for a small `qwen3.5:4b`; a larger,
-> current coding model catches more. See
-> [Which model?](docs/how-to/run-locally-with-ollama.md#which-model-and-will-it-fit).
+> **Picking a model:** compare cloud and local models separately. In the current
+> cloud breadth results, Qwen 3.8 Max and GLM 5.2 scored 71.4% and 72.2%
+> balanced F1; Qwen reported 8 false positives and GLM reported 24. The only
+> current local breadth run is Qwen 3.6 35B at 57.1% balanced F1. See the
+> [cloud and local model guide](docs/how-to/choose-a-review-model.md), or inspect
+> the
+> [live benchmark results](https://github.com/MattJColes/lgtmaybe-benchmarks).
 
 ## Providers
 
@@ -180,6 +183,7 @@ are published at the docs root.
 
 **How-to guides** — task recipes
 
+- [Choose a review model](docs/how-to/choose-a-review-model.md)
 - [Review with OpenAI](docs/how-to/review-with-openai.md)
 - [Review with Claude (Anthropic)](docs/how-to/review-with-anthropic.md)
 - [Review with OpenRouter](docs/how-to/review-with-openrouter.md)

--- a/docs/how-to/choose-a-review-model.md
+++ b/docs/how-to/choose-a-review-model.md
@@ -1,0 +1,118 @@
+---
+description: Choose a cloud or local lgtmaybe review model using measured breadth, precision, false-positive, clean-change, and long-diff results.
+---
+
+# Choose a Review Model
+
+Cloud and local models need separate comparisons. The hosted models currently
+score higher. Local models keep the code on your hardware and avoid API charges.
+There are fewer published local runs, and they scored lower.
+
+These recommendations are a snapshot from 19 August 2026. See the
+[lgtmaybe benchmark repository][bench] for the live leaderboard, complete
+results, raw run records, and reproduction instructions.
+
+## Choose a Cloud Model
+
+| Model through OpenRouter | Breadth result | Notes |
+|---|---|---|
+| `qwen/qwen3.8-max` | 71.4% balanced F1; 61.4% recall; 84.9% precision; 8 false positives; 77.8% clean pass | Quieter than GLM. The result is provisional: 1.9% of candidate findings await adjudication. Its current-version long-horizon run scored 71.7% with 75.0% recall. |
+| `z-ai/glm-5.2` | 72.2% balanced F1; 72.9% recall; 69.6% precision; 24 false positives; 11.1% clean pass | Caught more planted issues than Qwen and reported three times as many false positives. The result is provisional. |
+| `google/gemini-3.7-flash` | 62.2% balanced F1; 54.3% recall; 72.7% precision; 15 false positives; 44.4% clean pass | The only fully adjudicated result in this group. Its 81.2% long-horizon recall came from lgtmaybe 2.1.4, so it is not comparable with the 2.2.0 run. |
+
+The main cloud comparison is Qwen against GLM. Their balanced F1 ranges overlap.
+Qwen reported fewer false positives and passed more clean changes. GLM found
+more planted issues. Gemini scored lower, but its breadth result is fully
+adjudicated.
+
+```bash
+lgtmaybe review --provider openrouter --model qwen/qwen3.8-max
+```
+
+Replace the model ID with either of the other cloud models without changing the
+provider setup. See [Review with OpenRouter](review-with-openrouter.md) for
+authentication and GitHub Action examples.
+
+## Choose a Local Model
+
+There is only one published local run under the current lgtmaybe 2.2.0 breadth
+comparison key:
+**`nvidia/Qwen3.6-35B-A3B-NVFP4`** behind an OpenAI-compatible server. It scored
+57.1% balanced F1 with 47.1% recall, 72.3% precision, 13 false positives, and a
+44.4% clean pass rate. It trailed the hosted models above. The result is
+provisional, with 2.0% of candidate findings awaiting adjudication. One result
+is not enough for a local leaderboard.
+
+The current long-horizon suite also includes
+**`RedHatAI/gemma-4-12B-it-FP8-Dynamic`**, a smaller model. It scored 40.5% with
+37.5% recall and 63.2% precision on lgtmaybe 2.2.0. It does not have a comparable
+current breadth run, so these numbers cannot be used to rank it against Qwen.
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model nvidia/Qwen3.6-35B-A3B-NVFP4 \
+  --api-base http://127.0.0.1:8000/v1
+```
+
+Model weights are only part of the memory requirement; the context window and
+KV cache need space too. Serving engine, quantisation, context size, and
+concurrency all affect local results. See
+[Run locally with ollama](run-locally-with-ollama.md) for hardware guidance, or
+[Other OpenAI-compatible servers](use-a-custom-openai-compatible-endpoint.md)
+for vLLM, llama.cpp, and LM Studio setup.
+
+## The Two Benchmark Suites
+
+The suites measure different things:
+
+- **Breadth** uses 32 small changes across seven programming languages, GitHub
+  Actions, and Terraform. It plants 72 findings across ten review lenses and
+  includes nine verified-clean changes. Its balanced F1, recall, precision,
+  false-positive count, and clean-pass rate describe general review quality.
+- **Long horizon** uses four defect-bearing Python changes that grow from about
+  3% to 90% of the input budget, plus one large clean change. Each defect case
+  plants the same eight bugs. It measures whether recall survives large diffs.
+
+Do not compare a breadth score with a long-horizon score. Do not rank runs from
+different lgtmaybe versions against each other either; prompt, parsing, and
+review-pipeline changes can move the result.
+
+## What the Numbers Mean
+
+- **Recall** is the share of planted issues the review found.
+- **Precision** is the share of reported findings that matched a planted issue.
+- **Balanced F1** combines breadth recall and precision; higher is better.
+- **False positives** are unmatched findings. The benchmark deliberately uses
+  a closed world, so a plausible issue outside the planted catalogue still
+  counts as false until adjudicated.
+- **Clean pass** is the share of verified-clean changes that received no
+  findings.
+
+A breadth score marked **provisional** still has unadjudicated candidates. The
+cloud Qwen, GLM, and local Qwen runs cited above have 98.1%, 98.8%, and 98.0%
+adjudication coverage, respectively. None of the cited runs has an immutable
+audit trace, which the live leaderboard reports separately as `audit: no`.
+
+## Source and Methodology
+
+The figures above come from benchmark commit
+[`27392b1`][snapshot]. The directly comparable breadth key is
+`breadth / canonical-breadth / lgtmaybe 2.2.0`; current long-horizon results use
+`long-horizon / canonical-long-horizon / lgtmaybe 2.2.0`.
+
+The [live benchmark repository][bench] provides:
+
+- the current leaderboard and scoring method in its README;
+- every completed run, including per-language and per-lens recall, in
+  [`RESULTS.md`][results];
+- append-only raw results under `results/raw/`; and
+- commands for running the corpus against another model.
+
+The corpus is synthetic. It does not measure provider price, availability, data
+handling, or performance on your repository. Test the shortlisted models on a
+few recent pull requests before setting a team-wide default.
+
+[bench]: https://github.com/MattJColes/lgtmaybe-benchmarks
+[results]: https://github.com/MattJColes/lgtmaybe-benchmarks/blob/main/RESULTS.md
+[snapshot]: https://github.com/MattJColes/lgtmaybe-benchmarks/tree/27392b1d796a86e757c33fcbe9c82505e6f0e945

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ flowchart LR
 <div class="grid cards" markdown>
 
 - **Tutorial** — [Getting started](tutorial/getting-started.md): your first review with ollama, locally and free.
-- **How-to** — task recipes: [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
+- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
 - **Reference** — [Configuration](reference/config.md): every config field and schema.
 - **Explanation** — [What gets reviewed](explanation/what-gets-reviewed.md), [Architecture](explanation/architecture.md), [Auth model](explanation/auth-model.md), [Data & privacy](explanation/data-and-privacy.md).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -66,7 +66,7 @@ flowchart LR
 <div class="grid cards" markdown>
 
 - **Tutorial** — [Getting started](tutorial/getting-started.md): your first review with ollama, locally and free.
-- **How-to** — task recipes: [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
+- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
 - **Reference** — [Configuration](reference/config.md): every config field and schema.
 - **Explanation** — [What gets reviewed](explanation/what-gets-reviewed.md), [Architecture](explanation/architecture.md), [Auth model](explanation/auth-model.md), [Data & privacy](explanation/data-and-privacy.md).
 
@@ -371,6 +371,125 @@ bundles all three and wires up the OIDC/WIF auth for you.
 - Run your first local review: [Getting started](../tutorial/getting-started.md).
 - Diagram what a change touches: [Generate a change diagram](generate-a-change-diagram.md).
 - Post reviews on real pull requests: [Use as a GitHub Action](use-as-github-action.md).
+
+---
+
+<!-- Source: https://lgtmaybe.coles.codes/how-to/choose-a-review-model/ -->
+
+# Choose a Review Model
+
+Cloud and local models need separate comparisons. The hosted models currently
+score higher. Local models keep the code on your hardware and avoid API charges.
+There are fewer published local runs, and they scored lower.
+
+These recommendations are a snapshot from 19 August 2026. See the
+[lgtmaybe benchmark repository][bench] for the live leaderboard, complete
+results, raw run records, and reproduction instructions.
+
+## Choose a Cloud Model
+
+| Model through OpenRouter | Breadth result | Notes |
+|---|---|---|
+| `qwen/qwen3.8-max` | 71.4% balanced F1; 61.4% recall; 84.9% precision; 8 false positives; 77.8% clean pass | Quieter than GLM. The result is provisional: 1.9% of candidate findings await adjudication. Its current-version long-horizon run scored 71.7% with 75.0% recall. |
+| `z-ai/glm-5.2` | 72.2% balanced F1; 72.9% recall; 69.6% precision; 24 false positives; 11.1% clean pass | Caught more planted issues than Qwen and reported three times as many false positives. The result is provisional. |
+| `google/gemini-3.7-flash` | 62.2% balanced F1; 54.3% recall; 72.7% precision; 15 false positives; 44.4% clean pass | The only fully adjudicated result in this group. Its 81.2% long-horizon recall came from lgtmaybe 2.1.4, so it is not comparable with the 2.2.0 run. |
+
+The main cloud comparison is Qwen against GLM. Their balanced F1 ranges overlap.
+Qwen reported fewer false positives and passed more clean changes. GLM found
+more planted issues. Gemini scored lower, but its breadth result is fully
+adjudicated.
+
+```bash
+lgtmaybe review --provider openrouter --model qwen/qwen3.8-max
+```
+
+Replace the model ID with either of the other cloud models without changing the
+provider setup. See [Review with OpenRouter](review-with-openrouter.md) for
+authentication and GitHub Action examples.
+
+## Choose a Local Model
+
+There is only one published local run under the current lgtmaybe 2.2.0 breadth
+comparison key:
+**`nvidia/Qwen3.6-35B-A3B-NVFP4`** behind an OpenAI-compatible server. It scored
+57.1% balanced F1 with 47.1% recall, 72.3% precision, 13 false positives, and a
+44.4% clean pass rate. It trailed the hosted models above. The result is
+provisional, with 2.0% of candidate findings awaiting adjudication. One result
+is not enough for a local leaderboard.
+
+The current long-horizon suite also includes
+**`RedHatAI/gemma-4-12B-it-FP8-Dynamic`**, a smaller model. It scored 40.5% with
+37.5% recall and 63.2% precision on lgtmaybe 2.2.0. It does not have a comparable
+current breadth run, so these numbers cannot be used to rank it against Qwen.
+
+```bash
+lgtmaybe review \
+  --provider openai-compatible \
+  --model nvidia/Qwen3.6-35B-A3B-NVFP4 \
+  --api-base http://127.0.0.1:8000/v1
+```
+
+Model weights are only part of the memory requirement; the context window and
+KV cache need space too. Serving engine, quantisation, context size, and
+concurrency all affect local results. See
+[Run locally with ollama](run-locally-with-ollama.md) for hardware guidance, or
+[Other OpenAI-compatible servers](use-a-custom-openai-compatible-endpoint.md)
+for vLLM, llama.cpp, and LM Studio setup.
+
+## The Two Benchmark Suites
+
+The suites measure different things:
+
+- **Breadth** uses 32 small changes across seven programming languages, GitHub
+  Actions, and Terraform. It plants 72 findings across ten review lenses and
+  includes nine verified-clean changes. Its balanced F1, recall, precision,
+  false-positive count, and clean-pass rate describe general review quality.
+- **Long horizon** uses four defect-bearing Python changes that grow from about
+  3% to 90% of the input budget, plus one large clean change. Each defect case
+  plants the same eight bugs. It measures whether recall survives large diffs.
+
+Do not compare a breadth score with a long-horizon score. Do not rank runs from
+different lgtmaybe versions against each other either; prompt, parsing, and
+review-pipeline changes can move the result.
+
+## What the Numbers Mean
+
+- **Recall** is the share of planted issues the review found.
+- **Precision** is the share of reported findings that matched a planted issue.
+- **Balanced F1** combines breadth recall and precision; higher is better.
+- **False positives** are unmatched findings. The benchmark deliberately uses
+  a closed world, so a plausible issue outside the planted catalogue still
+  counts as false until adjudicated.
+- **Clean pass** is the share of verified-clean changes that received no
+  findings.
+
+A breadth score marked **provisional** still has unadjudicated candidates. The
+cloud Qwen, GLM, and local Qwen runs cited above have 98.1%, 98.8%, and 98.0%
+adjudication coverage, respectively. None of the cited runs has an immutable
+audit trace, which the live leaderboard reports separately as `audit: no`.
+
+## Source and Methodology
+
+The figures above come from benchmark commit
+[`27392b1`][snapshot]. The directly comparable breadth key is
+`breadth / canonical-breadth / lgtmaybe 2.2.0`; current long-horizon results use
+`long-horizon / canonical-long-horizon / lgtmaybe 2.2.0`.
+
+The [live benchmark repository][bench] provides:
+
+- the current leaderboard and scoring method in its README;
+- every completed run, including per-language and per-lens recall, in
+  [`RESULTS.md`][results];
+- append-only raw results under `results/raw/`; and
+- commands for running the corpus against another model.
+
+The corpus is synthetic. It does not measure provider price, availability, data
+handling, or performance on your repository. Test the shortlisted models on a
+few recent pull requests before setting a team-wide default.
+
+[bench]: https://github.com/MattJColes/lgtmaybe-benchmarks
+[results]: https://github.com/MattJColes/lgtmaybe-benchmarks/blob/main/RESULTS.md
+[snapshot]: https://github.com/MattJColes/lgtmaybe-benchmarks/tree/27392b1d796a86e757c33fcbe9c82505e6f0e945
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,6 +9,7 @@
 ## How-to
 
 - [Install the CLI](https://lgtmaybe.coles.codes/how-to/install-the-cli/): Install the lgtmaybe CLI with pip (any OS), Homebrew (macOS/Linuxbrew), or winget (Windows), and add cloud extras for keyless Bedrock/Vertex/Azure.
+- [Choose a review model](https://lgtmaybe.coles.codes/how-to/choose-a-review-model/): Choose a cloud or local lgtmaybe review model using measured breadth, precision, false-positive, clean-change, and long-diff results.
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
 - [Post as lgtmaybe[bot]](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews as lgtmaybe[bot] with the public App, or use a self-managed GitHub App.
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - How-to:
       - Install & run:
           - Install the CLI: how-to/install-the-cli.md
+          - Choose a review model: how-to/choose-a-review-model.md
           - Use as a GitHub Action: how-to/use-as-github-action.md
           - Post as lgtmaybe[bot]: how-to/post-as-a-github-app.md
       - Cloud providers (API key):

--- a/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-19
+skip_specs: true

--- a/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/design.md
+++ b/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/design.md
@@ -1,0 +1,33 @@
+## Context
+
+See `proposal.md` for motivation. Model advice in the current README is generic, while the separate benchmark repository owns generated results for two non-comparable suites: breadth across languages and review lenses, and long-horizon behavior as Python diffs grow. The docs must remain useful when that repository gains new runs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give a new user separate cloud and local decision paths, with choices keyed to their priority.
+- Explain the difference between benchmark suites and qualify every reported result by date and lgtmaybe version.
+- Keep detailed rankings, raw data, and methodology in the benchmark repository.
+
+**Non-Goals:**
+
+- Reproduce the complete leaderboard in lgtmaybe's docs.
+- Claim cost, latency, or provider availability that the benchmark does not establish.
+- Compare scores across suites or lgtmaybe versions.
+- Automate cross-repository documentation updates in this change.
+
+## Decisions
+
+1. Add one `docs/how-to/choose-a-review-model.md` guide organized by user decision rather than by model. A how-to page fits the task users are performing; adding the same detail to each provider guide would duplicate evidence and drift.
+2. Ask users to choose cloud or local first. Within cloud, present `qwen/qwen3.8-max` for balanced, lower-noise review, `z-ai/glm-5.2` for maximum breadth recall, and `google/gemini-3.7-flash` as the fully adjudicated baseline. Within local, present `nvidia/Qwen3.6-35B-A3B-NVFP4` as the best-supported current-version breadth result without claiming it is a universal local winner.
+3. Put only the cloud-versus-local decision and compact evidence in the README. Link to the guide and benchmark repository for details instead of copying a leaderboard that will age quickly.
+4. Label provisional benchmark results and state the comparison key. Percentages will be copied from generated benchmark output at commit `27392b1` and described as a 2026-08-19 snapshot.
+5. Add the guide to MkDocs navigation and the README's documentation index so both rendered-site and repository readers can find it.
+
+## Risks / Trade-offs
+
+- [Model rankings change as new runs land] → Date the guidance, link the live leaderboard, and avoid claiming permanence.
+- [Readers treat different suite scores as directly comparable] → Explain that breadth and long-horizon answer different questions and keep their metrics separate.
+- [Provisional results are read as audited ground truth] → Mark them provisional and explain that adjudication is high but audit traces were unavailable for those runs.
+- [Sparse comparable local results invite a false local leaderboard] → Name the best-supported current-version local breadth run, disclose the limited comparison set, and direct readers to test on their hardware.

--- a/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/proposal.md
+++ b/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+People choosing a review model currently get generic advice instead of evidence from lgtmaybe's benchmark corpus. The benchmark repository now contains breadth and long-horizon results that can support a practical recommendation while making the limits of those results clear.
+
+## What Changes
+
+- Add a focused model-selection guide that translates benchmark results into recommendations for balanced quality, long-diff recall, lower noise, and local/private operation.
+- Replace the README's generic model advice with a concise benchmark-backed cloud-versus-local decision and a link to the full guide.
+- Add the guide to the rendered documentation navigation and source index.
+- Cite the benchmark repository as the source of truth rather than copying its full leaderboard, so detailed results and methodology remain maintainable in one place.
+- Verify links, the MkDocs build, and OpenSpec/spec-anchor checks.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change documents existing benchmark evidence and does not alter product behavior.
+
+### Modified Capabilities
+
+None. This is a documentation-only change, so `.openspec.yaml` opts out of spec deltas.
+
+## Impact
+
+The change affects `README.md`, the documentation navigation/index, and one new how-to guide under `docs/how-to/`. It changes no APIs, runtime behavior, dependencies, or living specifications. Benchmark numbers remain owned by `MattJColes/lgtmaybe-benchmarks` and are dated/version-qualified in the guide.

--- a/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/tasks.md
+++ b/openspec/changes/archive/2026-08-19-document-benchmark-model-selection/tasks.md
@@ -1,0 +1,26 @@
+## 1. Benchmark evidence
+
+- [x] 1.1 Extract the current comparable breadth and long-horizon results from the benchmark repository and record the comparison keys, provisional state, and source commit.
+- [x] 1.2 Add a documentation acceptance check that requires the model-selection guide to be linked from both the README and MkDocs navigation.
+
+## 2. Documentation
+
+- [x] 2.1 Add the model-selection guide with a balanced default, priority-based alternatives, metric definitions, and reproducibility caveats.
+- [x] 2.2 Replace the README's generic model advice with the benchmark-backed recommendation and link the guide from the documentation index.
+- [x] 2.3 Add the guide to `mkdocs.yml` and the generated LLM documentation index inputs as required by the existing docs workflow.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused documentation acceptance check, regenerate derived docs if needed, and build the MkDocs site.
+- [x] 3.2 Run OpenSpec/spec-anchor validation and inspect the final diff for stale or cross-suite claims.
+
+## 4. Cloud and local decision paths
+
+- [x] 4.1 Extend the documentation acceptance check to require separate cloud and local model guidance.
+- [x] 4.2 Restructure the guide and README around a cloud-versus-local decision without naming a universal default.
+- [x] 4.3 Regenerate derived docs and repeat documentation, site, OpenSpec, and spec-drift validation.
+
+## 5. Plain-language edit
+
+- [x] 5.1 Rewrite the guide and README summary in direct technical prose without changing the benchmark claims.
+- [x] 5.2 Regenerate derived docs and rerun documentation and OpenSpec validation.

--- a/tests/docs/test_homepage.py
+++ b/tests/docs/test_homepage.py
@@ -31,3 +31,15 @@ def test_homepage_overview_is_concise_without_hiding_features() -> None:
         "ponytail",
     ):
         assert feature in overview
+
+
+def test_model_selection_guide_is_linked_from_readme_and_docs_nav() -> None:
+    guide = "how-to/choose-a-review-model.md"
+    guide_text = Path("docs", guide).read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+    mkdocs = Path("mkdocs.yml").read_text(encoding="utf-8")
+
+    assert "## Choose a Cloud Model" in guide_text
+    assert "## Choose a Local Model" in guide_text
+    assert f"docs/{guide}" in readme
+    assert f"Choose a review model: {guide}" in mkdocs


### PR DESCRIPTION
## What changed

- add a benchmark-backed guide for choosing cloud and local review models
- replace the README's generic model advice with current breadth results
- add the guide to MkDocs navigation and regenerate the LLM documentation indexes
- archive the completed OpenSpec change

## Why

People choosing an lgtmaybe model should be able to compare recall, precision, false positives, clean-pass rate, and large-diff performance using the project's published benchmark results.

## Checks

- `uv run pytest tests/docs tests/specs -q` — 28 passed
- `uv run ruff check tests/docs/test_homepage.py`
- `uv run mkdocs build --strict`
- `openspec validate --all --strict --no-interactive`