### PR TITLE
refactor: draw the forge seam so a second code host can be added

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -14,7 +14,7 @@ lets tests swap in fakes without patching.
 ```mermaid
 flowchart TB
     subgraph core["core — never imports an adapter"]
-        ports["ports.py<br/>ProviderClient · GitHubGateway · ReviewEngine"]
+        ports["ports.py<br/>ProviderClient · ReviewGateway · ReviewEngine"]
         models["models.py<br/>ReviewConfig · ReviewFinding · ProviderResult · PRContext"]
     end
     providers["providers/<br/>litellm adapter"] -- implements --> ports
@@ -25,10 +25,14 @@ flowchart TB
 
 - `ProviderClient` — one method: `complete(messages, model)` returns a
   `ProviderResult` (text + token usage).
-- `GitHubGateway` — `get_pr_context()` fetches the PR diff and metadata;
+- `ReviewGateway` — `get_pr_context()` fetches the change diff and metadata;
   `post_review()` posts batched inline comments and a summary;
   `post_issue_comment()` posts a standalone comment (used by `/ask` and as the
-  describe/diagram fallback).
+  describe/diagram fallback). These three are the whole required surface, so a
+  new forge adapter can be useful long before it is complete; richer behaviour
+  (file reads, incremental review, thread resolution, labels, checks, feedback)
+  is declared by an optional `Supports*` capability protocol that callers probe
+  for and skip when absent.
 - `ReviewEngine` — `review(ctx, cfg)` returns `(findings, summary)`.
 
 The ports were frozen in the foundation step. Other tracks (providers, github,
@@ -64,8 +68,8 @@ flowchart TD
 on every provider — worker count decides only whether they overlap. The `full`
 preset fans out one call per category, and custom lenses join the same fan-out.)
 
-1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
-   metadata from the GitHub REST API. No PR code is checked out or executed.
+1. **fetch** — `ReviewGateway.get_pr_context()` retrieves the change diff and
+   metadata from the forge's API. No change code is checked out or executed.
    The diff is treated as untrusted input throughout.
 
 2. **compress** — the diff is filtered to remove generated files, lockfiles,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6512,7 +6512,7 @@ lets tests swap in fakes without patching.
 ```mermaid
 flowchart TB
     subgraph core["core — never imports an adapter"]
-        ports["ports.py<br/>ProviderClient · GitHubGateway · ReviewEngine"]
+        ports["ports.py<br/>ProviderClient · ReviewGateway · ReviewEngine"]
         models["models.py<br/>ReviewConfig · ReviewFinding · ProviderResult · PRContext"]
     end
     providers["providers/<br/>litellm adapter"] -- implements --> ports
@@ -6523,10 +6523,14 @@ flowchart TB
 
 - `ProviderClient` — one method: `complete(messages, model)` returns a
   `ProviderResult` (text + token usage).
-- `GitHubGateway` — `get_pr_context()` fetches the PR diff and metadata;
+- `ReviewGateway` — `get_pr_context()` fetches the change diff and metadata;
   `post_review()` posts batched inline comments and a summary;
   `post_issue_comment()` posts a standalone comment (used by `/ask` and as the
-  describe/diagram fallback).
+  describe/diagram fallback). These three are the whole required surface, so a
+  new forge adapter can be useful long before it is complete; richer behaviour
+  (file reads, incremental review, thread resolution, labels, checks, feedback)
+  is declared by an optional `Supports*` capability protocol that callers probe
+  for and skip when absent.
 - `ReviewEngine` — `review(ctx, cfg)` returns `(findings, summary)`.
 
 The ports were frozen in the foundation step. Other tracks (providers, github,
@@ -6562,8 +6566,8 @@ flowchart TD
 on every provider — worker count decides only whether they overlap. The `full`
 preset fans out one call per category, and custom lenses join the same fan-out.)
 
-1. **fetch** — `GitHubGateway.get_pr_context()` retrieves the PR diff and
-   metadata from the GitHub REST API. No PR code is checked out or executed.
+1. **fetch** — `ReviewGateway.get_pr_context()` retrieves the change diff and
+   metadata from the forge's API. No change code is checked out or executed.
    The diff is treated as untrusted input throughout.
 
 2. **compress** — the diff is filtered to remove generated files, lockfiles,

--- a/openspec/specs/core-contracts/anchors.yml
+++ b/openspec/specs/core-contracts/anchors.yml
@@ -10,7 +10,7 @@ core.provider-port:
 core.gateway-port:
   rule:
     kind: class_definition
-    has: { field: name, regex: '^GitHubGateway$' }
+    has: { field: name, regex: '^ReviewGateway$' }
   files: [src/lgtmaybe/**/*.py]
 
 core.engine-port:

--- a/openspec/specs/core-contracts/spec.md
+++ b/openspec/specs/core-contracts/spec.md
@@ -21,11 +21,15 @@ a model.
 - **THEN** it calls `ProviderClient.complete(messages, model, **opts)` and gets
   a `ProviderResult` back, with no provider-specific branching in the engine
 
-### Requirement: GitHub gateway port
+### Requirement: Review gateway port
 
-`GitHubGateway` SHALL expose PR context retrieval and review posting as the
-only GitHub seam. Implementations fetch the diff via API only — PR code is
-never checked out or executed (fork safety under `pull_request_target`).
+`ReviewGateway` SHALL expose change-request context retrieval and review posting
+as the only code-host seam, for every forge. Implementations fetch the diff via
+API only — change-request code is never checked out or executed (fork safety
+under `pull_request_target`). Richer behaviour an adapter may not have — file
+reads, incremental re-review, thread resolution, labels, checks, feedback — is
+declared by a separate optional `Supports*` capability protocol, and a caller
+SHALL degrade gracefully when a gateway does not offer one.
 <!-- anchor: core.gateway-port -->
 
 #### Scenario: review round-trip through the port

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -24,11 +24,11 @@ github.fingerprint:
   - rule:
       kind: function_definition
       has: { field: name, regex: '^finding_fingerprint$' }
-    files: [src/lgtmaybe/github/**/*.py]
+    files: [src/lgtmaybe/core/findings.py]
   - rule:
       kind: function_definition
       has: { field: name, regex: '^finding_identity$' }
-    files: [src/lgtmaybe/github/**/*.py]
+    files: [src/lgtmaybe/core/findings.py]
 
 github.demote:
   rule:
@@ -86,7 +86,7 @@ github.reviewable:
   rule:
     kind: function_definition
     has: { field: name, regex: '^is_reviewable$' }
-  files: [src/lgtmaybe/github/**/*.py]
+  files: [src/lgtmaybe/core/diff.py]
 
 github.labels:
   - rule:

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -144,7 +144,7 @@ engine.scan-manifests:
   rule:
     kind: function_definition
     has: { field: name, regex: '^is_scannable_manifest$' }
-  files: [src/lgtmaybe/github/**/*.py]
+  files: [src/lgtmaybe/core/diff.py]
 
 engine.profile-findings:
   rule:

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import signal
 import sys
 from collections import Counter
@@ -29,6 +28,8 @@ import click
 
 from lgtmaybe.cli.render import flatten_details, render_findings
 from lgtmaybe.core.diffparse import FILE_HEADER_RE
+from lgtmaybe.core.forge import Forge, PRLocator, token_env_var
+from lgtmaybe.core.forge import parse_pr_url as locate_pr
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
     PRContext,
@@ -38,7 +39,13 @@ from lgtmaybe.core.models import (
     ReviewPreset,
     Severity,
 )
-from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
+from lgtmaybe.core.ports import (
+    ProviderClient,
+    ReviewEngine,
+    ReviewGateway,
+    SupportsBaseCheckout,
+    SupportsFileContents,
+)
 from lgtmaybe.core.version import package_version
 from lgtmaybe.engine import (
     INCOMPLETE_MARKER,
@@ -78,8 +85,6 @@ class RuntimeOptions:
 
 _log = get_logger(__name__)
 
-_PR_URL_RE = re.compile(r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)")
-
 
 def _should_auto_post(enabled: bool, event_action: str) -> bool:
     """Gate an automatic extra to newly opened or reopened pull requests."""
@@ -97,7 +102,7 @@ def should_auto_diagram(cfg: ReviewConfig, *, event_action: str) -> bool:
 
 
 def _run_upsert(
-    github: GitHubGateway,
+    github: ReviewGateway,
     provider: ProviderClient,
     cfg: ReviewConfig,
     *,
@@ -122,7 +127,7 @@ def _run_upsert(
 
 
 def run_describe(
-    github: GitHubGateway,
+    github: ReviewGateway,
     provider: ProviderClient,
     cfg: ReviewConfig,
     ctx: PRContext | None = None,
@@ -136,7 +141,7 @@ def run_describe(
 
 
 def run_diagram(
-    github: GitHubGateway,
+    github: ReviewGateway,
     provider: ProviderClient,
     cfg: ReviewConfig,
     ctx: PRContext | None = None,
@@ -177,17 +182,35 @@ def resolve_auto_incremental(cfg: ReviewConfig, *, event_action: str) -> ReviewC
 
 
 def parse_pr_url(pr_url: str) -> tuple[str, int]:
-    """Parse a GitHub PR URL into ("owner/repo", pr_number).
+    """Parse a pull/merge request URL into ("owner/repo", number).
 
-    Raises ValueError with a clear message for anything that is not a PR URL.
+    Thin wrapper over ``core.forge.parse_pr_url`` for the callers that only want
+    the project path and number. Use the locator directly when the forge or host
+    matters. Raises ValueError with a clear message for anything unparseable.
     """
-    match = _PR_URL_RE.search(pr_url)
-    if match is None:
-        raise ValueError(
-            f"Could not parse a GitHub PR URL from {pr_url!r}. "
-            "Expected something like https://github.com/org/repo/pull/42"
-        )
-    return f"{match['owner']}/{match['repo']}", int(match["number"])
+    located = locate_pr(pr_url)
+    return located.repo, located.number
+
+
+# Which forges lgtmaybe can build a gateway for. A forge that parses but is not
+# in here is recognised-but-unimplemented, which earns a different (and much more
+# useful) error than an unparseable URL.
+_GATEWAY_BUILDERS: dict[Forge, Callable[[PRLocator, str, ReviewConfig], ReviewGateway]] = {
+    Forge.github: lambda located, token, cfg: RestGitHubGateway(
+        repo=located.repo,
+        pr_number=located.number,
+        token=token,
+        marker_key=f"{cfg.provider}/{cfg.model}",
+        resolve_fixed=cfg.resolve_fixed,
+    ),
+}
+
+
+def gateway_builder(
+    forge: Forge,
+) -> Callable[[PRLocator, str, ReviewConfig], ReviewGateway] | None:
+    """The gateway factory for ``forge``, or None when it is not implemented yet."""
+    return _GATEWAY_BUILDERS.get(forge)
 
 
 def _bounded_default(cfg: ReviewConfig, concurrency: int) -> int:
@@ -334,32 +357,35 @@ def build_provider_engine(
 
 def build_review_context(
     cfg: ReviewConfig, runtime: RuntimeOptions
-) -> tuple[RestGitHubGateway, LLMReviewEngine, ProviderClient]:
+) -> tuple[ReviewGateway, LLMReviewEngine, ProviderClient]:
     """Construct the gateway, engine, and provider from config + runtime.
 
-    Builds the model side via ``build_provider_engine`` and points a REST gateway
-    at the parsed PR. Raises ValueError with an actionable message when the
-    GitHub token is missing. The provider is returned too so slash commands
-    (/ask, /describe) can use it directly.
+    Builds the model side via ``build_provider_engine`` and points the gateway
+    for the URL's forge at the parsed change request. Raises ValueError with an
+    actionable message when the forge is unsupported or its token is missing.
+    The provider is returned too so slash commands (/ask, /describe) can use it
+    directly.
     """
     if runtime.pr_url is None:
-        raise ValueError("a PR URL is required to build the GitHub review context")
-    repo, pr_number = parse_pr_url(runtime.pr_url)
+        raise ValueError("a PR URL is required to build the review context")
+    located = locate_pr(runtime.pr_url)
 
-    token = os.environ.get("GITHUB_TOKEN")
+    build_gateway = gateway_builder(located.forge)
+    if build_gateway is None:
+        raise ValueError(
+            f"{located.forge} is not supported yet — lgtmaybe can only post reviews to "
+            f"{', '.join(sorted(_GATEWAY_BUILDERS))} so far."
+        )
+
+    token_var = token_env_var(located.forge)
+    token = os.environ.get(token_var)
     if not token:
         raise ValueError(
-            "GITHUB_TOKEN is required to fetch the PR and post the review. "
+            f"{token_var} is required to fetch the change and post the review. "
             "Set it in the environment (the GitHub Action provides it automatically)."
         )
 
-    github = RestGitHubGateway(
-        repo=repo,
-        pr_number=pr_number,
-        token=token,
-        marker_key=f"{cfg.provider}/{cfg.model}",
-        resolve_fixed=cfg.resolve_fixed,
-    )
+    github = build_gateway(located, token, cfg)
     # Wire the gateway's read-only file fetcher so the reflection pass can resolve a
     # deferred verdict (fetch a referenced file the auditor needs) instead of
     # dropping the finding. Read-only API fetch — never a checkout (fork-safe).
@@ -367,16 +393,21 @@ def build_review_context(
     # ast-grep finds its defining file in a lazily-cloned checkout of the trusted base
     # branch. Read-only (clone + parse, never execute the PR head), and a no-op when
     # ast-grep is absent. The clone happens only on the first symbol deferral.
+    # Both reads are optional capabilities: a forge adapter that cannot serve
+    # file text still reviews the diff, it just cannot resolve a deferral.
     resolve_symbol = (
-        build_symbol_resolver(github.base_checkout_root) if cfg.symbol_resolution else None
+        build_symbol_resolver(github.base_checkout_root)
+        if cfg.symbol_resolution and isinstance(github, SupportsBaseCheckout)
+        else None
     )
+    fetch_file = github.get_file_contents if isinstance(github, SupportsFileContents) else None
     engine, provider = build_provider_engine(
-        cfg, runtime, fetch_file=github.get_file_contents, resolve_symbol=resolve_symbol
+        cfg, runtime, fetch_file=fetch_file, resolve_symbol=resolve_symbol
     )
     return github, engine, provider
 
 
-def _apply_learned_feedback(github: GitHubGateway, ctx: PRContext, cfg: ReviewConfig) -> PRContext:
+def _apply_learned_feedback(github: ReviewGateway, ctx: PRContext, cfg: ReviewConfig) -> PRContext:
     """Attach 👎-downvoted finding fingerprints to ``ctx.feedback_downvotes``.
 
     A human with write access reacting thumbs-down to one of our inline finding
@@ -407,7 +438,7 @@ def _apply_learned_feedback(github: GitHubGateway, ctx: PRContext, cfg: ReviewCo
 
 def run_review(
     *,
-    github: GitHubGateway,
+    github: ReviewGateway,
     engine: ReviewEngine,
     cfg: ReviewConfig,
     dry_run: bool,
@@ -549,7 +580,7 @@ def _fail_on_check(findings: list[ReviewFinding], fail_on: Severity) -> tuple[st
 
 
 def _incremental_context(
-    github: GitHubGateway,
+    github: ReviewGateway,
     ctx: PRContext,
     cfg: ReviewConfig,
     *,
@@ -597,7 +628,7 @@ def _diff_paths(diff: str) -> set[str]:
 
 
 def _validate_prior_findings(
-    github: GitHubGateway,
+    github: ReviewGateway,
     provider: ProviderClient | None,
     cfg: ReviewConfig,
     ctx: PRContext,
@@ -618,9 +649,9 @@ def _validate_prior_findings(
         set_fixed(set())
         return ""
 
+    from lgtmaybe.core.findings import finding_fingerprint, finding_identity
     from lgtmaybe.core.models import FindingValidation, FindingValidationStatus
     from lgtmaybe.engine.validate import validate_findings
-    from lgtmaybe.github.rest_gateway import finding_fingerprint, finding_identity
 
     current_keys = {
         key
@@ -771,7 +802,7 @@ def execute_local_diagram(
 
 
 def _post_extras(
-    github: GitHubGateway,
+    github: ReviewGateway,
     provider: ProviderClient,
     cfg: ReviewConfig,
     ctx: PRContext,
@@ -895,7 +926,7 @@ def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: RuntimeOp
         raise click.ClickException(f"/{parsed.name} failed: {exc}") from exc
 
 
-def _post_failure(github: GitHubGateway, exc: Exception) -> None:
+def _post_failure(github: ReviewGateway, exc: Exception) -> None:
     """Post a short failure notice to the PR; never raise from here."""
     # Name the version: unlike the summary line this notice carries no model,
     # so without it a failure report says nothing about what was running.

--- a/src/lgtmaybe/core/diff.py
+++ b/src/lgtmaybe/core/diff.py
@@ -1,6 +1,11 @@
 """Diff utilities: commentable-line index and skip filter.
 
-Commentable-line index: GitHub anchors a review comment with `line` + `side`
+Host-neutral, and in ``core`` for that reason: every forge lgtmaybe posts to
+anchors a comment to a line of a unified diff, and every one of them wants the
+same files skipped. A forge adapter translates these tuples into its own
+position vocabulary; none of them owns the parsing.
+
+Commentable-line index: a review comment is anchored with `line` + `side`
 (`side="RIGHT"` → the new-file line number, `side="LEFT"` → the old-file line
 number) rather than the deprecated, fragile `position` count. We build the set
 of (filename, line, side) tuples a comment can legally attach to — every added,
@@ -32,7 +37,7 @@ CommentableLines = set[tuple[str, int, str]]
 def build_commentable_lines(diff: str) -> CommentableLines:
     """Parse a unified diff into the set of commentable (file, line, side) tuples.
 
-    GitHub anchors a review comment by file line and side, not by a running
+    A review comment is anchored by file line and side, not by a running
     position count, so this avoids the off-by-N drift the `position` count
     suffered across multiple hunks. A line is commentable when it appears in the
     diff:

--- a/src/lgtmaybe/core/findings.py
+++ b/src/lgtmaybe/core/findings.py
@@ -1,0 +1,54 @@
+"""Stable hidden ids that let a re-run recognise a finding it already made.
+
+Host-neutral, and in ``core`` for that reason: every forge adapter embeds these
+ids in the comments it posts so the next run can tell "already reported" from
+"new", and "still true" from "fixed". Neither id contains model prose, so both
+are safe to write into a comment body verbatim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from .models import ReviewFinding
+
+
+def finding_fingerprint(path: str, title: str) -> str:
+    """Stable short id for a finding's identity (its file and what it flags).
+
+    Used to recognise the same finding across review runs: if a fingerprint that
+    opened a conversation is no longer produced, that conversation is a candidate
+    to auto-resolve. Only the path and title feed the hash (never model prose),
+    so the marker is safe to embed in a comment body verbatim.
+    """
+    digest = hashlib.sha256(f"{path}\n{title.strip().lower()}".encode())
+    return digest.hexdigest()[:12]
+
+
+def finding_identity(finding: ReviewFinding) -> str:
+    """Stable short id for *what* a finding is about, independent of how it reads.
+
+    ``finding_fingerprint`` hashes the title, and the title is model prose: ask a
+    model to review the same diff twice and it flags the same problem in different
+    words, producing a different fingerprint each run. Dedupe keyed on that alone
+    cannot survive a re-run, so this is the key that can — built only from fields
+    the model does not paraphrase:
+
+    - ``path`` — the file.
+    - ``category`` — the lens that raised it (engine-stamped, a fixed vocabulary),
+      so two different concerns about one line stay distinct.
+    - ``anchor`` — the verbatim source line the finding is about. Copied out of the
+      diff rather than composed, so it is code, not prose. It also absorbs line
+      drift: the model miscounts diff line numbers (the reason anchors exist at
+      all), and the same flagged line reported at 428 on one run and 501 on the
+      next is one finding, not two.
+
+    With no anchor there is nothing to key on but the reported line, so identity
+    falls back to it — still prose-free, just less tolerant of a miscount.
+    """
+    # Collapse whitespace runs so re-indentation of the same statement doesn't read
+    # as a different line; keep case, because code is case-sensitive.
+    anchor = " ".join(finding.anchor.split()) if finding.anchor else ""
+    locator = anchor or f"L{finding.line}"
+    digest = hashlib.sha256(f"{finding.path}\n{finding.category or ''}\n{locator}".encode())
+    return digest.hexdigest()[:12]

--- a/src/lgtmaybe/core/forge.py
+++ b/src/lgtmaybe/core/forge.py
@@ -1,0 +1,98 @@
+"""Which code host a review targets, and how to authenticate to it.
+
+lgtmaybe reviews merge requests on more than one forge. Almost nothing in the
+codebase needs to know which one: the engine never sees a gateway at all, and
+the diff, prompt, and finding types are host-neutral by construction. The
+knowledge is concentrated here — parse a URL into a locator, name the token
+variable — so a new forge is an adapter plus an entry in these tables, not a
+change spread through the pipeline.
+
+"Forge" rather than "provider" deliberately: ``Provider`` is already taken by
+the LLM backend, which is a separate axis (any forge can be reviewed by any
+model).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Forge(StrEnum):
+    """A code host lgtmaybe can read a change from and post a review back to."""
+
+    github = "github"
+    gitlab = "gitlab"
+    gitea = "gitea"
+
+
+@dataclass(frozen=True, slots=True)
+class PRLocator:
+    """Everything needed to address one change request, host included.
+
+    ``repo`` is the forge's project path ("owner/repo", or a nested
+    "group/subgroup/project" on GitLab). ``host`` is kept because self-hosted
+    GitLab and Gitea are the common case, so the API base cannot be a constant.
+    """
+
+    forge: Forge
+    host: str
+    repo: str
+    number: int
+
+
+# One pattern per forge, discriminated by the segment before the number. GitHub
+# and Gitea differ only in singular/plural ("pull" vs "pulls"), so Gitea is
+# matched first — its pattern is the more specific of the two. GitLab's ``/-/``
+# separator is what makes an arbitrarily nested group path unambiguous.
+_URL_PATTERNS: tuple[tuple[Forge, re.Pattern[str]], ...] = (
+    (
+        Forge.gitlab,
+        re.compile(r"(?P<host>[^/]+)/(?P<repo>.+?)/-/merge_requests/(?P<number>\d+)"),
+    ),
+    (
+        Forge.gitea,
+        re.compile(r"(?P<host>[^/]+)/(?P<repo>[^/]+/[^/]+)/pulls/(?P<number>\d+)"),
+    ),
+    (
+        Forge.github,
+        re.compile(r"(?P<host>[^/]+)/(?P<repo>[^/]+/[^/]+)/pull/(?P<number>\d+)"),
+    ),
+)
+
+_TOKEN_ENV_VARS: dict[Forge, str] = {
+    Forge.github: "GITHUB_TOKEN",
+    Forge.gitlab: "GITLAB_TOKEN",
+    Forge.gitea: "GITEA_TOKEN",
+}
+
+
+def parse_pr_url(pr_url: str) -> PRLocator:
+    """Resolve a pull/merge request URL to the forge and project it names.
+
+    Raises ValueError naming every supported shape when nothing matches — the
+    user could be on any of three hosts, so a GitHub-only example would send
+    two thirds of them looking for a mistake they did not make.
+    """
+    stripped = pr_url.split("://", 1)[-1]
+    for forge, pattern in _URL_PATTERNS:
+        match = pattern.search(stripped)
+        if match is not None:
+            return PRLocator(
+                forge=forge,
+                host=match["host"],
+                repo=match["repo"],
+                number=int(match["number"]),
+            )
+    raise ValueError(
+        f"Could not parse a pull/merge request URL from {pr_url!r}. Expected one of "
+        "https://github.com/org/repo/pull/42, "
+        "https://gitlab.com/org/repo/-/merge_requests/42, or "
+        "https://gitea.example.com/org/repo/pulls/42"
+    )
+
+
+def token_env_var(forge: Forge) -> str:
+    """The environment variable holding ``forge``'s API token."""
+    return _TOKEN_ENV_VARS[forge]

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -8,9 +8,10 @@ parallel tracks can build against stable signatures.
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
-from .models import PRContext, ProviderResult, ReviewConfig, ReviewFinding
+from .models import ActiveFinding, PRContext, ProviderResult, ReviewConfig, ReviewFinding
 
 # A chat message in the provider-neutral shape litellm expects.
 Message = dict[str, str]
@@ -84,8 +85,16 @@ class ProviderClient(Protocol):
         ...
 
 
-class GitHubGateway(Protocol):
-    """Port: read a PR's context and post a review back."""
+class ReviewGateway(Protocol):
+    """Port: read a change request's context and post a review back.
+
+    The required surface, and deliberately small: a forge adapter that
+    implements these three methods produces a working review. Everything
+    richer — incremental re-review, thread resolution, labels, checks — is an
+    optional capability declared by one of the ``Supports*`` protocols below,
+    and the CLI degrades gracefully when an adapter does not offer it. That is
+    what lets a new forge ship a useful adapter before it ships a complete one.
+    """
 
     def get_pr_context(self) -> PRContext:
         """Fetch the PR diff and metadata via API (never check out PR code)."""
@@ -107,9 +116,147 @@ class GitHubGateway(Protocol):
         ...
 
 
+# ---------------------------------------------------------------------------
+# Optional capabilities
+# ---------------------------------------------------------------------------
+#
+# Beyond the required port above, the CLI probes a gateway for these groups and
+# skips the corresponding feature when they are absent. They are grouped by
+# feature rather than by method because each group is semantically
+# all-or-nothing: half of an incremental review is worse than none of it.
+#
+# ``runtime_checkable`` protocols check method *presence*, not signatures, so
+# they are a checklist for adapter authors rather than a proof of correctness.
+# ``tests/test_ports.py`` asserts the shipped adapters satisfy the ones they
+# claim, which is what keeps this list honest.
+
+
+@runtime_checkable
+class SupportsFileContents(Protocol):
+    """Read file text at the change's head, for context expansion and retrieval."""
+
+    def get_file_contents(self, path: str) -> str | None:
+        """Fetch one file's head text via API — never a checkout (fork-safe)."""
+        ...
+
+
+@runtime_checkable
+class SupportsBaseCheckout(Protocol):
+    """Expose a lazily-cloned tree of the trusted base branch for symbol lookup."""
+
+    def base_checkout_root(self) -> Path | None:
+        """Root of a read-only clone of the base branch, or None if unavailable."""
+        ...
+
+
+@runtime_checkable
+class SupportsDescribe(Protocol):
+    """Upsert a structured PR description comment in its own marker family."""
+
+    def post_describe_comment(self, body: str) -> None:
+        """Post or edit-in-place the description comment."""
+        ...
+
+
+@runtime_checkable
+class SupportsDiagram(Protocol):
+    """Upsert a change-diagram comment in its own marker family."""
+
+    def post_diagram_comment(self, body: str, *, completed_sha: str | None = None) -> None:
+        """Post or edit-in-place the diagram comment."""
+        ...
+
+
+@runtime_checkable
+class SupportsIncremental(Protocol):
+    """Review only the commits pushed since the last successful review.
+
+    Requires somewhere durable to stamp a watermark (in practice an editable
+    bot comment) and an API for the diff between two commits.
+    """
+
+    def last_reviewed_sha(self) -> str | None:
+        """The head SHA stamped by the last review, or None."""
+        ...
+
+    def last_completed_sha(self, *, diagram_required: bool) -> str | None:
+        """The head SHA of the last run that finished every required artefact."""
+        ...
+
+    def compare_diff(self, base_sha: str, head_sha: str) -> str | None:
+        """Unified diff between two commits, or None when not comparable."""
+        ...
+
+    def mark_reviewed(self, head_sha: str | None) -> None:
+        """Stamp ``head_sha`` as reviewed (success path only)."""
+        ...
+
+    def set_incremental_scope(self, paths: set[str] | None) -> None:
+        """Limit resolve-on-fix to the files this increment re-reviewed."""
+        ...
+
+    def set_scan_manifests(self, enabled: bool) -> None:
+        """Ask the gateway to also fetch dependency-manifest text for scanning."""
+        ...
+
+
+@runtime_checkable
+class SupportsThreadResolution(Protocol):
+    """Reply in, and resolve, the conversations opened by earlier findings."""
+
+    def list_active_findings(self) -> list[ActiveFinding]:
+        """Open finding conversations, keyed by their hidden ids."""
+        ...
+
+    def set_validated_fixed_threads(self, thread_ids: set[str]) -> None:
+        """Nominate the threads confirmed fixed and safe to resolve."""
+        ...
+
+    def reply_in_thread(self, thread_id: str, body: str) -> None:
+        """Reply to one existing review conversation."""
+        ...
+
+    def count_open_finding_threads(self) -> int:
+        """How many finding conversations are still open."""
+        ...
+
+
+@runtime_checkable
+class SupportsLabels(Protocol):
+    """Reconcile lgtmaybe's own label families on the change request."""
+
+    def apply_pr_labels(self, labels: list[str]) -> None:
+        """Add/remove only labels in lgtmaybe's families, best-effort."""
+        ...
+
+
+@runtime_checkable
+class SupportsChecks(Protocol):
+    """Report the review as a commit status / check run."""
+
+    def create_check_run(self, head_sha: str, conclusion: str, title: str, summary: str) -> None:
+        """Publish the review outcome against ``head_sha``."""
+        ...
+
+
+@runtime_checkable
+class SupportsFeedback(Protocol):
+    """Read 👎 reactions so a rejected finding stops being resurfaced."""
+
+    def list_downvoted_fingerprints(self) -> set[str]:
+        """Fingerprints of findings downvoted by someone with write access."""
+        ...
+
+
 class ReviewEngine(Protocol):
     """Port: turn a PR context + config into findings and a summary."""
 
     def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
         """Produce (findings, summary) for the given PR and config."""
         ...
+
+
+# Back-compat alias: the port was GitHub-only before lgtmaybe reviewed more than
+# one forge. Kept so an out-of-tree adapter typed against the old name still
+# imports; new code should use ``ReviewGateway``.
+GitHubGateway = ReviewGateway

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -21,6 +21,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+from lgtmaybe.core.diff import is_reviewable
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
@@ -41,7 +42,6 @@ from lgtmaybe.core.ports import (
     ProviderWallTimeout,
 )
 from lgtmaybe.core.version import package_version
-from lgtmaybe.github import is_reviewable
 
 from . import specs
 from .astgrep import SymbolResolver

--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from lgtmaybe.core.diff import is_scannable_manifest
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
     _SCAN_CATEGORY_PREFIX,
@@ -48,7 +49,6 @@ from lgtmaybe.core.models import (
     StaticAnalysisTool,
     ToolMode,
 )
-from lgtmaybe.github.diff import is_scannable_manifest
 
 from .redact import redact
 

--- a/src/lgtmaybe/engine/suppress.py
+++ b/src/lgtmaybe/engine/suppress.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 import re
 
+from lgtmaybe.core.findings import finding_fingerprint
 from lgtmaybe.core.models import ReviewCategory, ReviewConfig, ReviewFinding, Severity
-from lgtmaybe.github.rest_gateway import finding_fingerprint
 
 # A `# lgtmaybe: ignore` pragma anywhere in a line (after a `#` comment marker).
 # Case-insensitive so `# LGTMAYBE: IGNORE` works too.

--- a/src/lgtmaybe/github/__init__.py
+++ b/src/lgtmaybe/github/__init__.py
@@ -1,19 +1,13 @@
 """github — GitHub REST adapter for lgtmaybe.
 
 Public surface:
-- RestGitHubGateway: implements GitHubGateway against the GitHub REST API.
-- build_commentable_lines: parse a unified diff into the set of (file, line, side)
-  tuples a review comment can anchor to.
-- is_reviewable: predicate that rejects lockfiles, minified, vendored, binary paths.
-- is_scannable_manifest: predicate for dependency manifests/lockfiles worth scanning.
+- RestGitHubGateway: implements ReviewGateway against the GitHub REST API.
+
+The diff helpers this adapter is built on (``build_commentable_lines``,
+``is_reviewable``, ``is_scannable_manifest``) are host-neutral and live in
+``lgtmaybe.core.diff``; import them from there.
 """
 
-from .diff import build_commentable_lines, is_reviewable, is_scannable_manifest
 from .rest_gateway import RestGitHubGateway
 
-__all__ = [
-    "RestGitHubGateway",
-    "build_commentable_lines",
-    "is_reviewable",
-    "is_scannable_manifest",
-]
+__all__ = ["RestGitHubGateway"]

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -10,7 +10,6 @@ All network calls carry an explicit timeout.
 
 from __future__ import annotations
 
-import hashlib
 import re
 import threading
 from collections.abc import Iterator
@@ -21,6 +20,13 @@ from urllib.parse import quote
 
 import httpx
 
+from lgtmaybe.core.diff import (
+    CommentableLines,
+    build_commentable_lines,
+    is_reviewable,
+    is_scannable_manifest,
+)
+from lgtmaybe.core.findings import finding_fingerprint, finding_identity
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
     EFFORT_PREFIX,
@@ -32,12 +38,6 @@ from lgtmaybe.core.models import (
 )
 
 from .checkout import clone_base_tree
-from .diff import (
-    CommentableLines,
-    build_commentable_lines,
-    is_reviewable,
-    is_scannable_manifest,
-)
 
 _log = get_logger(__name__)
 
@@ -95,47 +95,6 @@ _RESOLVED_IDENTITY_PREFIX = "<!-- lgtmaybe-resolved-identity:"
 # since (commit-scoped incremental review). The capture group is the SHA.
 _REVIEWED_MARKER = re.compile(r"<!-- lgtmaybe-reviewed:([0-9a-f]{7,40}) -->")
 _DIAGRAMMED_MARKER = re.compile(r"<!-- lgtmaybe-diagrammed:([0-9a-f]{7,40}) -->")
-
-
-def finding_fingerprint(path: str, title: str) -> str:
-    """Stable short id for a finding's identity (its file and what it flags).
-
-    Used to recognise the same finding across review runs: if a fingerprint that
-    opened a conversation is no longer produced, that conversation is a candidate
-    to auto-resolve. Only the path and title feed the hash (never model prose),
-    so the marker is safe to embed in a comment body verbatim.
-    """
-    digest = hashlib.sha256(f"{path}\n{title.strip().lower()}".encode())
-    return digest.hexdigest()[:12]
-
-
-def finding_identity(finding: ReviewFinding) -> str:
-    """Stable short id for *what* a finding is about, independent of how it reads.
-
-    ``finding_fingerprint`` hashes the title, and the title is model prose: ask a
-    model to review the same diff twice and it flags the same problem in different
-    words, producing a different fingerprint each run. Dedupe keyed on that alone
-    cannot survive a re-run, so this is the key that can — built only from fields
-    the model does not paraphrase:
-
-    - ``path`` — the file.
-    - ``category`` — the lens that raised it (engine-stamped, a fixed vocabulary),
-      so two different concerns about one line stay distinct.
-    - ``anchor`` — the verbatim source line the finding is about. Copied out of the
-      diff rather than composed, so it is code, not prose. It also absorbs line
-      drift: the model miscounts diff line numbers (the reason anchors exist at
-      all), and the same flagged line reported at 428 on one run and 501 on the
-      next is one finding, not two.
-
-    With no anchor there is nothing to key on but the reported line, so identity
-    falls back to it — still prose-free, just less tolerant of a miscount.
-    """
-    # Collapse whitespace runs so re-indentation of the same statement doesn't read
-    # as a different line; keep case, because code is case-sensitive.
-    anchor = " ".join(finding.anchor.split()) if finding.anchor else ""
-    locator = anchor or f"L{finding.line}"
-    digest = hashlib.sha256(f"{finding.path}\n{finding.category or ''}\n{locator}".encode())
-    return digest.hexdigest()[:12]
 
 
 def _finding_keys(body: str) -> set[str]:

--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -12,8 +12,8 @@ import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
+from lgtmaybe.core.diff import is_reviewable, is_scannable_manifest
 from lgtmaybe.core.models import PRContext
-from lgtmaybe.github.diff import is_reviewable, is_scannable_manifest
 
 # `git diff` over a large working tree (or a repo whose objects are cold) can
 # take a while; the timeout only caps a hung git, never a slow one.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -516,7 +516,7 @@ class TestParsePrUrl:
     def test_rejects_non_pr_url(self):
         from lgtmaybe.cli import parse_pr_url
 
-        with pytest.raises(ValueError, match="PR URL"):
+        with pytest.raises(ValueError, match="Could not parse"):
             parse_pr_url("https://github.com/org/my-repo/issues/42")
 
 

--- a/tests/core/test_diff.py
+++ b/tests/core/test_diff.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from lgtmaybe.github import build_commentable_lines, is_reviewable
-from lgtmaybe.github.diff import is_scannable_manifest
+from lgtmaybe.core.diff import build_commentable_lines, is_reviewable, is_scannable_manifest
 
 # ---------------------------------------------------------------------------
 # Commentable-line index

--- a/tests/core/test_forge.py
+++ b/tests/core/test_forge.py
@@ -1,0 +1,91 @@
+"""The forge seam: which code host a PR/MR URL belongs to, and how to auth it.
+
+lgtmaybe posts reviews to more than one code host. Everything upstream of the
+gateway (engine, prompts, diff parsing) is host-neutral, so the only thing that
+has to know *which* host is the small locator + credential layer tested here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.core.forge import Forge, PRLocator, parse_pr_url, token_env_var
+
+
+class TestParsePRUrl:
+    """A PR/MR URL resolves to (forge, host, repo, number)."""
+
+    def test_parses_a_github_pull_request(self) -> None:
+        assert parse_pr_url("https://github.com/org/repo/pull/42") == PRLocator(
+            forge=Forge.github, host="github.com", repo="org/repo", number=42
+        )
+
+    def test_parses_a_gitlab_merge_request(self) -> None:
+        assert parse_pr_url("https://gitlab.com/org/repo/-/merge_requests/7") == PRLocator(
+            forge=Forge.gitlab, host="gitlab.com", repo="org/repo", number=7
+        )
+
+    def test_gitlab_project_paths_may_nest_in_subgroups(self) -> None:
+        """GitLab groups nest arbitrarily; the ``/-/`` separator ends the path."""
+        located = parse_pr_url("https://gitlab.example.com/grp/sub/proj/-/merge_requests/3")
+        assert located == PRLocator(
+            forge=Forge.gitlab, host="gitlab.example.com", repo="grp/sub/proj", number=3
+        )
+
+    def test_parses_a_gitea_pull_request(self) -> None:
+        """Gitea mirrors GitHub's URL shape but pluralises the ``pulls`` segment."""
+        assert parse_pr_url("https://gitea.example.com/org/repo/pulls/9") == PRLocator(
+            forge=Forge.gitea, host="gitea.example.com", repo="org/repo", number=9
+        )
+
+    def test_rejects_a_url_that_is_not_a_pull_request(self) -> None:
+        with pytest.raises(ValueError, match="Could not parse"):
+            parse_pr_url("https://github.com/org/repo")
+
+    def test_the_error_names_every_supported_url_shape(self) -> None:
+        """The message has to be actionable on whichever host the user is on."""
+        with pytest.raises(ValueError) as excinfo:
+            parse_pr_url("nonsense")
+        message = str(excinfo.value)
+        assert "/pull/" in message
+        assert "/merge_requests/" in message
+        assert "/pulls/" in message
+
+
+class TestTokenEnvVar:
+    """Each forge reads its own conventional token variable."""
+
+    @pytest.mark.parametrize(
+        ("forge", "expected"),
+        [
+            (Forge.github, "GITHUB_TOKEN"),
+            (Forge.gitlab, "GITLAB_TOKEN"),
+            (Forge.gitea, "GITEA_TOKEN"),
+        ],
+    )
+    def test_names_the_conventional_variable(self, forge: Forge, expected: str) -> None:
+        assert token_env_var(forge) == expected
+
+    def test_every_forge_has_one(self) -> None:
+        """A forge with no token variable could never authenticate."""
+        assert {token_env_var(forge) for forge in Forge} == {
+            "GITHUB_TOKEN",
+            "GITLAB_TOKEN",
+            "GITEA_TOKEN",
+        }
+
+
+class TestGatewayRegistry:
+    """Which forges lgtmaybe can actually build a gateway for."""
+
+    def test_github_is_registered(self) -> None:
+        from lgtmaybe.cli import gateway_builder
+
+        assert gateway_builder(Forge.github) is not None
+
+    @pytest.mark.parametrize("forge", [Forge.gitlab, Forge.gitea])
+    def test_an_unimplemented_forge_says_so_by_name(self, forge: Forge) -> None:
+        """A recognised-but-unbuilt forge must not read as an unparseable URL."""
+        from lgtmaybe.cli import gateway_builder
+
+        assert gateway_builder(forge) is None

--- a/tests/evals/test_fixtures.py
+++ b/tests/evals/test_fixtures.py
@@ -15,6 +15,7 @@ import shutil
 import pytest
 
 from evals import run as run_mod
+from lgtmaybe.core.diff import is_reviewable
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
 from lgtmaybe.core.models import (
     PRContext,
@@ -29,7 +30,6 @@ from lgtmaybe.engine.astgrep import build_symbol_resolver
 from lgtmaybe.engine.compress import split_patch_into_hunks
 from lgtmaybe.engine.redact import redact
 from lgtmaybe.engine.reflect import reflect_findings
-from lgtmaybe.github import is_reviewable
 from lgtmaybe.local import local_file_reader
 from tests.fakes import FakeProvider
 

--- a/tests/github/test_manifests.py
+++ b/tests/github/test_manifests.py
@@ -9,7 +9,7 @@ and reflection never read.
 
 from __future__ import annotations
 
-from lgtmaybe.github.diff import is_reviewable, is_scannable_manifest
+from lgtmaybe.core.diff import is_reviewable, is_scannable_manifest
 
 
 def test_lockfiles_are_scannable_but_never_reviewable() -> None:

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -2,18 +2,56 @@
 
 from __future__ import annotations
 
-from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine
+import pytest
+
+from lgtmaybe.core import ports
+from lgtmaybe.core.ports import GitHubGateway, ProviderClient, ReviewEngine, ReviewGateway
 from lgtmaybe.engine.engine import LLMReviewEngine
 from lgtmaybe.github.rest_gateway import RestGitHubGateway
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
+# Every optional capability a gateway may declare, by name, so the conformance
+# test below fails loudly when one is added without being wired up.
+CAPABILITIES = [
+    name
+    for name in dir(ports)
+    if name.startswith("Supports") and getattr(getattr(ports, name), "_is_protocol", False)
+]
+
 
 def test_ports_are_protocols() -> None:
-    for port in (ProviderClient, GitHubGateway, ReviewEngine):
+    for port in (ProviderClient, ReviewGateway, ReviewEngine):
         assert getattr(port, "_is_protocol", False)
 
 
 def test_production_implementations_do_not_inherit_ports() -> None:
     assert ProviderClient not in LiteLLMProvider.__mro__
-    assert GitHubGateway not in RestGitHubGateway.__mro__
+    assert ReviewGateway not in RestGitHubGateway.__mro__
     assert ReviewEngine not in LLMReviewEngine.__mro__
+
+
+def test_the_old_github_only_port_name_still_resolves() -> None:
+    """Renamed when lgtmaybe grew past one forge; the alias keeps adapters importing."""
+    assert GitHubGateway is ReviewGateway
+
+
+class TestCapabilities:
+    """The ``Supports*`` protocols are a checklist for forge adapter authors.
+
+    They are only worth having if they describe methods that really exist, so
+    the reference adapter is asserted against every one of them.
+    """
+
+    def test_there_is_at_least_one(self) -> None:
+        assert CAPABILITIES
+
+    @pytest.mark.parametrize("name", CAPABILITIES)
+    def test_capabilities_are_runtime_checkable(self, name: str) -> None:
+        """The CLI probes a gateway at run time, so presence must be testable."""
+        assert getattr(ports, name)._is_runtime_protocol
+
+    @pytest.mark.parametrize("name", CAPABILITIES)
+    def test_the_github_adapter_satisfies_every_capability(self, name: str) -> None:
+        """GitHub is the complete adapter — it is what the full surface is drawn from."""
+        gateway = RestGitHubGateway.__new__(RestGitHubGateway)
+        assert isinstance(gateway, getattr(ports, name))


### PR DESCRIPTION
Phase 0 of adding GitLab and Gitea support. **No behaviour changes** — this moves a boundary so the adapters that follow are additive units rather than a rewrite.

## Why

lgtmaybe's engine is already host-neutral: `LLMReviewEngine.__init__` takes no gateway at all, and local mode (`lgtmaybe review` on a git diff) already runs the whole pipeline — batching, lenses, reflection, redaction, injection hardening — with no forge involved. GitHub only enters at two points: producing a `PRContext`, and rendering findings back as comments.

But the seam between them was drawn in the wrong place:

- the port was named `GitHubGateway` and declared 3 methods while the adapter shipped 20, the other 17 reached for via `getattr` at 16 call sites;
- `build_review_context` returned the concrete `RestGitHubGateway` and parsed only `github.com/org/repo/pull/N`;
- three core/engine modules imported the GitHub adapter package for code that was never GitHub-specific.

That last one is the blocker: a `lgtmaybe.gitlab` package would have had to import `lgtmaybe.github` to filter a diff.

## What changed

**Host-neutral code moved into `core/`**
- `github/diff.py` → `core/diff.py`. Every forge anchors comments to unified-diff lines and wants the same lockfiles/vendored/binary files skipped.
- `finding_fingerprint` / `finding_identity` → `core/findings.py`. Every adapter embeds these hidden ids so a re-run can tell "already reported" from "new".
- Kills all four `core`/`engine` → adapter import leaks.

**Port renamed and widened**
- `GitHubGateway` → `ReviewGateway` (alias kept so an out-of-tree adapter still imports).
- The 17 adapter-only methods are now declared as optional `Supports*` capability protocols — `SupportsIncremental`, `SupportsThreadResolution`, `SupportsChecks`, `SupportsLabels`, `SupportsFeedback`, `SupportsFileContents`, `SupportsBaseCheckout`, `SupportsDescribe`, `SupportsDiagram`.
- Grouped by feature, not per-method, because each is semantically all-or-nothing: half an incremental review is worse than none.
- The **required** surface stays three methods, so a forge adapter can be useful long before it is complete. The existing `getattr` degradation is left exactly as it was — it already works and is tested; the protocols document the surface and give `build_review_context` something typed to probe.
- `tests/test_ports.py` asserts `RestGitHubGateway` satisfies every declared capability, which is what stops the list becoming decorative.

**The forge seam itself** — new `core/forge.py`
- `Forge` enum, `PRLocator` (forge + host + repo + number), URL parsing for all three hosts, per-forge token variable.
- Host is carried because self-hosted GitLab and Gitea are the common case, so the API base cannot be a constant.
- `build_review_context` dispatches through a gateway registry. Only GitHub is registered, so a GitLab URL now fails with "gitlab is not supported yet" rather than "could not parse a PR URL".

`Forge` rather than reusing `Provider` deliberately — `Provider` is the LLM backend, a separate axis.

## Verification

- Full gate green: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest` — 2278 passed, 3 skipped.
- Baseline before this change was 2243 passed; the 35 new tests are `tests/core/test_forge.py` plus the capability conformance cases.
- Spec anchors re-resolved (`tests/specs`, 17 passed) and the `core.gateway-port` section updated for the rename; `docs/explanation/architecture.md` updated and `llms-full.txt` regenerated.

## Follow-ups

- Phase 1 — Gitea adapter (cheap: its API and Actions runtime mirror GitHub's).
- Phase 2 — GitLab adapter (MR discussions, `old_line`/`new_line` positions, `CI_*` env instead of an event payload).

---
_Generated by [Claude Code](https://claude.ai/code/session_013KoK6xvv72d6x1Z5qaCk37)_