### PR TITLE
docs: correct the gitea token scopes and drop a flag that does not exist

### DIFF
--- a/docs/how-to/review-on-gitea.md
+++ b/docs/how-to/review-on-gitea.md
@@ -8,8 +8,15 @@ the comments is different.
 ## Set it up
 
 1. **Create a token.** In Gitea, go to *Settings → Applications → Access Tokens*
-   and create a token with `read:repository` and `write:issue` scopes. Add it to
+   and create a token with `write:repository` and `write:issue` scopes. Add it to
    your repository as a secret named `GITEA_TOKEN`.
+
+    Both are needed, and `write:repository` covers reading too. Gitea scopes the
+    review endpoints lgtmaybe posts inline comments through (`POST
+    /pulls/{index}/reviews`) and the commit-status endpoint under the
+    *repository* category, not the *issue* one — a token with only
+    `read:repository` is refused on the one call the whole setup exists to make.
+    `write:issue` covers the summary comment and the PR labels.
 
 2. **Add a provider key.** Add the API key for whichever model you want as a
    second secret — for example `ANTHROPIC_API_KEY`.
@@ -22,16 +29,21 @@ That is the whole setup. Gitea Actions reimplements the GitHub Actions runtime,
 so lgtmaybe's container image runs unchanged, and it reads `GITHUB_SERVER_URL`
 — which Gitea points at your own instance — to know which host to post back to.
 
-## Run it locally instead
+## Try it locally first
 
-The CLI takes a Gitea pull-request URL directly:
+Reviewing a pull request by URL happens in the Actions run — that is where the
+token and the PR context live. Locally, `lgtmaybe review` reviews the branch you
+have checked out, against the remote primary branch, and prints the findings
+instead of posting them:
 
 ```bash
-export GITEA_TOKEN=...
+git switch my-feature-branch
 export ANTHROPIC_API_KEY=...
-lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
-  --pr-url https://gitea.example.com/team/service/pulls/12
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6
 ```
+
+Same lenses, same reflection pass, same findings — so it is the quick way to see
+what a model will say about your change before you wire up the workflow.
 
 ## What works, and what does not
 

--- a/docs/how-to/review-on-gitlab.md
+++ b/docs/how-to/review-on-gitlab.md
@@ -23,18 +23,21 @@ The job must run on merge request pipelines — `rules: - if: $CI_PIPELINE_SOURC
 == "merge_request_event"`. On a branch pipeline there is no merge request to
 review, and lgtmaybe will tell you so by name rather than guessing.
 
-## Run it locally instead
+## Try it locally first
 
-The CLI takes a merge request URL directly:
+Reviewing a merge request by URL happens in CI — that is where the token and the
+MR context live. Locally, `lgtmaybe review` reviews the branch you have checked
+out, against the remote primary branch, and prints the findings instead of
+posting them:
 
 ```bash
-export GITLAB_TOKEN=...
+git switch my-feature-branch
 export ANTHROPIC_API_KEY=...
-lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
-  --pr-url https://gitlab.com/group/subgroup/project/-/merge_requests/7
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6
 ```
 
-Nested group paths work — everything before `/-/merge_requests/` is the project.
+Same lenses, same reflection pass, same findings — so it is the quick way to see
+what a model will say about your change before you wire up the pipeline.
 
 ## How it differs from GitHub
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1219,8 +1219,15 @@ the comments is different.
 ## Set it up
 
 1. **Create a token.** In Gitea, go to *Settings → Applications → Access Tokens*
-   and create a token with `read:repository` and `write:issue` scopes. Add it to
+   and create a token with `write:repository` and `write:issue` scopes. Add it to
    your repository as a secret named `GITEA_TOKEN`.
+
+    Both are needed, and `write:repository` covers reading too. Gitea scopes the
+    review endpoints lgtmaybe posts inline comments through (`POST
+    /pulls/{index}/reviews`) and the commit-status endpoint under the
+    *repository* category, not the *issue* one — a token with only
+    `read:repository` is refused on the one call the whole setup exists to make.
+    `write:issue` covers the summary comment and the PR labels.
 
 2. **Add a provider key.** Add the API key for whichever model you want as a
    second secret — for example `ANTHROPIC_API_KEY`.
@@ -1233,16 +1240,21 @@ That is the whole setup. Gitea Actions reimplements the GitHub Actions runtime,
 so lgtmaybe's container image runs unchanged, and it reads `GITHUB_SERVER_URL`
 — which Gitea points at your own instance — to know which host to post back to.
 
-## Run it locally instead
+## Try it locally first
 
-The CLI takes a Gitea pull-request URL directly:
+Reviewing a pull request by URL happens in the Actions run — that is where the
+token and the PR context live. Locally, `lgtmaybe review` reviews the branch you
+have checked out, against the remote primary branch, and prints the findings
+instead of posting them:
 
 ```bash
-export GITEA_TOKEN=...
+git switch my-feature-branch
 export ANTHROPIC_API_KEY=...
-lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
-  --pr-url https://gitea.example.com/team/service/pulls/12
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6
 ```
+
+Same lenses, same reflection pass, same findings — so it is the quick way to see
+what a model will say about your change before you wire up the workflow.
 
 ## What works, and what does not
 
@@ -1301,18 +1313,21 @@ The job must run on merge request pipelines — `rules: - if: $CI_PIPELINE_SOURC
 == "merge_request_event"`. On a branch pipeline there is no merge request to
 review, and lgtmaybe will tell you so by name rather than guessing.
 
-## Run it locally instead
+## Try it locally first
 
-The CLI takes a merge request URL directly:
+Reviewing a merge request by URL happens in CI — that is where the token and the
+MR context live. Locally, `lgtmaybe review` reviews the branch you have checked
+out, against the remote primary branch, and prints the findings instead of
+posting them:
 
 ```bash
-export GITLAB_TOKEN=...
+git switch my-feature-branch
 export ANTHROPIC_API_KEY=...
-lgtmaybe review --provider anthropic --model claude-sonnet-4-6 \
-  --pr-url https://gitlab.com/group/subgroup/project/-/merge_requests/7
+lgtmaybe review --provider anthropic --model claude-sonnet-4-6
 ```
 
-Nested group paths work — everything before `/-/merge_requests/` is the project.
+Same lenses, same reflection pass, same findings — so it is the quick way to see
+what a model will say about your change before you wire up the pipeline.
 
 ## How it differs from GitHub
 


### PR DESCRIPTION
**#500 — a documented flag that isn't there.** Both `review-on-gitlab.md` and `review-on-gitea.md` carried a "Run it locally instead" example passing `--pr-url` to `lgtmaybe review`. That option does not exist anywhere in `src/` — the command reviews the local `git` diff, and `RuntimeOptions.pr_url` is only ever populated by the three internal helpers behind the Action, comment and `gitlab-ci` entrypoints. Invoking it exits 2 with `Error: No such option '--pr-url'`.

The issue offered two ways out: remove the section, or build a real by-URL local review. I took neither literally — both sections now describe what the command genuinely does (review the checked-out branch against the remote primary branch and print the findings), which keeps the useful "try it before wiring up CI" step the section was there for, without promising a mode that doesn't exist. Adding `--pr-url` would be a new capability, and belongs in its own change rather than a doc fix.

**#501 — token scopes that can't post a review.** The Gitea setup step asked for `read:repository` and `write:issue`. I checked this against go-gitea's own routing rather than taking it on inference (`routers/api/v1/api.go`, main):

- the `/repos` group opened at line 1309 — which contains `/pulls` (1512, with `/reviews` at 1528) and `/statuses` (1550) — closes at line 1625 with `tokenRequiresScopes(auth_model.AccessTokenScopeCategoryRepository)`;
- `/issues/...` comments and labels live in a *separate* `/repos` group (1641) closed at 1764 with the `Issue` category.

So a token made exactly as the doc instructed would be refused on `POST /pulls/{index}/reviews` — the inline comments, which is the one thing the setup guide exists to enable. It now asks for `write:repository` (which covers reading, so `read:repository` becomes redundant) alongside `write:issue`, with a short note on which endpoints each one buys.

`docs/llms.txt` and `docs/llms-full.txt` regenerated; `tests/docs` passes.

Closes #500
Closes #501

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_