### PR TITLE
fix: read a self-hosted server's tool-call rejection wording

### DIFF
--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -360,6 +360,12 @@ def _retry_wait(retry_state: RetryCallState) -> float:
 # loosely because the wording is the backend's, not litellm's.
 _REJECTION_PHRASES = ("not permitted", "not supported", "unsupported", "unknown", "unexpected")
 
+# A self-hosted OpenAI-compatible server refuses a tool call by naming the
+# start-up flag it is missing, not by calling the field unsupported — so these
+# stand on their own rather than needing a phrase from the tuple above. Specific
+# enough that a genuine 400 (context length, bad model) cannot match.
+_TOOL_PARSER_PHRASES = ("--enable-auto-tool-choice", "tool-call-parser")
+
 
 def _rejects_field(exc: Exception, *names: str) -> bool:
     """True when *exc* reads as "this route does not take <one of names>"."""
@@ -396,7 +402,16 @@ def _rejects_tool_config(exc: Exception) -> bool:
     instead, and a route that refuses *that* has genuinely no structured-output
     mechanism left. Bedrock names the Converse field (``toolConfig``); the
     OpenAI-shaped routes name ``tools`` / ``tool_choice``.
+
+    A self-hosted OpenAI-compatible server refuses differently: it names the
+    server flag it was started without rather than calling the field
+    unsupported. vLLM answers ``"auto" tool choice requires
+    --enable-auto-tool-choice and --tool-call-parser to be set``, which carries
+    none of ``_REJECTION_PHRASES`` — so without these the 400 read as permanent
+    and killed the review rather than degrading to prompt-instructed JSON.
     """
+    if any(phrase in str(exc).lower() for phrase in _TOOL_PARSER_PHRASES):
+        return True
     return _rejects_field(exc, "toolconfig", "tool_choice", "toolchoice", "tools")
 
 

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -2279,3 +2279,69 @@ class TestTheFloorRespectsRouteCapability:
         )
 
         assert provider.lower_reasoning_effort() == {"reasoning_effort": "medium"}
+
+
+class TestOpenAICompatibleToolRejectionWording:
+    """The tool-config fallback is matched off the backend's own error prose, and
+    every existing test uses Bedrock's wording. vLLM refuses a tool call with
+    "requires --enable-auto-tool-choice and --tool-call-parser to be set", which
+    carries none of the phrases the matcher looked for — so the BadRequestError
+    read as permanent and killed the review instead of degrading to
+    prompt-instructed JSON, the exact failure this machinery exists to prevent.
+    """
+
+    # vLLM's own wording, as served by an instance started without the tool
+    # flags; the JSON envelope around it is litellm's.
+    VLLM_400 = (
+        "litellm.BadRequestError: OpenAIException - "
+        "'auto' tool choice requires --enable-auto-tool-choice "
+        "and --tool-call-parser to be set"
+    )
+    MODEL = "openai/local-model"
+
+    def test_vllms_missing_flags_error_reads_as_a_tool_rejection(self) -> None:
+        from lgtmaybe.providers.litellm_provider import _rejects_tool_config
+
+        assert _rejects_tool_config(
+            litellm.BadRequestError(message=self.VLLM_400, model=self.MODEL, llm_provider="openai")
+        )
+
+    def test_an_unrelated_bad_request_is_still_not_a_tool_rejection(self) -> None:
+        """The matcher must stay narrow: a genuine 400 has to keep failing."""
+        from lgtmaybe.providers.litellm_provider import _rejects_tool_config
+
+        assert not _rejects_tool_config(
+            litellm.BadRequestError(
+                message="litellm.BadRequestError: context length exceeded",
+                model=self.MODEL,
+                llm_provider="openai",
+            )
+        )
+
+    def test_a_route_refusing_both_shapes_falls_back_to_prompted_json(self) -> None:
+        """End to end: response_format refused, then the forced tool call
+        refused with vLLM's wording — the review still gets its findings."""
+        seen: list[dict[str, Any]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message="response_format is not supported by this model",
+                    model=kwargs["model"],
+                    llm_provider="openai",
+                )
+            if "tools" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.VLLM_400, model=kwargs["model"], llm_provider="openai"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert "tools" not in seen[-1] and "response_format" not in seen[-1]


### PR DESCRIPTION
Structured output degrades in three steps — `response_format` → forced tool call → prompt-instructed JSON — and the switch between them is driven by matching the *backend's own error prose* against `_REJECTION_PHRASES` ("not permitted", "not supported", "unsupported", "unknown", "unexpected"). Every one of those phrases came from Bedrock, and so does every existing test of the fallback.

A self-hosted OpenAI-compatible server refuses differently: it names the start-up flag it is missing rather than calling the field unsupported. vLLM answers `"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set`, which contains none of the five phrases — so `_rejects_tool_config` returned `False`, the `BadRequestError` was treated as permanent, and it propagated unrecovered. That is the "one unsupported field kills the whole review" failure the machinery exists to prevent, on the routes it was least tested against.

`_TOOL_PARSER_PHRASES` now matches those two flag names on their own, without needing a phrase from the general tuple. They are specific enough that a genuine 400 — context length, bad model — cannot match, which a test pins.

Deliberately narrower than the issue suggested: it also proposed llama.cpp's wording, but I could not verify llama.cpp's actual error text, and asserting on a string I invented would be worse than not covering it. Only vLLM's documented phrasing is claimed here.

Three tests: the real vLLM error reading as a tool rejection, an unrelated 400 still failing, and an end-to-end run where `response_format` is refused, the forced tool call is refused with vLLM's wording, and the review still comes back with findings from the prompted-JSON path.

`tests/providers`: 401 passing.

Closes #499

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_