### PR TITLE
ci: share the ollama bring-up and use gh for the winget existence check

### DIFF
--- a/.github/actions/ollama-bringup/action.yml
+++ b/.github/actions/ollama-bringup/action.yml
@@ -1,0 +1,55 @@
+name: Ollama bring-up
+description: >-
+  Install uv + dev deps, install ollama, restore the model cache, and serve the
+  model. Shared by the two workflows that need a live local model
+  (e2e-local, rlm-bench) so their bring-up cannot drift from each other — or,
+  since the last step is the same script DEVELOPMENT.md tells a developer to
+  run, from a local run.
+
+inputs:
+  model:
+    description: "ollama model tag to serve"
+    required: true
+  models-path:
+    description: "where ollama keeps its models (the path the cache restores)"
+    required: false
+    default: /home/runner/.ollama/models
+  python-version:
+    description: "python version for the uv toolchain"
+    required: false
+    default: "3.12"
+
+runs:
+  using: composite
+  # No checkout here: a `uses: ./.github/actions/...` step can only resolve once
+  # the repository is already in the workspace, so the calling job checks out
+  # first and this picks up from there.
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+
+    - name: Sync (with dev deps)
+      shell: bash
+      run: uv sync --dev
+
+    - name: Install ollama
+      shell: bash
+      run: curl -fsSL https://ollama.com/install.sh | sh
+
+    - name: Cache ollama model
+      uses: actions/cache@v6
+      with:
+        path: ${{ inputs.models-path }}
+        key: ollama-${{ runner.os }}-${{ inputs.model }}
+
+    # The same script a developer runs locally (DEVELOPMENT.md) — serve,
+    # readiness wait, pull — so the bring-up can't drift from local either.
+    - name: Start ollama and pull the model
+      shell: bash
+      env:
+        LGTMAYBE_E2E_OLLAMA_MODEL: ${{ inputs.model }}
+        OLLAMA_MODELS: ${{ inputs.models-path }}
+      run: scripts/e2e-up.sh ollama

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -32,28 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Bring up ollama
+        uses: ./.github/actions/ollama-bringup
         with:
-          python-version: "3.12"
-          enable-cache: true
-
-      - name: Sync (with dev deps)
-        run: uv sync --dev
-
-      - name: Install ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
-
-      - name: Cache ollama model
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.OLLAMA_MODELS }}
-          key: ollama-${{ runner.os }}-${{ env.LGTMAYBE_E2E_OLLAMA_MODEL }}
-
-      # The same script a developer runs locally (DEVELOPMENT.md) — serve,
-      # readiness wait, pull — so the bring-up can't drift from local either.
-      - name: Start ollama and pull the model
-        run: scripts/e2e-up.sh ollama
+          model: ${{ env.LGTMAYBE_E2E_OLLAMA_MODEL }}
+          models-path: ${{ env.OLLAMA_MODELS }}
 
       # llama.cpp + vLLM legs auto-skip (no server here); the ollama leg runs.
       - name: Run the e2e suite

--- a/.github/workflows/rlm-bench.yml
+++ b/.github/workflows/rlm-bench.yml
@@ -44,28 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Bring up ollama
+        uses: ./.github/actions/ollama-bringup
         with:
-          python-version: "3.12"
-          enable-cache: true
-
-      - name: Sync (with dev deps)
-        run: uv sync --dev
-
-      - name: Install ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
-
-      - name: Cache ollama model
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.OLLAMA_MODELS }}
-          key: ollama-${{ runner.os }}-${{ env.LGTMAYBE_E2E_OLLAMA_MODEL }}
-
-      # The same script a developer runs locally (DEVELOPMENT.md) — serve,
-      # readiness wait, pull — so the bring-up can't drift from local either.
-      - name: Start ollama and pull the model
-        run: scripts/e2e-up.sh ollama
+          model: ${{ env.LGTMAYBE_E2E_OLLAMA_MODEL }}
+          models-path: ${{ env.OLLAMA_MODELS }}
 
       # The generic sweep owns both legs, keeping this workflow and the local
       # command aligned. --max-input-tokens forces the over-budget split.

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -53,24 +53,21 @@ jobs:
             }
           }
 
+      # `gh` is preinstalled on windows-latest and already drives this pipeline's
+      # release steps (windows-exe.yml), so the "does this path exist" question
+      # is one call with the auth and API headers handled for us.
       - name: Check whether the winget package exists
         id: package
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $manifestUrl = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe"
-          try {
-            Invoke-WebRequest -Uri $manifestUrl -Method Get -TimeoutSec 30 -Headers @{
-              Accept = "application/vnd.github+json"
-              "X-GitHub-Api-Version" = "2022-11-28"
-            } | Out-Null
+          gh api repos/microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe --silent
+          if ($LASTEXITCODE -eq 0) {
             "exists=true" >> $env:GITHUB_OUTPUT
-          } catch {
-            if ([int]$_.Exception.Response.StatusCode -eq 404) {
-              "exists=false" >> $env:GITHUB_OUTPUT
-              Write-Warning "MattJColes.lgtmaybe is not published in winget yet. Submit and moderate the first manifest manually; automatic updates will start with the next release."
-              exit 0
-            }
-            throw
+          } else {
+            "exists=false" >> $env:GITHUB_OUTPUT
+            Write-Warning "MattJColes.lgtmaybe is not published in winget yet. Submit and moderate the first manifest manually; automatic updates will start with the next release."
           }
 
       - name: Install wingetcreate

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -62,12 +62,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api repos/microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe --silent
+          $failure = gh api repos/microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe --silent 2>&1
           if ($LASTEXITCODE -eq 0) {
             "exists=true" >> $env:GITHUB_OUTPUT
-          } else {
+          } elseif ("$failure" -match "HTTP 404") {
             "exists=false" >> $env:GITHUB_OUTPUT
             Write-Warning "MattJColes.lgtmaybe is not published in winget yet. Submit and moderate the first manifest manually; automatic updates will start with the next release."
+          } else {
+            # Only a 404 means "not published yet". A 401/403/5xx/timeout must
+            # fail the job rather than silently skip the winget submission.
+            throw "gh api could not reach the winget manifest path: $failure"
           }
 
       - name: Install wingetcreate

--- a/tests/test_ollama_bringup_action.py
+++ b/tests/test_ollama_bringup_action.py
@@ -1,0 +1,68 @@
+"""The shared ollama bring-up composite action.
+
+Two workflows need a live local model (e2e-local, rlm-bench) and used to carry
+byte-identical bring-up steps. One composite action owns them now, so the two
+cannot drift — the thing this suite is here to keep true.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.conftest import read_workflow
+
+_ACTION = Path(__file__).parent.parent / ".github" / "actions" / "ollama-bringup" / "action.yml"
+_USERS = ("e2e-local.yml", "rlm-bench.yml")
+
+
+def _action() -> dict:
+    return yaml.safe_load(_ACTION.read_text(encoding="utf-8"))
+
+
+def test_the_action_takes_the_model_it_serves_as_an_input() -> None:
+    action = _action()
+
+    assert action["runs"]["using"] == "composite"
+    assert action["inputs"]["model"]["required"] is True
+    assert "models-path" in action["inputs"]
+
+
+def test_the_action_installs_uv_ollama_and_serves_the_model() -> None:
+    steps = _action()["runs"]["steps"]
+    uses = [step.get("uses", "") for step in steps]
+    runs = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert any(u.startswith("astral-sh/setup-uv@") for u in uses)
+    assert any(u.startswith("actions/cache@") for u in uses)
+    assert "uv sync --dev" in runs
+    assert "ollama.com/install.sh" in runs
+    # The same script DEVELOPMENT.md tells a developer to run, so CI's bring-up
+    # cannot drift from a local one either.
+    assert "scripts/e2e-up.sh ollama" in runs
+
+
+def test_the_action_does_not_check_out_the_repository() -> None:
+    """A local `uses: ./…` step only resolves once the workspace already holds
+    the repo, so the checkout has to stay with the calling job."""
+    uses = [step.get("uses", "") for step in _action()["runs"]["steps"]]
+
+    assert not any(u.startswith("actions/checkout") for u in uses)
+
+
+@pytest.mark.parametrize("workflow", _USERS)
+def test_both_model_workflows_call_the_shared_action(workflow: str) -> None:
+    _text, parsed = read_workflow(workflow)
+    steps = [step for job in parsed["jobs"].values() for step in job["steps"]]
+    uses = [step.get("uses", "") for step in steps]
+    runs = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "./.github/actions/ollama-bringup" in uses
+    assert any(u.startswith("actions/checkout") for u in uses), "the caller checks out"
+    # The bring-up itself must live in one place only: no workflow may still
+    # carry its own copy of the install/serve steps.
+    assert "ollama.com/install.sh" not in runs
+    assert "scripts/e2e-up.sh" not in runs
+    assert not any(u.startswith("actions/cache@") for u in uses)

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -65,7 +65,12 @@ def test_winget_workflow_updates_the_portable_package() -> None:
     package_check = steps["Check whether the winget package exists"]
     assert package_check["id"] == "package"
     assert "microsoft/winget-pkgs/contents/manifests/m/MattJColes/lgtmaybe" in package_check["run"]
-    assert "StatusCode -eq 404" in package_check["run"]
+    # `gh` is preinstalled on windows runners and already drives the release
+    # steps in windows-exe.yml — the existence check reuses it rather than
+    # hand-rolling the request, so it needs the same token in scope.
+    assert "gh api" in package_check["run"]
+    assert "$LASTEXITCODE" in package_check["run"]
+    assert package_check["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
     for name in ("Install wingetcreate", "Submit winget update"):
         assert steps[name]["if"] == "steps.package.outputs.exists == 'true'"
 

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -71,6 +71,10 @@ def test_winget_workflow_updates_the_portable_package() -> None:
     assert "gh api" in package_check["run"]
     assert "$LASTEXITCODE" in package_check["run"]
     assert package_check["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+    # Only a 404 means "not published yet" — a 401/403/5xx/timeout must fail the
+    # job, not silently skip the submission by reading as a missing package.
+    assert "HTTP 404" in package_check["run"]
+    assert "throw" in package_check["run"]
     for name in ("Install wingetcreate", "Submit winget update"):
         assert steps[name]["if"] == "steps.package.outputs.exists == 'true'"
 


### PR DESCRIPTION
Two workflow findings.

**#497 — the ollama bring-up existed twice, byte for byte.** `e2e-local.yml` and `rlm-bench.yml` both carried the same six steps: checkout, `setup-uv`, `uv sync --dev`, the ollama install script, the model cache keyed on the model tag, and `scripts/e2e-up.sh ollama`. Extracted to `.github/actions/ollama-bringup`, taking `model` (and `models-path`, `python-version`) as inputs.

One deviation from the issue's sketch: the checkout **stays in each calling job**. A `uses: ./.github/actions/…` step can only resolve once the repository is already in the workspace, so a composite action cannot own the checkout that makes it reachable. The action's own comment says so, and `test_the_action_does_not_check_out_the_repository` holds it in place.

New `tests/test_ollama_bringup_action.py` covers the action's inputs and steps, and asserts both workflows call it *and* no longer carry their own install/serve/cache steps — so a future copy-paste fails the suite rather than drifting quietly.

**#498 — winget.yml hand-rolled a GitHub API existence check.** An `Invoke-WebRequest` with manual `Accept` / `X-GitHub-Api-Version` headers and a try/catch on the 404 status, to ask whether a path exists. `gh` is preinstalled on `windows-latest` and already drives this pipeline's release steps (`windows-exe.yml`), so it is now `gh api … --silent` branching on `$LASTEXITCODE`. `test_winget_workflow_updates_the_portable_package` was updated first to require the `gh` call and the `GH_TOKEN` the step needs.

Both workflows still parse as valid YAML and keep their existing inputs/gating; neither runs on a normal PR (dispatch/release only), so this lands unexercised by CI — the tests are the guard rail that remains.

Closes #497
Closes #498

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_