### PR TITLE
fix: read a fenced reply in /ask and follow-up validation

### DIFF
--- a/src/lgtmaybe/cli/slash.py
+++ b/src/lgtmaybe/cli/slash.py
@@ -56,6 +56,20 @@ _ASK_SYSTEM = (
 _ASK_FALLBACK = "I couldn't produce a valid answer. Please try again."
 
 
+def _unfence(text: str) -> str:
+    """*text* with one wrapping ``` code fence removed, if it has one.
+
+    Only a fence that opens the response and closes it — an inner fence quoting
+    an example is part of the prose around it, not a wrapper.
+    """
+    if not (text.startswith("```") and text.endswith("```")):
+        return text
+    body = text.removeprefix("```")
+    # The opening fence may carry a language tag ("```json"); drop that line.
+    _tag, _, rest = body.partition("\n")
+    return rest.removesuffix("```").strip()
+
+
 def _is_json_envelope(text: str) -> bool:
     """Is the WHOLE response a JSON object/array rather than an answer?
 
@@ -67,8 +81,13 @@ def _is_json_envelope(text: str) -> bool:
     and a fenced JSON example in an otherwise good answer — eating the answers the
     guard exists to protect. An envelope is the entire response, or it is prose
     that happens to quote one. Arrays count: `[]` is as much an envelope as `{}`.
+
+    One wrapping code fence is stripped first: a model told "return ONLY a JSON
+    object" commonly fences it anyway, and the fenced envelope is the same
+    machine payload wearing a backtick. That stays whole-response — a fence
+    around prose leaves prose behind, which is relayed as it always was.
     """
-    stripped = text.strip()
+    stripped = _unfence(text.strip())
     if not stripped.startswith(("{", "[")):
         return False
     try:

--- a/src/lgtmaybe/engine/validate.py
+++ b/src/lgtmaybe/engine/validate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from lgtmaybe.core.logging import get_logger
@@ -17,6 +16,7 @@ from lgtmaybe.core.models import (
 from lgtmaybe.core.ports import ProviderClient
 
 from .injection import wrap_validation
+from .parse import parse_structured
 from .profiling import timed_complete
 from .redact import redact
 
@@ -96,7 +96,18 @@ def validate_findings(
             label="validate",
             **opts,
         )
-        parsed = FindingValidationResult.model_validate(json.loads(result.text))
+        # Through the shared lenient parser, like every other structured-output
+        # consumer: a bare json.loads made this the one call that refused a
+        # fenced, reasoning-wrapped or prose-wrapped reply — the exact shapes
+        # ollama and openai-compatible gateways produce, where the same run's
+        # review and reflect calls parse fine.
+        parsed = parse_structured(
+            result.text,
+            FindingValidationResult,
+            lambda data: isinstance(data.get("verdicts"), list),
+        )
+        if parsed is None:
+            raise ValueError("no verdicts object in the reply")
     except Exception as exc:  # noqa: BLE001 - validation fails closed
         _log.warning("follow-up finding validation failed: %s", exc)
         return _uncertain(findings, "validation output was unavailable or invalid")

--- a/tests/cli/test_slash.py
+++ b/tests/cli/test_slash.py
@@ -515,3 +515,17 @@ class TestAskRelaysProseThatMerelyQuotesJson:
 
         assert self._ask("[]") == _ASK_FALLBACK
         assert self._ask('[{"path": "a.py"}]') == _ASK_FALLBACK
+
+    def test_a_fenced_whole_response_envelope_is_refused(self) -> None:
+        """A model told "return ONLY a JSON object" commonly fences it anyway.
+        The trimmed text then starts with a backtick, not `{`, so the envelope
+        check missed it and the raw fenced JSON was posted into a human thread."""
+        from lgtmaybe.cli.slash import _ASK_FALLBACK
+
+        assert self._ask('```json\n{"findings": []}\n```') == _ASK_FALLBACK
+        assert self._ask("```\n[]\n```") == _ASK_FALLBACK
+
+    def test_a_fence_wrapping_prose_is_still_relayed(self) -> None:
+        """Stripping the fence must not turn a fenced *answer* into a refusal."""
+        answer = "```\nNo — it dereferences before the None check.\n```"
+        assert self._ask(answer) == answer

--- a/tests/engine/test_validate_followup.py
+++ b/tests/engine/test_validate_followup.py
@@ -151,3 +151,44 @@ def test_validate_findings_neutralises_forged_markers() -> None:
     assert prompt.count("===VALIDATION_END===") == 1
     assert "VALIDATION-END" in prompt
     assert verdicts[0].status is FindingValidationStatus.uncertain
+
+
+def test_a_fenced_verdict_is_parsed_like_every_other_structured_reply() -> None:
+    """Bare json.loads made this path the one structured-output consumer without
+    the lenient extraction the review, reflect and triage calls all get — so on
+    the very routes that tolerance exists for (ollama, openai-compatible), every
+    previously-posted finding silently collapsed to `uncertain`."""
+    payload = json.dumps(
+        {"verdicts": [{"thread_id": "T1", "status": "fixed", "reason": "call removed"}]}
+    )
+    provider = FakeProvider(
+        result=ProviderResult(
+            text=f"Here is my assessment:\n\n```json\n{payload}\n```\n",
+            input_tokens=1,
+            output_tokens=1,
+        )
+    )
+
+    verdicts = validate_findings(provider, make_cfg(), [_finding()], CTX)
+
+    assert verdicts[0].status is FindingValidationStatus.fixed
+    assert verdicts[0].reason == "call removed"
+
+
+def test_a_reply_wrapped_in_a_reasoning_block_is_parsed_too() -> None:
+    """The other shape parse.py's tolerance exists for: qwen-style local models
+    that emit their thinking before the JSON."""
+    payload = json.dumps(
+        {"verdicts": [{"thread_id": "T1", "status": "still_open", "reason": "still there"}]}
+    )
+    provider = FakeProvider(
+        result=ProviderResult(
+            text=f"<think>the call is still present</think>{payload}",
+            input_tokens=1,
+            output_tokens=1,
+        )
+    )
+
+    verdicts = validate_findings(provider, make_cfg(), [_finding()], CTX)
+
+    assert verdicts[0].status is FindingValidationStatus.still_open


### PR DESCRIPTION
Two structured-output paths refused a reply shape the rest of the codebase accepts.

**#510 — `/ask` posted raw fenced JSON into a human thread.** `_is_json_envelope` only recognised a machine payload when the trimmed text started with `{` or `[`. A model told "Return ONLY a JSON object" commonly fences it anyway, and then the trimmed text starts with a backtick — so the guard returned `False`, `parse_structured` found no `answer` key, and execution fell through to `return result.text.strip()`, putting ```` ```json\n{"findings": []}\n``` ```` verbatim into the PR conversation.

One wrapping fence is now stripped before the check. It stays a whole-response test: a fence around *prose* leaves prose behind, so a fenced answer is still relayed, and the existing "prose that quotes JSON" tests are untouched. New tests cover the fenced envelope (object and array) and the fenced answer.

**#511 — follow-up validation was the one consumer without lenient parsing.** `validate.py` used a bare `json.loads`, while review lenses, `repair.py`, `triage.py`, `describe.py` and `reflect.py` all route through `parse.py`. Its extraction exists specifically to strip reasoning blocks, code fences and surrounding prose — "most for `openai-compatible` gateways that don't honour the `response_format` JSON-mode hint". Wrapped in a broad `except` → `_uncertain()`, the practical effect was silent and provider-shaped: on exactly those routes, every previously-posted finding in a `/review` follow-up collapsed to `uncertain` while the same run's review and reflect calls parsed the same model's output fine.

It now uses `parse_structured(...)` with a `verdicts`-list predicate, and an absent object raises into the existing fail-closed path — so a genuinely unparseable reply still yields `uncertain`, as before. New tests cover a fenced verdict and a `<think>`-wrapped one; both were confirmed red first.

`tests/cli`, `tests/engine`: 1243 passing.

Closes #510
Closes #511

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_