### PR TITLE
docs: cover GitLab and Gitea across the documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,8 +16,9 @@ each requirement bound to the code it describes by ast-grep anchors (see
 ## Design in one breath
 
 lgtmaybe is **hexagonal** (ports & adapters). The core defines three ports in
-`core/ports.py`; the outside world (litellm, GitHub, git) plugs in as adapters.
-The engine depends only on the ports, so providers and gateways swap without it
+`core/ports.py`; the outside world (litellm, the code hosts, git) plugs in as
+adapters. The engine depends only on the ports, so **which model reviews** and
+**which host is posted to** are independent choices that swap without it
 noticing — and tests inject fakes instead of patching.
 
 ```
@@ -34,16 +35,20 @@ noticing — and tests inject fakes instead of patching.
    │          cached preamble+diff prefix) → parse  │
    │        → merge/dedupe → reflect → filter       │
    └───────┬───────────────────────────┬───────────┘
-           │ ProviderClient            │ GitHubGateway
+           │ ProviderClient            │ ReviewGateway
            ▼                           ▼
-   providers/ (litellm)        github/ (REST)  ·  local/ (git)
+   providers/ (litellm)        github/ · gitlab/ · gitea/
+           │                    (REST)  ·  local/ (git)
            │                           │
            ▼                           ▼
-   OpenAI · Anthropic ·         GitHub PR: inline
-   OpenRouter · z.ai ·          comments + summary
+   OpenAI · Anthropic ·         inline comments + summary
+   OpenRouter · z.ai ·          on a pull / merge request
    Bedrock · Vertex · Azure ·   (or CLI stdout)
    Ollama · OpenAI-compatible
 ```
+
+Neither column knows about the other, so any of the nine model backends can
+review a change on any of the three hosts.
 
 ## Project layout
 
@@ -53,9 +58,13 @@ lgtmaybe/
 │   ├── __main__.py          # `python -m lgtmaybe` / Docker ENTRYPOINT → Click CLI
 │   │
 │   ├── core/                # the hexagon's centre — no outward dependencies
-│   │   ├── ports.py         #   ProviderClient · GitHubGateway · ReviewEngine (frozen)
+│   │   ├── ports.py         #   ProviderClient · ReviewGateway · Supports* · ReviewEngine
 │   │   ├── models.py        #   pydantic data contracts (ReviewConfig, ReviewFinding, …)
+│   │   ├── forge.py         #   which code host: Forge · PRLocator · URL parsing · tokens
 │   │   ├── diffparse.py     #   unified-diff primitives (file split, hunk headers)
+│   │   ├── diff.py          #   commentable-line index · is_reviewable() skip filter
+│   │   ├── findings.py      #   stable hidden finding ids (fingerprint · identity)
+│   │   ├── comment.py       #   the Markdown every host posts (badges, demoted sections)
 │   │   └── logging.py       #   structured JSON logs with secret redaction
 │   │
 │   ├── engine/              # the review pipeline (adapter-agnostic)
@@ -74,9 +83,11 @@ lgtmaybe/
 │   │   ├── credentials.py   #   chain-of-responsibility credential resolver
 │   │   └── constants.py     #   shared provider defaults (e.g. ollama base URL)
 │   │
-│   ├── github/              # GitHub adapter (the GitHubGateway side)
+│   ├── github/              # GitHub adapter (a ReviewGateway) — the complete one
 │   │   ├── rest_gateway.py  #   fetch PR context · post review · in-thread replies
-│   │   └── diff.py          #   commentable-line index · is_reviewable() skip filter
+│   │   └── checkout.py      #   read-only base-branch clone for symbol resolution
+│   ├── gitlab/              # GitLab adapter — discussions, REST thread resolution
+│   ├── gitea/               # Gitea adapter — immutable reviews, pre-post de-dupe
 │   │
 │   ├── lenses/              # bundled opt-in lens packs (design/robustness/interface/frontend), loaded via pack:<name>
 │   ├── local/               # local-mode adapter: build a PRContext from `git`
@@ -94,7 +105,9 @@ lgtmaybe/
 ├── tests/                   # mirrors src/ ; fakes in tests/fakes/, snapshots, fixtures
 ├── evals/                   # offline scoring harness against fixture diffs
 ├── docs/                    # MkDocs site: tutorial / how-to / reference / explanation
-├── examples/workflows/      # one ready-to-copy GitHub workflow per posting provider
+├── examples/workflows/      # one ready-to-copy GitHub workflow per model provider
+├── examples/gitlab/         # ready-to-copy .gitlab-ci.yml
+├── examples/gitea/          # ready-to-copy Gitea Actions workflow
 │
 ├── action.yml              # composite Action: keyless OIDC/WIF auth → docker run GHCR image
 ├── Dockerfile              # lean runtime image (uv sync --no-dev --frozen)
@@ -124,6 +137,31 @@ backends, each with its own native auth (resolved by the credential chain in
 **The wedge:** first-class **Bedrock + Vertex + Azure with keyless OIDC/WIF**, so cloud
 reviews need no static keys in GitHub secrets. The `LiteLLMProvider` adds retries
 (exponential backoff + jitter, 4 attempts) and an optional `--fallback-model`.
+
+## Code hosts
+
+A second axis, independent of the model provider: which forge the review is
+posted to. `core/forge.py` parses a change-request URL into a `PRLocator`
+(forge + host + repo + number) and names the token variable; `cli` maps the
+resolved forge to its adapter.
+
+| Forge | URL shape | Token | Entrypoint |
+|---|---|---|---|
+| GitHub | `/pull/42` | `GITHUB_TOKEN` | `lgtmaybe action` (GitHub Actions) |
+| GitLab | `/-/merge_requests/42` | `GITLAB_TOKEN` | `lgtmaybe gitlab-ci` (CI_* vars) |
+| Gitea | `/pulls/42` | `GITEA_TOKEN` | `lgtmaybe action` (same runtime as GitHub) |
+
+`ReviewGateway` requires only three methods — fetch context, post a review, post
+a comment. Everything richer (incremental review, thread resolution, labels,
+checks, feedback, file reads) is an optional `Supports*` protocol the CLI probes
+for and skips when absent. That is what lets an adapter be **honest** about what
+its host cannot do rather than failing at run time: Gitea claims neither
+incremental review nor thread resolution, and GitLab claims thread resolution
+but not (yet) incremental.
+
+The engine never sees a gateway at all — it takes a `PRContext` and returns
+findings — which is why `local/` can produce one from `git` with no host
+involved.
 
 ## Components inside the application
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -44,7 +44,7 @@ needs. Tuning knobs earn their visibility when the user signals intent
 
 1. **First-run local dev** — installed via pip/brew, wants findings on their
    branch in under two minutes. Touches: `config init`, `review`.
-2. **CI adopter** — wires the GitHub Action; configures via `action.yml`
+2. **CI adopter** — wires the GitHub Action, a GitLab CI job, or Gitea Actions; configures via `action.yml` or CLI flags
    inputs and `.lgtmaybe.yml`. Mostly out of scope here (the Action surface is
    fine), but benefits from the same key curation in docs.
 3. **Power tuner** — slow local model, custom endpoint, eval-driven. Needs

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 # lgtmaybe
 
-Provider-agnostic PR reviewer. Seven hosted providers, local ollama, and any
-OpenAI-compatible endpoint — one flag, no static keys for cloud providers. Posts
-inline review comments and a summary.
+Provider-agnostic code reviewer for **GitHub, GitLab, and Gitea**. Seven hosted
+model providers, local ollama, and any OpenAI-compatible endpoint — one flag, no
+static keys for cloud providers. Posts inline review comments and a summary.
 
 📖 **Full documentation:** <https://lgtmaybe.coles.codes/>
 
 ## What it reviews
 
-lgtmaybe fetches the PR diff from the GitHub API and reviews the lines a pull
-request changes. It never checks out or runs your code. To judge each change in
+lgtmaybe fetches the diff through your code host's API and reviews the lines a
+pull request (or merge request) changes. It never checks out or runs your code. To judge each change in
 context it also reads a few surrounding lines from the file. It only ever
 comments on what the PR actually changed, not the whole repository.
 
@@ -100,8 +100,8 @@ reviewing files whole, with its *worst* run matching the whole-file method's
 title, an explanation, and an optional suggested fix — so it renders the same
 everywhere:
 
-- **On a GitHub PR** — an inline comment on the exact changed line for each finding, plus one summary comment naming the model used. Re-running updates the same comments instead of duplicating them, auto-resolves a conversation once its finding is fixed, and a clean PR gets a 👍 **LGTM!**.
-- **On the CLI** — `lgtmaybe review` reads your local `git` diff and prints the findings (a readable listing, a JSON array with `--json`, or `--format agent` for an AI coding agent to read and apply); nothing is posted to GitHub.
+- **On a pull or merge request** — an inline comment on the exact changed line for each finding, plus one summary comment naming the model used. Re-running updates the summary instead of duplicating it, never repeats a finding it already posted, and a clean change gets a 👍 **LGTM!**. On GitHub and GitLab a conversation auto-resolves once its finding is verified fixed; Gitea has no thread-resolution API, so its comments stay open. See [Where it posts](#where-it-posts).
+- **On the CLI** — `lgtmaybe review` reads your local `git` diff and prints the findings (a readable listing, a JSON array with `--json`, or `--format agent` for an AI coding agent to read and apply); nothing is posted anywhere.
 
 Beyond the review, slash commands on the PR route to the same engine: **`/review`** and **`/improve`** post (or refresh) the review, **`/ask <question>`** answers a question about the change in-thread, **`/describe`** (`auto_describe`) posts a **structured description**, and **`/diagram`** (`auto_diagram`) posts a **compact change diagram** — an automatically laid-out Mermaid flowchart of the components the PR touches, with changes marked on nodes, plus a Mermaid **sequence diagram** of the run-time flow the change alters (omitted when there isn't one), both rendered natively in the comment, with a text fallback that also prints from `lgtmaybe diagram` locally. See [Generate a change diagram](docs/how-to/generate-a-change-diagram.md).
 
@@ -143,8 +143,9 @@ pull request. See
 
 `lgtmaybe --help` lists every command with usage examples; `lgtmaybe review --help`
 shows the full option reference. To post reviews on real pull requests, wire up
-the
-[GitHub Action](#use-as-a-github-action). See
+the [GitHub Action](#use-as-a-github-action) — or, on another host,
+[GitLab CI](docs/how-to/review-on-gitlab.md) or
+[Gitea Actions](docs/how-to/review-on-gitea.md). See
 [Getting Started](docs/tutorial/getting-started.md) for the full walkthrough.
 
 > **Picking a model:** compare cloud and local models separately. In the current
@@ -168,6 +169,29 @@ the
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint | [Azure](docs/how-to/review-with-azure.md) |
 | `ollama` | None — local only, zero cost | [ollama](docs/how-to/run-locally-with-ollama.md) |
 | `openai-compatible` | Any OpenAI `/v1` endpoint via `--api-base` (DeepSeek, llama.cpp, LM Studio, vLLM). Key optional — `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, or none for local servers | [Local & OpenAI-compatible](docs/how-to/use-a-custom-openai-compatible-endpoint.md) |
+
+## Where it posts
+
+The model provider and the code host are independent choices — any provider
+above works on any host below.
+
+| Host | How it runs | Token | Guide |
+|---|---|---|---|
+| GitHub | GitHub Action (`MattJColes/lgtmaybe@v2`) | `GITHUB_TOKEN` | [GitHub Action](docs/how-to/use-as-github-action.md) |
+| GitLab | GitLab CI job (`lgtmaybe gitlab-ci`) | `GITLAB_TOKEN` | [Review on GitLab](docs/how-to/review-on-gitlab.md) |
+| Gitea | Gitea Actions (same container) | `GITEA_TOKEN` | [Review on Gitea](docs/how-to/review-on-gitea.md) |
+| None | `lgtmaybe review` on your local diff | — | [Install the CLI](docs/how-to/install-the-cli.md) |
+
+The review is the same everywhere — same lenses, same reflection pass, same
+findings. What differs is what each host's API can do with the result:
+
+| | GitHub | GitLab | Gitea |
+|---|---|---|---|
+| Inline comments + summary | ✅ | ✅ | ✅ |
+| Slash commands | ✅ | ✅ | ✅ |
+| Auto-resolve a fixed finding | ✅ | ✅ | ✗ no thread API |
+| Incremental re-review | ✅ | not yet | ✗ no compare diff |
+| Keyless cloud auth (OIDC/WIF) | ✅ | ✗ use an API key | ✗ use an API key |
 
 ## Documentation
 
@@ -194,6 +218,8 @@ are published at the docs root.
 - [Run locally with ollama](docs/how-to/run-locally-with-ollama.md)
 - [Local models & other OpenAI providers](docs/how-to/use-a-custom-openai-compatible-endpoint.md)
 - [Use as a GitHub Action](docs/how-to/use-as-github-action.md)
+- [Review on GitLab](docs/how-to/review-on-gitlab.md)
+- [Review on Gitea](docs/how-to/review-on-gitea.md)
 - [Configure .lgtmaybe.yml](docs/how-to/configure-lgtmaybe-yml.md)
 - [Releasing (maintainers)](docs/how-to/releasing.md)
 
@@ -252,14 +278,29 @@ jobs:
           api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-Using another platform? Copy-paste workflows for every cloud and API-key
-provider live in
+Using a different **model provider**? Copy-paste workflows for every cloud and
+API-key provider live in
 [`examples/workflows/`](examples/workflows/). Cloud providers (Bedrock, Vertex,
 Azure) are **keyless** — pass `aws_role_arn` / `gcp_wif_provider` /
 `azure_client_id` and the action does the OIDC/WIF exchange for you (needs
 `id-token: write`). See
 [Use as a GitHub Action](docs/how-to/use-as-github-action.md). ollama is local
 only — run it through the [CLI](docs/how-to/run-locally-with-ollama.md) instead.
+
+### Not on GitHub?
+
+lgtmaybe runs the same review on GitLab and Gitea. Only the wiring changes:
+
+- **GitLab** — a CI job running `lgtmaybe gitlab-ci`, gated on merge request
+  pipelines. See [Review on GitLab](docs/how-to/review-on-gitlab.md) and
+  [`examples/gitlab/`](examples/gitlab/).
+- **Gitea** — Gitea Actions runs the same container as GitHub, because it
+  reimplements the same runtime. See
+  [Review on Gitea](docs/how-to/review-on-gitea.md) and
+  [`examples/gitea/`](examples/gitea/).
+
+Keyless cloud auth is a GitHub Actions feature, so on GitLab and Gitea use an
+API-key provider — or `ollama` against a runner-local model for zero cost.
 
 By default, reviews post as `github-actions[bot]`. To post as
 `lgtmaybe[bot]`, install the public

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -18,8 +18,15 @@ flowchart TB
         models["models.py<br/>ReviewConfig · ReviewFinding · ProviderResult · PRContext"]
     end
     providers["providers/<br/>litellm adapter"] -- implements --> ports
-    github["github/<br/>REST adapter"] -- implements --> ports
+    github["github/<br/>GitHub REST adapter"] -- implements --> ports
+    gitlab["gitlab/<br/>GitLab REST adapter"] -- implements --> ports
+    gitea["gitea/<br/>Gitea REST adapter"] -- implements --> ports
 ```
+
+Two independent axes meet at these ports: which **model** reviews the code
+(`ProviderClient`) and which **code host** the review is posted to
+(`ReviewGateway`). Any combination works, because neither side knows about the
+other.
 
 **`core/ports.py`** — the seam. Three abstract base classes:
 
@@ -38,6 +45,77 @@ flowchart TB
 The ports were frozen in the foundation step. Other tracks (providers, github,
 engine, CLI) build against these stable signatures. Changing a port requires
 consensus across all tracks.
+
+## Code hosts (forges)
+
+lgtmaybe calls a code host a **forge** internally, to keep it distinct from a
+model *provider* — the two are separate choices. `core/forge.py` holds
+everything host-specific outside the adapters themselves: a `Forge` enum, a
+`PRLocator` (forge + host + repo + number) parsed from a change-request URL, and
+the environment variable each host's token lives in.
+
+A URL is all lgtmaybe needs to work out the rest:
+
+| URL shape | Forge | Token |
+|---|---|---|
+| `github.com/org/repo/pull/42` | GitHub | `GITHUB_TOKEN` |
+| `gitlab.com/group/sub/project/-/merge_requests/42` | GitLab | `GITLAB_TOKEN` |
+| `gitea.example.com/org/repo/pulls/42` | Gitea | `GITEA_TOKEN` |
+
+The host is carried, not assumed, because self-hosted GitLab and Gitea are the
+normal case. `cli._GATEWAY_BUILDERS` maps the resolved forge to its adapter.
+
+### Required surface vs optional capabilities
+
+`ReviewGateway` is deliberately three methods. Everything richer is an optional
+`Supports*` protocol that a caller probes for and skips when absent, so an
+adapter can be useful long before it is complete — and, more importantly, so it
+can be **honest** about what its host genuinely cannot do rather than failing at
+run time.
+
+| Capability | GitHub | GitLab | Gitea |
+|---|---|---|---|
+| `SupportsFileContents` — read head text for context | ✅ | ✅ | ✅ |
+| `SupportsDescribe` / `SupportsDiagram` — upserted comments | ✅ | ✅ | ✅ |
+| `SupportsLabels` | ✅ | ✅ | ✅ |
+| `SupportsChecks` — check run / commit status | ✅ | ✅ | ✅ |
+| `SupportsThreadResolution` — auto-resolve a fixed finding | ✅ GraphQL | ✅ REST | ✗ no API |
+| `SupportsIncremental` — review only new commits | ✅ | not yet | ✗ no compare diff |
+| `SupportsBaseCheckout` — clone base for symbol lookup | ✅ | ✗ | ✗ |
+
+A test asserts the GitHub adapter satisfies every declared capability, and that
+the others do **not** claim the ones their host cannot serve — which is what
+stops the list drifting into fiction.
+
+### Where the hosts genuinely differ
+
+Gitea is nearly a copy of GitHub; GitLab is not.
+
+- **GitHub** batches every inline comment into one review object it can later
+  edit, and resolves threads over GraphQL.
+- **Gitea** mirrors GitHub's API, but a submitted review is **immutable**. So
+  the summary lives in an ordinary issue comment (which can be edited) and
+  findings are de-duplicated *before* posting, by reading the hidden ids already
+  on the pull request.
+- **GitLab** has no batched review object at all: each finding is its own
+  **discussion**, positioned by old/new path and line plus the merge request's
+  `base_sha`/`start_sha`/`head_sha`. Threads resolve over plain REST.
+
+lgtmaybe keeps GitHub's `RIGHT`/`LEFT` side vocabulary internally and translates
+it at each adapter's boundary — `new_position`/`old_position` on Gitea,
+`new_line`/`old_line` on GitLab.
+
+### Entrypoints
+
+GitHub and Gitea share one entrypoint: Gitea Actions reimplements the GitHub
+Actions runtime, so the same `action` command and the same container work on
+both. The only variable that differs is `GITHUB_SERVER_URL`, which Gitea points
+at your own instance.
+
+GitLab CI has neither an event payload file nor an `INPUT_*` convention, so it
+gets its own `gitlab-ci` command that reads GitLab's predefined `CI_*`
+variables. Everything downstream — locator, gateway registry, engine — is
+shared.
 
 ## Review pipeline
 

--- a/docs/explanation/auth-model.md
+++ b/docs/explanation/auth-model.md
@@ -96,6 +96,29 @@ chain:
 | ollama | None | `--api-base` pointing to the local or remote server |
 | openai-compatible | Optional key, + endpoint | `--api-base` / `OPENAI_COMPATIBLE_API_BASE` (e.g. `https://api.deepseek.com/v1` or `http://localhost:8000/v1`); key via `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, or none for keyless local servers |
 
+## Code-host auth
+
+Everything above authenticates lgtmaybe to a **model provider**. Reaching the
+change itself — reading the diff, posting the review — is a separate credential,
+resolved from the host in the change-request URL:
+
+| Host | Variable | What it needs |
+|---|---|---|
+| GitHub | `GITHUB_TOKEN` | `contents: read` and `pull-requests: write`. The Action's default token is sufficient |
+| GitLab | `GITLAB_TOKEN` | A project access token with the `api` scope, Developer role or above |
+| Gitea | `GITEA_TOKEN` | A token with `read:repository` and `write:issue` |
+
+These are always tokens — there is no keyless path to a code host, and lgtmaybe
+does not attempt one. The token is read from the environment only; like a
+provider key it is never persisted to `.lgtmaybe.yml` or logged.
+
+!!! note "Keyless cloud auth is GitHub-only"
+
+    Bedrock, Vertex, and Azure go keyless by exchanging a **GitHub Actions**
+    OIDC token. GitLab CI and Gitea Actions have no equivalent exchange wired
+    up, so on those hosts use an API-key provider — or `ollama` against a
+    runner-local model, which needs no credential at all.
+
 ## Least-privilege IAM
 
 For Bedrock, the minimum IAM policy is `bedrock:InvokeModel` and (if streaming)
@@ -112,7 +135,8 @@ contributor role is required.
 
 ## API keys in secrets, not config
 
-For openai, anthropic, and openrouter, the key must live in a GitHub Actions
-secret (or an equivalent secret store). It must never be committed to
+For openai, anthropic, and openrouter, the key must live in a secret store —
+a GitHub Actions secret, a GitLab masked CI/CD variable, or a Gitea Actions
+secret. It must never be committed to
 `.lgtmaybe.yml` or any other file in the repository. lgtmaybe does not log or
 display key values.

--- a/docs/explanation/data-and-privacy.md
+++ b/docs/explanation/data-and-privacy.md
@@ -193,7 +193,14 @@ The token is not sent to any LLM provider. It requires the minimum scopes:
 
 ## Fork pull requests
 
-lgtmaybe uses the `pull_request_target` trigger, which runs in the context of
-the **base branch**. PR code from the fork is never checked out or executed.
-The diff is fetched exclusively through the GitHub API. This prevents a
-malicious PR from gaining access to repository secrets.
+On GitHub, lgtmaybe uses the `pull_request_target` trigger, which runs in the
+context of the **base branch**. PR code from the fork is never checked out or
+executed. The diff is fetched exclusively through the host's API. This prevents
+a malicious PR from gaining access to repository secrets.
+
+GitLab and Gitea have no `pull_request_target` equivalent — their merge- and
+pull-request pipelines run with the project's own secrets. The protection is
+unchanged and holds for the same reason: lgtmaybe never checks out or executes
+change-request code on any host, so there is nothing for an attacker to run. The
+supplied GitLab job even sets `GIT_STRATEGY: none`, so the repository is never
+cloned at all.

--- a/docs/explanation/trust-and-cost.md
+++ b/docs/explanation/trust-and-cost.md
@@ -113,9 +113,11 @@ Optional, for repos where you want belt-and-braces:
 
 ## Reviews are safe to run for anyone
 
-Whoever triggers a review, a malicious PR can't use it to do harm: lgtmaybe
-triggers on `pull_request_target` (so it has the secrets it needs) but **never
-checks out or executes PR code** — it fetches the diff through the GitHub API and
-treats it as untrusted input. So opening the gate wide is a cost decision, not a
+Whoever triggers a review, a malicious PR can't use it to do harm: on GitHub
+lgtmaybe triggers on `pull_request_target` (so it has the secrets it needs) but
+**never checks out or executes PR code** — it fetches the diff through the
+host's API and treats it as untrusted input. That second half is what actually
+does the work, and it holds identically on GitLab and Gitea, which have no
+`pull_request_target` of their own. So opening the gate wide is a cost decision, not a
 security one. The full boundary — secret redaction, prompt-injection defence, and
 fork safety — is in [Data and Privacy](data-and-privacy.md).

--- a/docs/explanation/what-gets-reviewed.md
+++ b/docs/explanation/what-gets-reviewed.md
@@ -5,14 +5,14 @@ description: What lgtmaybe reviews and how it bounds the work — only changed l
 # What gets reviewed
 
 This page explains what lgtmaybe looks at, how it bounds the work, and what the
-output looks like — on a GitHub PR and on the command line.
+output looks like — on a pull or merge request, and on the command line.
 
 ## What it looks at
 
-lgtmaybe reviews the **diff of a pull request** — the lines the PR adds or
-changes — not the whole repository. It fetches that diff from the GitHub REST
-API and **never checks out or executes your code**, so a malicious PR can't run
-anything in the reviewer's environment. The diff is treated as untrusted input
+lgtmaybe reviews the **diff of a pull request** (or a GitLab merge request) —
+the lines it adds or changes, not the whole repository. It fetches that diff
+from your code host's REST API and **never checks out or executes your code**,
+so a malicious change can't run anything in the reviewer's environment. The diff is treated as untrusted input
 throughout, including against prompt-injection attempts hidden in PR text.
 
 To review changes in context rather than in isolation, lgtmaybe also pads each
@@ -58,7 +58,7 @@ hunt the bugs a change introduces and grade them by impact:
 - **Aliasing & mutation** — mutable default arguments, mutating a collection while
   iterating it, sharing a mutable value the caller still owns.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [HIGH] possible None dereference, where get_user can return None but .email is accessed without a guard](../assets/review-correctness.png){ width="660" }
 
@@ -95,7 +95,7 @@ vulnerability class in the title. It actively looks for:
 - **Resource / DoS safety** — missing timeouts, unbounded loops or allocations,
   regexes vulnerable to catastrophic backtracking (ReDoS).
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability in a find_user function, explaining the unsafe string concatenation and suggesting a parameterized query](../assets/review-sql-injection.png){ width="660" }
 
@@ -124,7 +124,7 @@ code when the diff shows it — these are objective, not stylistic:
 The reviewer only raises these when the diff itself shows the change; it does not
 speculate about code it cannot see.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [MEDIUM] deprecated datetime.utcnow() call and suggesting datetime.now(timezone.utc)](../assets/review-deprecation.png){ width="660" }
 
@@ -152,7 +152,7 @@ Two lighter-weight checks round out a review:
 
 A missing test — note the runnable test dropped into the suggestion:
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [LOW] new branch added without a test, with a runnable pytest suggestion](../assets/review-tests.png){ width="660" }
 
@@ -162,7 +162,7 @@ A missing test — note the runnable test dropped into the suggestion:
 
 A documentation gap on a new public function:
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging an [INFO] public function missing a docstring, with a suggested docstring](../assets/review-documentation.png){ width="660" }
 
@@ -194,7 +194,7 @@ in a hot path):
 It sticks to changes the diff actually shows and avoids micro-optimisations with
 no measurable impact.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [HIGH] N+1 query inside a loop, suggesting a single batched query](../assets/review-performance.png){ width="660" }
 
@@ -219,7 +219,7 @@ it needs to be (`info`/`medium`), preferring a concrete simplification in the
 
 Like the documentation lens, it stays quiet on self-evident, already-simple code.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [MEDIUM] deeply nested conditional and suggesting guard clauses](../assets/review-complexity.png){ width="660" }
 
@@ -439,7 +439,11 @@ public surface left undocumented — are explicitly exempt and still raised.
 
 ## What the response looks like
 
-### On a GitHub pull request
+### On a pull or merge request
+
+The rendering below is GitHub's. GitLab and Gitea show the same findings with
+the same badges; [how each host posts them](#how-each-host-posts) differs, and
+is covered at the end of this section.
 
 lgtmaybe posts **one review** containing:
 
@@ -478,8 +482,9 @@ A comment's title line carries the finding's provenance in its brackets:
 Each half drops away when it isn't there: with `reflect: false` there is no score
 and the badge is just the lens.
 
-One asymmetry worth knowing: GitHub's review API can't edit an inline comment
-once it's posted, so an inline comment's score is **frozen at first post** — a
+One asymmetry worth knowing: neither GitHub's nor Gitea's review API can edit an
+inline comment once it's posted, so an inline comment's score is **frozen at
+first post** — a
 later run that judges the same finding differently won't change it. Findings in
 the summary body (the "Additional findings" and "Broader observations" sections)
 are rewritten on every run, so those badges do track. That's how severity and
@@ -502,6 +507,27 @@ Resolving a thread uses GitHub's GraphQL API; the workflow's default
 `GITHUB_TOKEN` (with `pull-requests: write`, already needed to post the review)
 is sufficient. The step is best-effort — if it can't run, the review itself still
 posts normally.
+
+On **GitLab** the same thing happens over plain REST rather than GraphQL. On
+**Gitea** it does not happen at all — Gitea has no thread-resolution API, so
+findings' comments stay open for a human to close.
+
+### How each host posts
+
+The findings are identical everywhere. What each host's API allows is not:
+
+| | GitHub | GitLab | Gitea |
+|---|---|---|---|
+| Inline comments | one batched review | one discussion per finding | one batched review |
+| Summary | the review body, edited in place | a note, edited in place | an issue comment, edited in place |
+| Avoiding duplicates on a re-run | edits the review | skips ids already posted | skips ids already posted |
+| Auto-resolve a fixed finding | ✅ GraphQL | ✅ REST | ✗ no API |
+| Incremental review of new commits | ✅ | not yet | ✗ no compare diff |
+
+The reason for the differences: a submitted **Gitea** review can't be edited, so
+its summary moves to an ordinary comment and duplicate findings are filtered
+*before* posting. **GitLab** has no batched review object at all, so each
+finding becomes its own positioned discussion.
 
 When a PR is clean (no findings, and every file was within the caps), the summary
 is a simple:

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -163,7 +163,7 @@ def generate() -> str:
     sections.append("## ReviewFinding\n")
     sections.append(
         "The structured output the model must return for each inline comment. "
-        "All fields are validated by pydantic before anything is posted to GitHub.\n"
+        "All fields are validated by pydantic before anything is posted.\n"
     )
     sections.append(_render_schema_table(review_finding_schema))
     sections.append("")

--- a/docs/how-to/scope-review-instructions-to-a-directory.md
+++ b/docs/how-to/scope-review-instructions-to-a-directory.md
@@ -117,8 +117,9 @@ They do not. On the recommended `pull_request_target` trigger, the workflow
 checks out the **base** branch — the code already merged — and never the PR
 head. `directory_rules` and the files it names are read from that checkout, the
 same source `.lgtmaybe.yml` and `lens_paths` already come from. lgtmaybe never
-fetches context files through the GitHub API, which would resolve them at the
-(untrusted) PR head.
+fetches context files through the host's API, which would resolve them at the
+(untrusted) PR head. The same holds on GitLab and Gitea: context comes from the
+checked-out workspace, never from the change's head.
 
 The practical rule: a fork PR can change `ARCHITECTURE.md` in its own branch and
 lgtmaybe will still read the base branch's copy. Review changes to your config

--- a/docs/how-to/use-as-github-action.md
+++ b/docs/how-to/use-as-github-action.md
@@ -7,6 +7,12 @@ description: Add lgtmaybe as a GitHub Action to review every pull request automa
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
+!!! tip "Not on GitHub?"
+
+    lgtmaybe runs the same review on GitLab and Gitea — see
+    [Review on GitLab](./review-on-gitlab.md) or
+    [Review on Gitea](./review-on-gitea.md).
+
 Use lgtmaybe from the
 [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
 It is a **GitHub Action**: the reviewer runs in your workflow, and its provider,
@@ -318,3 +324,17 @@ use a full version tag:
 ```yaml
 uses: MattJColes/lgtmaybe@v2.0.0
 ```
+
+## On another code host
+
+The review is identical on GitLab and Gitea; only the wiring and a few
+host-capability differences change:
+
+- [Review on GitLab](./review-on-gitlab.md) — a CI job running
+  `lgtmaybe gitlab-ci` on merge request pipelines.
+- [Review on Gitea](./review-on-gitea.md) — Gitea Actions, running the same
+  container as GitHub.
+
+Keyless cloud auth (Bedrock, Vertex, Azure) relies on GitHub Actions' OIDC
+token, so it is available here only. On the other hosts use an API-key provider
+or `ollama`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: Provider-agnostic AI code review for pull requests — OpenAI, Claude, Bedrock, Vertex, Azure, ollama and any OpenAI-compatible endpoint. Inline review comments, keyless OIDC/WIF cloud auth, GitHub Action + CLI.
+description: Provider-agnostic AI code review for pull and merge requests on GitHub, GitLab and Gitea — OpenAI, Claude, Bedrock, Vertex, Azure, ollama and any OpenAI-compatible endpoint. Inline review comments, keyless OIDC/WIF cloud auth, GitHub Action + GitLab CI + CLI.
 ---
 
 <div class="hero" markdown>
@@ -11,13 +11,13 @@ description: Provider-agnostic AI code review for pull requests — OpenAI, Clau
 </div>
 
 lgtmaybe reviews the code a pull request changes. Pick OpenAI, Claude, Bedrock,
-Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it as a
-GitHub Action or from your terminal. GitHub gets inline comments and one
-summary; locally, you get the same findings before you push.
+Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it on
+**GitHub, GitLab, or Gitea** — or from your terminal. The change gets inline
+comments and one summary; locally, you get the same findings before you push.
 
 It reads the diff and a little surrounding code, but only comments on changed
-lines. On GitHub it never checks out or runs the pull request. Generated files
-and binaries are skipped, secrets are redacted, and all PR text is treated as
+lines. It never checks out or runs the change. Generated files and binaries are
+skipped, secrets are redacted, and all author-supplied text is treated as
 untrusted.
 
 It checks for:
@@ -37,8 +37,8 @@ Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
 **`/describe`** writes a structured overview, **`/diagram`** draws
 [the change](how-to/generate-a-change-diagram.md) — a flowchart of what it
 touches, plus a sequence diagram of the flow it alters — and
-**`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
-map locally before you push.
+**`/ask <question>`** answers in the change. Run `lgtmaybe diagram` to draw the
+same map locally before you push.
 
 ```mermaid
 flowchart LR
@@ -60,7 +60,7 @@ flowchart LR
 <div class="grid cards" markdown>
 
 - **Tutorial** — [Getting started](tutorial/getting-started.md): your first review with ollama, locally and free.
-- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
+- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md), [GitLab](how-to/review-on-gitlab.md), [Gitea](how-to/review-on-gitea.md).
 - **Reference** — [Configuration](reference/config.md): every config field and schema.
 - **Explanation** — [What gets reviewed](explanation/what-gets-reviewed.md), [Architecture](explanation/architecture.md), [Auth model](explanation/auth-model.md), [Data & privacy](explanation/data-and-privacy.md).
 
@@ -79,6 +79,23 @@ flowchart LR
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |
 | `ollama` | None — local only, zero cost |
 | `openai-compatible` | `--api-base` to any OpenAI `/v1` endpoint; key optional (placeholder for keyless local servers) |
+
+## Where it posts
+
+The model provider and the code host are independent — any provider above works
+on any host below.
+
+| Host | How it runs | Token | Guide |
+|---|---|---|---|
+| GitHub | GitHub Action | `GITHUB_TOKEN` | [GitHub Action](how-to/use-as-github-action.md) |
+| GitLab | GitLab CI job | `GITLAB_TOKEN` | [Review on GitLab](how-to/review-on-gitlab.md) |
+| Gitea | Gitea Actions | `GITEA_TOKEN` | [Review on Gitea](how-to/review-on-gitea.md) |
+| None | `lgtmaybe review` locally | — | [Install the CLI](how-to/install-the-cli.md) |
+
+The review is identical on all three. What differs is what each host's API can
+do with the result — auto-resolving a fixed finding, reviewing only new commits,
+and keyless cloud auth are not available everywhere. See
+[Architecture](explanation/architecture.md#code-hosts-forges) for the details.
 
 ## For AI agents
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17,13 +17,13 @@ Source: https://lgtmaybe.coles.codes/ — generated from the docs/ tree.
 </div>
 
 lgtmaybe reviews the code a pull request changes. Pick OpenAI, Claude, Bedrock,
-Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it as a
-GitHub Action or from your terminal. GitHub gets inline comments and one
-summary; locally, you get the same findings before you push.
+Vertex, Azure, ollama, or any OpenAI-compatible endpoint, then run it on
+**GitHub, GitLab, or Gitea** — or from your terminal. The change gets inline
+comments and one summary; locally, you get the same findings before you push.
 
 It reads the diff and a little surrounding code, but only comments on changed
-lines. On GitHub it never checks out or runs the pull request. Generated files
-and binaries are skipped, secrets are redacted, and all PR text is treated as
+lines. It never checks out or runs the change. Generated files and binaries are
+skipped, secrets are redacted, and all author-supplied text is treated as
 untrusted.
 
 It checks for:
@@ -43,8 +43,8 @@ Reviews aren't all it does. **`/review`** and **`/improve`** run the review,
 **`/describe`** writes a structured overview, **`/diagram`** draws
 [the change](how-to/generate-a-change-diagram.md) — a flowchart of what it
 touches, plus a sequence diagram of the flow it alters — and
-**`/ask <question>`** answers in the PR. Run `lgtmaybe diagram` to draw the same
-map locally before you push.
+**`/ask <question>`** answers in the change. Run `lgtmaybe diagram` to draw the
+same map locally before you push.
 
 ```mermaid
 flowchart LR
@@ -66,7 +66,7 @@ flowchart LR
 <div class="grid cards" markdown>
 
 - **Tutorial** — [Getting started](tutorial/getting-started.md): your first review with ollama, locally and free.
-- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md).
+- **How-to** — task recipes: [choose a review model](how-to/choose-a-review-model.md), [run locally](how-to/run-locally-with-ollama.md), [Bedrock OIDC](how-to/review-with-bedrock-oidc.md), [Vertex WIF](how-to/review-with-vertex-wif.md), [Azure OpenAI](how-to/review-with-azure.md), [GitHub Action](how-to/use-as-github-action.md), [GitLab](how-to/review-on-gitlab.md), [Gitea](how-to/review-on-gitea.md).
 - **Reference** — [Configuration](reference/config.md): every config field and schema.
 - **Explanation** — [What gets reviewed](explanation/what-gets-reviewed.md), [Architecture](explanation/architecture.md), [Auth model](explanation/auth-model.md), [Data & privacy](explanation/data-and-privacy.md).
 
@@ -85,6 +85,23 @@ flowchart LR
 | `azure` | Ambient Azure AD creds — GitHub OIDC, no static key (or `AZURE_API_KEY`) + endpoint |
 | `ollama` | None — local only, zero cost |
 | `openai-compatible` | `--api-base` to any OpenAI `/v1` endpoint; key optional (placeholder for keyless local servers) |
+
+## Where it posts
+
+The model provider and the code host are independent — any provider above works
+on any host below.
+
+| Host | How it runs | Token | Guide |
+|---|---|---|---|
+| GitHub | GitHub Action | `GITHUB_TOKEN` | [GitHub Action](how-to/use-as-github-action.md) |
+| GitLab | GitLab CI job | `GITLAB_TOKEN` | [Review on GitLab](how-to/review-on-gitlab.md) |
+| Gitea | Gitea Actions | `GITEA_TOKEN` | [Review on Gitea](how-to/review-on-gitea.md) |
+| None | `lgtmaybe review` locally | — | [Install the CLI](how-to/install-the-cli.md) |
+
+The review is identical on all three. What differs is what each host's API can
+do with the result — auto-resolving a fixed finding, reviewing only new commits,
+and keyless cloud auth are not available everywhere. See
+[Architecture](explanation/architecture.md#code-hosts-forges) for the details.
 
 ## For AI agents
 
@@ -207,8 +224,15 @@ to see it drawn. See
 ## Step 6 — Post reviews on real pull requests
 
 The CLI reviews local changes. To run lgtmaybe on actual pull requests — inline
-comments and a summary posted back to GitHub — add the GitHub Action to your
-repo. See [Use as a GitHub Action](../how-to/use-as-github-action.md).
+comments and a summary posted back to the change — wire it into your code host.
+The review is the same on all three; only the plumbing differs:
+
+- **GitHub** — add the Action to your repo:
+  [Use as a GitHub Action](../how-to/use-as-github-action.md)
+- **GitLab** — add a CI job:
+  [Review on GitLab](../how-to/review-on-gitlab.md)
+- **Gitea** — add a Gitea Actions workflow:
+  [Review on Gitea](../how-to/review-on-gitea.md)
 
 ## What happened under the hood
 
@@ -705,6 +729,12 @@ The [live benchmark repository][bench] provides:
 Use this guide to add lgtmaybe to a repository as a GitHub Actions workflow
 that reviews pull requests automatically.
 
+!!! tip "Not on GitHub?"
+
+    lgtmaybe runs the same review on GitLab and Gitea — see
+    [Review on GitLab](./review-on-gitlab.md) or
+    [Review on Gitea](./review-on-gitea.md).
+
 Use lgtmaybe from the
 [GitHub Marketplace listing](https://github.com/marketplace/actions/lgtmaybe).
 It is a **GitHub Action**: the reviewer runs in your workflow, and its provider,
@@ -1016,6 +1046,20 @@ use a full version tag:
 ```yaml
 uses: MattJColes/lgtmaybe@v2.0.0
 ```
+
+## On another code host
+
+The review is identical on GitLab and Gitea; only the wiring and a few
+host-capability differences change:
+
+- [Review on GitLab](./review-on-gitlab.md) — a CI job running
+  `lgtmaybe gitlab-ci` on merge request pipelines.
+- [Review on Gitea](./review-on-gitea.md) — Gitea Actions, running the same
+  container as GitHub.
+
+Keyless cloud auth (Bedrock, Vertex, Azure) relies on GitHub Actions' OIDC
+token, so it is available here only. On the other hosts use an API-key provider
+or `ollama`.
 
 ---
 
@@ -3783,8 +3827,9 @@ They do not. On the recommended `pull_request_target` trigger, the workflow
 checks out the **base** branch — the code already merged — and never the PR
 head. `directory_rules` and the files it names are read from that checkout, the
 same source `.lgtmaybe.yml` and `lens_paths` already come from. lgtmaybe never
-fetches context files through the GitHub API, which would resolve them at the
-(untrusted) PR head.
+fetches context files through the host's API, which would resolve them at the
+(untrusted) PR head. The same holds on GitLab and Gitea: context comes from the
+checked-out workspace, never from the change's head.
 
 The practical rule: a fork PR can change `ARCHITECTURE.md` in its own branch and
 lgtmaybe will still read the base branch's copy. Review changes to your config
@@ -4757,7 +4802,7 @@ Finding severity, ordered low to high. Use `min_severity` in config to suppress 
 
 ## ReviewFinding
 
-The structured output the model must return for each inline comment. All fields are validated by pydantic before anything is posted to GitHub.
+The structured output the model must return for each inline comment. All fields are validated by pydantic before anything is posted.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
@@ -6074,14 +6119,14 @@ altering what it means is.
 # What gets reviewed
 
 This page explains what lgtmaybe looks at, how it bounds the work, and what the
-output looks like — on a GitHub PR and on the command line.
+output looks like — on a pull or merge request, and on the command line.
 
 ## What it looks at
 
-lgtmaybe reviews the **diff of a pull request** — the lines the PR adds or
-changes — not the whole repository. It fetches that diff from the GitHub REST
-API and **never checks out or executes your code**, so a malicious PR can't run
-anything in the reviewer's environment. The diff is treated as untrusted input
+lgtmaybe reviews the **diff of a pull request** (or a GitLab merge request) —
+the lines it adds or changes, not the whole repository. It fetches that diff
+from your code host's REST API and **never checks out or executes your code**,
+so a malicious change can't run anything in the reviewer's environment. The diff is treated as untrusted input
 throughout, including against prompt-injection attempts hidden in PR text.
 
 To review changes in context rather than in isolation, lgtmaybe also pads each
@@ -6127,7 +6172,7 @@ hunt the bugs a change introduces and grade them by impact:
 - **Aliasing & mutation** — mutable default arguments, mutating a collection while
   iterating it, sharing a mutable value the caller still owns.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [HIGH] possible None dereference, where get_user can return None but .email is accessed without a guard](../assets/review-correctness.png){ width="660" }
 
@@ -6164,7 +6209,7 @@ vulnerability class in the title. It actively looks for:
 - **Resource / DoS safety** — missing timeouts, unbounded loops or allocations,
   regexes vulnerable to catastrophic backtracking (ReDoS).
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [CRITICAL] SQL injection vulnerability in a find_user function, explaining the unsafe string concatenation and suggesting a parameterized query](../assets/review-sql-injection.png){ width="660" }
 
@@ -6193,7 +6238,7 @@ code when the diff shows it — these are objective, not stylistic:
 The reviewer only raises these when the diff itself shows the change; it does not
 speculate about code it cannot see.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [MEDIUM] deprecated datetime.utcnow() call and suggesting datetime.now(timezone.utc)](../assets/review-deprecation.png){ width="660" }
 
@@ -6221,7 +6266,7 @@ Two lighter-weight checks round out a review:
 
 A missing test — note the runnable test dropped into the suggestion:
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [LOW] new branch added without a test, with a runnable pytest suggestion](../assets/review-tests.png){ width="660" }
 
@@ -6231,7 +6276,7 @@ A missing test — note the runnable test dropped into the suggestion:
 
 A documentation gap on a new public function:
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging an [INFO] public function missing a docstring, with a suggested docstring](../assets/review-documentation.png){ width="660" }
 
@@ -6263,7 +6308,7 @@ in a hot path):
 It sticks to changes the diff actually shows and avoids micro-optimisations with
 no measurable impact.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [HIGH] N+1 query inside a loop, suggesting a single batched query](../assets/review-performance.png){ width="660" }
 
@@ -6288,7 +6333,7 @@ it needs to be (`info`/`medium`), preferring a concrete simplification in the
 
 Like the documentation lens, it stays quiet on self-evident, already-simple code.
 
-=== "On a GitHub PR"
+=== "On a pull request"
 
     ![An inline lgtmaybe review comment flagging a [MEDIUM] deeply nested conditional and suggesting guard clauses](../assets/review-complexity.png){ width="660" }
 
@@ -6508,7 +6553,11 @@ public surface left undocumented — are explicitly exempt and still raised.
 
 ## What the response looks like
 
-### On a GitHub pull request
+### On a pull or merge request
+
+The rendering below is GitHub's. GitLab and Gitea show the same findings with
+the same badges; [how each host posts them](#how-each-host-posts) differs, and
+is covered at the end of this section.
 
 lgtmaybe posts **one review** containing:
 
@@ -6547,8 +6596,9 @@ A comment's title line carries the finding's provenance in its brackets:
 Each half drops away when it isn't there: with `reflect: false` there is no score
 and the badge is just the lens.
 
-One asymmetry worth knowing: GitHub's review API can't edit an inline comment
-once it's posted, so an inline comment's score is **frozen at first post** — a
+One asymmetry worth knowing: neither GitHub's nor Gitea's review API can edit an
+inline comment once it's posted, so an inline comment's score is **frozen at
+first post** — a
 later run that judges the same finding differently won't change it. Findings in
 the summary body (the "Additional findings" and "Broader observations" sections)
 are rewritten on every run, so those badges do track. That's how severity and
@@ -6571,6 +6621,27 @@ Resolving a thread uses GitHub's GraphQL API; the workflow's default
 `GITHUB_TOKEN` (with `pull-requests: write`, already needed to post the review)
 is sufficient. The step is best-effort — if it can't run, the review itself still
 posts normally.
+
+On **GitLab** the same thing happens over plain REST rather than GraphQL. On
+**Gitea** it does not happen at all — Gitea has no thread-resolution API, so
+findings' comments stay open for a human to close.
+
+### How each host posts
+
+The findings are identical everywhere. What each host's API allows is not:
+
+| | GitHub | GitLab | Gitea |
+|---|---|---|---|
+| Inline comments | one batched review | one discussion per finding | one batched review |
+| Summary | the review body, edited in place | a note, edited in place | an issue comment, edited in place |
+| Avoiding duplicates on a re-run | edits the review | skips ids already posted | skips ids already posted |
+| Auto-resolve a fixed finding | ✅ GraphQL | ✅ REST | ✗ no API |
+| Incremental review of new commits | ✅ | not yet | ✗ no compare diff |
+
+The reason for the differences: a submitted **Gitea** review can't be edited, so
+its summary moves to an ordinary comment and duplicate findings are filtered
+*before* posting. **GitLab** has no batched review object at all, so each
+finding becomes its own positioned discussion.
 
 When a PR is clean (no findings, and every file was within the caps), the summary
 is a simple:
@@ -6650,8 +6721,15 @@ flowchart TB
         models["models.py<br/>ReviewConfig · ReviewFinding · ProviderResult · PRContext"]
     end
     providers["providers/<br/>litellm adapter"] -- implements --> ports
-    github["github/<br/>REST adapter"] -- implements --> ports
+    github["github/<br/>GitHub REST adapter"] -- implements --> ports
+    gitlab["gitlab/<br/>GitLab REST adapter"] -- implements --> ports
+    gitea["gitea/<br/>Gitea REST adapter"] -- implements --> ports
 ```
+
+Two independent axes meet at these ports: which **model** reviews the code
+(`ProviderClient`) and which **code host** the review is posted to
+(`ReviewGateway`). Any combination works, because neither side knows about the
+other.
 
 **`core/ports.py`** — the seam. Three abstract base classes:
 
@@ -6670,6 +6748,77 @@ flowchart TB
 The ports were frozen in the foundation step. Other tracks (providers, github,
 engine, CLI) build against these stable signatures. Changing a port requires
 consensus across all tracks.
+
+## Code hosts (forges)
+
+lgtmaybe calls a code host a **forge** internally, to keep it distinct from a
+model *provider* — the two are separate choices. `core/forge.py` holds
+everything host-specific outside the adapters themselves: a `Forge` enum, a
+`PRLocator` (forge + host + repo + number) parsed from a change-request URL, and
+the environment variable each host's token lives in.
+
+A URL is all lgtmaybe needs to work out the rest:
+
+| URL shape | Forge | Token |
+|---|---|---|
+| `github.com/org/repo/pull/42` | GitHub | `GITHUB_TOKEN` |
+| `gitlab.com/group/sub/project/-/merge_requests/42` | GitLab | `GITLAB_TOKEN` |
+| `gitea.example.com/org/repo/pulls/42` | Gitea | `GITEA_TOKEN` |
+
+The host is carried, not assumed, because self-hosted GitLab and Gitea are the
+normal case. `cli._GATEWAY_BUILDERS` maps the resolved forge to its adapter.
+
+### Required surface vs optional capabilities
+
+`ReviewGateway` is deliberately three methods. Everything richer is an optional
+`Supports*` protocol that a caller probes for and skips when absent, so an
+adapter can be useful long before it is complete — and, more importantly, so it
+can be **honest** about what its host genuinely cannot do rather than failing at
+run time.
+
+| Capability | GitHub | GitLab | Gitea |
+|---|---|---|---|
+| `SupportsFileContents` — read head text for context | ✅ | ✅ | ✅ |
+| `SupportsDescribe` / `SupportsDiagram` — upserted comments | ✅ | ✅ | ✅ |
+| `SupportsLabels` | ✅ | ✅ | ✅ |
+| `SupportsChecks` — check run / commit status | ✅ | ✅ | ✅ |
+| `SupportsThreadResolution` — auto-resolve a fixed finding | ✅ GraphQL | ✅ REST | ✗ no API |
+| `SupportsIncremental` — review only new commits | ✅ | not yet | ✗ no compare diff |
+| `SupportsBaseCheckout` — clone base for symbol lookup | ✅ | ✗ | ✗ |
+
+A test asserts the GitHub adapter satisfies every declared capability, and that
+the others do **not** claim the ones their host cannot serve — which is what
+stops the list drifting into fiction.
+
+### Where the hosts genuinely differ
+
+Gitea is nearly a copy of GitHub; GitLab is not.
+
+- **GitHub** batches every inline comment into one review object it can later
+  edit, and resolves threads over GraphQL.
+- **Gitea** mirrors GitHub's API, but a submitted review is **immutable**. So
+  the summary lives in an ordinary issue comment (which can be edited) and
+  findings are de-duplicated *before* posting, by reading the hidden ids already
+  on the pull request.
+- **GitLab** has no batched review object at all: each finding is its own
+  **discussion**, positioned by old/new path and line plus the merge request's
+  `base_sha`/`start_sha`/`head_sha`. Threads resolve over plain REST.
+
+lgtmaybe keeps GitHub's `RIGHT`/`LEFT` side vocabulary internally and translates
+it at each adapter's boundary — `new_position`/`old_position` on Gitea,
+`new_line`/`old_line` on GitLab.
+
+### Entrypoints
+
+GitHub and Gitea share one entrypoint: Gitea Actions reimplements the GitHub
+Actions runtime, so the same `action` command and the same container work on
+both. The only variable that differs is `GITHUB_SERVER_URL`, which Gitea points
+at your own instance.
+
+GitLab CI has neither an event payload file nor an `INPUT_*` convention, so it
+gets its own `gitlab-ci` command that reads GitLab's predefined `CI_*`
+variables. Everything downstream — locator, gateway registry, engine — is
+shared.
 
 ## Review pipeline
 
@@ -7057,6 +7206,29 @@ chain:
 | ollama | None | `--api-base` pointing to the local or remote server |
 | openai-compatible | Optional key, + endpoint | `--api-base` / `OPENAI_COMPATIBLE_API_BASE` (e.g. `https://api.deepseek.com/v1` or `http://localhost:8000/v1`); key via `--api-key` / `OPENAI_COMPATIBLE_API_KEY`, or none for keyless local servers |
 
+## Code-host auth
+
+Everything above authenticates lgtmaybe to a **model provider**. Reaching the
+change itself — reading the diff, posting the review — is a separate credential,
+resolved from the host in the change-request URL:
+
+| Host | Variable | What it needs |
+|---|---|---|
+| GitHub | `GITHUB_TOKEN` | `contents: read` and `pull-requests: write`. The Action's default token is sufficient |
+| GitLab | `GITLAB_TOKEN` | A project access token with the `api` scope, Developer role or above |
+| Gitea | `GITEA_TOKEN` | A token with `read:repository` and `write:issue` |
+
+These are always tokens — there is no keyless path to a code host, and lgtmaybe
+does not attempt one. The token is read from the environment only; like a
+provider key it is never persisted to `.lgtmaybe.yml` or logged.
+
+!!! note "Keyless cloud auth is GitHub-only"
+
+    Bedrock, Vertex, and Azure go keyless by exchanging a **GitHub Actions**
+    OIDC token. GitLab CI and Gitea Actions have no equivalent exchange wired
+    up, so on those hosts use an API-key provider — or `ollama` against a
+    runner-local model, which needs no credential at all.
+
 ## Least-privilege IAM
 
 For Bedrock, the minimum IAM policy is `bedrock:InvokeModel` and (if streaming)
@@ -7073,8 +7245,9 @@ contributor role is required.
 
 ## API keys in secrets, not config
 
-For openai, anthropic, and openrouter, the key must live in a GitHub Actions
-secret (or an equivalent secret store). It must never be committed to
+For openai, anthropic, and openrouter, the key must live in a secret store —
+a GitHub Actions secret, a GitLab masked CI/CD variable, or a Gitea Actions
+secret. It must never be committed to
 `.lgtmaybe.yml` or any other file in the repository. lgtmaybe does not log or
 display key values.
 
@@ -7273,10 +7446,17 @@ The token is not sent to any LLM provider. It requires the minimum scopes:
 
 ## Fork pull requests
 
-lgtmaybe uses the `pull_request_target` trigger, which runs in the context of
-the **base branch**. PR code from the fork is never checked out or executed.
-The diff is fetched exclusively through the GitHub API. This prevents a
-malicious PR from gaining access to repository secrets.
+On GitHub, lgtmaybe uses the `pull_request_target` trigger, which runs in the
+context of the **base branch**. PR code from the fork is never checked out or
+executed. The diff is fetched exclusively through the host's API. This prevents
+a malicious PR from gaining access to repository secrets.
+
+GitLab and Gitea have no `pull_request_target` equivalent — their merge- and
+pull-request pipelines run with the project's own secrets. The protection is
+unchanged and holds for the same reason: lgtmaybe never checks out or executes
+change-request code on any host, so there is nothing for an attacker to run. The
+supplied GitLab job even sets `GIT_STRATEGY: none`, so the repository is never
+cloned at all.
 
 ---
 
@@ -7393,9 +7573,11 @@ Optional, for repos where you want belt-and-braces:
 
 ## Reviews are safe to run for anyone
 
-Whoever triggers a review, a malicious PR can't use it to do harm: lgtmaybe
-triggers on `pull_request_target` (so it has the secrets it needs) but **never
-checks out or executes PR code** — it fetches the diff through the GitHub API and
-treats it as untrusted input. So opening the gate wide is a cost decision, not a
+Whoever triggers a review, a malicious PR can't use it to do harm: on GitHub
+lgtmaybe triggers on `pull_request_target` (so it has the secrets it needs) but
+**never checks out or executes PR code** — it fetches the diff through the
+host's API and treats it as untrusted input. That second half is what actually
+does the work, and it holds identically on GitLab and Gitea, which have no
+`pull_request_target` of their own. So opening the gate wide is a cost decision, not a
 security one. The full boundary — secret redaction, prompt-injection defence, and
 fork safety — is in [Data and Privacy](data-and-privacy.md).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -93,7 +93,7 @@ Finding severity, ordered low to high. Use `min_severity` in config to suppress 
 
 ## ReviewFinding
 
-The structured output the model must return for each inline comment. All fields are validated by pydantic before anything is posted to GitHub.
+The structured output the model must return for each inline comment. All fields are validated by pydantic before anything is posted.
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -113,8 +113,15 @@ to see it drawn. See
 ## Step 6 — Post reviews on real pull requests
 
 The CLI reviews local changes. To run lgtmaybe on actual pull requests — inline
-comments and a summary posted back to GitHub — add the GitHub Action to your
-repo. See [Use as a GitHub Action](../how-to/use-as-github-action.md).
+comments and a summary posted back to the change — wire it into your code host.
+The review is the same on all three; only the plumbing differs:
+
+- **GitHub** — add the Action to your repo:
+  [Use as a GitHub Action](../how-to/use-as-github-action.md)
+- **GitLab** — add a CI job:
+  [Review on GitLab](../how-to/review-on-gitlab.md)
+- **Gitea** — add a Gitea Actions workflow:
+  [Review on Gitea](../how-to/review-on-gitea.md)
 
 ## What happened under the hood
 


### PR DESCRIPTION
Follow-up to #480/#481/#482. The adapters shipped with their own how-to guides, but the rest of the docs still read as though GitHub were the only place lgtmaybe posts.

That left readers with two wrong impressions: that lgtmaybe is a GitHub tool, and that picking a *provider* is the only choice they make. There are two independent axes now — which model reviews the code, and which host the review is posted to — so the host axis gets the same treatment the provider axis already had.

## What changed

**Front doors** — `README.md`, `docs/index.md`
A **"Where it posts"** table beside the existing providers table, plus a capability matrix. The review is identical on all three hosts; what each host's API allows is not, and that distinction is the thing a reader actually needs. Also a "Not on GitHub?" section in the README's Action walkthrough, since that's where a GitLab reader would otherwise dead-end.

**Architecture** — `docs/explanation/architecture.md`, `ARCHITECTURE.md`
A code-hosts section: how a change-request URL resolves to a forge, why `ReviewGateway` requires only three methods, which optional `Supports*` capabilities each host can serve, and where the three genuinely differ (Gitea's immutable reviews, GitLab's per-finding discussions). The ports diagram showed one adapter implementing the gateway port; it now shows three.

**Auth** — `docs/explanation/auth-model.md`
This covered provider credentials but never *host* tokens, which is a real gap now there are three. Adds a code-host auth table (`GITHUB_TOKEN` / `GITLAB_TOKEN` / `GITEA_TOKEN`, with the scopes each needs) and states plainly that keyless cloud auth is a GitHub Actions feature — so a GitLab reader doesn't go hunting for an OIDC path that isn't there.

**Fork safety** — `docs/explanation/data-and-privacy.md`, `trust-and-cost.md`
Both said "the GitHub API" where they meant "the host's API". More importantly, both framed the protection as coming from `pull_request_target`. It doesn't — it comes from never checking out change-request code. The claim now says which half does the work, and that it holds identically on hosts with no `pull_request_target` at all.

**Output** — `docs/explanation/what-gets-reviewed.md`
The content tabs said `=== "On a GitHub PR"` for output that renders the same everywhere. The posting-mechanics section that *is* genuinely host-specific now says so, and gains a table covering how each host posts and why they differ.

**Tutorial** — step 6 now names all three routes to a posted review, not just the Action.

**Generated reference** — fixed `docs/generate_reference.py` and regenerated, rather than hand-editing generated output.

## Verification

- `mkdocs build --strict` — clean.
- Internal-link check across `docs/` and root markdown — all resolve, including the new cross-references and the `#code-hosts-forges` anchor.
- `llms.txt` / `llms-full.txt` regenerated; both new how-tos are indexed.
- Full code gate still green: ruff, ruff format, mypy (strict), pytest — 2341 passed, 3 skipped.

## Scope note

I deliberately did **not** add a host note to each of the nine `review-with-*.md` provider guides — those are about providers, and nine near-identical inserts would be noise. The host choice is covered once in each front door, once in the auth model, and once at the top and bottom of the GitHub Action guide, which is where a reader on the wrong host actually lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_013KoK6xvv72d6x1Z5qaCk37)_