### PR TITLE
feat: hold the advisory lenses to the severity their prompt asks for

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -78,6 +78,7 @@ from .redact import redact
 from .reflect import reflect_findings
 from .repair import repair_findings
 from .retrieve import MAX_FETCH_FILES, FileFetcher, resolve_needs
+from .severity import clamp_to_category_ceiling
 from .static_analysis import (
     SCAN_CATEGORY_PREFIX,
     UNANCHORABLE_SCAN_CATEGORIES,
@@ -2203,7 +2204,7 @@ def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[Review
     like any other.
     """
     allowed = lens.allowed_categories
-    return [
+    stamped = [
         f.model_copy(
             update={
                 "category": (
@@ -2213,6 +2214,11 @@ def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[Review
         )
         for f in findings
     ]
+    # Now that each finding knows which lens it came from, hold the advisory
+    # ones to the grade the prompt asked them for. Before the per-lens bound
+    # below, which drops the least severe first: an over-graded nit would
+    # otherwise survive at the expense of a real finding.
+    return clamp_to_category_ceiling(stamped)
 
 
 def _summary_line(count: int, cfg: ReviewConfig) -> str:

--- a/src/lgtmaybe/engine/severity.py
+++ b/src/lgtmaybe/engine/severity.py
@@ -1,0 +1,62 @@
+"""Severity ceilings for the advisory lenses.
+
+The prompt already grades these lenses itself — complexity and ponytail `info`
+to `medium`, documentation `info` to `low`, tests `low`/`medium` — but a graded
+instruction is a request, not a constraint, and benchmark runs across a dozen
+models are full of style commentary arriving at `high`, occasionally
+`critical`.
+
+An over-graded nit costs twice. It sits above a real bug wherever findings are
+ordered by severity — the summary, the per-lens bound that drops the least
+severe first — and it defeats `min_severity`, the one dial a team has for
+turning advisory noise down, because noise graded as signal survives a floor
+set at the signal.
+
+So the grade is clamped here, deterministically, after the model has answered.
+Clamping is deliberately not dropping: every finding is still posted, so recall
+is untouched by construction. Only the claim about how much it matters changes,
+back to the range the prompt asked for.
+
+The lenses graded by impact — security, correctness, performance, intent, spec,
+deprecation — are not capped. A bug is as severe as it is, and capping those
+would hide exactly what the reviewer exists to find.
+"""
+
+from __future__ import annotations
+
+from lgtmaybe.core.logging import get_logger
+from lgtmaybe.core.models import ReviewCategory, ReviewFinding, Severity
+
+_log = get_logger(__name__)
+
+# Keyed by category, and only by category: in the `fast` preset an
+# unattributed finding falls back to its GROUP id (`code-health`, `artefacts`),
+# which spans capped and uncapped concerns — clamping a whole group would
+# downgrade real bugs. A custom lens is likewise absent: it sets its own rules,
+# and the engine has no rubric for it.
+CATEGORY_SEVERITY_CEILING: dict[ReviewCategory, Severity] = {
+    ReviewCategory.complexity: Severity.medium,
+    ReviewCategory.ponytail: Severity.medium,
+    ReviewCategory.documentation: Severity.medium,
+    ReviewCategory.tests: Severity.medium,
+}
+
+
+def clamp_to_category_ceiling(findings: list[ReviewFinding]) -> list[ReviewFinding]:
+    """Lower any advisory finding graded above its category's ceiling."""
+    out: list[ReviewFinding] = []
+    for finding in findings:
+        ceiling = CATEGORY_SEVERITY_CEILING.get(finding.category)  # type: ignore[arg-type]
+        if ceiling is None or finding.severity.rank <= ceiling.rank:
+            out.append(finding)
+            continue
+        _log.info(
+            "advisory finding graded above its lens ceiling — lowering",
+            extra={
+                "category": finding.category,
+                "claimed": finding.severity.value,
+                "ceiling": ceiling.value,
+            },
+        )
+        out.append(finding.model_copy(update={"severity": ceiling}))
+    return out

--- a/src/lgtmaybe/engine/severity.py
+++ b/src/lgtmaybe/engine/severity.py
@@ -34,7 +34,9 @@ _log = get_logger(__name__)
 # which spans capped and uncapped concerns — clamping a whole group would
 # downgrade real bugs. A custom lens is likewise absent: it sets its own rules,
 # and the engine has no rubric for it.
-CATEGORY_SEVERITY_CEILING: dict[ReviewCategory, Severity] = {
+# Keyed by the category STRING a finding carries (ReviewCategory is a StrEnum,
+# so its members are valid keys and compare equal to the stamped value).
+CATEGORY_SEVERITY_CEILING: dict[str, Severity] = {
     ReviewCategory.complexity: Severity.medium,
     ReviewCategory.ponytail: Severity.medium,
     ReviewCategory.documentation: Severity.medium,
@@ -46,7 +48,7 @@ def clamp_to_category_ceiling(findings: list[ReviewFinding]) -> list[ReviewFindi
     """Lower any advisory finding graded above its category's ceiling."""
     out: list[ReviewFinding] = []
     for finding in findings:
-        ceiling = CATEGORY_SEVERITY_CEILING.get(finding.category)  # type: ignore[arg-type]
+        ceiling = CATEGORY_SEVERITY_CEILING.get(finding.category or "")
         if ceiling is None or finding.severity.rank <= ceiling.rank:
             out.append(finding)
             continue

--- a/tests/engine/test_severity_ceiling.py
+++ b/tests/engine/test_severity_ceiling.py
@@ -1,0 +1,138 @@
+"""The advisory lenses cannot out-shout the ones that find bugs.
+
+The prompt grades the style lenses itself — complexity and ponytail `info` to
+`medium`, documentation `info` to `low`, tests `low`/`medium` — but nothing
+enforced it, and benchmark runs are full of style commentary arriving at `high`
+and occasionally `critical`.
+
+That costs twice. A `critical` "this function is a bit long" sits above a real
+SQL injection in a severity-ordered summary; and `min_severity`, the one dial a
+team has for turning the noise down, cannot filter noise that arrives graded as
+the signal. Clamping is deliberately not dropping: every finding is still
+posted, so recall is untouched by construction — only the grade changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lgtmaybe.core.models import ReviewCategory, ReviewFinding, Severity
+from lgtmaybe.engine.severity import CATEGORY_SEVERITY_CEILING, clamp_to_category_ceiling
+
+
+def _finding(category: str, severity: Severity) -> ReviewFinding:
+    return ReviewFinding(
+        path="a.py",
+        line=1,
+        side="RIGHT",
+        severity=severity,
+        title="t",
+        body="b",
+        category=category,
+    )
+
+
+@pytest.mark.parametrize("category", ["complexity", "ponytail", "documentation", "tests"])
+def test_an_advisory_lens_cannot_claim_more_than_its_ceiling(category: str) -> None:
+    ceiling = CATEGORY_SEVERITY_CEILING[category]
+
+    clamped = clamp_to_category_ceiling([_finding(category, Severity.critical)])
+
+    assert clamped[0].severity is ceiling
+
+
+@pytest.mark.parametrize("category", ["security", "correctness", "performance", "intent", "spec"])
+def test_a_lens_that_grades_by_impact_is_left_alone(category: str) -> None:
+    """Performance is graded by impact up to `high`, and a security or
+    correctness bug is as severe as it is — clamping those would hide bugs."""
+    clamped = clamp_to_category_ceiling([_finding(category, Severity.critical)])
+
+    assert clamped[0].severity is Severity.critical
+
+
+def test_a_finding_already_within_its_ceiling_is_untouched() -> None:
+    finding = _finding("complexity", Severity.info)
+
+    assert clamp_to_category_ceiling([finding])[0] is finding
+
+
+def test_nothing_is_dropped() -> None:
+    """Clamping trades grade for noise, never coverage."""
+    findings = [_finding("tests", Severity.high), _finding("security", Severity.high)]
+
+    assert len(clamp_to_category_ceiling(findings)) == 2
+
+
+def test_a_merged_lens_id_is_not_mistaken_for_a_category() -> None:
+    """In the fast preset a finding the model did not attribute falls back to
+    the GROUP id (`code-health`, `artefacts`), which spans capped and uncapped
+    concerns — clamping the whole group would silently downgrade a real bug."""
+    clamped = clamp_to_category_ceiling([_finding("code-health", Severity.high)])
+
+    assert clamped[0].severity is Severity.high
+
+
+def test_a_custom_lens_is_not_capped() -> None:
+    """A user-defined lens sets its own rules; the engine has no rubric for it."""
+    clamped = clamp_to_category_ceiling([_finding("our-house-style", Severity.critical)])
+
+    assert clamped[0].severity is Severity.critical
+
+
+def test_the_ceilings_cover_every_advisory_category_and_nothing_else() -> None:
+    assert set(CATEGORY_SEVERITY_CEILING) == {
+        ReviewCategory.complexity,
+        ReviewCategory.ponytail,
+        ReviewCategory.documentation,
+        ReviewCategory.tests,
+    }
+
+
+def test_a_review_posts_the_clamped_grade_not_the_claimed_one() -> None:
+    """End to end through the engine, where the stamping happens."""
+    import json
+
+    from lgtmaybe.core.models import PRContext, ProviderResult
+    from lgtmaybe.engine import LLMReviewEngine
+    from tests.conftest import make_cfg
+    from tests.fakes import FakeProvider
+
+    diff = (
+        "diff --git a/a.py b/a.py\n"
+        "index 111..222 100644\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " import os\n"
+        "+def helper(a, b, c, d, e): pass\n"
+    )
+    payload = json.dumps(
+        {
+            "findings": [
+                {
+                    "path": "a.py",
+                    "line": 2,
+                    "side": "RIGHT",
+                    "severity": "critical",
+                    "title": "This helper takes too many parameters",
+                    "body": "Long parameter list.",
+                    "anchor": "def helper(a, b, c, d, e): pass",
+                }
+            ]
+        }
+    )
+    provider = FakeProvider(result=ProviderResult(text=payload, input_tokens=1, output_tokens=1))
+    ctx = PRContext(
+        diff=diff,
+        changed_files=["a.py"],
+        base_sha="base",
+        head_sha="head",
+        repo="org/repo",
+        pr_number=1,
+    )
+
+    findings, _summary = LLMReviewEngine(provider).review(
+        ctx, make_cfg(categories=[ReviewCategory.complexity], reflect=False)
+    )
+
+    assert [f.severity for f in findings] == [Severity.medium]


### PR DESCRIPTION
Closes #514 — a first, measurable step, not the whole answer.

## What the stored runs show

I pulled five stored runs from `lgtmaybe-benchmarks` (`gpt-oss-20b` long-horizon, `mistral-small-2603` context-v1, `gemini-3.7-flash` breadth, `claude-opus-5` breadth, `qwen3.8-max` long-horizon) and looked at the findings themselves rather than the totals.

Two things stand out, and only one of them is a model problem.

**1. Advisory lenses dominate a weak model's output.** Findings from `complexity`, `ponytail`, `documentation` and `tests` were 83% of everything `gpt-oss-20b` produced (85/103) and 53% of `mistral-small`'s (373/708). On the strong models they are a minority (49/165 for `gemini-3.7-flash`, 9/96 for `claude-opus-5`).

**2. Those lenses routinely claim a severity the prompt never authorised.** `engine/prompt.py` grades them itself — complexity and ponytail `info` to `medium`, documentation `info` to `low`, tests `low`/`medium` — but nothing enforced it:

| model | advisory findings | graded above `medium` |
|---|---:|---:|
| openai/gpt-oss-20b | 85 | 33 |
| mistralai/mistral-small-2603 | 373 | 67 |
| qwen/qwen3.8-max | 10 | 2 |
| google/gemini-3.7-flash | 49 | 0 |
| anthropic/claude-opus-5 | 9 | 0 |

Pooled, 19% of advisory findings ignored their own rubric — 41% of `tests` findings and 22% of `complexity` ones, occasionally reaching `critical`. Every instance is in a weak model; the strong models grade themselves correctly.

## What this changes

A deterministic ceiling per advisory category, applied right where the engine stamps a finding's originating lens (`engine/severity.py`, wired into `_stamp_categories`, before the per-lens bound).

It **clamps, it does not drop** — every finding is still posted, so recall is untouched by construction. What changes is the claim about how much it matters, and that matters twice:

- an over-graded nit sits above real bugs wherever findings are ordered by severity, including `max_findings_per_lens`, which drops the *least* severe first — so a `critical` "this function is long" could evict a genuine finding;
- it defeats `min_severity`, the one dial a team has for turning advisory noise down, because noise graded as signal survives a floor set at the signal. After this, `min_severity: high` reliably means "bugs only".

The clamp is keyed on `ReviewCategory` alone. A merged `fast`-preset group id (`code-health`, `artefacts`) spans capped and uncapped concerns, and a custom lens sets its own rules — both are deliberately left alone rather than downgraded on a guess. The impact-graded lenses (security, correctness, performance, intent, spec, deprecation) are never capped: a bug is as severe as it is.

Note what the table implies: **on `gemini-3.7-flash` and `claude-opus-5` this is a no-op.** It is a floor of discipline for the models that need one, and it cannot make a well-behaved model worse.

## What it does not do

It does not, by itself, prove a false-positive reduction, and I want to be careful not to claim that. The benchmark counts a false positive by adjudication, and lowering a finding's severity does not remove it from that count — what it removes is the finding's ability to crowd out real ones and to evade `min_severity`. Measuring the precision effect needs a `bench` re-run on the same suites, which needs live models and sits outside the pytest gate by design.

(Method note: my per-category tallies come from re-reading the stored `results/raw/*.json` and matching findings against each fixture's `expected` keywords. That is a cruder rule than the benchmark's own adjudication — my totals do not reproduce the published TP/FP columns — so I have leant only on the severity-vs-rubric numbers above, which are read directly off each finding and do not depend on matching at all.)

Two further levers came out of the same data, worth a separate look rather than bundling here:

- **Advisory volume, not just grade.** `max_findings_per_lens` exists and is unbounded by default; the data suggests a cap aimed at the advisory lenses is the bigger single lever for weak models. It changes what gets posted, so it should be measured before any default moves.
- **Reflection confidence is not discriminative on weak models.** On the `gpt-oss-20b` run, 84 of 97 unmatched findings scored `1` — and so did most of the matched ones, so `min_confidence` cannot separate them there. It works as designed on models that grade themselves honestly, which is the same split as above.

## Tests

`tests/engine/test_severity_ceiling.py`: the ceiling per advisory category, the impact-graded categories left alone, a finding already inside its ceiling untouched, nothing dropped, a merged group id and a custom lens id both refused as ceilings, the ceiling map covering exactly the advisory set, and an end-to-end review posting the clamped grade.

Full suite: 2408 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MoKtKnCdgeR2dqccpcErL)_