### PR TITLE
fix: escape the file path when fetching file contents

### DIFF
--- a/src/lgtmaybe/gitea/gateway.py
+++ b/src/lgtmaybe/gitea/gateway.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import base64
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -398,7 +399,10 @@ class GiteaGateway:
         """One file's text at ``ref``, or None when absent or undecodable."""
         try:
             resp = self._client.get(
-                f"{self._api}/contents/{path}",
+                # quote() the path, keeping `/` as a real separator — an
+                # unescaped `#` opens a URL fragment, truncating the path and
+                # discarding the `ref` query with the rest of the filename.
+                f"{self._api}/contents/{quote(path)}",
                 headers=self._headers,
                 params={"ref": ref},
                 timeout=_TIMEOUT,

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -894,7 +894,11 @@ class RestGitHubGateway:
         Deleted/renamed-away files (404) and any other fetch error degrade to
         None so the engine simply reviews the bare diff for that file.
         """
-        url = f"{self._api}/contents/{path}?ref={ref}"
+        # quote() the path, keeping `/` as a real separator: `#` in a filename
+        # would otherwise open a client-side URL fragment, truncating the request
+        # path and swallowing the `?ref=` query — a request that 404s and reads
+        # exactly like a deleted file.
+        url = f"{self._api}/contents/{quote(path)}?ref={ref}"
         try:
             resp = self._client.get(
                 url,

--- a/tests/gitea/test_gateway.py
+++ b/tests/gitea/test_gateway.py
@@ -406,3 +406,24 @@ class TestCheckRun:
     def test_a_status_failure_never_fails_the_review(self) -> None:
         respx.post(f"{API}/statuses/head456").mock(return_value=httpx.Response(500))
         _gateway(httpx.Client()).create_check_run("head456", "success", "t", "s")  # must not raise
+
+
+class TestFileContentEscaping:
+    @respx.mock
+    def test_a_path_with_a_fragment_character_still_reaches_the_server(self) -> None:
+        """An unescaped `#` opens a URL fragment: the path truncates and the
+        `ref` query is swallowed into the discarded remainder."""
+        captured: list[httpx.Request] = []
+
+        def _record(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"content": "aW1wb3J0IG9z", "encoding": "base64"})
+
+        respx.route(method="GET", url__startswith=f"{API}/contents/").mock(side_effect=_record)
+
+        assert (
+            _gateway(httpx.Client())._get_file_content("src/C#/Foo.cs", "deadbeef") == "import os"
+        )
+        # `.path` decodes; the wire form is what the `#` breaks.
+        assert captured[0].url.raw_path.endswith(b"/contents/src/C%23/Foo.cs?ref=deadbeef")
+        assert captured[0].url.params["ref"] == "deadbeef"

--- a/tests/github/test_rest_gateway.py
+++ b/tests/github/test_rest_gateway.py
@@ -435,3 +435,26 @@ def test_content_fetches_keep_full_concurrency_while_the_count_runs() -> None:
         f"content fetches peaked at {peak} concurrent while the count ran; "
         f"the count is taking a worker from them (expected {_CONTENT_FETCH_WORKERS})"
     )
+
+
+@respx.mock
+def test_a_path_with_a_fragment_character_still_reaches_the_server() -> None:
+    """`#` in a path starts a client-side URL fragment, so an unescaped path
+    truncates the request to `.../contents/src/C` and drops the `?ref=` with it —
+    a silent 404 that reads exactly like a deleted file."""
+    captured: list[httpx.Request] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, text="class Foo {}")
+
+    respx.route(method="GET", url__startswith=f"{BASE_URL}/repos/{REPO}/contents/").mock(
+        side_effect=_record
+    )
+
+    gw = RestGitHubGateway(repo=REPO, pr_number=PR_NUMBER, token=TOKEN, client=httpx.Client())
+
+    assert gw._get_file_content("src/C#/Foo.cs", "deadbeef") == "class Foo {}"
+    # `.path` decodes; the wire form is what the `#` breaks.
+    assert captured[0].url.raw_path.endswith(b"/contents/src/C%23/Foo.cs?ref=deadbeef")
+    assert captured[0].url.params["ref"] == "deadbeef"


### PR DESCRIPTION
`RestGitHubGateway._get_file_content` and `GiteaGateway._get_file_content` interpolated the file path into the contents URL raw. A path containing `#` or `?` — both legal, and both real (a `src/C#/` directory, a `notes#1.md`) — then breaks the request:

```
httpx.URL('https://api.github.com/repos/x/y/contents/src/C#/Foo.cs?ref=deadbeef')
  path:     /repos/x/y/contents/src/C
  query:    b''
  fragment: b'Foo.cs?ref=deadbeef'
```

The `#` opens a client-side URL fragment, so the path truncates at it and the `?ref=` query is swallowed along with the rest of the filename. The server 404s, `_get_file_content` catches the `HTTPError` and returns `None` — no crash, nothing surfaced, and the file silently loses hunk-context expansion, the dependency-manifest scan, and the reflection deferral fetch. It looks exactly like a deleted file.

Both now `quote()` the path. Its default `safe='/'` keeps `/` a real path separator (GitHub's and Gitea's `contents/{path}` want path segments, unlike GitLab's endpoint) and leaves ordinary ASCII paths byte-identical, so this is backward compatible. The GitLab adapter already quoted its path — this was the inconsistency, not a deliberate difference.

A test per adapter asserts the wire form (`raw_path`, since `.path` decodes) carries `%23` and still has its `ref`; both were confirmed red before the fix.

`tests/github`, `tests/gitea`: 150 passing.

Closes #508

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_