### PR TITLE
refactor: drop the dead duplicate _ZWSP constant in rest_gateway

### DIFF
--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -105,10 +105,6 @@ _CONTENT_FETCH_WORKERS = 8
 # is stricter about concurrent mutations than concurrent reads.
 _RESOLVE_WORKERS = 4
 
-# Zero-width space, inserted to break up a triple-backtick run so it can't be
-# parsed as a Markdown fence delimiter.
-_ZWSP = "​"
-
 
 def _head_ref(meta: dict[str, Any]) -> str:
     """The PR's head branch name, or ``""`` when the payload doesn't carry one.


### PR DESCRIPTION
`src/lgtmaybe/github/rest_gateway.py` defined a `_ZWSP` constant that was a byte-for-byte copy of `core/comment.py`'s, with no references anywhere in the file. The copy in `core/comment.py` is the one that is actually used (by `core/comment.py:37`).

Deleted the dead constant and its comment. No behaviour change; `tests/github` passes unchanged.

Closes #485

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_