### PR TITLE
refactor: one workspace-file reader for the directory and spec lenses

### DIFF
--- a/src/lgtmaybe/engine/directory.py
+++ b/src/lgtmaybe/engine/directory.py
@@ -77,26 +77,9 @@ def load_context_files(cfg: ReviewConfig, root: Path) -> dict[str, str]:
     if not wanted:
         return {}
 
-    resolved_root = root.resolve()
-
-    def read(path: str) -> str | None:
-        """Read one workspace file, or None when it isn't readable under *root*.
-
-        Config is trusted, so the containment check is defence in depth: two
-        cheap lines that keep a stray ``../`` from ever reaching outside the
-        repository being reviewed.
-        """
-        try:
-            target = (resolved_root / path).resolve()
-            if not target.is_relative_to(resolved_root):
-                return None
-            return target.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return None
-
     return retrieve.resolve_needs(
         wanted,
-        read,
+        retrieve.local_file_fetcher(root),
         already=set(),
         budget_tokens=max(1, cfg.max_input_tokens // _CONTEXT_BUDGET_DIVISOR),
         max_files=retrieve.MAX_FETCH_FILES,

--- a/src/lgtmaybe/engine/retrieve.py
+++ b/src/lgtmaybe/engine/retrieve.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 from .astgrep import SymbolResolver
 from .compress import count_tokens
@@ -32,6 +33,33 @@ FileFetcher = Callable[[str], "str | None"]
 # hard stops that keep a deferral from looping or fetching the whole repo.
 MAX_HOPS = 2
 MAX_FETCH_FILES = 5
+
+
+def local_file_fetcher(root: Path) -> FileFetcher:
+    """A ``FileFetcher`` reading files out of the workspace under *root*.
+
+    The lenses that read committed context rather than PR content — directory
+    rules and the spec lens — both need exactly this: read a repository-relative
+    path, return None when it isn't readable. Written once here, beside the
+    resolver that consumes it, because two copies of a containment check are two
+    places for it to drift.
+
+    Config naming these paths is trusted, so the containment check is defence in
+    depth: two cheap lines that keep a stray ``../`` from ever reaching outside
+    the repository being reviewed.
+    """
+    resolved_root = root.resolve()
+
+    def read(path: str) -> str | None:
+        try:
+            target = (resolved_root / path).resolve()
+            if not target.is_relative_to(resolved_root):
+                return None
+            return target.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+
+    return read
 
 
 def resolve_needs(

--- a/src/lgtmaybe/engine/specs.py
+++ b/src/lgtmaybe/engine/specs.py
@@ -401,19 +401,11 @@ def _reader(root: Path, head_texts: Mapping[str, str]) -> Callable[[str], str | 
     the lens the version *before* the requirements it is meant to check. It is
     untrusted, which is why the rendered block is wrapped as untrusted data.
     """
-    resolved_root = root.resolve()
+    from_workspace = retrieve.local_file_fetcher(root)
 
     def read(path: str) -> str | None:
         head = head_texts.get(path)
-        if head is not None:
-            return head
-        try:
-            target = (resolved_root / path).resolve()
-            if not target.is_relative_to(resolved_root):
-                return None
-            return target.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return None
+        return head if head is not None else from_workspace(path)
 
     return read
 

--- a/tests/engine/test_retrieve.py
+++ b/tests/engine/test_retrieve.py
@@ -7,6 +7,7 @@ from lgtmaybe.engine.parse import coerce_needs, parse_needs
 from lgtmaybe.engine.retrieve import (
     MAX_FETCH_FILES,
     MAX_HOPS,
+    local_file_fetcher,
     resolve_needs,
 )
 
@@ -356,3 +357,38 @@ def test_symbol_candidates_keep_trying_past_an_unfetchable_one() -> None:
     )
 
     assert list(out) == ["real.py"]
+
+
+class TestLocalFileFetcher:
+    """The one containment-checked workspace reader both lenses read through."""
+
+    def test_reads_a_file_under_the_root(self, tmp_path) -> None:
+        (tmp_path / "ARCHITECTURE.md").write_text("the shape of it", encoding="utf-8")
+
+        assert local_file_fetcher(tmp_path)("ARCHITECTURE.md") == "the shape of it"
+
+    def test_a_path_escaping_the_root_reads_as_missing(self, tmp_path) -> None:
+        """Config is trusted, so this is defence in depth — but a stray `../`
+        must never reach outside the repository being reviewed."""
+        outside = tmp_path.parent / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        assert local_file_fetcher(root)("../outside.md") is None
+
+    def test_a_missing_file_reads_as_none_rather_than_raising(self, tmp_path) -> None:
+        assert local_file_fetcher(tmp_path)("nope.md") is None
+
+    def test_a_directory_reads_as_none_rather_than_raising(self, tmp_path) -> None:
+        (tmp_path / "docs").mkdir()
+
+        assert local_file_fetcher(tmp_path)("docs") is None
+
+    def test_undecodable_bytes_are_replaced_rather_than_failing_the_review(self, tmp_path) -> None:
+        (tmp_path / "weird.md").write_bytes(b"ok \xff\xfe end")
+
+        text = local_file_fetcher(tmp_path)("weird.md")
+
+        assert text is not None
+        assert text.startswith("ok ")


### PR DESCRIPTION
`directory.load_context_files` and `specs._reader` each defined the same inner closure — resolve the path under the root, refuse anything that escapes it, read it, answer `None` on `OSError` — and both fed the result into `retrieve.resolve_needs`, which both modules already import.

Two copies of a containment check is two places for it to drift, so it now lives once as `retrieve.local_file_fetcher(root)`, beside the resolver that consumes it. `specs._reader` keeps its one genuine extra step: prefer the PR's head text when the file has one (a spec is usually committed in the PR that implements it), else read the workspace through the shared fetcher.

New tests in `tests/engine/test_retrieve.py` cover the reader directly: a file under the root, a `../` escape reading as missing, a missing path, a directory, and undecodable bytes being replaced rather than failing the review — the containment behaviour that was previously only exercised indirectly through two callers.

`tests/engine`: 1005 passing.

Closes #488

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_