### PR TITLE
fix: honour resolve_fixed on GitLab

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -193,6 +193,7 @@ _GATEWAY_BUILDERS: dict[Forge, Callable[[PRLocator, str, ReviewConfig], ReviewGa
         pr_number=located.number,
         token=token,
         marker_key=f"{cfg.provider}/{cfg.model}",
+        resolve_fixed=cfg.resolve_fixed,
     ),
     Forge.gitea: lambda located, token, cfg: GiteaGateway(
         host=located.host,

--- a/src/lgtmaybe/gitlab/gateway.py
+++ b/src/lgtmaybe/gitlab/gateway.py
@@ -71,6 +71,7 @@ class GitLabGateway:
         pr_number: Merge request *iid* (the per-project number in the URL).
         token:     GitLab access token (project, group, or personal).
         client:    Injected httpx.Client; a default is created if omitted.
+        resolve_fixed: Whether to resolve threads the caller validated as fixed.
     """
 
     def __init__(
@@ -82,6 +83,7 @@ class GitLabGateway:
         client: httpx.Client | None = None,
         marker_key: str | None = None,
         scheme: str = "https",
+        resolve_fixed: bool = True,
     ) -> None:
         self._repo = repo
         self._pr_number = pr_number
@@ -92,6 +94,9 @@ class GitLabGateway:
         self._mr_api = f"{self._api}/merge_requests/{pr_number}"
         self._headers = {"PRIVATE-TOKEN": token, "Accept": "application/json"}
         self._client = client if client is not None else httpx.Client(timeout=_TIMEOUT)
+        # One setting across forges: without this GitLab resolved regardless of
+        # what the user configured, while GitHub honoured it.
+        self._resolve_fixed = resolve_fixed
         self._marker = marker("lgtmaybe", marker_key)
         self._describe_marker = marker("lgtmaybe-describe", marker_key)
         self._diagram_marker = marker("lgtmaybe-diagram", marker_key)
@@ -200,7 +205,8 @@ class GitLabGateway:
 
         body = f"{summary}{render_demoted(demoted)}{render_broad(broad)}\n\n{self._marker}"
         self._upsert_note(body, self._marker)
-        self._resolve_fixed_threads()
+        if self._resolve_fixed:
+            self._resolve_fixed_threads()
 
     def post_issue_comment(self, body: str) -> None:
         """Post a standalone note to the merge request conversation."""

--- a/tests/gitlab/test_gateway.py
+++ b/tests/gitlab/test_gateway.py
@@ -471,3 +471,56 @@ class TestResilience:
 
         assert not created.called
         assert "Hardcoded password" in json.loads(note.calls[0].request.content)["body"]
+
+
+class TestResolveFixedIsHonoured:
+    """`resolve_fixed` is one setting across forges: GitHub threaded it through
+    and GitLab did not, so turning it off left GitLab resolving anyway."""
+
+    def _post_with(self, resolve_fixed: bool):
+        _stub_context_routes()
+        _stub_post_routes()
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "thread-1",
+                        "notes": [
+                            {
+                                "id": 11,
+                                "body": "old finding\n<!-- lgtmaybe-finding:abc -->",
+                                "resolved": False,
+                                "position": {"new_path": "app.py"},
+                            }
+                        ],
+                    }
+                ],
+            )
+        )
+        respx.post(f"{MR_URL}/discussions/thread-1/notes").mock(
+            return_value=httpx.Response(201, json={"id": 12})
+        )
+        resolve = respx.put(f"{MR_URL}/discussions/thread-1").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        gateway = GitLabGateway(
+            host=HOST,
+            repo=REPO,
+            pr_number=MR_IID,
+            token=TOKEN,
+            client=httpx.Client(),
+            resolve_fixed=resolve_fixed,
+        )
+        gateway.list_active_findings()
+        gateway.set_validated_fixed_threads({"thread-1"})
+        gateway.post_review([], "👍 LGTM!")
+        return resolve
+
+    @respx.mock
+    def test_a_validated_thread_resolves_when_the_setting_is_on(self) -> None:
+        assert self._post_with(True).called
+
+    @respx.mock
+    def test_nothing_resolves_when_the_setting_is_off(self) -> None:
+        assert not self._post_with(False).called


### PR DESCRIPTION
`_GATEWAY_BUILDERS` passes `resolve_fixed=cfg.resolve_fixed` into `RestGitHubGateway`, which gates its resolve-on-fix pass on it. The GitLab lambda passed nothing, and `GitLabGateway.__init__` had no such parameter — `post_review` called `_resolve_fixed_threads()` unconditionally.

So `resolve_fixed: false` silently did nothing on GitLab. Nothing in `review-on-gitlab.md` or the Action-inputs table in `use-as-github-action.md` presents it as per-forge, so a team setting it globally and expecting it to apply would have been surprised in the direction that matters — threads closing when they asked for them to stay open.

Threaded through `GitLabGateway` (defaulting `True`, so existing behaviour is unchanged unless configured otherwise) and its builder, matching GitHub. The issue offered documenting the divergence as the alternative; making the setting mean the same thing on every forge seemed the better answer, since the resolve path is already gated on the caller's validated allowlist and this just adds the user's own switch in front of it.

Two tests drive `post_review` with a validated fixed thread and assert the `PUT` fires with the setting on and does not with it off.

`tests/gitlab`, `tests/cli`: 270 passing.

Closes #502

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_