### PR TITLE
docs: define the benchmark suites before the tables that use them

### DIFF
--- a/docs/how-to/choose-a-review-model.md
+++ b/docs/how-to/choose-a-review-model.md
@@ -24,8 +24,23 @@ results, raw run records, and instructions for reproducing them.
 
 ## How to Read the Numbers
 
-The benchmark plants known bugs in a set of code changes, asks each model to
-review them, and checks what comes back:
+The benchmark plants known bugs in code changes, asks each model to review
+them, and checks what comes back. It has two suites:
+
+- **Breadth** measures everyday review quality: 32 small changes across
+  seven programming languages, GitHub Actions, and Terraform, with 72
+  planted findings spanning ten review lenses, plus nine verified-clean
+  changes.
+- **Long horizon** measures whether the model still finds bugs when the diff
+  is very large: four defect-bearing Python changes that grow from about 3%
+  to 90% of the input budget, plus one large clean change. Each plants the
+  same eight bugs at the same relative positions, so recall differences come
+  from size alone.
+
+The two suites use different scoring formulas, so a breadth score and a
+long-horizon score cannot be compared with each other. Compare breadth
+against breadth and long horizon against long horizon, as the tables below
+do. Each table reports:
 
 - **Recall**: of the planted bugs, how many did the review find? Higher means
   fewer missed issues.
@@ -279,24 +294,12 @@ concurrency all affect local results. See
 [Other OpenAI-compatible servers](use-a-custom-openai-compatible-endpoint.md)
 for vLLM, llama.cpp, and LM Studio setup.
 
-## The Two Benchmark Suites
+## Before Setting a Default
 
-The scores above come from two suites that measure different things:
-
-- **Breadth** asks: how good is the model at everyday review? It uses 32 small
-  changes across seven programming languages, GitHub Actions, and Terraform,
-  with 72 planted findings spanning ten review lenses plus nine verified-clean
-  changes. Its balanced F1, recall, precision, false-positive count, and
-  clean-pass rate are the headline quality numbers.
-- **Long horizon** asks: does the model still find bugs when the diff is very
-  large? It uses four defect-bearing Python changes that grow from about 3% to
-  90% of the input budget, plus one large clean change, each planting the same
-  eight bugs at the same relative positions, so recall differences come from
-  size alone.
-
-The two suites use different scoring formulas, so a breadth score and a
-long-horizon score cannot be compared with each other. Compare breadth
-against breadth and long horizon against long horizon, as the tables above do.
+The corpus is synthetic. It says nothing about provider price, availability,
+data handling, or how a model performs on your codebase. Shortlist a model or
+two here, then try them on a few recent pull requests before setting a
+team-wide default.
 
 ## Source and Methodology
 
@@ -314,11 +317,6 @@ The [live benchmark repository][bench] provides:
   curves and wall-times the notes above draw on;
 - append-only raw results under `results/raw/`; and
 - commands for running the corpus against another model.
-
-The corpus is synthetic. It says nothing about provider price, availability,
-data handling, or how a model performs on your codebase. Shortlist a model or
-two here, then try them on a few recent pull requests before setting a
-team-wide default.
 
 [bench]: https://github.com/MattJColes/lgtmaybe-benchmarks
 [results]: https://github.com/MattJColes/lgtmaybe-benchmarks/blob/main/RESULTS.md

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -398,8 +398,23 @@ results, raw run records, and instructions for reproducing them.
 
 ## How to Read the Numbers
 
-The benchmark plants known bugs in a set of code changes, asks each model to
-review them, and checks what comes back:
+The benchmark plants known bugs in code changes, asks each model to review
+them, and checks what comes back. It has two suites:
+
+- **Breadth** measures everyday review quality: 32 small changes across
+  seven programming languages, GitHub Actions, and Terraform, with 72
+  planted findings spanning ten review lenses, plus nine verified-clean
+  changes.
+- **Long horizon** measures whether the model still finds bugs when the diff
+  is very large: four defect-bearing Python changes that grow from about 3%
+  to 90% of the input budget, plus one large clean change. Each plants the
+  same eight bugs at the same relative positions, so recall differences come
+  from size alone.
+
+The two suites use different scoring formulas, so a breadth score and a
+long-horizon score cannot be compared with each other. Compare breadth
+against breadth and long horizon against long horizon, as the tables below
+do. Each table reports:
 
 - **Recall**: of the planted bugs, how many did the review find? Higher means
   fewer missed issues.
@@ -653,24 +668,12 @@ concurrency all affect local results. See
 [Other OpenAI-compatible servers](use-a-custom-openai-compatible-endpoint.md)
 for vLLM, llama.cpp, and LM Studio setup.
 
-## The Two Benchmark Suites
+## Before Setting a Default
 
-The scores above come from two suites that measure different things:
-
-- **Breadth** asks: how good is the model at everyday review? It uses 32 small
-  changes across seven programming languages, GitHub Actions, and Terraform,
-  with 72 planted findings spanning ten review lenses plus nine verified-clean
-  changes. Its balanced F1, recall, precision, false-positive count, and
-  clean-pass rate are the headline quality numbers.
-- **Long horizon** asks: does the model still find bugs when the diff is very
-  large? It uses four defect-bearing Python changes that grow from about 3% to
-  90% of the input budget, plus one large clean change, each planting the same
-  eight bugs at the same relative positions, so recall differences come from
-  size alone.
-
-The two suites use different scoring formulas, so a breadth score and a
-long-horizon score cannot be compared with each other. Compare breadth
-against breadth and long horizon against long horizon, as the tables above do.
+The corpus is synthetic. It says nothing about provider price, availability,
+data handling, or how a model performs on your codebase. Shortlist a model or
+two here, then try them on a few recent pull requests before setting a
+team-wide default.
 
 ## Source and Methodology
 
@@ -688,11 +691,6 @@ The [live benchmark repository][bench] provides:
   curves and wall-times the notes above draw on;
 - append-only raw results under `results/raw/`; and
 - commands for running the corpus against another model.
-
-The corpus is synthetic. It says nothing about provider price, availability,
-data handling, or how a model performs on your codebase. Shortlist a model or
-two here, then try them on a few recent pull requests before setting a
-team-wide default.
 
 [bench]: https://github.com/MattJColes/lgtmaybe-benchmarks
 [results]: https://github.com/MattJColes/lgtmaybe-benchmarks/blob/main/RESULTS.md


### PR DESCRIPTION
Structure fix for `docs/how-to/choose-a-review-model.md`: the page explained what the breadth and long-horizon suites actually are only *after* both sets of tables, so readers were interpreting scores for tests they hadn't been told about.

- "How to Read the Numbers" now opens with the two suite descriptions (32 changes / 72 plants / ten lenses; the same eight bugs in growing diffs) and the cannot-compare-across-suites warning, before the metric definitions the tables use.
- The late "The Two Benchmark Suites" section is deleted; its content moved up, minus the sentence that duplicated the metric definitions.
- The "corpus is synthetic — try your shortlist on a few real PRs first" advice moves out of the Source and Methodology tail into its own short "Before Setting a Default" section at the end of the page body, where readers who stop at their command will still see it.
- Regenerates `docs/llms-full.txt`.

No numbers, tables, or recommendations changed. `uv run pytest tests/specs tests/docs -q` passes (28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GKDVExdLJfa4WdccMNtUu

---
_Generated by [Claude Code](https://claude.ai/code/session_014GKDVExdLJfa4WdccMNtUu)_