### PR TITLE
feat: review pull requests on Gitea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,31 @@ autocrlf before checkout.
   static `AZURE_API_KEY` is accepted but not required). Never accept or require a
   service-account JSON or static AWS key.
 
+### Forges — which code host the review is posted to
+
+A second axis, orthogonal to the LLM provider: **`Forge`** (`core/forge.py`) is
+github / gitlab / gitea, and `Provider` stays the model backend. Never overload
+"provider" for a code host.
+
+- The **engine never sees a gateway.** It takes a `PRContext` and returns
+  findings; `local/` already produces a `PRContext` from `git` with no forge at
+  all. Anything host-neutral therefore belongs in `core/`, not in an adapter
+  package — diff parsing and the skip filter (`core/diff.py`), finding
+  fingerprints (`core/findings.py`), and comment Markdown (`core/comment.py`)
+  are all shared. A new adapter that reimplements any of those is a bug.
+- **`ReviewGateway` (`core/ports.py`) is three methods.** Everything richer is an
+  optional `Supports*` capability protocol the CLI probes for and skips when
+  absent, so an adapter ships useful before it ships complete. Declare only what
+  the host can actually serve — claiming a capability that cannot work is worse
+  than not claiming it.
+- A URL is resolved by `core/forge.parse_pr_url` into a `PRLocator`
+  (forge + host + repo + number); `cli._GATEWAY_BUILDERS` maps forge to adapter.
+  Host is carried because self-hosted GitLab/Gitea is the norm.
+- **GitHub** is the complete adapter. **Gitea** (`gitea/gateway.py`) mirrors it
+  minus incremental review and thread resolution (its API cannot serve either);
+  its summary lives in an editable issue comment because a submitted Gitea review
+  is immutable, and it de-dupes findings by reading the hidden ids already posted.
+
 ## Key decisions (do not relitigate)
 
 - **Language:** Python.

--- a/docs/how-to/review-on-gitea.md
+++ b/docs/how-to/review-on-gitea.md
@@ -1,0 +1,62 @@
+# Review pull requests on Gitea
+
+lgtmaybe posts reviews to Gitea as well as GitHub. The review itself is
+identical — same lenses, same reflection pass, same findings — because none of
+that ever depended on the host. Only the adapter that fetches the diff and posts
+the comments is different.
+
+## Set it up
+
+1. **Create a token.** In Gitea, go to *Settings → Applications → Access Tokens*
+   and create a token with `read:repository` and `write:issue` scopes. Add it to
+   your repository as a secret named `GITEA_TOKEN`.
+
+2. **Add a provider key.** Add the API key for whichever model you want as a
+   second secret — for example `ANTHROPIC_API_KEY`.
+
+3. **Add the workflow.** Copy
+   [`examples/gitea/lgtmaybe.yml`](https://github.com/MattJColes/lgtmaybe/blob/main/examples/gitea/lgtmaybe.yml)
+   into your repository at `.gitea/workflows/lgtmaybe.yml`.
+
+That is the whole setup. Gitea Actions reimplements the GitHub Actions runtime,
+so lgtmaybe's container image runs unchanged, and it reads `GITHUB_SERVER_URL`
+— which Gitea points at your own instance — to know which host to post back to.
+
+## Run it locally instead
+
+The CLI takes a Gitea pull-request URL directly:
+
+```bash
+export GITEA_TOKEN=...
+export ANTHROPIC_API_KEY=...
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
+  --pr-url https://gitea.example.com/team/service/pulls/12
+```
+
+## What works, and what does not
+
+Everything about the *review* works: every lens, the self-reflection pass,
+secret redaction, prompt-injection hardening, static-analysis fusion, path
+filters, finding rules, and the `/review`, `/improve`, `/ask`, `/describe` and
+`/diagram` slash commands.
+
+Three things are unavailable on Gitea, and lgtmaybe skips them rather than
+failing:
+
+| Not available | Why | What happens instead |
+|---|---|---|
+| Incremental review | Gitea's compare endpoint returns commit metadata, not a unified diff | Every run is a full review |
+| Resolve-on-fix | Gitea has no thread-resolution API | Fixed findings' comments stay open |
+| Keyless cloud auth | The OIDC/WIF exchange is a GitHub Actions feature | Use an API key, or `ollama` for a local model |
+
+Because a submitted Gitea review cannot be edited, lgtmaybe reads the hidden
+finding ids already on the pull request and declines to post a finding twice.
+The summary lives in an ordinary comment, which *is* editable, so it updates in
+place on each run.
+
+## Fork safety
+
+Gitea has no `pull_request_target`, so the `pull_request` event runs with the
+repository's secrets. The safety rule is unchanged and holds for the same
+reason: lgtmaybe never checks out or executes pull-request code. It reads the
+diff through the API and treats every byte of it as untrusted input.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1139,6 +1139,73 @@ Do not combine `app_id` / `app_private_key` with
 
 ---
 
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-on-gitea/ -->
+
+# Review pull requests on Gitea
+
+lgtmaybe posts reviews to Gitea as well as GitHub. The review itself is
+identical — same lenses, same reflection pass, same findings — because none of
+that ever depended on the host. Only the adapter that fetches the diff and posts
+the comments is different.
+
+## Set it up
+
+1. **Create a token.** In Gitea, go to *Settings → Applications → Access Tokens*
+   and create a token with `read:repository` and `write:issue` scopes. Add it to
+   your repository as a secret named `GITEA_TOKEN`.
+
+2. **Add a provider key.** Add the API key for whichever model you want as a
+   second secret — for example `ANTHROPIC_API_KEY`.
+
+3. **Add the workflow.** Copy
+   [`examples/gitea/lgtmaybe.yml`](https://github.com/MattJColes/lgtmaybe/blob/main/examples/gitea/lgtmaybe.yml)
+   into your repository at `.gitea/workflows/lgtmaybe.yml`.
+
+That is the whole setup. Gitea Actions reimplements the GitHub Actions runtime,
+so lgtmaybe's container image runs unchanged, and it reads `GITHUB_SERVER_URL`
+— which Gitea points at your own instance — to know which host to post back to.
+
+## Run it locally instead
+
+The CLI takes a Gitea pull-request URL directly:
+
+```bash
+export GITEA_TOKEN=...
+export ANTHROPIC_API_KEY=...
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
+  --pr-url https://gitea.example.com/team/service/pulls/12
+```
+
+## What works, and what does not
+
+Everything about the *review* works: every lens, the self-reflection pass,
+secret redaction, prompt-injection hardening, static-analysis fusion, path
+filters, finding rules, and the `/review`, `/improve`, `/ask`, `/describe` and
+`/diagram` slash commands.
+
+Three things are unavailable on Gitea, and lgtmaybe skips them rather than
+failing:
+
+| Not available | Why | What happens instead |
+|---|---|---|
+| Incremental review | Gitea's compare endpoint returns commit metadata, not a unified diff | Every run is a full review |
+| Resolve-on-fix | Gitea has no thread-resolution API | Fixed findings' comments stay open |
+| Keyless cloud auth | The OIDC/WIF exchange is a GitHub Actions feature | Use an API key, or `ollama` for a local model |
+
+Because a submitted Gitea review cannot be edited, lgtmaybe reads the hidden
+finding ids already on the pull request and declines to post a finding twice.
+The summary lives in an ordinary comment, which *is* editable, so it updates in
+place on each run.
+
+## Fork safety
+
+Gitea has no `pull_request_target`, so the `pull_request` event runs with the
+repository's secrets. The safety rule is unchanged and holds for the same
+reason: lgtmaybe never checks out or executes pull-request code. It reads the
+diff through the API and treats every byte of it as untrusted input.
+
+---
+
 <!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-openai/ -->
 
 # Review with OpenAI

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,6 +12,7 @@
 - [Choose a review model](https://lgtmaybe.coles.codes/how-to/choose-a-review-model/): Choose a cloud or local lgtmaybe review model using measured breadth, precision, false-positive, clean-change, and long-diff results.
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
 - [Post as lgtmaybe[bot]](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews as lgtmaybe[bot] with the public App, or use a self-managed GitHub App.
+- [Review on Gitea](https://lgtmaybe.coles.codes/how-to/review-on-gitea/)
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
 - [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
 - [Review with OpenRouter](https://lgtmaybe.coles.codes/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.

--- a/examples/gitea/lgtmaybe.yml
+++ b/examples/gitea/lgtmaybe.yml
@@ -1,0 +1,49 @@
+# Copy into your Gitea repo at .gitea/workflows/lgtmaybe.yml
+#
+# Gitea Actions reimplements the GitHub Actions runtime, so lgtmaybe's container
+# runs unchanged. Two things differ from the GitHub examples:
+#
+#   * There is no `pull_request_target`. Gitea runs `pull_request` with the
+#     repository's secrets, so the same fork-safety rule applies for the same
+#     reason: lgtmaybe never checks out or executes pull-request code, it only
+#     reads the diff through the API.
+#   * The token variable is GITEA_TOKEN, and lgtmaybe reads GITHUB_SERVER_URL
+#     (which Gitea sets to your own instance) to know which host to post to.
+#
+# Add an API key secret for whichever model provider you use. Cloud providers
+# with keyless OIDC (Bedrock, Vertex, Azure) are GitHub-only for now — on Gitea
+# use an API key, or ollama for a fully local review.
+name: lgtmaybe
+
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: lgtmaybe-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # The issue_comment arm fires on every comment on every pull request, so
+    # require a slash command in the body before claiming a runner.
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/improve') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '/describe') ||
+        contains(github.event.comment.body, '/diagram')))
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mattjcoles/lgtmaybe:v2
+    steps:
+      - name: Review
+        run: python -m lgtmaybe action
+        env:
+          GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          INPUT_PROVIDER: anthropic
+          INPUT_MODEL: claude-sonnet-4-6
+          INPUT_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
           - Choose a review model: how-to/choose-a-review-model.md
           - Use as a GitHub Action: how-to/use-as-github-action.md
           - Post as lgtmaybe[bot]: how-to/post-as-a-github-app.md
+          - Review on Gitea: how-to/review-on-gitea.md
       - Cloud providers (API key):
           - Review with OpenAI: how-to/review-with-openai.md
           - Review with Claude (Anthropic): how-to/review-with-anthropic.md

--- a/openspec/specs/gitea-posting/anchors.yml
+++ b/openspec/specs/gitea-posting/anchors.yml
@@ -1,0 +1,29 @@
+gitea.context:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^get_pr_context$' }
+  files: [src/lgtmaybe/gitea/**/*.py]
+
+gitea.upsert:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_upsert_comment$' }
+  files: [src/lgtmaybe/gitea/**/*.py]
+
+gitea.dedupe:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_existing_finding_keys$' }
+  files: [src/lgtmaybe/gitea/**/*.py]
+
+gitea.positions:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_partition_findings$' }
+  files: [src/lgtmaybe/gitea/**/*.py]
+
+gitea.capabilities:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^GiteaGateway$' }
+  files: [src/lgtmaybe/gitea/**/*.py]

--- a/openspec/specs/gitea-posting/spec.md
+++ b/openspec/specs/gitea-posting/spec.md
@@ -1,0 +1,73 @@
+# gitea-posting Specification
+
+## Purpose
+
+The Gitea REST adapter (`gitea/gateway.py`): the second forge lgtmaybe posts to,
+and the one that proves the seam. Gitea's API mirrors GitHub's closely, so this
+spec records only where it does not — an immutable review object, a different
+position vocabulary, and the capabilities Gitea cannot serve at all.
+
+## Requirements
+
+### Requirement: Context comes from the API, never a checkout
+
+`get_pr_context` SHALL fetch the diff, metadata, and head text of reviewable
+files through the Gitea REST API only — pull-request code is never checked out
+or executed. Head file text is returned base64-encoded and SHALL be decoded
+before it reaches the engine.
+<!-- anchor: gitea.context -->
+
+#### Scenario: metadata without SHAs is fatal
+- **WHEN** the API returns a payload carrying no base or head SHA
+- **THEN** the adapter raises rather than reviewing an empty diff
+
+### Requirement: The summary lives in an editable comment
+
+A Gitea review object cannot be edited after submission, so the summary SHALL be
+posted as an ordinary issue comment carrying the hidden marker, upserted in
+place on a re-run, while the review object carries only inline comments. Each
+comment family — summary, description, diagram — SHALL use a disjoint marker so
+updating one never clobbers another.
+<!-- anchor: gitea.upsert -->
+
+#### Scenario: a re-run edits rather than duplicates
+- **WHEN** a review runs a second time on the same pull request
+- **THEN** the existing summary comment is edited and no second one is posted
+
+### Requirement: Findings are de-duplicated before posting
+
+Because a submitted review cannot be amended, the adapter SHALL read the hidden
+finding ids already present in its earlier review comments and drop any finding
+matching one before posting. Failure to read them SHALL be non-fatal — a
+duplicated comment is a better outcome than a failed review.
+<!-- anchor: gitea.dedupe -->
+
+#### Scenario: a repeated finding is not posted twice
+- **WHEN** a re-run produces a finding whose id is already on the pull request
+- **THEN** no new inline comment is created for it
+
+### Requirement: Positions translate at the adapter boundary
+
+Inline comments SHALL be anchored with Gitea's `new_position` (new-file line) or
+`old_position` (old-file line), translated from lgtmaybe's internal RIGHT/LEFT
+side vocabulary. A finding that is not confidently anchored, or that does not
+land on a real commentable diff line, SHALL be demoted into the summary body
+rather than posted on a line the reviewer cannot stand behind.
+<!-- anchor: gitea.positions -->
+
+#### Scenario: a left-side finding uses the old-file line
+- **WHEN** a finding carries side LEFT
+- **THEN** the posted comment sets `old_position` and not `new_position`
+
+### Requirement: Unavailable capabilities are not claimed
+
+The adapter SHALL declare only the optional capability protocols Gitea can
+actually serve. Incremental review and review-thread resolution SHALL NOT be
+claimed — Gitea's compare endpoint returns commit metadata rather than a unified
+diff, and it has no thread-resolution API — so a caller degrades to a full
+review instead of calling a method that cannot work.
+<!-- anchor: gitea.capabilities -->
+
+#### Scenario: thread resolution is absent
+- **WHEN** a caller probes the adapter for thread resolution
+- **THEN** the check fails and resolve-on-fix is skipped

--- a/openspec/specs/github-posting/anchors.yml
+++ b/openspec/specs/github-posting/anchors.yml
@@ -33,14 +33,14 @@ github.fingerprint:
 github.demote:
   rule:
     kind: function_definition
-    has: { field: name, regex: '^_render_demoted$' }
-  files: [src/lgtmaybe/github/**/*.py]
+    has: { field: name, regex: '^render_demoted$' }
+  files: [src/lgtmaybe/core/comment.py]
 
 github.finding-badge:
   rule:
     kind: function_definition
-    has: { field: name, regex: '^_finding_badge$' }
-  files: [src/lgtmaybe/github/**/*.py]
+    has: { field: name, regex: '^finding_badge$' }
+  files: [src/lgtmaybe/core/comment.py]
 
 github.incremental:
   - rule:

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -57,6 +57,7 @@ from lgtmaybe.engine import (
     request_interrupt,
 )
 from lgtmaybe.engine.profiling import profiler
+from lgtmaybe.gitea import GiteaGateway
 from lgtmaybe.github import RestGitHubGateway
 from lgtmaybe.local import local_file_reader, local_pr_context
 from lgtmaybe.providers.credentials import resolve_credentials
@@ -202,6 +203,13 @@ _GATEWAY_BUILDERS: dict[Forge, Callable[[PRLocator, str, ReviewConfig], ReviewGa
         token=token,
         marker_key=f"{cfg.provider}/{cfg.model}",
         resolve_fixed=cfg.resolve_fixed,
+    ),
+    Forge.gitea: lambda located, token, cfg: GiteaGateway(
+        host=located.host,
+        repo=located.repo,
+        pr_number=located.number,
+        token=token,
+        marker_key=f"{cfg.provider}/{cfg.model}",
     ),
 }
 
@@ -912,7 +920,7 @@ def execute_comment(event: dict[str, Any], cfg: ReviewConfig, runtime: RuntimeOp
         pr_number = issue["number"]
     except (KeyError, TypeError) as exc:
         raise click.ClickException(f"event payload missing required field: {exc}") from exc
-    runtime = replace(runtime, pr_url=f"https://github.com/{repo}/pull/{pr_number}")
+    runtime = replace(runtime, pr_url=_change_url(repo, pr_number))
 
     try:
         github, engine, provider_client = build_review_context(cfg, runtime)
@@ -956,18 +964,33 @@ def _post_failure(github: ReviewGateway, exc: Exception) -> None:
         pass
 
 
-def pr_url_from_event(event: dict[str, Any]) -> str:
-    """Build the PR URL from a pull_request(_target) event payload.
+def _change_url(repo: str, number: int) -> str:
+    """Build the change-request URL for whichever host is running this job.
 
-    Only github.com is supported end to end — the URL parser and the REST
-    gateway both speak to api.github.com.
+    Gitea Actions reimplements GitHub Actions' env contract — same
+    ``GITHUB_EVENT_NAME``, same ``GITHUB_EVENT_PATH``, same ``INPUT_*`` — so the
+    entrypoint needs no forge switch of its own. The one variable that does
+    differ is ``GITHUB_SERVER_URL``, which points at the Gitea instance; reading
+    it is the whole difference between reviewing the right PR and posting to
+    github.com. Absent (or github.com), the URL is unchanged from before.
+
+    The path segment is what ``core.forge`` discriminates on, so it has to match
+    the host's own convention: GitHub singularises ``pull``, Gitea pluralises it.
     """
+    server = os.environ.get("GITHUB_SERVER_URL", "").rstrip("/")
+    if not server or server == "https://github.com":
+        return f"https://github.com/{repo}/pull/{number}"
+    return f"{server}/{repo}/pulls/{number}"
+
+
+def pr_url_from_event(event: dict[str, Any]) -> str:
+    """Build the change-request URL from a pull_request(_target) event payload."""
     try:
         repo = event["repository"]["full_name"]
         number = event["pull_request"]["number"]
     except (KeyError, TypeError) as exc:
         raise click.ClickException(f"event payload missing required field: {exc}") from exc
-    return f"https://github.com/{repo}/pull/{number}"
+    return _change_url(repo, number)
 
 
 #: Inputs ``action()`` handles itself rather than passing to ``ReviewConfig``:

--- a/src/lgtmaybe/core/comment.py
+++ b/src/lgtmaybe/core/comment.py
@@ -1,0 +1,176 @@
+"""Rendering the Markdown a review comment is made of.
+
+Host-neutral, and in ``core`` for that reason: every forge lgtmaybe posts to
+renders Markdown, so the severity badge, the demoted/broad body sections, the
+fence defanging that stops attacker-controlled model prose escaping a code
+block, and the hidden idempotency markers are the same on all of them. Only the
+*transport* — which endpoint, which position vocabulary — belongs to an adapter.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .findings import finding_fingerprint, finding_identity
+from .models import ReviewFinding
+
+# The hidden per-finding ids stamped into every inline comment we post, and read
+# back on a re-run to tell "already reported" from "new".
+FINDING_MARKER = re.compile(r"<!-- lgtmaybe-finding:([0-9a-f]+) -->")
+IDENTITY_MARKER = re.compile(r"<!-- lgtmaybe-identity:([0-9a-f]+) -->")
+
+# Zero-width space, inserted to break up a triple-backtick run so it can't be
+# parsed as a Markdown fence delimiter.
+_ZWSP = "​"
+
+
+def defang_fences(text: str) -> str:
+    """Neutralise embedded triple-backticks in model-supplied text (title, body,
+    suggestion) so it can't break out of a Markdown fence and inject content
+    (e.g. a phishing link) into the rendered comment.
+
+    The diff is attacker-controlled on a fork PR, so a prompt injection that
+    survives the guard could steer the model into fence-breaking output. We insert
+    zero-width spaces between the backticks: the run no longer reads as a fence,
+    while the text stays visually intact.
+    """
+    return text.replace("```", f"`{_ZWSP}`{_ZWSP}`")
+
+
+def finding_badge(f: ReviewFinding) -> str:
+    """The provenance suffix for a finding's title line: lens, then confidence.
+
+    Both values are already computed and already shown by the local CLI — the
+    lens the engine stamped (``category``) and the 0-10 score the reflection
+    auditor gave it (``confidence``) — but a GitHub reader could never see them.
+    They answer the two questions a reviewer asks of a bot comment: which pass
+    raised this, and how sure was it. Rendered inside the existing severity
+    brackets (``**[HIGH · security · 80%] Title**``) so the title line gains no
+    new visual furniture, and appended by the caller so it can never displace the
+    hidden fingerprint/identity markers that key re-run dedupe.
+
+    The 0-10 score is shown as a **percentage** — "how likely is this a real
+    issue" reads plainly as ``80%``, where ``8/10`` invites a reader to mistake
+    it for a rating out of ten. The scale is unchanged; only the rendering is.
+
+    Each half is omitted when absent, so nothing renders empty: no category (a
+    legacy finding) means no badge at all — byte-identical to the pre-badge
+    rendering — and no score (``--no-reflect``, or a deterministic
+    static-analysis finding) means just the lens. A ``0`` is a real verdict, not
+    a missing one, so it renders.
+    """
+    if not f.category:
+        return ""
+    badge = f" · {defang_fences(f.category)}"
+    return badge if f.confidence is None else f"{badge} · {f.confidence * 10}%"
+
+
+def marker(family: str, key: str | None) -> str:
+    """A hidden idempotency marker for one comment *family*.
+
+    Scoped to *key* (a provider/model) when there is one, so concurrent reviews
+    from different backends update their own comment instead of clobbering each
+    other; an unkeyed gateway keeps the legacy unscoped marker (``_MARKER`` and
+    its describe/diagram siblings).
+    """
+    return f"<!-- {family}:{key} -->" if key else f"<!-- {family} -->"
+
+
+def finding_bullet(f: ReviewFinding) -> str:
+    """One finding as a Markdown list item — shared by both body sections."""
+    return (
+        f"- **[{f.severity.upper()}{finding_badge(f)}] {defang_fences(f.title)}** "
+        f"(`{f.path}`) — {defang_fences(f.body)}"
+    )
+
+
+def render_demoted(demoted: list[ReviewFinding]) -> str:
+    """Render findings that couldn't be confidently placed inline as a body section.
+
+    These keep their severity, file, and explanation — only the precise line (and
+    its one-click suggestion) is dropped, because we could not anchor it. Returns
+    "" when there is nothing to demote, so a normal review's body is unchanged.
+    """
+    if not demoted:
+        return ""
+    lines = [
+        "",
+        "",
+        "### Additional findings",
+        "",
+        "_These relate to the changes but aren't tied to a single line:_",
+        "",
+    ]
+    lines += [finding_bullet(f) for f in demoted]
+    return "\n".join(lines)
+
+
+def render_broad(broad: list[ReviewFinding]) -> str:
+    """Render broad (redesign / infra / contract / needs-verification) findings.
+
+    These are real findings the reflection pass judged too wide-reaching to action
+    on a single line, so they're collapsed into a ``<details>`` block to keep the
+    must-fix inline list tight without dropping the observation. Returns "" when
+    there is nothing broad, so a normal review's body is unchanged.
+    """
+    if not broad:
+        return ""
+    lines = [
+        "",
+        "",
+        "<details><summary>Broader observations</summary>",
+        "",
+        "_These are wider-reaching — a redesign, an infra/contract change, or one "
+        "needing independent verification — so they're collected here rather than "
+        "pinned to a line:_",
+        "",
+    ]
+    lines += [finding_bullet(f) for f in broad]
+    lines += ["", "</details>"]
+    return "\n".join(lines)
+
+
+def finding_keys(body: str) -> set[str]:
+    """Every active hidden id carried by a comment body (fingerprint + identity).
+
+    Two ids of the same finding, pooled into one set so "have we posted this?" is
+    a single intersection. A body predating the identity marker yields just its
+    fingerprint, which still matches whenever the title is unchanged — so old
+    conversations keep deduping exactly as they did.
+    """
+    return set(FINDING_MARKER.findall(body)) | set(IDENTITY_MARKER.findall(body))
+
+
+def current_finding_keys(findings: list[ReviewFinding]) -> set[str]:
+    """Both hidden ids for every finding this run produced.
+
+    The counterpart to ``_finding_keys``: what an existing conversation is matched
+    against to decide whether its finding is still being reported.
+    """
+    keys: set[str] = set()
+    for f in findings:
+        keys.add(finding_fingerprint(f.path, f.title))
+        keys.add(finding_identity(f))
+    return keys
+
+
+def render_inline_body(f: ReviewFinding) -> str:
+    """The full body of one inline finding comment, hidden ids included.
+
+    Shared by every adapter: the text of a finding does not change with the host,
+    only the position fields wrapped around it. Ends with the two hidden ids so a
+    later run can recognise this conversation — to skip re-posting the finding,
+    and to auto-resolve the thread once it is gone. The fingerprint keys the
+    user-facing channels (``ignore_fingerprints``, 👎 feedback) and hashes the
+    title; the identity is prose-free, so it still matches after the model
+    rewords the same finding. Either one matching means "already posted".
+    """
+    body = (
+        f"**[{f.severity.upper()}{finding_badge(f)}] {defang_fences(f.title)}**"
+        f"\n\n{defang_fences(f.body)}"
+    )
+    if f.suggestion is not None:
+        body += f"\n\n```suggestion\n{defang_fences(f.suggestion)}\n```"
+    body += f"\n\n<!-- lgtmaybe-finding:{finding_fingerprint(f.path, f.title)} -->"
+    body += f"\n<!-- lgtmaybe-identity:{finding_identity(f)} -->"
+    return body

--- a/src/lgtmaybe/gitea/__init__.py
+++ b/src/lgtmaybe/gitea/__init__.py
@@ -1,0 +1,9 @@
+"""gitea — Gitea REST adapter for lgtmaybe.
+
+Public surface:
+- GiteaGateway: implements ReviewGateway against the Gitea REST API.
+"""
+
+from .gateway import GiteaGateway
+
+__all__ = ["GiteaGateway"]

--- a/src/lgtmaybe/gitea/gateway.py
+++ b/src/lgtmaybe/gitea/gateway.py
@@ -1,0 +1,440 @@
+"""Gitea REST adapter.
+
+Gitea's API is close enough to GitHub's that most of this reads the same, and
+everything it renders — badges, demoted sections, hidden ids — comes from
+``core.comment`` rather than being reimplemented. Three differences are load
+bearing, and they are why this is a separate adapter rather than a base-URL
+switch on the GitHub one:
+
+1. **Reviews are not editable.** GitHub updates its review body in place on a
+   re-run; Gitea has no equivalent. So the summary lives in an ordinary issue
+   comment, which *is* editable, and the review object carries only the inline
+   comments.
+2. **Positions, not sides.** A Gitea review comment is anchored with
+   ``new_position`` (a line in the new file) or ``old_position`` (a line in the
+   old file), where GitHub uses ``line`` + ``side``. lgtmaybe keeps GitHub's
+   RIGHT/LEFT vocabulary internally and translates at this boundary.
+3. **No resolvable threads.** Gitea has no ``resolveReviewThread`` equivalent,
+   so this adapter does not claim ``SupportsThreadResolution`` — and, because
+   an immutable review cannot be de-duplicated after the fact, it instead reads
+   the hidden ids already on the PR and declines to post those findings again.
+
+Also deliberately absent: incremental review (Gitea's compare API returns commit
+metadata, not a unified diff, so there is nothing to review an increment from)
+and base-branch checkout for symbol resolution. Both are optional capabilities,
+so the CLI simply runs a full review without them.
+"""
+
+from __future__ import annotations
+
+import base64
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import httpx
+
+from lgtmaybe.core.comment import (
+    current_finding_keys,
+    finding_keys,
+    marker,
+    render_broad,
+    render_demoted,
+    render_inline_body,
+)
+from lgtmaybe.core.diff import (
+    CommentableLines,
+    build_commentable_lines,
+    is_reviewable,
+    is_scannable_manifest,
+)
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import PRContext, ReviewFinding
+
+_log = get_logger(__name__)
+
+# Matches the GitHub adapter: a cap on a hung socket, not on a slow-but-alive
+# request. A self-hosted Gitea behind a slow proxy is the common case.
+_TIMEOUT = 30.0
+
+# Concurrency for the per-file head-content fetch. Independent GETs, so fetching
+# them serially on a wide PR is pure round-trip latency.
+_CONTENT_FETCH_WORKERS = 8
+
+# Gitea pages most list endpoints at 50 by default; ask for the maximum.
+_PAGE_LIMIT = 50
+
+# Commit statuses are Gitea's equivalent of a check run. Its state vocabulary is
+# narrower than GitHub's conclusions, so map rather than pass through.
+_STATUS_STATES = {
+    "success": "success",
+    "neutral": "success",
+    "skipped": "success",
+    "failure": "failure",
+    "action_required": "failure",
+    "cancelled": "error",
+    "timed_out": "error",
+}
+
+
+class GiteaGateway:
+    """Gitea REST adapter.
+
+    Args:
+        host:      Gitea hostname, e.g. "gitea.example.com" (self-hosted is the norm).
+        repo:      Full repo name, e.g. "owner/repo".
+        pr_number: Pull-request index.
+        token:     Gitea API token.
+        client:    Injected httpx.Client; a default is created if omitted.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        repo: str,
+        pr_number: int,
+        token: str,
+        client: httpx.Client | None = None,
+        marker_key: str | None = None,
+        scheme: str = "https",
+    ) -> None:
+        self._repo = repo
+        self._pr_number = pr_number
+        self._api = f"{scheme}://{host}/api/v1/repos/{repo}"
+        self._pr_api = f"{self._api}/pulls/{pr_number}"
+        self._issue_api = f"{self._api}/issues/{pr_number}"
+        self._headers = {
+            "Authorization": f"token {token}",
+            "Accept": "application/json",
+        }
+        self._client = client if client is not None else httpx.Client(timeout=_TIMEOUT)
+        # Disjoint marker families, matching the GitHub adapter, so a summary
+        # update never clobbers the description or the diagram.
+        self._marker = marker("lgtmaybe", marker_key)
+        self._describe_marker = marker("lgtmaybe-describe", marker_key)
+        self._diagram_marker = marker("lgtmaybe-diagram", marker_key)
+        self._head_sha: str | None = None
+        self._scan_manifests = False
+
+    # ------------------------------------------------------------------
+    # ReviewGateway implementation
+    # ------------------------------------------------------------------
+
+    def get_pr_context(self) -> PRContext:
+        """Fetch PR metadata, unified diff, changed files, and head file text."""
+        meta = self._get_json(self._pr_api)
+        try:
+            base_sha: str = meta["base"]["sha"]
+            head_sha: str = meta["head"]["sha"]
+        except (KeyError, TypeError) as exc:
+            raise RuntimeError(
+                f"PR metadata for {self._repo}#{self._pr_number} is missing the "
+                f"base/head SHA — unexpected Gitea API response ({exc})."
+            ) from exc
+        self._head_sha = head_sha
+
+        diff = self._fetch_pr_diff()
+        changed_files = [item["filename"] for item in self._paginate(f"{self._pr_api}/files")]
+
+        # Head-revision text so the engine can pad hunks with surrounding
+        # context. Read-only API fetch — never a checkout (fork-safe) — and the
+        # engine redacts it before it leaves the process.
+        reviewable = [path for path in changed_files if is_reviewable(path)]
+        scannable = (
+            [path for path in changed_files if is_scannable_manifest(path)]
+            if self._scan_manifests
+            else []
+        )
+        file_contents: dict[str, str] = {}
+        scan_contents: dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS) as pool:
+            if scannable:
+                fetched = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), scannable)
+                scan_contents = {path: text for path, text in fetched if text is not None}
+            if reviewable:
+                fetched = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), reviewable)
+                file_contents = {path: text for path, text in fetched if text is not None}
+
+        return PRContext(
+            diff=diff,
+            changed_files=changed_files,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            repo=self._repo,
+            pr_number=self._pr_number,
+            file_contents=file_contents,
+            scan_contents=scan_contents,
+            title=meta.get("title") or "",
+            description=meta.get("body") or "",
+            commit_messages=self._fetch_commit_subjects(),
+            head_branch=(meta.get("head") or {}).get("ref") or "",
+        )
+
+    def post_review(
+        self,
+        findings: list[ReviewFinding],
+        summary: str,
+        diff: str | None = None,
+    ) -> None:
+        """Post inline comments as a review, and the summary as an upserted comment.
+
+        Split in two because a Gitea review cannot be edited afterwards: the
+        summary has to live somewhere re-runnable, and an issue comment is that
+        place. Findings already carrying one of our hidden ids on the PR are
+        dropped before posting, which is what keeps a re-run from duplicating
+        every inline comment it made last time.
+        """
+        if diff is None and findings:
+            diff = self._fetch_pr_diff()
+
+        commentable: CommentableLines = build_commentable_lines(diff or "")
+        inline, demoted, broad = self._partition_findings(findings, commentable)
+
+        if inline:
+            already = self._existing_finding_keys()
+            inline = [
+                (comment, f) for comment, f in inline if not (current_finding_keys([f]) & already)
+            ]
+
+        if inline:
+            resp = self._client.post(
+                f"{self._pr_api}/reviews",
+                headers=self._headers,
+                json={
+                    "body": "",
+                    "event": "COMMENT",
+                    "comments": [comment for comment, _f in inline],
+                },
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+
+        body = f"{summary}{render_demoted(demoted)}{render_broad(broad)}\n\n{self._marker}"
+        self._upsert_comment(body, self._marker)
+
+    def post_issue_comment(self, body: str) -> None:
+        """Post a standalone comment to the PR conversation."""
+        resp = self._client.post(
+            f"{self._issue_api}/comments",
+            headers=self._headers,
+            json={"body": body},
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Optional capabilities
+    # ------------------------------------------------------------------
+
+    def get_file_contents(self, path: str) -> str | None:
+        """Head-revision text of one file, or None when it can't be read."""
+        if self._head_sha is None:
+            return None
+        return self._get_file_content(path, self._head_sha)
+
+    def post_describe_comment(self, body: str) -> None:
+        """Upsert the structured description in its own marker family."""
+        self._upsert_comment(f"{body}\n\n{self._describe_marker}", self._describe_marker)
+
+    def post_diagram_comment(self, body: str, *, completed_sha: str | None = None) -> None:
+        """Upsert the change diagram in its own marker family.
+
+        ``completed_sha`` is accepted and ignored: it exists to drive incremental
+        review, which this adapter does not offer.
+        """
+        self._upsert_comment(f"{body}\n\n{self._diagram_marker}", self._diagram_marker)
+
+    def set_scan_manifests(self, enabled: bool) -> None:
+        """Also fetch dependency-manifest text on the next context fetch."""
+        self._scan_manifests = enabled
+
+    def apply_pr_labels(self, labels: list[str]) -> None:
+        """Add lgtmaybe's labels to the PR, best-effort.
+
+        Gitea addresses labels by id, so this resolves names against the repo's
+        label set and silently skips any that do not exist — creating labels on
+        someone's repo is not this tool's business.
+        """
+        if not labels:
+            return
+        try:
+            known = {item["name"]: item["id"] for item in self._paginate(f"{self._api}/labels")}
+            wanted = [known[name] for name in labels if name in known]
+            if wanted:
+                resp = self._client.post(
+                    f"{self._issue_api}/labels",
+                    headers=self._headers,
+                    json={"labels": wanted},
+                    timeout=_TIMEOUT,
+                )
+                resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — labels must never fail a review
+            _log.warning("applying labels failed: %s", exc)
+
+    def create_check_run(self, head_sha: str, conclusion: str, title: str, summary: str) -> None:
+        """Publish the review outcome as a Gitea commit status, best-effort."""
+        try:
+            resp = self._client.post(
+                f"{self._api}/statuses/{head_sha}",
+                headers=self._headers,
+                json={
+                    "state": _STATUS_STATES.get(conclusion, "success"),
+                    "context": "lgtmaybe",
+                    "description": title[:255],
+                },
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — a status must never fail a review
+            _log.warning("creating commit status failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _partition_findings(
+        findings: list[ReviewFinding],
+        commentable: CommentableLines,
+    ) -> tuple[
+        list[tuple[dict[str, Any], ReviewFinding]],
+        list[ReviewFinding],
+        list[ReviewFinding],
+    ]:
+        """Split findings into inline comments, body-demoted, and broad findings.
+
+        Same rule as the GitHub adapter — a finding goes inline only when it is
+        confidently anchored AND lands on a real commentable diff line — with
+        Gitea's position vocabulary substituted at the end.
+        """
+        inline: list[tuple[dict[str, Any], ReviewFinding]] = []
+        demoted: list[ReviewFinding] = []
+        broad: list[ReviewFinding] = []
+        for f in findings:
+            if f.broad:
+                broad.append(f)
+                continue
+            if not f.anchored or (f.path, f.line, f.side) not in commentable:
+                demoted.append(f)
+                continue
+            comment: dict[str, Any] = {"path": f.path, "body": render_inline_body(f)}
+            # RIGHT is a line in the new file, LEFT a line in the old one.
+            if f.side == "LEFT":
+                comment["old_position"] = f.line
+            else:
+                comment["new_position"] = f.line
+            inline.append((comment, f))
+        return inline, demoted, broad
+
+    def _existing_finding_keys(self) -> set[str]:
+        """Every hidden finding id already posted on this PR by us.
+
+        Best-effort: a failure here means a duplicate comment, which is far
+        better than failing the whole review.
+        """
+        keys: set[str] = set()
+        try:
+            for review in self._paginate(f"{self._pr_api}/reviews"):
+                review_id = review.get("id")
+                if review_id is None:
+                    continue
+                for comment in self._paginate(f"{self._pr_api}/reviews/{review_id}/comments"):
+                    keys |= finding_keys(comment.get("body") or "")
+        except Exception as exc:  # noqa: BLE001 — dedupe is best-effort
+            _log.warning("reading existing review comments failed: %s", exc)
+        return keys
+
+    def _upsert_comment(self, body: str, family: str) -> None:
+        """Edit our previous comment in this marker family, or post a new one."""
+        existing_id = self._find_comment(family)
+        if existing_id is not None:
+            resp = self._client.patch(
+                f"{self._api}/issues/comments/{existing_id}",
+                headers=self._headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+        else:
+            resp = self._client.post(
+                f"{self._issue_api}/comments",
+                headers=self._headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+        resp.raise_for_status()
+
+    def _find_comment(self, family: str) -> int | None:
+        """The id of our existing comment in ``family``, or None."""
+        for comment in self._paginate(f"{self._issue_api}/comments"):
+            if family in (comment.get("body") or ""):
+                comment_id = comment.get("id")
+                return int(comment_id) if comment_id is not None else None
+        return None
+
+    def _fetch_pr_diff(self) -> str:
+        """The PR's unified diff. Gitea serves it from the API path directly."""
+        resp = self._client.get(f"{self._pr_api}.diff", headers=self._headers, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.text
+
+    def _fetch_commit_subjects(self) -> list[str]:
+        """Commit subject lines, feeding the intent lens. Never fails the review."""
+        try:
+            return [
+                (item.get("commit", {}).get("message") or "").splitlines()[0]
+                for item in self._paginate(f"{self._pr_api}/commits")
+                if (item.get("commit", {}).get("message") or "").strip()
+            ]
+        except Exception as exc:  # noqa: BLE001 — intent is a nice-to-have
+            _log.warning("fetching commit subjects failed: %s", exc)
+            return []
+
+    def _get_file_content(self, path: str, ref: str) -> str | None:
+        """One file's text at ``ref``, or None when absent or undecodable."""
+        try:
+            resp = self._client.get(
+                f"{self._api}/contents/{path}",
+                headers=self._headers,
+                params={"ref": ref},
+                timeout=_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                return None
+            payload = resp.json()
+            content = payload.get("content")
+            if not isinstance(content, str):
+                return None
+            # Gitea returns base64 like GitHub; a binary file simply won't decode
+            # as UTF-8, and is not reviewable anyway.
+            return base64.b64decode(content).decode("utf-8")
+        except Exception as exc:  # noqa: BLE001 — a missing file is not fatal
+            _log.debug("fetching %s failed: %s", path, exc)
+            return None
+
+    def _get_json(self, url: str) -> Any:
+        resp = self._client.get(url, headers=self._headers, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _paginate(self, url: str) -> list[dict[str, Any]]:
+        """Every page of a Gitea list endpoint, flattened.
+
+        Gitea signals the end of a listing with a short page rather than a Link
+        header, so this stops on the first page below the limit.
+        """
+        items: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = self._client.get(
+                url,
+                headers=self._headers,
+                params={"page": page, "limit": _PAGE_LIMIT},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            batch = resp.json()
+            if not isinstance(batch, list) or not batch:
+                return items
+            items.extend(batch)
+            if len(batch) < _PAGE_LIMIT:
+                return items
+            page += 1

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -754,7 +754,7 @@ class RestGitHubGateway:
         """
         if not inline:
             return []
-        unmatched = self._existingfinding_keys()
+        unmatched = self._existing_finding_keys()
         url = f"{self._pr_api}/comments"
         rejected: list[ReviewFinding] = []
         for comment, finding in inline:
@@ -809,7 +809,7 @@ class RestGitHubGateway:
             resp.raise_for_status()
         return rejected
 
-    def _existingfinding_keys(self) -> list[set[str]]:
+    def _existing_finding_keys(self) -> list[set[str]]:
         """Hidden ids of the lgtmaybe findings already posted inline on the PR.
 
         One entry **per posted comment** (its fingerprint and identity together),

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -20,13 +20,22 @@ from urllib.parse import quote
 
 import httpx
 
+from lgtmaybe.core.comment import (
+    FINDING_MARKER,
+    IDENTITY_MARKER,
+    current_finding_keys,
+    finding_keys,
+    marker,
+    render_broad,
+    render_demoted,
+    render_inline_body,
+)
 from lgtmaybe.core.diff import (
     CommentableLines,
     build_commentable_lines,
     is_reviewable,
     is_scannable_manifest,
 )
-from lgtmaybe.core.findings import finding_fingerprint, finding_identity
 from lgtmaybe.core.logging import get_logger
 from lgtmaybe.core.models import (
     EFFORT_PREFIX,
@@ -68,11 +77,6 @@ _THREADS_QUERY = """
 # name as a required status check in branch protection, so it must not change.
 _CHECK_RUN_NAME = "lgtmaybe"
 
-# Hidden marker stamped into every inline comment so a later run can match an
-# existing review conversation back to the finding that opened it. The capture
-# group is the finding fingerprint.
-_FINDING_MARKER = re.compile(r"<!-- lgtmaybe-finding:([0-9a-f]+) -->")
-
 # When resolve-on-fix collapses a thread, the original comment's marker is
 # rewritten into this disjoint "resolved" family so the active-marker scan
 # (``_existing_finding_keys``) no longer sees it — a finding that
@@ -80,13 +84,8 @@ _FINDING_MARKER = re.compile(r"<!-- lgtmaybe-finding:([0-9a-f]+) -->")
 _ACTIVE_MARKER_PREFIX = "<!-- lgtmaybe-finding:"
 _RESOLVED_MARKER_PREFIX = "<!-- lgtmaybe-resolved-fingerprint:"
 
-# Second hidden marker, stamped alongside the fingerprint: the finding's
-# reword-robust identity (see ``finding_identity``). The fingerprint above hashes
-# the model's *title*, so it changes when the model rephrases the same finding on
-# a re-run — which is exactly when dedupe has to work. This family carries no
-# prose at all. Its own resolved-family prefix, mirroring the fingerprint's, so
-# collapsing a thread hides both of its markers from the active scan.
-_IDENTITY_MARKER = re.compile(r"<!-- lgtmaybe-identity:([0-9a-f]+) -->")
+# The identity family's own resolved-family prefix, mirroring the fingerprint's,
+# so collapsing a thread hides both of a comment's markers from the active scan.
 _ACTIVE_IDENTITY_PREFIX = "<!-- lgtmaybe-identity:"
 _RESOLVED_IDENTITY_PREFIX = "<!-- lgtmaybe-resolved-identity:"
 
@@ -95,30 +94,6 @@ _RESOLVED_IDENTITY_PREFIX = "<!-- lgtmaybe-resolved-identity:"
 # since (commit-scoped incremental review). The capture group is the SHA.
 _REVIEWED_MARKER = re.compile(r"<!-- lgtmaybe-reviewed:([0-9a-f]{7,40}) -->")
 _DIAGRAMMED_MARKER = re.compile(r"<!-- lgtmaybe-diagrammed:([0-9a-f]{7,40}) -->")
-
-
-def _finding_keys(body: str) -> set[str]:
-    """Every active hidden id carried by a comment body (fingerprint + identity).
-
-    Two ids of the same finding, pooled into one set so "have we posted this?" is
-    a single intersection. A body predating the identity marker yields just its
-    fingerprint, which still matches whenever the title is unchanged — so old
-    conversations keep deduping exactly as they did.
-    """
-    return set(_FINDING_MARKER.findall(body)) | set(_IDENTITY_MARKER.findall(body))
-
-
-def _current_finding_keys(findings: list[ReviewFinding]) -> set[str]:
-    """Both hidden ids for every finding this run produced.
-
-    The counterpart to ``_finding_keys``: what an existing conversation is matched
-    against to decide whether its finding is still being reported.
-    """
-    keys: set[str] = set()
-    for f in findings:
-        keys.add(finding_fingerprint(f.path, f.title))
-        keys.add(finding_identity(f))
-    return keys
 
 
 # Concurrency for the per-file head-content fetch. The contents are independent
@@ -133,58 +108,6 @@ _RESOLVE_WORKERS = 4
 # Zero-width space, inserted to break up a triple-backtick run so it can't be
 # parsed as a Markdown fence delimiter.
 _ZWSP = "​"
-
-
-def _defang_fences(text: str) -> str:
-    """Neutralise embedded triple-backticks in model-supplied text (title, body,
-    suggestion) so it can't break out of a Markdown fence and inject content
-    (e.g. a phishing link) into the rendered comment.
-
-    The diff is attacker-controlled on a fork PR, so a prompt injection that
-    survives the guard could steer the model into fence-breaking output. We insert
-    zero-width spaces between the backticks: the run no longer reads as a fence,
-    while the text stays visually intact.
-    """
-    return text.replace("```", f"`{_ZWSP}`{_ZWSP}`")
-
-
-def _finding_badge(f: ReviewFinding) -> str:
-    """The provenance suffix for a finding's title line: lens, then confidence.
-
-    Both values are already computed and already shown by the local CLI — the
-    lens the engine stamped (``category``) and the 0-10 score the reflection
-    auditor gave it (``confidence``) — but a GitHub reader could never see them.
-    They answer the two questions a reviewer asks of a bot comment: which pass
-    raised this, and how sure was it. Rendered inside the existing severity
-    brackets (``**[HIGH · security · 80%] Title**``) so the title line gains no
-    new visual furniture, and appended by the caller so it can never displace the
-    hidden fingerprint/identity markers that key re-run dedupe.
-
-    The 0-10 score is shown as a **percentage** — "how likely is this a real
-    issue" reads plainly as ``80%``, where ``8/10`` invites a reader to mistake
-    it for a rating out of ten. The scale is unchanged; only the rendering is.
-
-    Each half is omitted when absent, so nothing renders empty: no category (a
-    legacy finding) means no badge at all — byte-identical to the pre-badge
-    rendering — and no score (``--no-reflect``, or a deterministic
-    static-analysis finding) means just the lens. A ``0`` is a real verdict, not
-    a missing one, so it renders.
-    """
-    if not f.category:
-        return ""
-    badge = f" · {_defang_fences(f.category)}"
-    return badge if f.confidence is None else f"{badge} · {f.confidence * 10}%"
-
-
-def _marker(family: str, key: str | None) -> str:
-    """A hidden idempotency marker for one comment *family*.
-
-    Scoped to *key* (a provider/model) when there is one, so concurrent reviews
-    from different backends update their own comment instead of clobbering each
-    other; an unkeyed gateway keeps the legacy unscoped marker (``_MARKER`` and
-    its describe/diagram siblings).
-    """
-    return f"<!-- {family}:{key} -->" if key else f"<!-- {family} -->"
 
 
 def _head_ref(meta: dict[str, Any]) -> str:
@@ -202,60 +125,6 @@ def _first_comment(node: dict[str, Any]) -> dict[str, Any]:
     """A review thread's opening comment, or ``{}`` when it has none."""
     comments = node.get("comments", {}).get("nodes", [])
     return comments[0] if comments else {}
-
-
-def _finding_bullet(f: ReviewFinding) -> str:
-    """One finding as a Markdown list item — shared by both body sections."""
-    return (
-        f"- **[{f.severity.upper()}{_finding_badge(f)}] {_defang_fences(f.title)}** "
-        f"(`{f.path}`) — {_defang_fences(f.body)}"
-    )
-
-
-def _render_demoted(demoted: list[ReviewFinding]) -> str:
-    """Render findings that couldn't be confidently placed inline as a body section.
-
-    These keep their severity, file, and explanation — only the precise line (and
-    its one-click suggestion) is dropped, because we could not anchor it. Returns
-    "" when there is nothing to demote, so a normal review's body is unchanged.
-    """
-    if not demoted:
-        return ""
-    lines = [
-        "",
-        "",
-        "### Additional findings",
-        "",
-        "_These relate to the changes but aren't tied to a single line:_",
-        "",
-    ]
-    lines += [_finding_bullet(f) for f in demoted]
-    return "\n".join(lines)
-
-
-def _render_broad(broad: list[ReviewFinding]) -> str:
-    """Render broad (redesign / infra / contract / needs-verification) findings.
-
-    These are real findings the reflection pass judged too wide-reaching to action
-    on a single line, so they're collapsed into a ``<details>`` block to keep the
-    must-fix inline list tight without dropping the observation. Returns "" when
-    there is nothing broad, so a normal review's body is unchanged.
-    """
-    if not broad:
-        return ""
-    lines = [
-        "",
-        "",
-        "<details><summary>Broader observations</summary>",
-        "",
-        "_These are wider-reaching — a redesign, an infra/contract change, or one "
-        "needing independent verification — so they're collected here rather than "
-        "pinned to a line:_",
-        "",
-    ]
-    lines += [_finding_bullet(f) for f in broad]
-    lines += ["", "</details>"]
-    return "\n".join(lines)
 
 
 class RestGitHubGateway:
@@ -295,9 +164,9 @@ class RestGitHubGateway:
         # Three disjoint marker families: the review summary, the describe
         # comment, and the change diagram, so an update of one never clobbers
         # another. Each is scoped to the provider/model key when there is one.
-        self._marker = _marker("lgtmaybe", marker_key)
-        self._describe_marker = _marker("lgtmaybe-describe", marker_key)
-        self._diagram_marker = _marker("lgtmaybe-diagram", marker_key)
+        self._marker = marker("lgtmaybe", marker_key)
+        self._describe_marker = marker("lgtmaybe-describe", marker_key)
+        self._diagram_marker = marker("lgtmaybe-diagram", marker_key)
         self._resolve_fixed = resolve_fixed
         # Per-run cache of "does this login have write+ access?" — feedback
         # learning only trusts a 👎 from someone who can push, and a PR's
@@ -443,7 +312,7 @@ class RestGitHubGateway:
         inline, demoted, broad = self._partition_findings(findings, commentable)
         comments = [comment for comment, _finding in inline]
 
-        body = f"{summary}{_render_demoted(demoted)}{_render_broad(broad)}\n\n{self._marker}"
+        body = f"{summary}{render_demoted(demoted)}{render_broad(broad)}\n\n{self._marker}"
         if self._reviewed_sha:
             # Record how far this review got, so the next run can review only
             # the commits pushed since (incremental review). Only stamped when
@@ -480,8 +349,8 @@ class RestGitHubGateway:
             )
             if rejected:
                 body = (
-                    f"{summary}{_render_demoted([*demoted, *rejected])}"
-                    f"{_render_broad(broad)}\n\n{self._marker}"
+                    f"{summary}{render_demoted([*demoted, *rejected])}"
+                    f"{render_broad(broad)}\n\n{self._marker}"
                 )
                 if self._reviewed_sha:
                     body += f"\n<!-- lgtmaybe-reviewed:{self._reviewed_sha} -->"
@@ -803,8 +672,8 @@ class RestGitHubGateway:
                 continue
             first = _first_comment(node)
             body = first.get("body", "") or ""
-            fingerprint = _FINDING_MARKER.search(body)
-            identity = _IDENTITY_MARKER.search(body)
+            fingerprint = FINDING_MARKER.search(body)
+            identity = IDENTITY_MARKER.search(body)
             if fingerprint is None and identity is None:
                 continue
             active.append(
@@ -885,11 +754,11 @@ class RestGitHubGateway:
         """
         if not inline:
             return []
-        unmatched = self._existing_finding_keys()
+        unmatched = self._existingfinding_keys()
         url = f"{self._pr_api}/comments"
         rejected: list[ReviewFinding] = []
         for comment, finding in inline:
-            keys = _finding_keys(comment.get("body", ""))
+            keys = finding_keys(comment.get("body", ""))
             already = next((i for i, e in enumerate(unmatched) if e & keys), None)
             if already is not None:
                 unmatched.pop(already)  # consumed — it can't absorb a second candidate
@@ -940,7 +809,7 @@ class RestGitHubGateway:
             resp.raise_for_status()
         return rejected
 
-    def _existing_finding_keys(self) -> list[set[str]]:
+    def _existingfinding_keys(self) -> list[set[str]]:
         """Hidden ids of the lgtmaybe findings already posted inline on the PR.
 
         One entry **per posted comment** (its fingerprint and identity together),
@@ -954,7 +823,7 @@ class RestGitHubGateway:
         posted: list[set[str]] = []
         for resp in self._paginate(url):
             for item in resp.json():
-                keys = _finding_keys(item.get("body", "") or "")
+                keys = finding_keys(item.get("body", "") or "")
                 if keys:
                     posted.append(keys)
         return posted
@@ -1120,7 +989,7 @@ class RestGitHubGateway:
         wherever the loop happened to stop.
         """
         try:
-            current = _current_finding_keys(findings)
+            current = current_finding_keys(findings)
             fixed = self._fixed_threads(current)
         except Exception as exc:  # noqa: BLE001 — best-effort; never fail the review
             _log.warning("auto-resolve of fixed conversations failed: %s", exc)
@@ -1218,7 +1087,7 @@ class RestGitHubGateway:
             for node in self._walk_review_threads("isResolved comments(first:1){ nodes{ body } }"):
                 if node.get("isResolved"):
                     continue
-                if _FINDING_MARKER.search(_first_comment(node).get("body", "")):
+                if FINDING_MARKER.search(_first_comment(node).get("body", "")):
                     open_threads += 1
         except Exception as exc:  # noqa: BLE001 — disclosure is never worth a failed review
             _log.warning("counting open finding conversations failed: %s", exc)
@@ -1257,7 +1126,7 @@ class RestGitHubGateway:
                     continue
             first = _first_comment(node)
             first_body = first.get("body", "")
-            keys = _finding_keys(first_body)
+            keys = finding_keys(first_body)
             if not keys:
                 continue  # not one of ours
             if self._validated_fixed_thread_ids is None and keys & current:
@@ -1344,7 +1213,7 @@ class RestGitHubGateway:
             "reactions(content: THUMBS_DOWN, first: 50){ nodes{ user{ login } } } } }"
         ):
             first = _first_comment(node)
-            match = _FINDING_MARKER.search(first.get("body", "") or "")
+            match = FINDING_MARKER.search(first.get("body", "") or "")
             if match is None:
                 continue  # not one of ours (or a thread with no comments)
             reactors = (first.get("reactions") or {}).get("nodes") or []
@@ -1435,25 +1304,13 @@ class RestGitHubGateway:
             if not f.anchored or (f.path, f.line, f.side) not in commentable:
                 demoted.append(f)
                 continue
+            # Only the position fields are GitHub's; the body is rendered the
+            # same way for every host.
             comment: dict[str, Any] = {
                 "path": f.path,
                 "line": f.line,
                 "side": f.side,
-                "body": f"**[{f.severity.upper()}{_finding_badge(f)}] "
-                f"{_defang_fences(f.title)}**"
-                f"\n\n{_defang_fences(f.body)}",
+                "body": render_inline_body(f),
             }
-            if f.suggestion is not None:
-                comment["body"] += f"\n\n```suggestion\n{_defang_fences(f.suggestion)}\n```"
-            # Stamp two hidden ids so a later run can recognise this conversation
-            # — to skip re-posting the finding, and to auto-resolve the thread
-            # once the finding is gone. The fingerprint keys the user-facing
-            # channels (`ignore_fingerprints`, 👎 feedback) and hashes the title;
-            # the identity is prose-free, so it still matches after the model
-            # rewords the same finding on a re-run. Either one matching means
-            # "already posted".
-            fp = finding_fingerprint(f.path, f.title)
-            comment["body"] += f"\n\n<!-- lgtmaybe-finding:{fp} -->"
-            comment["body"] += f"\n<!-- lgtmaybe-identity:{finding_identity(f)} -->"
             inline.append((comment, f))
         return inline, demoted, broad

--- a/tests/cli/test_feedback_learning.py
+++ b/tests/cli/test_feedback_learning.py
@@ -13,6 +13,7 @@ run.
 from __future__ import annotations
 
 from lgtmaybe.cli import run_review
+from lgtmaybe.core.findings import finding_fingerprint
 from lgtmaybe.core.models import (
     PRContext,
     ReviewConfig,
@@ -20,7 +21,6 @@ from lgtmaybe.core.models import (
     Severity,
 )
 from lgtmaybe.engine.suppress import apply_suppressions
-from lgtmaybe.github.rest_gateway import finding_fingerprint
 from tests.conftest import make_cfg
 from tests.fakes import FakeGitHub
 

--- a/tests/core/test_forge.py
+++ b/tests/core/test_forge.py
@@ -78,14 +78,27 @@ class TestTokenEnvVar:
 class TestGatewayRegistry:
     """Which forges lgtmaybe can actually build a gateway for."""
 
-    def test_github_is_registered(self) -> None:
+    @pytest.mark.parametrize("forge", [Forge.github, Forge.gitea])
+    def test_implemented_forges_are_registered(self, forge: Forge) -> None:
         from lgtmaybe.cli import gateway_builder
 
-        assert gateway_builder(Forge.github) is not None
+        assert gateway_builder(forge) is not None
 
-    @pytest.mark.parametrize("forge", [Forge.gitlab, Forge.gitea])
+    @pytest.mark.parametrize("forge", [Forge.gitlab])
     def test_an_unimplemented_forge_says_so_by_name(self, forge: Forge) -> None:
         """A recognised-but-unbuilt forge must not read as an unparseable URL."""
         from lgtmaybe.cli import gateway_builder
 
         assert gateway_builder(forge) is None
+
+    def test_the_gitea_builder_carries_the_host_through(self) -> None:
+        """Self-hosted is the norm on Gitea, so the API base cannot be a constant."""
+        from lgtmaybe.cli import gateway_builder
+        from lgtmaybe.core.models import ReviewConfig
+
+        build = gateway_builder(Forge.gitea)
+        assert build is not None
+        located = parse_pr_url("https://git.acme.internal/team/svc/pulls/12")
+        gateway = build(located, "token", ReviewConfig(provider="ollama", model="llama3"))
+        assert "git.acme.internal" in gateway._api
+        assert gateway._pr_number == 12

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -392,7 +392,7 @@ def test_custom_lens_finding_without_failure_scenario_remains_eligible() -> None
 def test_suppressed_finding_skips_reflection_and_output() -> None:
     """A finding whose fingerprint is in ignore_fingerprints is dropped right
     after dedupe — it costs no reflection tokens and is never returned."""
-    from lgtmaybe.github.rest_gateway import finding_fingerprint
+    from lgtmaybe.core.findings import finding_fingerprint
 
     suppressed = ReviewFinding(
         path="a.py", line=1, severity=Severity.high, title="known fine", body="dismissed"
@@ -1486,7 +1486,7 @@ def test_review_logs_a_heartbeat_as_each_lens_runs(engine_logs) -> None:
 def test_suppressed_findings_are_logged_with_a_count(engine_logs) -> None:
     """A suppression silently dropping findings is invisible; log how many went, so
     a team can tell a too-broad fingerprint/pragma from a genuinely clean review."""
-    from lgtmaybe.github.rest_gateway import finding_fingerprint
+    from lgtmaybe.core.findings import finding_fingerprint
 
     provider = _provider_for([_HIGH], reflection_keeps_all=True)
     engine = LLMReviewEngine(provider)

--- a/tests/engine/test_lgtm_honesty.py
+++ b/tests/engine/test_lgtm_honesty.py
@@ -80,7 +80,7 @@ class TestSuppressedFindingsAreDisclosed:
         """learn_feedback drops a 👎'd finding before posting. Reporting the
         resulting zero as LGTM would let a downvote silently convert a real
         finding into a clean bill of health."""
-        from lgtmaybe.github.rest_gateway import finding_fingerprint
+        from lgtmaybe.core.findings import finding_fingerprint
 
         fp = finding_fingerprint("a.py", "Something")
         findings, summary = LLMReviewEngine(_Flags()).review(
@@ -92,7 +92,7 @@ class TestSuppressedFindingsAreDisclosed:
         assert "suppress" in summary.lower()
 
     def test_an_ignored_fingerprint_blocks_lgtm(self) -> None:
-        from lgtmaybe.github.rest_gateway import finding_fingerprint
+        from lgtmaybe.core.findings import finding_fingerprint
 
         fp = finding_fingerprint("a.py", "Something")
         _findings, summary = LLMReviewEngine(_Flags()).review(

--- a/tests/engine/test_suppress.py
+++ b/tests/engine/test_suppress.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from lgtmaybe.core.findings import finding_fingerprint
 from lgtmaybe.core.models import Provider, ReviewConfig, ReviewFinding, Severity
 from lgtmaybe.engine.suppress import apply_suppressions
-from lgtmaybe.github.rest_gateway import finding_fingerprint
 
 _CFG = ReviewConfig(provider=Provider.ollama, model="llama3")
 

--- a/tests/gitea/test_actions_entrypoint.py
+++ b/tests/gitea/test_actions_entrypoint.py
@@ -1,0 +1,56 @@
+"""Gitea Actions reuses GitHub Actions' env contract, so the entrypoint mostly works.
+
+The one thing it cannot inherit is the host: Gitea Actions sets the same
+``GITHUB_*`` variables, but ``GITHUB_SERVER_URL`` points at the Gitea instance.
+Reading it is what makes the difference between reviewing the right PR and
+trying to post to github.com.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.cli import pr_url_from_event
+from lgtmaybe.core.forge import Forge, parse_pr_url
+
+EVENT = {"repository": {"full_name": "team/service"}, "pull_request": {"number": 12}}
+
+
+class TestPRUrlFromEvent:
+    def test_defaults_to_github_when_no_server_url_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+        assert pr_url_from_event(EVENT) == "https://github.com/team/service/pull/12"
+
+    def test_an_explicit_github_server_url_still_resolves_to_github(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+        url = pr_url_from_event(EVENT)
+        assert parse_pr_url(url).forge is Forge.github
+
+    def test_a_gitea_server_url_produces_a_gitea_pull_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gitea pluralises the segment, which is also how the forge is told apart."""
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://gitea.example.com")
+        url = pr_url_from_event(EVENT)
+
+        assert url == "https://gitea.example.com/team/service/pulls/12"
+        located = parse_pr_url(url)
+        assert located.forge is Forge.gitea
+        assert located.host == "gitea.example.com"
+        assert located.repo == "team/service"
+        assert located.number == 12
+
+    def test_a_trailing_slash_on_the_server_url_does_not_break_the_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://gitea.example.com/")
+        assert pr_url_from_event(EVENT) == "https://gitea.example.com/team/service/pulls/12"
+
+    def test_a_malformed_payload_still_fails_loudly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://gitea.example.com")
+        with pytest.raises(Exception, match="missing required field"):
+            pr_url_from_event({"repository": {}})

--- a/tests/gitea/test_gateway.py
+++ b/tests/gitea/test_gateway.py
@@ -1,0 +1,283 @@
+"""Tests for GiteaGateway — respx-mocked Gitea REST API.
+
+Gitea's API mirrors GitHub's closely enough that the interesting cases are the
+places it *doesn't*: reviews are not editable, so the summary lives in an
+upserted issue comment; inline comments are positioned by ``new_position`` /
+``old_position`` rather than ``line`` + ``side``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from lgtmaybe.core.models import ReviewFinding, Severity
+from lgtmaybe.gitea import GiteaGateway
+
+HOST = "gitea.example.com"
+REPO = "owner/repo"
+PR_NUMBER = 7
+TOKEN = "gitea_test_token"
+
+API = f"https://{HOST}/api/v1/repos/{REPO}"
+PR_URL = f"{API}/pulls/{PR_NUMBER}"
+
+DIFF = """diff --git a/app.py b/app.py
+index 111..222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,4 @@
+ import os
++password = "hunter2"
+ 
+ def main():
+"""
+
+PR_DETAIL = {
+    "base": {"sha": "base123", "ref": "main"},
+    "head": {"sha": "head456", "ref": "feature-branch"},
+    "title": "Add a thing",
+    "body": "This adds the thing.",
+}
+
+
+def _gateway(client: httpx.Client) -> GiteaGateway:
+    return GiteaGateway(host=HOST, repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=client)
+
+
+def _stub_context_routes() -> None:
+    """The read routes get_pr_context needs, in first-match order."""
+    respx.get(f"{PR_URL}.diff").mock(return_value=httpx.Response(200, text=DIFF))
+    respx.get(PR_URL).mock(return_value=httpx.Response(200, json=PR_DETAIL))
+    respx.route(method="GET", url__startswith=f"{PR_URL}/files").mock(
+        return_value=httpx.Response(200, json=[{"filename": "app.py"}])
+    )
+    respx.route(method="GET", url__startswith=f"{PR_URL}/commits").mock(
+        return_value=httpx.Response(200, json=[{"commit": {"message": "add a thing\n\nbody"}}])
+    )
+    respx.route(method="GET", url__startswith=f"{API}/contents/").mock(
+        return_value=httpx.Response(200, json={"content": "aW1wb3J0IG9z", "encoding": "base64"})
+    )
+
+
+class TestGetPRContext:
+    @respx.mock
+    def test_returns_the_diff_and_both_shas(self) -> None:
+        _stub_context_routes()
+        ctx = _gateway(httpx.Client()).get_pr_context()
+
+        assert ctx.diff == DIFF
+        assert ctx.base_sha == "base123"
+        assert ctx.head_sha == "head456"
+        assert ctx.changed_files == ["app.py"]
+
+    @respx.mock
+    def test_carries_the_stated_intent_for_the_intent_lens(self) -> None:
+        _stub_context_routes()
+        ctx = _gateway(httpx.Client()).get_pr_context()
+
+        assert ctx.title == "Add a thing"
+        assert ctx.description == "This adds the thing."
+        assert ctx.commit_messages == ["add a thing"], "only the subject line, not the body"
+        assert ctx.head_branch == "feature-branch"
+
+    @respx.mock
+    def test_decodes_base64_file_contents_for_hunk_expansion(self) -> None:
+        _stub_context_routes()
+        ctx = _gateway(httpx.Client()).get_pr_context()
+
+        assert ctx.file_contents == {"app.py": "import os"}
+
+    @respx.mock
+    def test_a_missing_sha_fails_loudly_rather_than_reviewing_nothing(self) -> None:
+        respx.get(f"{PR_URL}.diff").mock(return_value=httpx.Response(200, text=DIFF))
+        respx.get(PR_URL).mock(return_value=httpx.Response(200, json={"title": "no shas"}))
+
+        with pytest.raises(RuntimeError, match="base/head SHA"):
+            _gateway(httpx.Client()).get_pr_context()
+
+
+class TestPostReview:
+    @respx.mock
+    def test_anchors_an_inline_comment_by_new_position(self) -> None:
+        """Gitea positions a comment by new/old file line, not GitHub's line+side."""
+        reviews = respx.post(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json={}))
+        respx.route(method="GET", url__startswith=f"{PR_URL}/reviews").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={"id": 1})
+        )
+
+        finding = ReviewFinding(
+            path="app.py",
+            line=2,
+            side="RIGHT",
+            severity=Severity.high,
+            title="Hardcoded password",
+            body="Move it to the environment.",
+            anchor='password = "hunter2"',
+            anchored=True,
+        )
+        _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
+
+        assert reviews.called
+        posted = reviews.calls[0].request
+        import json as _json
+
+        comment = _json.loads(posted.content)["comments"][0]
+        assert comment["path"] == "app.py"
+        assert comment["new_position"] == 2
+        assert "old_position" not in comment
+        assert "Hardcoded password" in comment["body"]
+
+    @respx.mock
+    def test_a_left_side_finding_uses_old_position(self) -> None:
+        reviews = respx.post(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json={}))
+        respx.route(method="GET", url__startswith=f"{PR_URL}/reviews").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={"id": 1})
+        )
+
+        finding = ReviewFinding(
+            path="app.py",
+            line=1,
+            side="LEFT",
+            severity=Severity.low,
+            title="Removed import",
+            body="Was this deliberate?",
+            anchor="import os",
+            anchored=True,
+        )
+        _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
+
+        import json as _json
+
+        comment = _json.loads(reviews.calls[0].request.content)["comments"][0]
+        assert comment["old_position"] == 1
+        assert "new_position" not in comment
+
+    @respx.mock
+    def test_the_summary_is_upserted_so_a_rerun_edits_it_in_place(self) -> None:
+        """Gitea reviews cannot be edited, so the summary lives in an issue comment."""
+        respx.route(method="GET", url__startswith=f"{PR_URL}/reviews").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"id": 99, "body": "old summary\n\n<!-- lgtmaybe -->"}],
+            )
+        )
+        edit = respx.patch(f"{API}/issues/comments/99").mock(
+            return_value=httpx.Response(200, json={"id": 99})
+        )
+        create = respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={"id": 100})
+        )
+
+        _gateway(httpx.Client()).post_review([], "👍 LGTM!", diff=DIFF)
+
+        assert edit.called, "an existing summary must be edited"
+        assert not create.called, "and not duplicated"
+
+    @respx.mock
+    def test_a_finding_already_posted_is_not_posted_twice(self) -> None:
+        """Reviews are immutable here, so dedupe has to happen before posting."""
+        from lgtmaybe.core.findings import finding_fingerprint
+
+        finding = ReviewFinding(
+            path="app.py",
+            line=2,
+            side="RIGHT",
+            severity=Severity.high,
+            title="Hardcoded password",
+            body="Move it to the environment.",
+            anchor='password = "hunter2"',
+            anchored=True,
+        )
+        already = finding_fingerprint("app.py", "Hardcoded password")
+        respx.route(method="GET", url=f"{PR_URL}/reviews").mock(
+            return_value=httpx.Response(200, json=[{"id": 5}])
+        )
+        respx.get(f"{PR_URL}/reviews/5/comments").mock(
+            return_value=httpx.Response(
+                200, json=[{"body": f"old text\n<!-- lgtmaybe-finding:{already} -->"}]
+            )
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={"id": 1})
+        )
+        reviews = respx.post(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json={}))
+
+        _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
+
+        assert not reviews.called, "the only finding was already on the PR"
+
+    @respx.mock
+    def test_an_unanchorable_finding_is_demoted_into_the_summary(self) -> None:
+        """A comment on a line we cannot stand behind is worse than no line at all."""
+        respx.route(method="GET", url__startswith=f"{PR_URL}/reviews").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        create = respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={"id": 1})
+        )
+        reviews = respx.post(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json={}))
+
+        finding = ReviewFinding(
+            path="app.py",
+            line=999,
+            side="RIGHT",
+            severity=Severity.medium,
+            title="Unplaceable",
+            body="Could not be anchored.",
+            anchored=False,
+        )
+        _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
+
+        import json as _json
+
+        body = _json.loads(create.calls[0].request.content)["body"]
+        assert "Additional findings" in body
+        assert "Unplaceable" in body
+        assert not reviews.called
+
+
+class TestCapabilities:
+    """What this adapter can and cannot do, declared rather than discovered."""
+
+    def test_declares_the_capabilities_it_implements(self) -> None:
+        from lgtmaybe.core import ports
+
+        gateway = GiteaGateway.__new__(GiteaGateway)
+        for name in (
+            "SupportsFileContents",
+            "SupportsDescribe",
+            "SupportsDiagram",
+            "SupportsLabels",
+            "SupportsChecks",
+        ):
+            assert isinstance(gateway, getattr(ports, name)), name
+
+    def test_does_not_claim_what_gitea_cannot_do(self) -> None:
+        """Gitea has no resolvable review threads; claiming it would break the caller."""
+        from lgtmaybe.core import ports
+
+        gateway = GiteaGateway.__new__(GiteaGateway)
+        assert not isinstance(gateway, ports.SupportsThreadResolution)

--- a/tests/gitea/test_gateway.py
+++ b/tests/gitea/test_gateway.py
@@ -281,3 +281,86 @@ class TestCapabilities:
 
         gateway = GiteaGateway.__new__(GiteaGateway)
         assert not isinstance(gateway, ports.SupportsThreadResolution)
+
+
+class TestLabels:
+    @respx.mock
+    def test_resolves_label_names_to_ids_before_applying(self) -> None:
+        """Gitea addresses labels by id, so names have to be looked up first."""
+        respx.route(method="GET", url__startswith=f"{API}/labels").mock(
+            return_value=httpx.Response(
+                200, json=[{"id": 3, "name": "review-effort/2"}, {"id": 4, "name": "other"}]
+            )
+        )
+        applied = respx.post(f"{API}/issues/{PR_NUMBER}/labels").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        _gateway(httpx.Client()).apply_pr_labels(["review-effort/2"])
+
+        import json as _json
+
+        assert _json.loads(applied.calls[0].request.content)["labels"] == [3]
+
+    @respx.mock
+    def test_a_label_the_repo_does_not_have_is_skipped_not_created(self) -> None:
+        """Creating labels on someone's repo is not this tool's business."""
+        respx.route(method="GET", url__startswith=f"{API}/labels").mock(
+            return_value=httpx.Response(200, json=[{"id": 3, "name": "known"}])
+        )
+        applied = respx.post(f"{API}/issues/{PR_NUMBER}/labels").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        _gateway(httpx.Client()).apply_pr_labels(["never-heard-of-it"])
+
+        assert not applied.called
+
+    @respx.mock
+    def test_a_label_failure_never_fails_the_review(self) -> None:
+        respx.route(method="GET", url__startswith=f"{API}/labels").mock(
+            return_value=httpx.Response(500)
+        )
+        _gateway(httpx.Client()).apply_pr_labels(["anything"])  # must not raise
+
+    def test_no_labels_makes_no_request(self) -> None:
+        with respx.mock:
+            _gateway(httpx.Client()).apply_pr_labels([])
+            assert not respx.calls
+
+
+class TestCheckRun:
+    @respx.mock
+    @pytest.mark.parametrize(
+        ("conclusion", "state"),
+        [("success", "success"), ("failure", "failure"), ("cancelled", "error")],
+    )
+    def test_maps_a_conclusion_onto_giteas_narrower_state_vocabulary(
+        self, conclusion: str, state: str
+    ) -> None:
+        posted = respx.post(f"{API}/statuses/head456").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        _gateway(httpx.Client()).create_check_run("head456", conclusion, "lgtmaybe", "summary")
+
+        import json as _json
+
+        payload = _json.loads(posted.calls[0].request.content)
+        assert payload["state"] == state
+        assert payload["context"] == "lgtmaybe"
+
+    @respx.mock
+    def test_an_unknown_conclusion_does_not_fail_the_review(self) -> None:
+        posted = respx.post(f"{API}/statuses/head456").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        _gateway(httpx.Client()).create_check_run("head456", "brand-new", "lgtmaybe", "summary")
+
+        import json as _json
+
+        assert _json.loads(posted.calls[0].request.content)["state"] == "success"
+
+    @respx.mock
+    def test_a_status_failure_never_fails_the_review(self) -> None:
+        respx.post(f"{API}/statuses/head456").mock(return_value=httpx.Response(500))
+        _gateway(httpx.Client()).create_check_run("head456", "success", "t", "s")  # must not raise

--- a/tests/github/test_incremental.py
+++ b/tests/github/test_incremental.py
@@ -23,9 +23,9 @@ import httpx
 import pytest
 import respx
 
+from lgtmaybe.core.findings import finding_fingerprint
 from lgtmaybe.core.models import ReviewFinding, Severity
 from lgtmaybe.github import RestGitHubGateway
-from lgtmaybe.github.rest_gateway import finding_fingerprint
 
 REPO = "owner/repo"
 PR_NUMBER = 42

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -8,14 +8,11 @@ import threading
 import httpx
 import respx
 
+from lgtmaybe.core.comment import finding_keys as _finding_keys
+from lgtmaybe.core.findings import finding_fingerprint, finding_identity
 from lgtmaybe.core.models import ReviewFinding, Severity
 from lgtmaybe.github import RestGitHubGateway
-from lgtmaybe.github.rest_gateway import (
-    _RESOLVE_WORKERS,
-    _finding_keys,
-    finding_fingerprint,
-    finding_identity,
-)
+from lgtmaybe.github.rest_gateway import _RESOLVE_WORKERS
 
 REPO = "owner/repo"
 PR_NUMBER = 42

--- a/tests/github/test_reword_dedupe.py
+++ b/tests/github/test_reword_dedupe.py
@@ -17,9 +17,9 @@ from typing import Any
 import httpx
 import respx
 
+from lgtmaybe.core.findings import finding_fingerprint, finding_identity
 from lgtmaybe.core.models import ReviewFinding, Severity
 from lgtmaybe.github import RestGitHubGateway
-from lgtmaybe.github.rest_gateway import finding_fingerprint, finding_identity
 
 REPO = "owner/repo"
 PR_NUMBER = 42

--- a/tests/test_incomplete_visibility.py
+++ b/tests/test_incomplete_visibility.py
@@ -330,8 +330,9 @@ def test_incomplete_marker_cannot_be_mistaken_for_another_marker_family() -> Non
     """Markers are matched by substring/regex elsewhere; this one must stay disjoint,
     or a summary that discloses incompleteness could be mistaken for the review's
     idempotency marker, a finding fingerprint, or the reviewed-SHA watermark."""
-    from lgtmaybe.github.rest_gateway import _FINDING_MARKER, _REVIEWED_MARKER
+    from lgtmaybe.core.comment import FINDING_MARKER as _FINDING_MARKER
     from lgtmaybe.github.rest_gateway import _MARKER as _SUMMARY_MARKER
+    from lgtmaybe.github.rest_gateway import _REVIEWED_MARKER
 
     assert _SUMMARY_MARKER not in INCOMPLETE_MARKER
     assert _FINDING_MARKER.search(INCOMPLETE_MARKER) is None


### PR DESCRIPTION
Phase 1 of adding GitLab and Gitea support — the second forge adapter, built on the seam from #480.

## Why Gitea first

Its API and its Actions runtime deliberately mirror GitHub's, so it is the cheap proof that the seam holds. The container image and the `action` entrypoint run unchanged; the only environment variable that differs is `GITHUB_SERVER_URL`, which Gitea points at your own instance.

The review itself is untouched — same lenses, same reflection pass, same findings — because none of that ever depended on the host.

## Where Gitea genuinely differs

Three things, and they are the whole reason this is a separate adapter rather than a base-URL switch:

1. **A submitted review cannot be edited.** GitHub updates its review body in place on a re-run; Gitea has no equivalent. So the summary lives in an ordinary issue comment (which *is* editable, and upserts on each run) and the review object carries only inline comments.
2. **De-dupe happens before posting, not after.** Since the review is immutable, the adapter reads the hidden finding ids already on the PR and declines to post a finding twice.
3. **Positions, not sides.** Comments are anchored by `new_position` / `old_position` rather than `line` + `side`. lgtmaybe keeps GitHub's RIGHT/LEFT vocabulary internally and translates at this boundary.

## Capabilities deliberately not claimed

| Not claimed | Why | Degrades to |
|---|---|---|
| `SupportsIncremental` | Gitea's compare endpoint returns commit metadata, not a unified diff | Full review each run |
| `SupportsThreadResolution` | Gitea has no thread-resolution API | Fixed findings' comments stay open |
| `SupportsBaseCheckout` | Not needed without symbol deferral | Symbol resolution off |

This is the capability seam doing its job: claiming a capability that cannot work would be worse than not claiming it, and a test asserts the adapter does *not* claim thread resolution.

Claimed and working: `SupportsFileContents`, `SupportsDescribe`, `SupportsDiagram`, `SupportsLabels`, `SupportsChecks` (via Gitea commit statuses).

## Shared rendering, not duplicated

Also lifts the comment Markdown — severity badge, demoted/broad body sections, fence defanging, hidden id markers, `render_inline_body` — out of the GitHub adapter into `core/comment.py`. Both adapters now render from one place rather than the new one duplicating ~150 lines. The GitHub adapter is ~130 lines shorter as a result and behaviourally identical.

## Fork safety

Gitea has no `pull_request_target`, so `pull_request` runs with repository secrets. The rule is unchanged and holds for the same reason: lgtmaybe never checks out or executes PR code — it reads the diff through the API and treats it as untrusted input throughout.

## What's included

- `src/lgtmaybe/gitea/gateway.py` — the adapter
- `src/lgtmaybe/core/comment.py` — shared Markdown rendering
- `tests/gitea/` — 19 tests (adapter behaviour + the Actions entrypoint's host resolution)
- `openspec/specs/gitea-posting/` — spec + anchors, recording the deliberate omissions
- `examples/gitea/lgtmaybe.yml` and `docs/how-to/review-on-gitea.md`
- `CLAUDE.md` — documents the forge axis so future work doesn't re-derive it

## Verification

- Full gate green: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest` — 2298 passed, 3 skipped (2293 before this change).
- Spec anchors resolve (`tests/specs`, 17 passed); `openspec validate --specs` — 11 passed, 0 failed.

Not yet exercised against a live Gitea instance — the adapter is covered by respx-mocked tests against the documented API shapes, same as the GitHub adapter's suite. A live smoke test against a `gitea/gitea` container would be a reasonable follow-up.

## Follow-up

Phase 2 — GitLab: MR discussions, `old_line`/`new_line` positions, `CI_*` env instead of an event payload, and real thread resolution (GitLab discussions resolve over plain REST).

---
_Generated by [Claude Code](https://claude.ai/code/session_013KoK6xvv72d6x1Z5qaCk37)_