### PR TITLE
perf: overlap the per-file boundary scans and guard the flood counter

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -825,7 +825,12 @@ class LLMReviewEngine:
         # second call (see repair.py). Keyed by lens for the same reason as
         # `_stepped_down`: one fact about the review, not one per batch.
         self._repaired: set[str] = set()
+        # Written from the fan-out's worker threads, and unlike the sets above
+        # a dict counter's `read, add, store` is not one atomic operation — two
+        # batches' primers flooding at once would otherwise lose an update and
+        # under-report the drop in the summary notice.
         self._flooded: dict[str, int] = {}
+        self._flooded_lock = threading.Lock()
         # Resolved once per review so every (batch, lens) result reads the same
         # bound without threading cfg through the fan-out's every hop.
         self._max_findings_per_lens = cfg.max_findings_per_lens
@@ -959,6 +964,13 @@ class LLMReviewEngine:
             ctx_lines = min(cfg.context_lines, context_lines_for_budget(remaining))
             if ctx_lines > 0 and ctx.file_contents:
                 after = trailing_context_lines(ctx_lines)
+                # Enclosing function/class boundaries (ast-grep; [] on any
+                # failure) so the leading pad reaches the signature. Each file
+                # costs its own temp dir + subprocess, and function_context is
+                # on by default — run serially a max-sized PR pays ~max_files
+                # spawn/teardown cycles before batching even starts. They are
+                # independent, so they overlap, like static analysis's tools.
+                boundaries = _definition_spans_by_path(ctx.file_contents, file_patches, cfg)
                 file_patches = [
                     (
                         path,
@@ -967,13 +979,7 @@ class LLMReviewEngine:
                             redact(ctx.file_contents.get(path, "")),
                             ctx_lines,
                             after=after,
-                            # Enclosing function/class boundaries (ast-grep; [] on
-                            # any failure) so the leading pad reaches the signature.
-                            boundaries=(
-                                definition_spans(ctx.file_contents.get(path, ""), path)
-                                if cfg.function_context and ctx.file_contents.get(path)
-                                else None
-                            ),
+                            boundaries=boundaries.get(path),
                         ),
                     )
                     for path, patch in file_patches
@@ -1894,7 +1900,8 @@ class LLMReviewEngine:
         # same selection policy `_dedupe` uses.
         kept = sorted(findings, key=lambda f: -f.severity.rank)[:cap]
         dropped = len(findings) - len(kept)
-        self._flooded[lens.id] = self._flooded.get(lens.id, 0) + dropped
+        with self._flooded_lock:
+            self._flooded[lens.id] = self._flooded.get(lens.id, 0) + dropped
         _log.warning(
             "lens exceeded the per-lens finding bound — dropping the least severe",
             extra={"lens": lens.id, "returned": len(findings), "kept": cap, "dropped": dropped},
@@ -2472,6 +2479,30 @@ def _scanner_covers(cfg: ReviewConfig, tool: StaticAnalysisTool) -> bool:
     """
     sa = cfg.static_analysis
     return sa.enabled and tool in sa.tools and mode_for(tool, cfg) is ToolMode.finding
+
+
+_BOUNDARY_SCAN_WORKERS = 8
+
+
+def _definition_spans_by_path(
+    file_contents: dict[str, str],
+    file_patches: Sequence[tuple[str, str]],
+    cfg: ReviewConfig,
+) -> dict[str, list[tuple[int, int]]]:
+    """Enclosing definition spans per path, scanned concurrently.
+
+    Empty when ``function_context`` is off, and a path with no fetched head text
+    is absent — so a caller reads ``.get(path)`` and gets ``None``, exactly the
+    "no boundaries" value ``expand_hunks`` took before.
+    """
+    if not cfg.function_context:
+        return {}
+    paths = [path for path, _ in file_patches if file_contents.get(path)]
+    if not paths:
+        return {}
+    with ThreadPoolExecutor(max_workers=min(_BOUNDARY_SCAN_WORKERS, len(paths))) as pool:
+        spans = pool.map(lambda path: definition_spans(file_contents[path], path), paths)
+        return dict(zip(paths, spans, strict=True))
 
 
 def _is_droppable_scan(finding: ReviewFinding) -> bool:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import threading
+import time
 
 import pytest
 
@@ -2747,3 +2749,116 @@ def test_a_repair_that_finds_nothing_still_counts_as_complete() -> None:
     assert findings == []
     assert "results may be incomplete" not in summary
     assert "reformatted by a second call" in summary
+
+
+class TestFloodedAccountingUnderConcurrency:
+    """`_stamp_and_bound` runs inside the fan-out's worker threads, so its
+    per-lens drop counter is written concurrently. A plain
+    `d[k] = d.get(k, 0) + n` is a read-modify-write, not an atomic op like the
+    `set.add()` the engine's other per-run state uses: two batches whose primer
+    (always the first lens) floods at the same instant can lose one update, and
+    the summary notice then under-reports how many findings were dropped.
+    """
+
+    class _SlowStoreDict(dict):
+        """A dict that yields the GIL between the read and the store, so the
+        read-modify-write window interleaves reliably rather than by luck.
+        Unguarded, this loses most of the updates; guarded, none."""
+
+        def __setitem__(self, key, value) -> None:
+            time.sleep(0.002)
+            super().__setitem__(key, value)
+
+    def test_concurrent_bounds_on_one_lens_do_not_lose_counts(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from lgtmaybe.engine.engine import _Lens
+
+        engine = LLMReviewEngine(FakeProvider())
+        engine._flooded = self._SlowStoreDict()
+        engine._flooded_lock = threading.Lock()
+        engine._max_findings_per_lens = 1
+        lens = _Lens(id="security", user_block="")
+        # 4 findings in, cap of 1 out ⇒ 3 dropped per call.
+        findings = [
+            ReviewFinding(
+                path="a.py",
+                line=index + 1,
+                side="RIGHT",
+                severity=Severity.low,
+                title=f"f{index}",
+                body="b",
+            )
+            for index in range(4)
+        ]
+        calls = 24
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: engine._stamp_and_bound(list(findings), lens), range(calls)))
+
+        assert engine._flooded["security"] == 3 * calls
+
+
+class TestBoundaryScansOverlap:
+    """`function_context` is on by default and each file costs its own temp dir
+    plus ast-grep subprocess, so scanning them serially put ~one spawn per
+    changed file in front of every review. They are independent."""
+
+    def _spans(self, monkeypatch, paths: list[str], *, function_context: bool = True):
+        from lgtmaybe.engine import engine as engine_mod
+
+        live = 0
+        peak = 0
+        guard = threading.Lock()
+
+        def fake_definition_spans(text: str, path: str) -> list[tuple[int, int]]:
+            nonlocal live, peak
+            with guard:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.02)
+            with guard:
+                live -= 1
+            return [(1, len(text))]
+
+        monkeypatch.setattr(engine_mod, "definition_spans", fake_definition_spans)
+        contents = {path: f"# {path}" for path in paths}
+        result = engine_mod._definition_spans_by_path(
+            contents,
+            [(path, "@@ -1 +1 @@") for path in paths],
+            make_cfg(function_context=function_context),
+        )
+        return result, peak
+
+    def test_every_file_gets_its_own_spans(self, monkeypatch) -> None:
+        result, _peak = self._spans(monkeypatch, ["a.py", "b.py", "c.py"])
+
+        assert set(result) == {"a.py", "b.py", "c.py"}
+        assert result["a.py"] == [(1, len("# a.py"))]
+
+    def test_the_scans_run_concurrently(self, monkeypatch) -> None:
+        _result, peak = self._spans(monkeypatch, [f"f{i}.py" for i in range(6)])
+
+        assert peak > 1, "the per-file scans ran one after another"
+
+    def test_nothing_is_scanned_when_function_context_is_off(self, monkeypatch) -> None:
+        result, peak = self._spans(monkeypatch, ["a.py"], function_context=False)
+
+        assert result == {}
+        assert peak == 0
+
+    def test_a_file_without_fetched_head_text_is_absent_not_empty(self, monkeypatch) -> None:
+        """`.get(path)` must yield None for it — the same "no boundaries" value
+        expand_hunks took before."""
+        from lgtmaybe.engine import engine as engine_mod
+
+        monkeypatch.setattr(engine_mod, "definition_spans", lambda text, path: [(1, 2)])
+
+        result = engine_mod._definition_spans_by_path(
+            {"a.py": "code"},
+            [("a.py", "patch"), ("b.py", "patch")],
+            make_cfg(),
+        )
+
+        assert result.get("b.py") is None
+        assert result["a.py"] == [(1, 2)]


### PR DESCRIPTION
**#505 — the default-on boundary scan was serial.** `cfg.function_context` defaults to `True`, so unlike static-analysis fusion this runs on every review; each changed file with fetched head text got its own `TemporaryDirectory` create/destroy cycle and its own `ast-grep scan` subprocess, spawned one after another inside a list comprehension. At the default `max_files = 50` that is ~50 spawn/teardown cycles sitting in the `expand` profiler stage before batching or a single model call begins.

They are independent scans over read-only text, so they now run through a bounded `ThreadPoolExecutor` — the idiom `static_analysis.py` already uses for its tools — via `_definition_spans_by_path`. A path with no fetched head text is simply absent from the result, so `.get(path)` yields `None`: exactly the "no boundaries" value `expand_hunks` received before, rather than an empty list that would mean something different.

**#506 — the per-lens drop counter could lose updates.** `_stamp_and_bound` runs inside the fan-out's worker threads and wrote `self._flooded[lens.id] = self._flooded.get(lens.id, 0) + dropped` — a read, an add and a store, not one atomic operation like the `set.add()` the engine's other per-run state (`_split_batches`, `_stepped_down`, `_repaired`, `_re_asked`) relies on. On a multi-batch PR each batch's cache-warm primer is the same first lens, so two threads can hit this at nearly the same instant; if both flood the cap, one update is lost and the summary under-reports the drop. The findings posted are unaffected — only the aggregate accounting. Now guarded by a lock reset alongside the rest of the per-review state.

The race test drives 24 concurrent `_stamp_and_bound` calls through a dict that yields the GIL between the read and the store, which loses ~2/3 of the updates unguarded and none guarded — so it fails for the real reason rather than by luck. The boundary tests cover per-file spans, actual concurrency (peak > 1 in flight), `function_context` off, and the absent-vs-empty distinction.

`tests/engine`: 1012 passing.

Closes #505
Closes #506

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_