### PR TITLE
fix(provider): send bedrock a schema subset its validator accepts

### DIFF
--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -40,6 +40,12 @@ provider.param-drop:
     has: { field: name, regex: '^_drop_rejected_param$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.schema-subset:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_bedrock_wire_response_format$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.param-support:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -188,6 +188,32 @@ reply that arrives well-formed and turns out not to be findings.
 - **WHEN** litellm maps a provider error while `--format json` is in force
 - **THEN** nothing is printed to stdout, so the findings array stays parseable
 
+### Requirement: The bedrock schema is narrowed to the subset its validator takes
+
+On the bedrock route the structured-output schema SHALL go out without the
+numeric-bound keywords pydantic derives from field constraints (`minimum`,
+`maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`): Bedrock's
+structured-output validator treats them as extra inputs and 400s the whole
+request before the model ever runs. The request SHALL otherwise carry the exact
+dict litellm would derive from the pydantic class itself, applied per effective
+model — a non-bedrock fallback keeps the class, whose own route derives its own
+schema dialect from it — and the strip SHALL remove only keywords, never a
+property that happens to share a keyword's name. Nothing is enforced less: the
+same pydantic model re-checks the bounds when the reply is parsed.
+<!-- anchor: provider.schema-subset -->
+
+#### Scenario: a bedrock model is asked for structured output
+- **WHEN** a review call goes out to a bedrock model with a pydantic
+  `response_format` whose fields carry `ge`/`le` bounds
+- **THEN** the request carries the schema litellm would derive minus the bound
+  keywords, and the reply is still validated against the full model on parse
+
+#### Scenario: the tool-mode fallback re-sends the schema
+- **WHEN** the route refuses `response_format` and the schema is re-sent as a
+  forced tool call
+- **THEN** the tool's parameters carry the stripped schema too, so the same
+  validator cannot reject the recovery
+
 ### Requirement: A configured param is never discarded in silence
 
 The factory SHALL name at startup every param the user configured that litellm's

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -6,11 +6,12 @@ optional fallback model.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import math
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import UTC, datetime
@@ -29,6 +30,11 @@ from litellm.exceptions import (
     PermissionDeniedError,
     RateLimitError,
 )
+
+# litellm.utils re-exports this without listing it in __all__, so mypy rejects
+# the re-export — import it from the module that defines it, like the
+# exceptions above.
+from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.utils import supports_prompt_caching
 from pydantic import BaseModel
 from tenacity import (
@@ -440,6 +446,67 @@ def _json_schema_of(response_format: Any) -> dict[str, Any] | None:
     return None
 
 
+_BEDROCK_PREFIX = "bedrock/"
+
+# Bedrock's structured-output validator accepts only a subset of JSON Schema:
+# the numeric-bound keywords pydantic emits for ``Field(ge=…, le=…)`` —
+# ``ReviewFinding.line``'s ``minimum``, ``confidence``'s ``minimum``/``maximum``
+# — are "Extra inputs" that 400 the whole request before the model ever runs
+# (issue #531). The bounds are re-checked by the same pydantic model when the
+# reply is parsed, so nothing is enforced less by not sending them.
+_SCHEMA_BOUND_KEYS = ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf")
+
+# Keys whose value maps property NAMES to schemas. The strip descends into
+# their values but never pops keys off the map itself: a field literally named
+# "minimum" is a field, not a keyword.
+_SCHEMA_NAME_MAPS = ("properties", "$defs", "definitions", "patternProperties")
+
+
+def _strip_numeric_bounds(schema: dict[str, Any]) -> None:
+    """Remove the numeric-bound keywords from *schema*, in place, recursively."""
+    for key in _SCHEMA_BOUND_KEYS:
+        schema.pop(key, None)
+    for key, value in schema.items():
+        if key in _SCHEMA_NAME_MAPS and isinstance(value, dict):
+            children: Iterable[Any] = value.values()
+        elif isinstance(value, list):
+            children = value
+        else:
+            children = (value,)
+        for child in children:
+            if isinstance(child, dict):
+                _strip_numeric_bounds(child)
+
+
+def _bedrock_wire_response_format(response_format: Any) -> Any:
+    """*response_format* as Bedrock's validator will take it, or unchanged.
+
+    A pydantic model is converted through litellm's own
+    ``type_to_response_format_param`` — the exact dict litellm would derive from
+    the class one layer down, so the request differs only by the stripped
+    keywords — and a dict shape is deep-copied before the strip, since the
+    caller's ``response_format`` is reused across the lens fan-out. Applied per
+    effective model on the bedrock route ONLY: every other route keeps the
+    class, because each litellm transformation knows its own schema dialect
+    (vertex deliberately derives a compact ``$ref`` schema from the class that a
+    pre-converted strict dict would deny it). A shape carrying no schema —
+    ``{"type": "json_object"}``, say — has nothing to strip and goes out as it
+    came.
+    """
+    if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+        converted: Any = type_to_response_format_param(response_format)
+    elif isinstance(response_format, Mapping):
+        converted = copy.deepcopy(dict(response_format))
+    else:
+        return response_format
+    nested = converted.get("json_schema") if isinstance(converted, Mapping) else None
+    schema = nested.get("schema") if isinstance(nested, Mapping) else None
+    if not isinstance(schema, dict):
+        return response_format
+    _strip_numeric_bounds(schema)
+    return converted
+
+
 def _schema_tool_kwargs(response_format: Any) -> dict[str, Any] | None:
     """The same schema expressed as a forced tool call, or None if it can't be.
 
@@ -804,6 +871,11 @@ class LiteLLMProvider:
         # in cache support), and to a copy — the caller's messages are not ours
         # to mutate.
         messages = self._with_cache_control(messages, model)
+        # Same per-model scope: only a bedrock model needs the schema stripped
+        # to the subset its validator takes, and a non-bedrock fallback must
+        # keep the class for its own route's conversion.
+        if model.startswith(_BEDROCK_PREFIX) and kwargs.get("response_format") is not None:
+            kwargs["response_format"] = _bedrock_wire_response_format(kwargs["response_format"])
         # Counted here (not read from tenacity's statistics) so the number lands
         # on the result even when the mocked/fake retry layer changes shape — and
         # counted per REQUEST, not per tenacity attempt: one attempt can issue a

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -966,6 +967,106 @@ class TestSchemaAsToolFallback:
             )
 
         assert seen == ["plain"]
+
+
+class TestBedrockSchemaSubset:
+    """Bedrock's structured-output validator accepts only a subset of JSON
+    Schema: the numeric-bound keywords pydantic emits for ``Field(ge=…, le=…)``
+    — ``ReviewFinding.line``'s ``minimum``, ``confidence``'s ``minimum`` and
+    ``maximum`` — are "Extra inputs" that 400 the whole request before the model
+    ever runs (issue #531). The bounds are re-checked by pydantic when the reply
+    is parsed, so on the bedrock route the schema goes out without them."""
+
+    MODEL = "bedrock/us.anthropic.claude-opus-5"
+    BOUND_KEYS = ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf")
+
+    def test_the_bedrock_schema_carries_no_numeric_bounds(self) -> None:
+        with patch(
+            "litellm.completion", return_value=_fake_response('{"findings": []}')
+        ) as mock_completion:
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        sent = mock_completion.call_args.kwargs["response_format"]
+        # Still the same enforced shape litellm would derive itself — only the
+        # keywords Bedrock's validator refuses are gone.
+        assert sent["json_schema"]["schema"]["properties"]["findings"]
+        assert sent["json_schema"]["strict"] is True
+        schema_text = json.dumps(sent)
+        for key in self.BOUND_KEYS:
+            assert f'"{key}"' not in schema_text
+
+    def test_the_tool_mode_fallback_schema_is_clean_too(self) -> None:
+        """A model whose route refuses ``response_format`` re-sends the schema
+        as a forced tool call — the same validator reads that schema, so the
+        bounds must not ride back in through it."""
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=TestRejectedStructuredOutputParam.BEDROCK_400,
+                    model=kwargs["model"],
+                    llm_provider="bedrock",
+                )
+            return _tool_call_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect) as mock_completion:
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        parameters = mock_completion.call_args.kwargs["tools"][0]["function"]["parameters"]
+        schema_text = json.dumps(parameters)
+        for key in self.BOUND_KEYS:
+            assert f'"{key}"' not in schema_text
+
+    def test_other_routes_send_the_pydantic_class_unchanged(self) -> None:
+        """Each route's litellm transformation knows its own schema dialect —
+        vertex deliberately derives a compact ``$ref`` schema from the class,
+        which a pre-converted dict would deny it. Only bedrock needs the strip."""
+        with patch(
+            "litellm.completion", return_value=_fake_response('{"findings": []}')
+        ) as mock_completion:
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "vertex_ai/gemini-2.5-pro",
+                response_format=ReviewResult,
+            )
+
+        assert mock_completion.call_args.kwargs["response_format"] is ReviewResult
+
+    def test_a_property_named_like_a_bound_keyword_survives(self) -> None:
+        """The strip removes schema keywords, not fields: a caller's schema with
+        a property literally named ``minimum`` keeps it."""
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "Range",
+                "schema": {
+                    "type": "object",
+                    "properties": {"minimum": {"type": "integer", "minimum": 0}},
+                },
+                "strict": True,
+            },
+        }
+        with patch("litellm.completion", return_value=_fake_response("{}")) as mock_completion:
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=response_format
+            )
+
+        sent = mock_completion.call_args.kwargs["response_format"]
+        prop = sent["json_schema"]["schema"]["properties"]["minimum"]
+        assert prop == {"type": "integer"}
+        # The caller's dict was not mutated in place.
+        assert response_format["json_schema"]["schema"]["properties"]["minimum"] == {
+            "type": "integer",
+            "minimum": 0,
+        }
 
 
 class TestEmptyStructuredOutputFallback:


### PR DESCRIPTION
Closes #531.

## Problem

Bedrock's structured-output validator accepts only a subset of JSON Schema. The numeric-bound keywords pydantic emits for `Field(ge=…, le=…)` — the `minimum` on `ReviewFinding.line` and the `minimum`/`maximum` on `confidence` — are treated as "Extra inputs" and 400 the whole request before the model ever runs. Since every lens sends the same schema, the entire review failed with no findings produced.

## Fix

On the bedrock route (per effective model — a non-bedrock fallback is untouched), `LiteLLMProvider` now pre-converts a pydantic `response_format` through litellm's own `type_to_response_format_param` — the exact dict litellm would derive from the class one layer down — and strips `minimum` / `maximum` / `exclusiveMinimum` / `exclusiveMaximum` / `multipleOf` from the schema, so the request differs only by the removed keywords. The sanitised dict also feeds the existing forced-tool-call fallback, so the recovery path can't re-send the rejected bounds either.

Every other route keeps the pydantic class: each litellm transformation derives its own schema dialect from it (vertex deliberately builds a compact `$ref` schema that a pre-converted strict dict would deny it). The strip removes only schema keywords, never a property that happens to share a keyword's name, and deep-copies dict shapes so the caller's `response_format` is never mutated across the lens fan-out.

Nothing is enforced less: the same pydantic models re-check the bounds when the reply is parsed, and a degenerate value (e.g. `line: 0`) still fails the lens loudly at the boundary.

## Tests

- `TestBedrockSchemaSubset` in `tests/providers/test_retry.py` (red first): the bedrock schema carries no bound keywords and stays strict; the tool-mode fallback schema is clean too; other routes still send the class unchanged; a property literally named `minimum` survives and the caller's dict is not mutated.
- New anchored spec requirement `provider.schema-subset` in `openspec/specs/provider-gateway/spec.md`; `tests/specs` and `openspec validate --specs` pass.
- Full suite: 2410+ passed; the only failures in my container are pre-existing on clean `main` and environmental (`ast-grep`/`mypy` subprocess tests needing tools this sandbox resolves differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mGsTe38VWzqijH1NJTmjj

---
_Generated by [Claude Code](https://claude.ai/code/session_015mGsTe38VWzqijH1NJTmjj)_