### PR TITLE
feat: review merge requests on GitLab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,16 @@ github / gitlab / gitea, and `Provider` stays the model backend. Never overload
   minus incremental review and thread resolution (its API cannot serve either);
   its summary lives in an editable issue comment because a submitted Gitea review
   is immutable, and it de-dupes findings by reading the hidden ids already posted.
+  **GitLab** (`gitlab/gateway.py`) is the one whose model really differs: no
+  batched review object, so each finding is its own *discussion* positioned by
+  old/new path + line and the MR's three diff refs; the summary is an upserted
+  note; thread resolution works over plain REST (no GraphQL), gated on the
+  caller's validated allowlist because GitLab exposes no "lines moved" signal.
+  Incremental is unbuilt there — a "not yet", not a "cannot".
+- **Entrypoints:** GitHub and Gitea Actions share `action` (Gitea reimplements
+  the same env contract; only `GITHUB_SERVER_URL` differs, and
+  `cli._change_url` reads it). GitLab CI has neither an event payload nor
+  `INPUT_*`, so it gets its own `gitlab-ci` command reading `CI_*`.
 
 ## Key decisions (do not relitigate)
 

--- a/docs/how-to/review-on-gitlab.md
+++ b/docs/how-to/review-on-gitlab.md
@@ -1,0 +1,62 @@
+# Review merge requests on GitLab
+
+lgtmaybe posts reviews to GitLab as well as GitHub. The review itself is
+identical — same lenses, same reflection pass, same findings — because none of
+that ever depended on the host. Only the adapter that fetches the diff and posts
+the comments is different.
+
+## Set it up
+
+1. **Create a token.** In your project, go to *Settings → Access Tokens* and
+   create a project access token with the `api` scope and at least the Developer
+   role. Add it under *Settings → CI/CD → Variables* as `GITLAB_TOKEN`, masked.
+
+2. **Add a provider key.** Add the API key for whichever model you want as a
+   second masked variable — for example `ANTHROPIC_API_KEY`.
+
+3. **Add the job.** Copy
+   [`examples/gitlab/.gitlab-ci.yml`](https://github.com/MattJColes/lgtmaybe/blob/main/examples/gitlab/.gitlab-ci.yml)
+   into your repository, or merge the `lgtmaybe` job into your existing
+   pipeline.
+
+The job must run on merge request pipelines — `rules: - if: $CI_PIPELINE_SOURCE
+== "merge_request_event"`. On a branch pipeline there is no merge request to
+review, and lgtmaybe will tell you so by name rather than guessing.
+
+## Run it locally instead
+
+The CLI takes a merge request URL directly:
+
+```bash
+export GITLAB_TOKEN=...
+export ANTHROPIC_API_KEY=...
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
+  --pr-url https://gitlab.com/group/subgroup/project/-/merge_requests/7
+```
+
+Nested group paths work — everything before `/-/merge_requests/` is the project.
+
+## How it differs from GitHub
+
+GitLab has no batched review object, so **each finding is posted as its own
+discussion**, anchored by the merge request's diff refs and the old or new file
+line. The summary lives in a note, which updates in place on each run.
+
+Resolve-on-fix **does** work here: GitLab discussions resolve over plain REST,
+where GitHub needs GraphQL. A finding is only resolved once the follow-up
+validation pass has confirmed it is actually fixed — never merely because it
+stopped being reported.
+
+One thing is not available yet:
+
+| Not available | Why | What happens instead |
+|---|---|---|
+| Incremental review | Not yet built — GitLab's compare endpoint returns per-file diffs that could be reassembled, so this is a "not yet", not a "cannot" | Every run is a full review |
+| Keyless cloud auth | The OIDC/WIF exchange is a GitHub Actions feature | Use an API key, or `ollama` |
+
+## Fork safety
+
+lgtmaybe never checks out or executes merge request code. It reads the diff
+through the API and treats every byte of it as untrusted input — which is why
+the example job sets `GIT_STRATEGY: none` and does not clone the repository at
+all.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1206,6 +1206,73 @@ diff through the API and treats every byte of it as untrusted input.
 
 ---
 
+<!-- Source: https://lgtmaybe.coles.codes/how-to/review-on-gitlab/ -->
+
+# Review merge requests on GitLab
+
+lgtmaybe posts reviews to GitLab as well as GitHub. The review itself is
+identical — same lenses, same reflection pass, same findings — because none of
+that ever depended on the host. Only the adapter that fetches the diff and posts
+the comments is different.
+
+## Set it up
+
+1. **Create a token.** In your project, go to *Settings → Access Tokens* and
+   create a project access token with the `api` scope and at least the Developer
+   role. Add it under *Settings → CI/CD → Variables* as `GITLAB_TOKEN`, masked.
+
+2. **Add a provider key.** Add the API key for whichever model you want as a
+   second masked variable — for example `ANTHROPIC_API_KEY`.
+
+3. **Add the job.** Copy
+   [`examples/gitlab/.gitlab-ci.yml`](https://github.com/MattJColes/lgtmaybe/blob/main/examples/gitlab/.gitlab-ci.yml)
+   into your repository, or merge the `lgtmaybe` job into your existing
+   pipeline.
+
+The job must run on merge request pipelines — `rules: - if: $CI_PIPELINE_SOURCE
+== "merge_request_event"`. On a branch pipeline there is no merge request to
+review, and lgtmaybe will tell you so by name rather than guessing.
+
+## Run it locally instead
+
+The CLI takes a merge request URL directly:
+
+```bash
+export GITLAB_TOKEN=...
+export ANTHROPIC_API_KEY=...
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
+  --pr-url https://gitlab.com/group/subgroup/project/-/merge_requests/7
+```
+
+Nested group paths work — everything before `/-/merge_requests/` is the project.
+
+## How it differs from GitHub
+
+GitLab has no batched review object, so **each finding is posted as its own
+discussion**, anchored by the merge request's diff refs and the old or new file
+line. The summary lives in a note, which updates in place on each run.
+
+Resolve-on-fix **does** work here: GitLab discussions resolve over plain REST,
+where GitHub needs GraphQL. A finding is only resolved once the follow-up
+validation pass has confirmed it is actually fixed — never merely because it
+stopped being reported.
+
+One thing is not available yet:
+
+| Not available | Why | What happens instead |
+|---|---|---|
+| Incremental review | Not yet built — GitLab's compare endpoint returns per-file diffs that could be reassembled, so this is a "not yet", not a "cannot" | Every run is a full review |
+| Keyless cloud auth | The OIDC/WIF exchange is a GitHub Actions feature | Use an API key, or `ollama` |
+
+## Fork safety
+
+lgtmaybe never checks out or executes merge request code. It reads the diff
+through the API and treats every byte of it as untrusted input — which is why
+the example job sets `GIT_STRATEGY: none` and does not clone the repository at
+all.
+
+---
+
 <!-- Source: https://lgtmaybe.coles.codes/how-to/review-with-openai/ -->
 
 # Review with OpenAI

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,6 +13,7 @@
 - [Use as a GitHub Action](https://lgtmaybe.coles.codes/how-to/use-as-github-action/): Add lgtmaybe as a GitHub Action to review every pull request automatically with inline comments and a summary.
 - [Post as lgtmaybe[bot]](https://lgtmaybe.coles.codes/how-to/post-as-a-github-app/): Post lgtmaybe reviews as lgtmaybe[bot] with the public App, or use a self-managed GitHub App.
 - [Review on Gitea](https://lgtmaybe.coles.codes/how-to/review-on-gitea/)
+- [Review on GitLab](https://lgtmaybe.coles.codes/how-to/review-on-gitlab/)
 - [Review with OpenAI](https://lgtmaybe.coles.codes/how-to/review-with-openai/): Set up lgtmaybe pull-request reviews with OpenAI — add OPENAI_API_KEY, pick a model, and run as a GitHub Action or locally.
 - [Review with Claude (Anthropic)](https://lgtmaybe.coles.codes/how-to/review-with-anthropic/): Review pull requests with Claude (Anthropic) in lgtmaybe — API-key setup, Claude model choice, and Action or local usage.
 - [Review with OpenRouter](https://lgtmaybe.coles.codes/how-to/review-with-openrouter/): Use OpenRouter as the lgtmaybe backend to reach many model vendors through one OpenAI-compatible API key.

--- a/examples/gitlab/.gitlab-ci.yml
+++ b/examples/gitlab/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+# Copy into your GitLab repo at .gitlab-ci.yml (or include it from one).
+#
+# GitLab CI has no event payload file and no INPUT_* convention, so lgtmaybe
+# reads the merge request from GitLab's own predefined variables and takes its
+# configuration from ordinary flags, environment, and .lgtmaybe.yml.
+#
+# Two CI/CD variables to add under Settings -> CI/CD -> Variables:
+#
+#   GITLAB_TOKEN      a project access token with `api` scope, so lgtmaybe can
+#                     read the merge request and post the review. Mark it
+#                     Masked; it does not need to be Protected unless your
+#                     merge request pipelines only run on protected branches.
+#   ANTHROPIC_API_KEY (or whichever provider you use) — Masked.
+#
+# Keyless cloud auth (Bedrock, Vertex, Azure) is a GitHub Actions feature; on
+# GitLab use an API key, or `ollama` against a runner-local model.
+
+lgtmaybe:
+  stage: test
+  image: ghcr.io/mattjcoles/lgtmaybe:v2
+  # Merge request pipelines only. Without this the job also runs on branch
+  # pipelines, where there is no merge request to review — lgtmaybe says so and
+  # exits non-zero, which reads as a broken pipeline rather than a misconfigured
+  # rule.
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - python -m lgtmaybe gitlab-ci --provider anthropic --model claude-sonnet-4-6
+  variables:
+    # lgtmaybe never checks out or executes merge request code — it reads the
+    # diff through the API — so the job does not need the repository at all.
+    GIT_STRATEGY: none

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - Use as a GitHub Action: how-to/use-as-github-action.md
           - Post as lgtmaybe[bot]: how-to/post-as-a-github-app.md
           - Review on Gitea: how-to/review-on-gitea.md
+          - Review on GitLab: how-to/review-on-gitlab.md
       - Cloud providers (API key):
           - Review with OpenAI: how-to/review-with-openai.md
           - Review with Claude (Anthropic): how-to/review-with-anthropic.md

--- a/openspec/specs/gitlab-posting/anchors.yml
+++ b/openspec/specs/gitlab-posting/anchors.yml
@@ -1,0 +1,29 @@
+gitlab.project:
+  rule:
+    kind: class_definition
+    has: { field: name, regex: '^GitLabGateway$' }
+  files: [src/lgtmaybe/gitlab/**/*.py]
+
+gitlab.context:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^get_pr_context$' }
+  files: [src/lgtmaybe/gitlab/**/*.py]
+
+gitlab.positions:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_partition_findings$' }
+  files: [src/lgtmaybe/gitlab/**/*.py]
+
+gitlab.upsert:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_upsert_note$' }
+  files: [src/lgtmaybe/gitlab/**/*.py]
+
+gitlab.resolve:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_resolve_fixed_threads$' }
+  files: [src/lgtmaybe/gitlab/**/*.py]

--- a/openspec/specs/gitlab-posting/spec.md
+++ b/openspec/specs/gitlab-posting/spec.md
@@ -1,0 +1,77 @@
+# gitlab-posting Specification
+
+## Purpose
+
+The GitLab REST adapter (`gitlab/gateway.py`): the forge whose model genuinely
+differs rather than renaming things. No batched review object, positions that
+carry the merge request's diff refs, and thread resolution over plain REST
+instead of GraphQL.
+
+## Requirements
+
+### Requirement: A project is addressed by its encoded path
+
+The adapter SHALL address a project by its URL-encoded full path, so an
+arbitrarily nested group path survives as a single URL segment, and SHALL take
+the host from the merge request URL rather than assuming gitlab.com — self-hosted
+GitLab is the common case.
+<!-- anchor: gitlab.project -->
+
+#### Scenario: a nested group path is encoded
+- **WHEN** the project is "group/subgroup/project"
+- **THEN** requests address it as "group%2Fsubgroup%2Fproject"
+
+### Requirement: Context comes from the API, never a checkout
+
+`get_pr_context` SHALL fetch the diff, metadata, and head text of reviewable
+files through the GitLab REST API only — merge request code is never checked out
+or executed. The adapter SHALL cache the merge request's `base_sha`,
+`start_sha`, and `head_sha`, because a positioned discussion cannot be created
+without all three, and SHALL fail loudly when they are absent rather than
+reviewing an empty diff.
+<!-- anchor: gitlab.context -->
+
+#### Scenario: metadata without diff refs is fatal
+- **WHEN** the API returns a merge request payload carrying no diff refs
+- **THEN** the adapter raises rather than posting positionless findings
+
+### Requirement: Each finding is its own positioned discussion
+
+GitLab has no batched review object, so every inline finding SHALL be posted as
+its own discussion carrying a `position` object that names the old and new path,
+the relevant old or new line translated from lgtmaybe's RIGHT/LEFT side
+vocabulary, and the three cached diff refs. A rejected position SHALL be logged
+and skipped rather than failing the review, and a finding SHALL be demoted into
+the summary when it is not confidently anchored, when it does not land on a real
+commentable diff line, or when the diff refs are unknown.
+<!-- anchor: gitlab.positions -->
+
+#### Scenario: one unplaceable finding does not lose the others
+- **WHEN** GitLab rejects a discussion's position
+- **THEN** the remaining findings and the summary still post
+
+### Requirement: The summary lives in an editable note
+
+The summary SHALL be posted as a merge request note carrying the hidden marker,
+upserted in place on a re-run, with disjoint marker families for the summary,
+the description, and the diagram. Findings whose hidden ids are already present
+on the merge request SHALL NOT be posted again.
+<!-- anchor: gitlab.upsert -->
+
+#### Scenario: a re-run edits rather than duplicates
+- **WHEN** a review runs a second time on the same merge request
+- **THEN** the existing summary note is edited and no second one is posted
+
+### Requirement: Threads resolve over REST, only when validated
+
+Resolve-on-fix SHALL reply in and then resolve only the discussions the caller
+has explicitly validated as fixed, via the discussion resolve endpoint — GitLab
+needs no GraphQL for this, unlike GitHub. With no validated allowlist installed,
+nothing SHALL be resolved: GitLab exposes no "the lines moved" signal, so an
+unvalidated close would have no evidence behind it. Resolving SHALL never fail
+the review.
+<!-- anchor: gitlab.resolve -->
+
+#### Scenario: an unvalidated thread stays open
+- **WHEN** a review completes with an empty validated allowlist
+- **THEN** no discussion is resolved

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -59,6 +59,7 @@ from lgtmaybe.engine import (
 from lgtmaybe.engine.profiling import profiler
 from lgtmaybe.gitea import GiteaGateway
 from lgtmaybe.github import RestGitHubGateway
+from lgtmaybe.gitlab import GitLabGateway
 from lgtmaybe.local import local_file_reader, local_pr_context
 from lgtmaybe.providers.credentials import resolve_credentials
 from lgtmaybe.providers.factory import (
@@ -203,6 +204,13 @@ _GATEWAY_BUILDERS: dict[Forge, Callable[[PRLocator, str, ReviewConfig], ReviewGa
         token=token,
         marker_key=f"{cfg.provider}/{cfg.model}",
         resolve_fixed=cfg.resolve_fixed,
+    ),
+    Forge.gitlab: lambda located, token, cfg: GitLabGateway(
+        host=located.host,
+        repo=located.repo,
+        pr_number=located.number,
+        token=token,
+        marker_key=f"{cfg.provider}/{cfg.model}",
     ),
     Forge.gitea: lambda located, token, cfg: GiteaGateway(
         host=located.host,
@@ -981,6 +989,36 @@ def _change_url(repo: str, number: int) -> str:
     if not server or server == "https://github.com":
         return f"https://github.com/{repo}/pull/{number}"
     return f"{server}/{repo}/pulls/{number}"
+
+
+def mr_url_from_ci_env() -> str:
+    """Build the merge request URL from GitLab CI's predefined variables.
+
+    GitLab CI has no event payload file and no ``INPUT_*`` convention, so this
+    is the one entrypoint that cannot be shared with the GitHub Actions path.
+    Everything downstream is identical: the URL goes through the same locator
+    and the same gateway registry.
+
+    Raises with the variable's own name when one is missing — the usual cause is
+    a job running on a branch pipeline rather than a merge request one, and
+    naming ``CI_MERGE_REQUEST_IID`` points straight at the ``rules:`` fix.
+    """
+    host = os.environ.get("CI_SERVER_HOST") or ""
+    server = host and f"https://{host}" or os.environ.get("CI_SERVER_URL", "").rstrip("/")
+    if not server:
+        raise click.ClickException(
+            "CI_SERVER_HOST is not set — lgtmaybe cannot tell which GitLab to post to."
+        )
+    project = os.environ.get("CI_MERGE_REQUEST_PROJECT_PATH") or os.environ.get("CI_PROJECT_PATH")
+    if not project:
+        raise click.ClickException("CI_PROJECT_PATH is not set — no project to review.")
+    iid = os.environ.get("CI_MERGE_REQUEST_IID")
+    if not iid:
+        raise click.ClickException(
+            "CI_MERGE_REQUEST_IID is not set — this pipeline is not for a merge request. "
+            'Run the job with `rules: - if: $CI_PIPELINE_SOURCE == "merge_request_event"`.'
+        )
+    return f"{server}/{project}/-/merge_requests/{iid}"
 
 
 def pr_url_from_event(event: dict[str, Any]) -> str:

--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -27,6 +27,7 @@ from lgtmaybe.cli import (
     execute_local_review,
     execute_review,
     main,
+    mr_url_from_ci_env,
     pr_url_from_event,
     resolve_auto_incremental,
     should_auto_describe,
@@ -579,6 +580,28 @@ def action() -> None:
         describe=should_auto_describe(cfg, event_action=event_action),
         diagram=should_auto_diagram(cfg, event_action=event_action),
     )
+
+
+@main.command("gitlab-ci")
+@model_options
+def gitlab_ci(
+    provider: str | None,
+    model: str | None,
+    fallback_model: str | None,
+    api_key: str | None,
+    api_base: str | None,
+    config_path: str | None,
+) -> None:
+    """GitLab CI entrypoint: review the merge request this pipeline is for.
+
+    The counterpart to ``action``. GitLab has no event payload file and no
+    ``INPUT_*`` convention, so the merge request comes from the predefined
+    ``CI_*`` variables and configuration comes from the ordinary flags,
+    environment, and ``.lgtmaybe.yml`` — everything downstream is shared.
+    """
+    cfg = _load_cfg(config_path, provider=provider, model=model)
+    runtime = replace(_runtime(api_key, api_base, fallback_model), pr_url=mr_url_from_ci_env())
+    execute_review(cfg, runtime)
 
 
 @config_cmd.command("path")

--- a/src/lgtmaybe/gitlab/__init__.py
+++ b/src/lgtmaybe/gitlab/__init__.py
@@ -1,0 +1,9 @@
+"""gitlab — GitLab REST adapter for lgtmaybe.
+
+Public surface:
+- GitLabGateway: implements ReviewGateway against the GitLab REST API.
+"""
+
+from .gateway import GitLabGateway
+
+__all__ = ["GitLabGateway"]

--- a/src/lgtmaybe/gitlab/gateway.py
+++ b/src/lgtmaybe/gitlab/gateway.py
@@ -1,0 +1,540 @@
+"""GitLab REST adapter.
+
+Of the three forges lgtmaybe posts to, GitLab is the one whose model genuinely
+differs rather than merely renaming things:
+
+1. **No batched review object.** GitHub and Gitea both submit one review
+   carrying every inline comment; GitLab has no such thing. Each finding is its
+   own *discussion*, posted individually, and the summary is an ordinary note.
+2. **Positions carry the diff refs.** A discussion is anchored by a ``position``
+   object naming ``old_path``/``new_path``, ``old_line``/``new_line``, **and**
+   the merge request's ``base_sha``/``start_sha``/``head_sha``. lgtmaybe keeps
+   GitHub's RIGHT/LEFT vocabulary internally and translates here.
+3. **Threads resolve over plain REST.** Resolving a GitHub thread needs GraphQL;
+   on GitLab it is a ``PUT`` on the discussion, which is why this adapter can
+   offer resolve-on-fix where the Gitea one cannot.
+
+Deliberately absent: incremental review. GitLab's compare endpoint returns
+per-file diffs that could be reassembled into a unified diff, so this is a
+"not yet" rather than a "cannot" — but until it is built and measured, the
+capability is not claimed and every run is a full review.
+"""
+
+from __future__ import annotations
+
+import base64
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from lgtmaybe.core.comment import (
+    current_finding_keys,
+    finding_keys,
+    marker,
+    render_broad,
+    render_demoted,
+    render_inline_body,
+)
+from lgtmaybe.core.diff import (
+    CommentableLines,
+    build_commentable_lines,
+    is_reviewable,
+    is_scannable_manifest,
+)
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import ActiveFinding, PRContext, ReviewFinding
+
+_log = get_logger(__name__)
+
+_TIMEOUT = 30.0
+_CONTENT_FETCH_WORKERS = 8
+
+# GitLab's list endpoints page at 20 by default and cap at 100.
+_PAGE_LIMIT = 100
+
+# Written into a resolved thread before it is closed, so the trail explains
+# itself to whoever reads the merge request later.
+_RESOLVED_REPLY = "✅ Looks resolved."
+
+# GitLab commit statuses are its check-run equivalent; its state vocabulary is
+# narrower than GitHub's conclusions, so map rather than pass through.
+_STATUS_STATES = {
+    "success": "success",
+    "neutral": "success",
+    "skipped": "success",
+    "failure": "failed",
+    "action_required": "failed",
+    "cancelled": "canceled",
+    "timed_out": "failed",
+}
+
+
+class GitLabGateway:
+    """GitLab REST adapter.
+
+    Args:
+        host:      GitLab hostname, e.g. "gitlab.com" or a self-hosted instance.
+        repo:      Full project path, e.g. "group/subgroup/project".
+        pr_number: Merge request *iid* (the per-project number in the URL).
+        token:     GitLab access token (project, group, or personal).
+        client:    Injected httpx.Client; a default is created if omitted.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        repo: str,
+        pr_number: int,
+        token: str,
+        client: httpx.Client | None = None,
+        marker_key: str | None = None,
+        scheme: str = "https",
+    ) -> None:
+        self._repo = repo
+        self._pr_number = pr_number
+        # GitLab addresses a project by its URL-encoded full path, which is what
+        # lets an arbitrarily nested group path travel in a URL segment.
+        self._project = quote(repo, safe="")
+        self._api = f"{scheme}://{host}/api/v4/projects/{self._project}"
+        self._mr_api = f"{self._api}/merge_requests/{pr_number}"
+        self._headers = {"PRIVATE-TOKEN": token, "Accept": "application/json"}
+        self._client = client if client is not None else httpx.Client(timeout=_TIMEOUT)
+        self._marker = marker("lgtmaybe", marker_key)
+        self._describe_marker = marker("lgtmaybe-describe", marker_key)
+        self._diagram_marker = marker("lgtmaybe-diagram", marker_key)
+        self._head_sha: str | None = None
+        # The three SHAs every positioned discussion must carry. Cached from the
+        # MR payload, because posting a finding needs them and post_review is
+        # reachable without a preceding get_pr_context (a failure notice).
+        self._diff_refs: dict[str, str] | None = None
+        self._scan_manifests = False
+        self._active_findings: list[ActiveFinding] | None = None
+        self._validated_fixed_thread_ids: set[str] | None = None
+
+    # ------------------------------------------------------------------
+    # ReviewGateway implementation
+    # ------------------------------------------------------------------
+
+    def get_pr_context(self) -> PRContext:
+        """Fetch MR metadata, unified diff, changed files, and head file text."""
+        meta = self._get_json(self._mr_api)
+        refs = meta.get("diff_refs") or {}
+        base_sha = refs.get("base_sha")
+        head_sha = refs.get("head_sha")
+        if not base_sha or not head_sha:
+            raise RuntimeError(
+                f"Merge request metadata for {self._repo}!{self._pr_number} is missing the "
+                "base/head SHA — unexpected GitLab API response."
+            )
+        self._head_sha = head_sha
+        self._diff_refs = {
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            # start_sha only differs from base_sha on a rebased MR; falling back
+            # keeps a position valid rather than rejecting it outright.
+            "start_sha": refs.get("start_sha") or base_sha,
+        }
+
+        diff = self._fetch_mr_diff()
+        changed_files = [
+            item.get("new_path") or item.get("old_path") or ""
+            for item in self._paginate(f"{self._mr_api}/diffs")
+        ]
+        changed_files = [path for path in changed_files if path]
+
+        reviewable = [path for path in changed_files if is_reviewable(path)]
+        scannable = (
+            [path for path in changed_files if is_scannable_manifest(path)]
+            if self._scan_manifests
+            else []
+        )
+        file_contents: dict[str, str] = {}
+        scan_contents: dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS) as pool:
+            if scannable:
+                fetched = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), scannable)
+                scan_contents = {path: text for path, text in fetched if text is not None}
+            if reviewable:
+                fetched = pool.map(lambda p: (p, self._get_file_content(p, head_sha)), reviewable)
+                file_contents = {path: text for path, text in fetched if text is not None}
+
+        return PRContext(
+            diff=diff,
+            changed_files=changed_files,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            repo=self._repo,
+            pr_number=self._pr_number,
+            file_contents=file_contents,
+            scan_contents=scan_contents,
+            title=meta.get("title") or "",
+            description=meta.get("description") or "",
+            commit_messages=self._fetch_commit_subjects(),
+            head_branch=meta.get("source_branch") or "",
+            open_finding_threads=self.count_open_finding_threads(),
+        )
+
+    def post_review(
+        self,
+        findings: list[ReviewFinding],
+        summary: str,
+        diff: str | None = None,
+    ) -> None:
+        """Post each finding as its own discussion, then upsert the summary note.
+
+        Findings already carrying one of our hidden ids on the MR are skipped, so
+        a re-run adds only what is new. Threads the caller validated as fixed are
+        replied to and resolved afterwards — never before, so a failure part-way
+        through leaves the record honest rather than closing a finding that was
+        never re-stated.
+        """
+        if diff is None and findings:
+            diff = self._fetch_mr_diff()
+
+        commentable: CommentableLines = build_commentable_lines(diff or "")
+        inline, demoted, broad = self._partition_findings(findings, commentable)
+
+        if inline:
+            already = self._existing_finding_keys()
+            inline = [
+                (position, f) for position, f in inline if not (current_finding_keys([f]) & already)
+            ]
+        for position, finding in inline:
+            self._post_discussion(position, render_inline_body(finding))
+
+        body = f"{summary}{render_demoted(demoted)}{render_broad(broad)}\n\n{self._marker}"
+        self._upsert_note(body, self._marker)
+        self._resolve_fixed_threads()
+
+    def post_issue_comment(self, body: str) -> None:
+        """Post a standalone note to the merge request conversation."""
+        resp = self._client.post(
+            f"{self._mr_api}/notes", headers=self._headers, json={"body": body}, timeout=_TIMEOUT
+        )
+        resp.raise_for_status()
+
+    # ------------------------------------------------------------------
+    # Optional capabilities
+    # ------------------------------------------------------------------
+
+    def get_file_contents(self, path: str) -> str | None:
+        """Head-revision text of one file, or None when it can't be read."""
+        if self._head_sha is None:
+            return None
+        return self._get_file_content(path, self._head_sha)
+
+    def post_describe_comment(self, body: str) -> None:
+        """Upsert the structured description in its own marker family."""
+        self._upsert_note(f"{body}\n\n{self._describe_marker}", self._describe_marker)
+
+    def post_diagram_comment(self, body: str, *, completed_sha: str | None = None) -> None:
+        """Upsert the change diagram in its own marker family.
+
+        ``completed_sha`` is accepted and ignored: it drives incremental review,
+        which this adapter does not offer.
+        """
+        self._upsert_note(f"{body}\n\n{self._diagram_marker}", self._diagram_marker)
+
+    def set_scan_manifests(self, enabled: bool) -> None:
+        """Also fetch dependency-manifest text on the next context fetch."""
+        self._scan_manifests = enabled
+
+    def list_active_findings(self) -> list[ActiveFinding]:
+        """Our own unresolved finding discussions, keyed by their hidden ids."""
+        active: list[ActiveFinding] = []
+        for discussion in self._discussions():
+            notes = discussion.get("notes") or []
+            if not notes:
+                continue
+            first = notes[0]
+            if first.get("resolved"):
+                continue
+            body = first.get("body") or ""
+            keys = finding_keys(body)
+            if not keys:
+                continue  # someone else's discussion
+            fingerprints = _marker_values(body, "lgtmaybe-finding")
+            identities = _marker_values(body, "lgtmaybe-identity")
+            active.append(
+                ActiveFinding(
+                    thread_id=str(discussion.get("id")),
+                    comment_id=first.get("id"),
+                    path=(first.get("position") or {}).get("new_path") or "",
+                    body=body,
+                    fingerprint=fingerprints[0] if fingerprints else None,
+                    identity=identities[0] if identities else None,
+                    # GitLab exposes no "the lines moved" signal, so resolution
+                    # here rests entirely on the caller's validated allowlist.
+                    outdated=False,
+                )
+            )
+        self._active_findings = active
+        return active
+
+    def set_validated_fixed_threads(self, thread_ids: set[str]) -> None:
+        """Install the allowlist of threads confirmed fixed and safe to resolve."""
+        self._validated_fixed_thread_ids = set(thread_ids)
+
+    def reply_in_thread(self, thread_id: str, body: str) -> None:
+        """Reply to one existing discussion."""
+        resp = self._client.post(
+            f"{self._mr_api}/discussions/{thread_id}/notes",
+            headers=self._headers,
+            json={"body": body},
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    def count_open_finding_threads(self) -> int:
+        """How many of our finding discussions are still unresolved."""
+        try:
+            return len(
+                [
+                    d
+                    for d in self._discussions()
+                    if (notes := d.get("notes") or [])
+                    and not notes[0].get("resolved")
+                    and finding_keys(notes[0].get("body") or "")
+                ]
+            )
+        except Exception as exc:  # noqa: BLE001 — disclosure metadata only
+            _log.warning("counting open finding threads failed: %s", exc)
+            return 0
+
+    def apply_pr_labels(self, labels: list[str]) -> None:
+        """Add lgtmaybe's labels to the merge request, best-effort."""
+        if not labels:
+            return
+        try:
+            resp = self._client.put(
+                self._mr_api,
+                headers=self._headers,
+                json={"add_labels": ",".join(labels)},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — labels must never fail a review
+            _log.warning("applying labels failed: %s", exc)
+
+    def create_check_run(self, head_sha: str, conclusion: str, title: str, summary: str) -> None:
+        """Publish the review outcome as a GitLab commit status, best-effort."""
+        try:
+            resp = self._client.post(
+                f"{self._api}/statuses/{head_sha}",
+                headers=self._headers,
+                json={
+                    "state": _STATUS_STATES.get(conclusion, "success"),
+                    "name": "lgtmaybe",
+                    "description": title[:255],
+                },
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — a status must never fail a review
+            _log.warning("creating commit status failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _partition_findings(
+        self,
+        findings: list[ReviewFinding],
+        commentable: CommentableLines,
+    ) -> tuple[
+        list[tuple[dict[str, Any], ReviewFinding]],
+        list[ReviewFinding],
+        list[ReviewFinding],
+    ]:
+        """Split findings into positioned discussions, body-demoted, and broad.
+
+        Same rule as the other adapters — a finding goes inline only when it is
+        confidently anchored AND lands on a real commentable diff line — with
+        GitLab's position object substituted at the end. A finding is also
+        demoted when the diff refs are unknown, since a position without them is
+        rejected by the API.
+        """
+        inline: list[tuple[dict[str, Any], ReviewFinding]] = []
+        demoted: list[ReviewFinding] = []
+        broad: list[ReviewFinding] = []
+        for f in findings:
+            if f.broad:
+                broad.append(f)
+                continue
+            if not f.anchored or (f.path, f.line, f.side) not in commentable:
+                demoted.append(f)
+                continue
+            if self._diff_refs is None:
+                demoted.append(f)
+                continue
+            position: dict[str, Any] = {
+                **self._diff_refs,
+                "position_type": "text",
+                "old_path": f.path,
+                "new_path": f.path,
+            }
+            # RIGHT is a line in the new file, LEFT a line in the old one.
+            if f.side == "LEFT":
+                position["old_line"] = f.line
+            else:
+                position["new_line"] = f.line
+            inline.append((position, f))
+        return inline, demoted, broad
+
+    def _post_discussion(self, position: dict[str, Any], body: str) -> None:
+        """Open one positioned discussion.
+
+        Best-effort per finding: GitLab rejects a position whose line no longer
+        exists in the current diff with a 400, and one unplaceable finding must
+        not take the rest of the review down with it.
+        """
+        try:
+            resp = self._client.post(
+                f"{self._mr_api}/discussions",
+                headers=self._headers,
+                json={"body": body, "position": position},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # noqa: BLE001 — one rejected position is not fatal
+            _log.warning("posting discussion at %s failed: %s", position.get("new_path"), exc)
+
+    def _resolve_fixed_threads(self) -> None:
+        """Reply in, then resolve, every thread the caller validated as fixed.
+
+        Gated on the allowlist being installed: with no validation step there is
+        no evidence a finding was fixed, and silently closing it would be worse
+        than leaving it open.
+        """
+        if not self._validated_fixed_thread_ids:
+            return
+        for thread_id in sorted(self._validated_fixed_thread_ids):
+            try:
+                self.reply_in_thread(thread_id, _RESOLVED_REPLY)
+                resp = self._client.put(
+                    f"{self._mr_api}/discussions/{thread_id}",
+                    headers=self._headers,
+                    json={"resolved": True},
+                    timeout=_TIMEOUT,
+                )
+                resp.raise_for_status()
+            except Exception as exc:  # noqa: BLE001 — resolving never fails a review
+                _log.warning("resolving thread %s failed: %s", thread_id, exc)
+
+    def _existing_finding_keys(self) -> set[str]:
+        """Every hidden finding id already posted on this MR by us."""
+        keys: set[str] = set()
+        try:
+            for discussion in self._discussions():
+                for note in discussion.get("notes") or []:
+                    keys |= finding_keys(note.get("body") or "")
+        except Exception as exc:  # noqa: BLE001 — dedupe is best-effort
+            _log.warning("reading existing discussions failed: %s", exc)
+        return keys
+
+    def _discussions(self) -> list[dict[str, Any]]:
+        return self._paginate(f"{self._mr_api}/discussions")
+
+    def _upsert_note(self, body: str, family: str) -> None:
+        """Edit our previous note in this marker family, or post a new one."""
+        existing_id = self._find_note(family)
+        if existing_id is not None:
+            resp = self._client.put(
+                f"{self._mr_api}/notes/{existing_id}",
+                headers=self._headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+        else:
+            resp = self._client.post(
+                f"{self._mr_api}/notes",
+                headers=self._headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+        resp.raise_for_status()
+
+    def _find_note(self, family: str) -> int | None:
+        """The id of our existing note in ``family``, or None."""
+        for note in self._paginate(f"{self._mr_api}/notes"):
+            if family in (note.get("body") or ""):
+                note_id = note.get("id")
+                return int(note_id) if note_id is not None else None
+        return None
+
+    def _fetch_mr_diff(self) -> str:
+        """The merge request's unified diff."""
+        resp = self._client.get(
+            f"{self._mr_api}/raw_diffs", headers=self._headers, timeout=_TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.text
+
+    def _fetch_commit_subjects(self) -> list[str]:
+        """Commit subject lines, feeding the intent lens. Never fails the review."""
+        try:
+            return [
+                title
+                for item in self._paginate(f"{self._mr_api}/commits")
+                if (title := (item.get("title") or "").strip())
+            ]
+        except Exception as exc:  # noqa: BLE001 — intent is a nice-to-have
+            _log.warning("fetching commit subjects failed: %s", exc)
+            return []
+
+    def _get_file_content(self, path: str, ref: str) -> str | None:
+        """One file's text at ``ref``, or None when absent or undecodable."""
+        try:
+            resp = self._client.get(
+                f"{self._api}/repository/files/{quote(path, safe='')}",
+                headers=self._headers,
+                params={"ref": ref},
+                timeout=_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                return None
+            content = resp.json().get("content")
+            if not isinstance(content, str):
+                return None
+            return base64.b64decode(content).decode("utf-8")
+        except Exception as exc:  # noqa: BLE001 — a missing file is not fatal
+            _log.debug("fetching %s failed: %s", path, exc)
+            return None
+
+    def _get_json(self, url: str) -> Any:
+        resp = self._client.get(url, headers=self._headers, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _paginate(self, url: str) -> list[dict[str, Any]]:
+        """Every page of a GitLab list endpoint, flattened.
+
+        Stops on the first short page rather than reading ``X-Next-Page``, so a
+        response without pagination headers (and a mocked one) behaves the same.
+        """
+        items: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = self._client.get(
+                url,
+                headers=self._headers,
+                params={"page": page, "per_page": _PAGE_LIMIT},
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            batch = resp.json()
+            if not isinstance(batch, list) or not batch:
+                return items
+            items.extend(batch)
+            if len(batch) < _PAGE_LIMIT:
+                return items
+            page += 1
+
+
+def _marker_values(body: str, family: str) -> list[str]:
+    """Every hidden id of one marker family carried by a comment body."""
+    import re
+
+    return re.findall(rf"<!-- {re.escape(family)}:([0-9a-f]+) -->", body)

--- a/tests/core/test_forge.py
+++ b/tests/core/test_forge.py
@@ -78,18 +78,24 @@ class TestTokenEnvVar:
 class TestGatewayRegistry:
     """Which forges lgtmaybe can actually build a gateway for."""
 
-    @pytest.mark.parametrize("forge", [Forge.github, Forge.gitea])
-    def test_implemented_forges_are_registered(self, forge: Forge) -> None:
+    @pytest.mark.parametrize("forge", list(Forge))
+    def test_every_forge_the_parser_knows_can_be_built(self, forge: Forge) -> None:
+        """A URL lgtmaybe parses but cannot act on would be a dead end."""
         from lgtmaybe.cli import gateway_builder
 
         assert gateway_builder(forge) is not None
 
-    @pytest.mark.parametrize("forge", [Forge.gitlab])
-    def test_an_unimplemented_forge_says_so_by_name(self, forge: Forge) -> None:
-        """A recognised-but-unbuilt forge must not read as an unparseable URL."""
+    def test_the_gitlab_builder_carries_the_nested_project_path(self) -> None:
+        """GitLab groups nest, and the whole path addresses the project."""
         from lgtmaybe.cli import gateway_builder
+        from lgtmaybe.core.models import ReviewConfig
 
-        assert gateway_builder(forge) is None
+        build = gateway_builder(Forge.gitlab)
+        assert build is not None
+        located = parse_pr_url("https://gl.internal/grp/sub/proj/-/merge_requests/9")
+        gateway = build(located, "token", ReviewConfig(provider="ollama", model="llama3"))
+        assert gateway._project == "grp%2Fsub%2Fproj"
+        assert "gl.internal" in gateway._api
 
     def test_the_gitea_builder_carries_the_host_through(self) -> None:
         """Self-hosted is the norm on Gitea, so the API base cannot be a constant."""

--- a/tests/gitlab/test_ci_entrypoint.py
+++ b/tests/gitlab/test_ci_entrypoint.py
@@ -1,0 +1,62 @@
+"""GitLab CI has no event payload file, so the entrypoint reads CI_* variables.
+
+This is the one place GitLab cannot reuse the GitHub Actions entrypoint: there
+is no ``GITHUB_EVENT_PATH`` to open and no ``INPUT_*`` convention, so the merge
+request under review has to be identified from the predefined CI variables.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.cli import mr_url_from_ci_env
+from lgtmaybe.core.forge import Forge, parse_pr_url
+
+ENV = {
+    "CI_SERVER_HOST": "gitlab.example.com",
+    "CI_PROJECT_PATH": "group/sub/project",
+    "CI_MERGE_REQUEST_IID": "7",
+}
+
+
+def _set(monkeypatch: pytest.MonkeyPatch, **overrides: str | None) -> None:
+    for key in ("CI_SERVER_HOST", "CI_PROJECT_PATH", "CI_MERGE_REQUEST_IID", "CI_SERVER_URL"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in {**ENV, **overrides}.items():
+        if value is not None:
+            monkeypatch.setenv(key, value)
+
+
+class TestMRUrlFromCIEnv:
+    def test_builds_a_parseable_gitlab_merge_request_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set(monkeypatch)
+        url = mr_url_from_ci_env()
+
+        assert url == "https://gitlab.example.com/group/sub/project/-/merge_requests/7"
+        located = parse_pr_url(url)
+        assert located.forge is Forge.gitlab
+        assert located.repo == "group/sub/project", "the nested group path survives"
+        assert located.number == 7
+
+    def test_falls_back_to_the_server_url_when_the_host_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set(monkeypatch, CI_SERVER_HOST=None, CI_SERVER_URL="https://gl.internal")
+        assert mr_url_from_ci_env() == "https://gl.internal/group/sub/project/-/merge_requests/7"
+
+    def test_a_pipeline_that_is_not_for_a_merge_request_says_so(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A branch pipeline has no MR iid; that is a config mistake worth naming."""
+        _set(monkeypatch, CI_MERGE_REQUEST_IID=None)
+
+        with pytest.raises(Exception, match="CI_MERGE_REQUEST_IID"):
+            mr_url_from_ci_env()
+
+    def test_a_missing_project_path_says_so(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set(monkeypatch, CI_PROJECT_PATH=None)
+
+        with pytest.raises(Exception, match="CI_PROJECT_PATH"):
+            mr_url_from_ci_env()

--- a/tests/gitlab/test_gateway.py
+++ b/tests/gitlab/test_gateway.py
@@ -1,0 +1,450 @@
+"""Tests for GitLabGateway — respx-mocked GitLab REST API.
+
+GitLab is the forge that differs most: merge requests, not pull requests;
+discussions positioned by old/new path and line rather than line + side; and no
+batched review object at all, so each finding is its own discussion.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from lgtmaybe.core.models import ReviewFinding, Severity
+from lgtmaybe.gitlab import GitLabGateway
+
+HOST = "gitlab.example.com"
+REPO = "group/sub/project"
+MR_IID = 7
+TOKEN = "glpat-test"
+
+# GitLab addresses a project by its URL-encoded path.
+PROJECT = "group%2Fsub%2Fproject"
+API = f"https://{HOST}/api/v4/projects/{PROJECT}"
+MR_URL = f"{API}/merge_requests/{MR_IID}"
+
+DIFF = """diff --git a/app.py b/app.py
+index 111..222 100644
+--- a/app.py
++++ b/app.py
+@@ -1,3 +1,4 @@
+ import os
++password = "hunter2"
+ 
+ def main():
+"""
+
+MR_DETAIL = {
+    "title": "Add a thing",
+    "description": "This adds the thing.",
+    "source_branch": "feature-branch",
+    "diff_refs": {"base_sha": "base123", "head_sha": "head456", "start_sha": "start789"},
+}
+
+FINDING = ReviewFinding(
+    path="app.py",
+    line=2,
+    side="RIGHT",
+    severity=Severity.high,
+    title="Hardcoded password",
+    body="Move it to the environment.",
+    anchor='password = "hunter2"',
+    anchored=True,
+)
+
+
+def _gateway(client: httpx.Client | None = None) -> GitLabGateway:
+    return GitLabGateway(
+        host=HOST,
+        repo=REPO,
+        pr_number=MR_IID,
+        token=TOKEN,
+        client=client if client is not None else httpx.Client(),
+    )
+
+
+def _stub_context_routes() -> None:
+    respx.get(f"{MR_URL}/raw_diffs").mock(return_value=httpx.Response(200, text=DIFF))
+    respx.get(MR_URL).mock(return_value=httpx.Response(200, json=MR_DETAIL))
+    respx.route(method="GET", url__startswith=f"{MR_URL}/diffs").mock(
+        return_value=httpx.Response(200, json=[{"new_path": "app.py", "old_path": "app.py"}])
+    )
+    respx.route(method="GET", url__startswith=f"{MR_URL}/commits").mock(
+        return_value=httpx.Response(200, json=[{"title": "add a thing"}])
+    )
+    respx.route(method="GET", url__startswith=f"{API}/repository/files/").mock(
+        return_value=httpx.Response(200, json={"content": "aW1wb3J0IG9z", "encoding": "base64"})
+    )
+
+
+def _stub_post_routes() -> None:
+    respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={"id": 1}))
+
+
+class TestProjectAddressing:
+    def test_the_project_path_is_url_encoded(self) -> None:
+        """GitLab groups nest, so the path needs encoding to survive the URL."""
+        assert _gateway()._project == PROJECT
+
+    def test_self_hosted_hosts_are_carried_through(self) -> None:
+        assert _gateway()._api.startswith(f"https://{HOST}/api/v4/")
+
+
+class TestGetPRContext:
+    @respx.mock
+    def test_returns_the_diff_and_both_shas(self) -> None:
+        _stub_context_routes()
+        ctx = _gateway().get_pr_context()
+
+        assert ctx.diff == DIFF
+        assert ctx.base_sha == "base123"
+        assert ctx.head_sha == "head456"
+        assert ctx.changed_files == ["app.py"]
+
+    @respx.mock
+    def test_carries_the_stated_intent_for_the_intent_lens(self) -> None:
+        _stub_context_routes()
+        ctx = _gateway().get_pr_context()
+
+        assert ctx.title == "Add a thing"
+        assert ctx.description == "This adds the thing."
+        assert ctx.commit_messages == ["add a thing"]
+        assert ctx.head_branch == "feature-branch"
+
+    @respx.mock
+    def test_decodes_base64_file_contents_for_hunk_expansion(self) -> None:
+        _stub_context_routes()
+        assert _gateway().get_pr_context().file_contents == {"app.py": "import os"}
+
+    @respx.mock
+    def test_missing_diff_refs_fail_loudly(self) -> None:
+        respx.get(f"{MR_URL}/raw_diffs").mock(return_value=httpx.Response(200, text=DIFF))
+        respx.get(MR_URL).mock(return_value=httpx.Response(200, json={"title": "no refs"}))
+
+        with pytest.raises(RuntimeError, match="base/head SHA"):
+            _gateway().get_pr_context()
+
+
+class TestPostReview:
+    @respx.mock
+    def test_each_finding_becomes_its_own_positioned_discussion(self) -> None:
+        """GitLab has no batched review object — a discussion per finding."""
+        _stub_post_routes()
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={"id": "abc"})
+        )
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.post_review([FINDING], "1 finding", diff=DIFF)
+
+        assert created.called
+        payload = json.loads(created.calls[0].request.content)
+        assert payload["position"]["new_path"] == "app.py"
+        assert payload["position"]["new_line"] == 2
+        assert payload["position"]["position_type"] == "text"
+        assert payload["position"]["base_sha"] == "base123"
+        assert payload["position"]["head_sha"] == "head456"
+        assert payload["position"]["start_sha"] == "start789"
+        assert "Hardcoded password" in payload["body"]
+
+    @respx.mock
+    def test_a_left_side_finding_positions_on_the_old_line(self) -> None:
+        _stub_post_routes()
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={"id": "abc"})
+        )
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.post_review(
+            [FINDING.model_copy(update={"side": "LEFT", "line": 1, "anchor": "import os"})],
+            "1 finding",
+            diff=DIFF,
+        )
+
+        position = json.loads(created.calls[0].request.content)["position"]
+        assert position["old_line"] == 1
+        assert "new_line" not in position
+
+    @respx.mock
+    def test_the_summary_note_is_upserted_so_a_rerun_edits_it(self) -> None:
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(
+                200, json=[{"id": 55, "body": "old summary\n\n<!-- lgtmaybe -->"}]
+            )
+        )
+        edit = respx.put(f"{MR_URL}/notes/55").mock(return_value=httpx.Response(200, json={}))
+        create = respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+
+        _gateway().post_review([], "👍 LGTM!", diff=DIFF)
+
+        assert edit.called
+        assert not create.called
+
+    @respx.mock
+    def test_a_finding_already_discussed_is_not_posted_again(self) -> None:
+        from lgtmaybe.core.findings import finding_fingerprint
+
+        already = finding_fingerprint("app.py", "Hardcoded password")
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "d1",
+                        "notes": [
+                            {
+                                "id": 9,
+                                "body": f"old\n<!-- lgtmaybe-finding:{already} -->",
+                                "resolved": False,
+                                "position": {"new_path": "app.py"},
+                            }
+                        ],
+                    }
+                ],
+            )
+        )
+        respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={})
+        )
+
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.post_review([FINDING], "1 finding", diff=DIFF)
+
+        assert not created.called
+
+    @respx.mock
+    def test_an_unanchorable_finding_is_demoted_into_the_summary(self) -> None:
+        _stub_post_routes()
+        create = respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={})
+        )
+
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.post_review(
+            [FINDING.model_copy(update={"line": 999, "anchored": False})], "1 finding", diff=DIFF
+        )
+
+        body = json.loads(create.calls[0].request.content)["body"]
+        assert "Additional findings" in body
+        assert not created.called
+
+
+class TestThreadResolution:
+    """GitLab discussions resolve over plain REST — no GraphQL, unlike GitHub."""
+
+    DISCUSSIONS = [
+        {
+            "id": "thread-1",
+            "notes": [
+                {
+                    "id": 11,
+                    "body": "a finding\n<!-- lgtmaybe-finding:aaaaaaaaaaaa -->",
+                    "resolved": False,
+                    "resolvable": True,
+                    "position": {"new_path": "app.py"},
+                }
+            ],
+        },
+        {
+            "id": "thread-2",
+            "notes": [
+                {
+                    "id": 22,
+                    "body": "a human comment",
+                    "resolved": False,
+                    "resolvable": True,
+                    "position": {"new_path": "app.py"},
+                }
+            ],
+        },
+    ]
+
+    @respx.mock
+    def test_lists_only_our_own_unresolved_findings(self) -> None:
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=self.DISCUSSIONS)
+        )
+        active = _gateway().list_active_findings()
+
+        assert [f.thread_id for f in active] == ["thread-1"], "a human's thread is not ours"
+        assert active[0].fingerprint == "aaaaaaaaaaaa"
+        assert active[0].path == "app.py"
+
+    @respx.mock
+    def test_a_resolved_thread_is_not_active(self) -> None:
+        resolved = [{**self.DISCUSSIONS[0]}]
+        resolved[0]["notes"] = [{**resolved[0]["notes"][0], "resolved": True}]
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=resolved)
+        )
+        assert _gateway().list_active_findings() == []
+
+    @respx.mock
+    def test_only_validated_threads_are_replied_to_and_resolved(self) -> None:
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=self.DISCUSSIONS)
+        )
+        respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+        reply = respx.post(f"{MR_URL}/discussions/thread-1/notes").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        resolve = respx.put(f"{MR_URL}/discussions/thread-1").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        other = respx.put(f"{MR_URL}/discussions/thread-2").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.list_active_findings()
+        gateway.set_validated_fixed_threads({"thread-1"})
+        gateway.post_review([], "👍 LGTM!", diff=DIFF)
+
+        assert reply.called, "a resolved finding is explained before it is closed"
+        assert resolve.called
+        assert not other.called, "a thread nobody validated stays open"
+
+    @respx.mock
+    def test_an_empty_allowlist_resolves_nothing(self) -> None:
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=self.DISCUSSIONS)
+        )
+        respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+        resolve = respx.put(f"{MR_URL}/discussions/thread-1").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.list_active_findings()
+        gateway.set_validated_fixed_threads(set())
+        gateway.post_review([], "👍 LGTM!", diff=DIFF)
+
+        assert not resolve.called
+
+    @respx.mock
+    def test_counts_open_finding_threads_for_the_disclosure_line(self) -> None:
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(200, json=self.DISCUSSIONS)
+        )
+        assert _gateway().count_open_finding_threads() == 1
+
+
+class TestCapabilities:
+    def test_declares_what_gitlab_can_serve(self) -> None:
+        from lgtmaybe.core import ports
+
+        gateway = GitLabGateway.__new__(GitLabGateway)
+        for name in (
+            "SupportsFileContents",
+            "SupportsDescribe",
+            "SupportsDiagram",
+            "SupportsLabels",
+            "SupportsChecks",
+            "SupportsThreadResolution",
+        ):
+            assert isinstance(gateway, getattr(ports, name)), name
+
+    def test_does_not_claim_incremental_review(self) -> None:
+        """Reviewing an increment needs a diff between two commits; that comes later."""
+        from lgtmaybe.core import ports
+
+        assert not isinstance(GitLabGateway.__new__(GitLabGateway), ports.SupportsIncremental)
+
+
+class TestLabels:
+    @respx.mock
+    def test_labels_are_added_in_one_update(self) -> None:
+        """GitLab takes labels as a comma-separated field on the MR itself."""
+        updated = respx.put(MR_URL).mock(return_value=httpx.Response(200, json={}))
+        _gateway().apply_pr_labels(["review-effort/2", "possible-security-issue"])
+
+        payload = json.loads(updated.calls[0].request.content)
+        assert payload["add_labels"] == "review-effort/2,possible-security-issue"
+
+    @respx.mock
+    def test_a_label_failure_never_fails_the_review(self) -> None:
+        respx.put(MR_URL).mock(return_value=httpx.Response(500))
+        _gateway().apply_pr_labels(["anything"])  # must not raise
+
+    def test_no_labels_makes_no_request(self) -> None:
+        with respx.mock:
+            _gateway().apply_pr_labels([])
+            assert not respx.calls
+
+
+class TestCheckRun:
+    @respx.mock
+    @pytest.mark.parametrize(
+        ("conclusion", "state"),
+        [("success", "success"), ("failure", "failed"), ("cancelled", "canceled")],
+    )
+    def test_maps_a_conclusion_onto_gitlabs_state_vocabulary(
+        self, conclusion: str, state: str
+    ) -> None:
+        posted = respx.post(f"{API}/statuses/head456").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        _gateway().create_check_run("head456", conclusion, "lgtmaybe", "summary")
+
+        assert json.loads(posted.calls[0].request.content)["state"] == state
+
+    @respx.mock
+    def test_a_status_failure_never_fails_the_review(self) -> None:
+        respx.post(f"{API}/statuses/head456").mock(return_value=httpx.Response(500))
+        _gateway().create_check_run("head456", "success", "t", "s")  # must not raise
+
+
+class TestResilience:
+    @respx.mock
+    def test_a_rejected_position_does_not_take_the_review_down(self) -> None:
+        """GitLab 400s a position whose line no longer exists in the current diff."""
+        _stub_post_routes()
+        respx.post(f"{MR_URL}/discussions").mock(return_value=httpx.Response(400))
+        note = respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+        gateway.post_review([FINDING], "1 finding", diff=DIFF)  # must not raise
+
+        assert note.called, "the summary still posts"
+
+    @respx.mock
+    def test_findings_are_demoted_when_the_diff_refs_are_unknown(self) -> None:
+        """A position without the three SHAs is rejected, so do not build one."""
+        _stub_post_routes()
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        note = respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+
+        _gateway().post_review([FINDING], "1 finding", diff=DIFF)
+
+        assert not created.called
+        assert "Hardcoded password" in json.loads(note.calls[0].request.content)["body"]


### PR DESCRIPTION
Phase 2, the last of the three — GitLab support, on the seam from #480 and alongside the Gitea adapter from #481.

The review itself is untouched — same lenses, same reflection pass, same findings — because none of that ever depended on the host.

## Where GitLab actually differs

Gitea was a near-copy of GitHub. GitLab is not, and these are the differences that made it a separate adapter rather than a base-URL switch:

**No batched review object.** GitHub and Gitea both submit one review carrying every inline comment. GitLab has no such thing, so each finding is posted as its own *discussion*.

**Positions carry the diff refs.** A discussion is anchored by a `position` object naming `old_path`/`new_path`, `old_line`/`new_line`, **and** the merge request's `base_sha`/`start_sha`/`head_sha`. lgtmaybe keeps GitHub's RIGHT/LEFT vocabulary internally and translates here. A finding is demoted into the summary when the diff refs are unknown — a position without them is rejected outright, so building one would just be a guaranteed 400.

**Threads resolve over plain REST.** Resolving a GitHub thread needs GraphQL; on GitLab it's a `PUT` on the discussion. So this adapter *does* offer resolve-on-fix, which the Gitea one cannot. It resolves only what the caller's follow-up validation confirmed fixed — GitLab exposes no "the lines moved" signal, so an unvalidated close would have no evidence behind it, and an empty allowlist resolves nothing.

**Projects are addressed by encoded path.** `group/subgroup/project` → `group%2Fsubgroup%2Fproject`, which is what lets an arbitrarily nested group path travel in one URL segment.

**Its own CI entrypoint.** GitHub and Gitea Actions share `action` — Gitea reimplements the same env contract. GitLab CI has neither an event payload file nor `INPUT_*`, so it gets a `gitlab-ci` command reading the predefined `CI_*` variables. A job running on a branch pipeline is named as the cause (`CI_MERGE_REQUEST_IID is not set`) with the `rules:` fix, rather than failing obscurely.

## Resilience

One rejected position doesn't lose the other findings or the summary; labels and commit statuses swallow their own errors; resolving never fails a review. All four are pinned by tests.

## Capabilities

Claimed: `SupportsFileContents`, `SupportsDescribe`, `SupportsDiagram`, `SupportsLabels`, `SupportsChecks`, `SupportsThreadResolution`.

Not claimed: `SupportsIncremental`. GitLab's compare endpoint returns per-file diffs that could be reassembled into a unified diff, so this is a **"not yet", not a "cannot"** — unlike Gitea, where the API genuinely can't serve it. Until it's built and measured, every run is a full review, and a test asserts the capability isn't claimed.

## What's included

- `src/lgtmaybe/gitlab/gateway.py` — the adapter
- `cli.mr_url_from_ci_env` + the `gitlab-ci` command
- `tests/gitlab/` — 31 tests (adapter, thread resolution, capabilities, resilience, CI entrypoint)
- `openspec/specs/gitlab-posting/` — spec + anchors
- `examples/gitlab/.gitlab-ci.yml` and `docs/how-to/review-on-gitlab.md`
- `CLAUDE.md` — the forge section now covers all three adapters and both entrypoints

## Verification

- Full gate green: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest` — 2341 passed, 3 skipped (2298 before this change).
- Spec anchors resolve (`tests/specs`, 17 passed); `openspec validate --specs` — 12 passed, 0 failed.

Not yet exercised against a live GitLab instance — covered by respx-mocked tests against the documented API shapes, same as the GitHub and Gitea suites. A live smoke test against gitlab.com would be a reasonable follow-up, alongside incremental review.

## Fork safety

Unchanged and holds for the same reason on all three hosts: lgtmaybe never checks out or executes change-request code. It reads the diff through the API and treats it as untrusted input throughout — which is why the example job sets `GIT_STRATEGY: none` and never clones the repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KoK6xvv72d6x1Z5qaCk37)_