### PR TITLE
fix(provider): read bedrock's Converse-level structured-output refusals

### DIFF
--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -186,25 +186,25 @@ slept past it.
 ### Requirement: A rejected request param degrades, it does not fail the review
 
 The adapter SHALL degrade a request param the model refuses and re-send once
-rather than fail — `temperature` when only the default value is accepted, and
-the structured-output `response_format` when the route rejects the field it
-becomes (Bedrock Converse answers `output_config.format: Extra inputs are not
-permitted`). `drop_params` cannot cover these: the capability map reports the
-param supported, and the refusal is only visible in the error. A rejected
-`response_format` SHALL first be re-sent as the SAME schema in the mechanism the
-route does implement — a forced tool call, read back from its arguments — and
-only a route refusing that too SHALL fall back to prompt-instructed JSON. Each
-outcome SHALL be remembered for THAT MODEL's later calls, never for every model
-the provider serves, and losing the schema SHALL be announced once: silently, it
-is indistinguishable from a model that stopped honouring it. litellm's stdout
-banner SHALL be suppressed, since stdout carries machine-readable output. The
-engine MAY ask for the same drop, on the one trigger the adapter cannot see: a
-reply that arrives well-formed and turns out not to be findings.
+rather than fail — `temperature` when only the default value is accepted,
+`reasoning_effort` when the route refuses the effort field it becomes (judged
+before the schema, whose matcher would otherwise claim `output_config.effort`
+and drop the wrong param), and the structured-output `response_format` under
+either spelling of the field it becomes: the Anthropic layer's
+`output_config.format` or the Converse-level `outputConfig`. `drop_params`
+cannot cover these — the capability map says the param is supported, so the
+refusal is only visible in the error. A rejected `response_format` SHALL first
+be re-sent as the SAME schema as a forced tool call; only a route refusing
+that too falls back to prompt-instructed JSON. Each outcome SHALL be
+remembered for THAT MODEL's later calls only, and losing the schema SHALL be
+announced once — silently, it reads as a model that stopped honouring it.
+litellm's stdout banner SHALL be suppressed, and the engine MAY ask for the
+same drop on the one trigger the adapter cannot see: a well-formed reply that
+is not findings.
 <!-- anchor: provider.param-drop -->
 
 #### Scenario: the route rejects the structured-output field
-- **WHEN** a Bedrock model 400s on the `output_config.format` field litellm
-  derived from `response_format`
+- **WHEN** a Bedrock model 400s on the field `response_format` became
 - **THEN** the same schema is re-sent as a forced tool call and the rest of the
   fan-out uses that shape up front, keeping enforcement instead of losing it
 

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -363,8 +363,19 @@ def _retry_wait(retry_state: RetryCallState) -> float:
 
 
 # Phrases a backend uses to say "I do not know this request field". Matched
-# loosely because the wording is the backend's, not litellm's.
-_REJECTION_PHRASES = ("not permitted", "not supported", "unsupported", "unknown", "unexpected")
+# loosely because the wording is the backend's, not litellm's. The two
+# "support" spellings are AWS's: Bedrock refuses a Converse feature a model
+# lacks with "This model doesn't support …" prose rather than naming the field
+# an extra input.
+_REJECTION_PHRASES = (
+    "not permitted",
+    "not supported",
+    "unsupported",
+    "unknown",
+    "unexpected",
+    "doesn't support",
+    "does not support",
+)
 
 # A self-hosted OpenAI-compatible server refuses a tool call by naming the
 # start-up flag it is missing, not by calling the field unsupported — so these
@@ -396,8 +407,38 @@ def _rejects_response_format(exc: Exception) -> bool:
     So the rejection is read off the error instead: the field name plus a
     rejection phrase. A false positive costs one re-send in tool mode (see
     :func:`_schema_tool_kwargs`); a false negative costs the whole review.
+
+    The field goes by TWO spellings, and both matter. ``output_config`` (snake
+    case) is the Anthropic model layer's name, reported when the schema reaches
+    the model's own validator. ``outputConfig`` (camelCase) is the
+    Converse-level field litellm now sends for Claude models it believes
+    support native structured output — a belief keyed on the model id alone, so
+    a region or endpoint without the feature refuses the request at the
+    Converse layer instead (``extraneous key [outputConfig] is not permitted``,
+    or "This model doesn't support …" prose). Matching only the snake case made
+    exactly those refusals read as permanent, and one unsupported field killed
+    every lens of the review at once.
     """
-    return _rejects_field(exc, "response_format", "output_config", "responseformat")
+    return _rejects_field(exc, "response_format", "output_config", "outputconfig", "responseformat")
+
+
+def _rejects_reasoning_effort(exc: Exception) -> bool:
+    """True when an API error means the route refused the reasoning effort.
+
+    litellm maps a configured ``reasoning_effort`` for adaptive Claude models
+    into Anthropic's ``output_config.effort`` (bedrock also knows a Converse
+    ``reasoningConfig`` for other families), and a Bedrock model or region
+    without the field 400s on it. The message names ``output_config`` — the
+    same word :func:`_rejects_response_format` matches — so without this the
+    refusal was blamed on the SCHEMA: structured output was downgraded for the
+    run, the re-send still carried the effort, and the call failed identically.
+    Checked first in :func:`LiteLLMProvider._drop_rejected_param`, and only
+    when the request actually carried the effort, so the schema recovery keeps
+    running for everything else.
+    """
+    return _rejects_field(
+        exc, "output_config.effort", "reasoning_effort", "reasoningconfig", "maxreasoningeffort"
+    )
 
 
 def _rejects_tool_config(exc: Exception) -> bool:
@@ -1027,12 +1068,15 @@ class LiteLLMProvider:
     def _drop_rejected_param(self, exc: Exception, model: str, kwargs: dict[str, Any]) -> bool:
         """Strip the one request param *exc* says this model won't take.
 
-        Two params are sent for review quality rather than necessity —
-        ``temperature`` (determinism) and ``response_format`` (structured output)
-        — and a model that refuses either would otherwise fail the whole review
-        over a preference. Both refusals are permanent 400s, so the recovery is
-        to drop the param and re-send; ``kwargs`` is the dict every later retry
-        of this call reuses, so the drop sticks for them too.
+        Three params are sent for review quality rather than necessity —
+        ``temperature`` (determinism), ``reasoning_effort`` (a thinking budget)
+        and ``response_format`` (structured output) — and a model that refuses
+        any of them would otherwise fail the whole review over a preference.
+        The refusals are permanent 400s, so the recovery is to drop the param
+        and re-send; ``kwargs`` is the dict every later retry of this call
+        reuses, so the drop sticks for them too. The effort is judged before
+        the schema because its refusal names ``output_config``, the schema
+        matcher's own word (see :func:`_rejects_reasoning_effort`).
 
         Structured output gets two recoveries rather than one, in order of how
         much they keep: a rejected ``response_format`` becomes the same schema as
@@ -1045,6 +1089,13 @@ class LiteLLMProvider:
             # The param is accepted, only our value isn't — let the model use its
             # own default.
             kwargs.pop("temperature")
+            return True
+        # Before the schema branch, deliberately: a refused reasoning effort
+        # arrives naming `output_config.effort`, which the schema matcher below
+        # would claim — dropping the wrong param and re-sending a request that
+        # fails identically, with structured output disabled as collateral.
+        if "reasoning_effort" in kwargs and _rejects_reasoning_effort(exc):
+            kwargs.pop("reasoning_effort")
             return True
         # Both branches remember the outcome for this model's later calls, not
         # just this one: the lens fan-out sends the same shape N times, and

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -2448,6 +2448,147 @@ class TestOpenAICompatibleToolRejectionWording:
         assert "tools" not in seen[-1] and "response_format" not in seen[-1]
 
 
+class TestBedrockConverseOutputConfigWording:
+    """litellm's bedrock route sends Claude structured output as the
+    Converse-level ``outputConfig`` field (camelCase), so the endpoint's
+    refusals name THAT spelling — ``extraneous key [outputConfig] is not
+    permitted`` from a region or model without the feature, or AWS's "This
+    model doesn't support …" prose. The matcher only knew the snake_case
+    ``output_config`` the Anthropic model layer uses, so these 400s read as
+    permanent and killed every lens at once instead of degrading to the forced
+    tool call — the exact failure the recovery ladder exists to prevent."""
+
+    MODEL = "bedrock/us.anthropic.claude-sonnet-4-6"
+
+    CONVERSE_400 = (
+        "litellm.BadRequestError: BedrockException - "
+        '{"message":"Malformed input request: #: extraneous key [outputConfig] '
+        'is not permitted, please reformat your input and try again."}'
+    )
+    UNSUPPORTED_400 = (
+        "litellm.BadRequestError: BedrockException - "
+        '{"message":"This model doesn\'t support the outputConfig field."}'
+    )
+
+    def test_converse_extraneous_key_reads_as_a_schema_rejection(self) -> None:
+        from lgtmaybe.providers.litellm_provider import _rejects_response_format
+
+        assert _rejects_response_format(
+            litellm.BadRequestError(
+                message=self.CONVERSE_400, model=self.MODEL, llm_provider="bedrock"
+            )
+        )
+
+    def test_aws_doesnt_support_prose_reads_as_a_schema_rejection(self) -> None:
+        from lgtmaybe.providers.litellm_provider import _rejects_response_format
+
+        assert _rejects_response_format(
+            litellm.BadRequestError(
+                message=self.UNSUPPORTED_400, model=self.MODEL, llm_provider="bedrock"
+            )
+        )
+
+    def test_an_unrelated_bedrock_400_is_still_not_a_schema_rejection(self) -> None:
+        """The matcher must stay narrow: a genuine 400 has to keep failing."""
+        from lgtmaybe.providers.litellm_provider import _rejects_response_format
+
+        assert not _rejects_response_format(
+            litellm.BadRequestError(
+                message=(
+                    "litellm.BadRequestError: BedrockException - "
+                    '{"message":"Input is too long for requested model."}'
+                ),
+                model=self.MODEL,
+                llm_provider="bedrock",
+            )
+        )
+
+    def test_converse_rejection_recovers_into_tool_mode(self) -> None:
+        """End to end: the camelCase refusal swaps the schema for the forced
+        tool call, exactly as the snake_case one always did."""
+        seen: list[dict[str, Any]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.CONVERSE_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert "tools" in seen[-1] and "response_format" not in seen[-1]
+
+
+class TestBedrockRejectedReasoningEffort:
+    """litellm maps a configured ``reasoning_effort`` for adaptive Claude models
+    into Anthropic's ``output_config.effort``, and some Bedrock models/regions
+    reject that field. The refusal names ``output_config`` — which without a
+    guard reads as a STRUCTURED-OUTPUT rejection: the schema (the wrong param)
+    is dropped, the re-send still carries the effort and fails identically, and
+    the review dies having also disabled structured output for the run."""
+
+    MODEL = "bedrock/us.anthropic.claude-sonnet-4-6"
+
+    EFFORT_400 = (
+        "litellm.BadRequestError: BedrockException - "
+        '{"message":"The model returned the following errors: '
+        'output_config.effort: Extra inputs are not permitted"}'
+    )
+
+    def test_the_effort_is_dropped_and_the_schema_is_kept(self) -> None:
+        seen: list[dict[str, Any]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            if "reasoning_effort" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.EFFORT_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                self.MODEL,
+                response_format=ReviewResult,
+                reasoning_effort="medium",
+            )
+
+        assert result.text == '{"findings": []}'
+        assert "reasoning_effort" not in seen[-1]
+        assert "response_format" in seen[-1], "the schema was blamed for the effort's refusal"
+
+    def test_without_an_effort_in_flight_the_schema_recovery_still_runs(self) -> None:
+        """The guard is scoped to a request that actually carried the effort:
+        the same wording on an effort-less request keeps the schema recovery."""
+        seen: list[dict[str, Any]] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            if "response_format" in kwargs:
+                raise litellm.BadRequestError(
+                    message=self.EFFORT_400, model=kwargs["model"], llm_provider="bedrock"
+                )
+            return _fake_response('{"findings": []}')
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], self.MODEL, response_format=ReviewResult
+            )
+
+        assert result.text == '{"findings": []}'
+        assert "response_format" not in seen[-1]
+
+
 def _truncated_response() -> Any:
     """A reply the route cut off at the output ceiling."""
     return SimpleNamespace(


### PR DESCRIPTION
## Why bedrock + Claude keeps failing structured output

Since the litellm 1.96.2 → 1.97.0 bump (#530), the bedrock route no longer sends `response_format` as a synthetic tool call for Claude 4.5/4.6-family models. litellm's capability map flags them `supports_native_structured_output`, so it sends the **native Converse `outputConfig.textFormat` field** instead — Bedrock's own constrained-decoding API. This path is **Claude-only** on bedrock (Nova and everything else still get the tool-call translation), which is exactly why the failure is "bedrock specifically with Claude".

That native path has failed twice, and each failure produced a different error *spelling*:

1. **Schema-keyword rejections** (#531): Bedrock's validator names the **snake_case Anthropic-layer field** — `output_config.format.…: Extra inputs are not permitted`. The matcher caught these, and #533 stripped the numeric-bound keywords. Fixed.
2. **Feature-level rejections** (this PR): litellm's "supports native structured output" flag is keyed on the **model id alone**, so a region/endpoint/profile where the feature isn't rolled out refuses the request at the **Converse layer, naming the camelCase field** — `Malformed input request: #: extraneous key [outputConfig] is not permitted`, or AWS's "This model doesn't support …" prose. `_rejects_response_format` only matched `output_config` (with the underscore), so these 400s read as a permanent, unrecoverable failure: **every lens died at once** ("N of N review calls failed") instead of degrading to the forced tool call the recovery ladder was built for. That's why every schema-content fix "didn't work" — the fallback ladder exists, but its trigger never fired for the spelling the new litellm path produces. (`_rejects_tool_config` already anticipated Converse camelCase with `toolconfig`; the response_format matcher was the asymmetric one.)

A third, related trap: a configured `reasoning_effort` is mapped by litellm to Anthropic's `output_config.effort` for adaptive Claude models, and some bedrock models/regions reject that field too. That refusal *names `output_config`*, so the old matcher blamed the **schema**: structured output got disabled for the whole run, and the re-send still carried the effort and failed identically.

## Fix

TDD, red first (`TestBedrockConverseOutputConfigWording`, `TestBedrockRejectedReasoningEffort` in `tests/providers/test_retry.py`):

- `_rejects_response_format` now also matches the camelCase `outputConfig` spelling, and `_REJECTION_PHRASES` covers AWS's "doesn't support" / "does not support" wording — so any native-path refusal falls to the forced tool call (enforcement kept), and only a route refusing that too degrades to prompt-instructed JSON.
- New `_rejects_reasoning_effort`, judged **before** the schema branch in `_drop_rejected_param` and only when the request actually carried the effort: the effort is dropped, the schema is kept, and the re-send succeeds instead of failing identically with structured output lost as collateral.
- Spec `provider.param-drop` updated to name both spellings and the effort-before-schema ordering.

## Verification

- New tests fail on `main` and pass here; the effort test's red trace reproduces the exact misattribution chain (schema blamed → tool-mode swap → call still dies on the effort).
- Full suite: 2335 passed, 3 skipped; `tests/specs` + `openspec validate --specs` green; ruff + format + mypy clean.
- Wire request verified offline: captured the exact Converse body litellm 1.97.0 builds for `bedrock/us.anthropic.claude-sonnet-4-6` with lgtmaybe's `response_format` (native `outputConfig`, schema already free of bound keywords post-#533; `default`/`title` are accepted per Anthropic's documented subset).

Refs: [litellm #27846](https://github.com/BerriAI/litellm/issues/27846) (structured output fails for Anthropic models on bedrock/converse; Nova fine), [claude-code-action #1005](https://github.com/anthropics/claude-code-action/issues/1005) (`output_config.effort: Extra inputs are not permitted` on bedrock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157WbXg9Q4nrbWLuKbt8tmj

---
_Generated by [Claude Code](https://claude.ai/code/session_0157WbXg9Q4nrbWLuKbt8tmj)_