### PR TITLE
fix: fall back to full review after merge

### DIFF
--- a/openspec/changes/fallback-full-review-after-base-merge/.openspec.yaml
+++ b/openspec/changes/fallback-full-review-after-base-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/fallback-full-review-after-base-merge/design.md
+++ b/openspec/changes/fallback-full-review-after-base-merge/design.md
@@ -1,0 +1,46 @@
+## Context
+
+GitHub's compare API answers whether the current head is ahead of the previous
+reviewed head, not whether every intervening commit belongs to the PR. A normal
+"merge base into branch" update is ahead, but its comparison contains the base
+branch history and can be much larger than the PR's current diff.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Never treat a merge-containing comparison as a safe incremental PR diff.
+- Reuse the established full-review fallback.
+- Preserve cheap incremental reviews for linear pushes.
+
+**Non-Goals:**
+
+- Reconstruct a minimal incremental diff across arbitrary merge topology.
+- Change event selection, review markers, or GitHub Action configuration.
+- Add reviewed-file telemetry as part of this correctness fix.
+
+## Decisions
+
+### Fall back when any compared commit has multiple parents
+
+`compare_diff` already fetches the comparison JSON to inspect `status`. It will
+also inspect the returned commits and return `None` when any commit has more
+than one parent. The caller already interprets `None` as "review the full PR",
+so the fix adds no new control flow or public interface.
+
+This deliberately sends feature-branch merge commits through a full review as
+well. That costs more model input but is safe; distinguishing every possible
+merge topology would add complexity to a merge-gate correctness path.
+
+## Risks / Trade-offs
+
+- PRs that use merge commits internally receive a full review on that push.
+- GitHub compare responses with missing commit metadata remain accepted when
+  linear, preserving current behavior for compatible API implementations.
+- Rebase updates already report `diverged` and retain their existing full-review
+  fallback.
+
+## Migration Plan
+
+Ship as a backward-compatible gateway fix. Roll back by removing the merge
+guard; no stored state or configuration migration is required.

--- a/openspec/changes/fallback-full-review-after-base-merge/proposal.md
+++ b/openspec/changes/fallback-full-review-after-base-merge/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Incremental review compares the last completed PR head with the current head.
+When a contributor merges the updated base branch into the PR, GitHub reports
+that comparison as `ahead` and includes the base branch's commits and files.
+lgtmaybe then reviews unrelated base-branch changes and can stamp the current
+PR head complete without reviewing its current PR diff.
+
+## What Changes
+
+- Treat an incremental comparison containing a merge commit as unsafe.
+- Fall back to the existing full-PR review path for that synchronization.
+- Keep linear incremental pushes and the existing force-push/API-failure
+  fallbacks unchanged.
+- Isolate tests from active spec proposals in the developer checkout.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-posting`: Make incremental review fall back to a full review after a
+  branch merge.
+
+## Impact
+
+- Incremental comparison handling in `src/lgtmaybe/github/rest_gateway.py`.
+- Focused HTTP-boundary coverage in `tests/github/test_incremental.py`.
+- Shared test working-directory isolation and repository-anchored docs tests.
+- One `github-posting` specification scenario; no API, configuration,
+  dependency, or marker changes.

--- a/openspec/changes/fallback-full-review-after-base-merge/specs/github-posting/spec.md
+++ b/openspec/changes/fallback-full-review-after-base-merge/specs/github-posting/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Incremental review is commit-scoped and safe
+<!-- anchor: github.incremental -->
+
+A follow-up run with a completed-head watermark SHALL review only a linear,
+merge-free compare-API diff since that head and explicitly validate earlier
+open findings against the new head. The completed watermark SHALL move only
+after a non-partial review result and, when automatic diagrams are enabled,
+the current-head diagram have posted. Force-push, missing marker, compare
+failure, merge-containing comparison, and incomplete attempts SHALL fall back
+to a full review. A run whose head already equals the completed head SHALL make
+no model calls or duplicate posts. LEFT-side new findings SHALL be dropped and
+resolution scope SHALL remain limited to findings actually validated.
+
+#### Scenario: a later push follows a complete review
+- **WHEN** the current head is ahead of the completed head without a merge
+- **THEN** only the compare diff is scanned for new problems and prior open
+  findings are classified against the new head
+
+#### Scenario: the PR branch merges its updated base
+- **WHEN** the comparison since the completed head contains a merge commit
+- **THEN** the comparison is rejected and the current full PR diff is reviewed
+
+#### Scenario: the completed head runs again
+- **WHEN** a run starts on the same head recorded as complete
+- **THEN** it succeeds without model calls or GitHub writes
+
+#### Scenario: a review attempt is incomplete
+- **WHEN** review calls fail, are interrupted, exceed a configured budget, or a
+  required diagram fails
+- **THEN** the completed watermark does not move, so the next run retries from
+  the last complete head
+
+#### Scenario: a review run fails
+- **WHEN** posting fails after review
+- **THEN** the watermark does not move, so nothing is skipped next run

--- a/openspec/changes/fallback-full-review-after-base-merge/tasks.md
+++ b/openspec/changes/fallback-full-review-after-base-merge/tasks.md
@@ -1,0 +1,19 @@
+## 1. Acceptance Coverage
+
+- [x] 1.1 Add a gateway test where an `ahead` comparison contains a merge
+  commit and returns no incremental diff.
+- [x] 1.2 Keep the existing linear `ahead` comparison behavior covered.
+
+## 2. GitHub Incremental Review
+
+- [x] 2.1 Reuse the comparison metadata request to detect multiple-parent
+  commits and fall back to a full review.
+- [x] 2.2 Keep diverged, identical, and API-failure fallbacks unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Run focused gateway and CLI incremental-review tests.
+- [x] 3.2 Isolate tests from the developer checkout so an active OpenSpec
+  proposal cannot alter unrelated engine call counts.
+- [x] 3.3 Validate the OpenSpec change strictly and inspect the final diff.
+- [x] 3.4 Run the full pytest suite, Ruff, mypy, and spec-anchor checks.

--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -613,20 +613,26 @@ class RestGitHubGateway:
         """Unified diff of the commits between *base_sha* and *head_sha*, or None.
 
         Uses the compare API (read-only — never a checkout). Returns the diff
-        only when head is strictly **ahead** of the last-reviewed SHA (a normal
-        push). A force-push/rebase (``diverged``/``behind``), an ``identical``
-        compare, and any API failure (e.g. a GC'd SHA 404ing after a
-        force-push) all return None — the caller falls back to a full review
-        rather than trusting a meaningless increment.
+        only when head is strictly **ahead** of the last-reviewed SHA through
+        linear commits (a normal push). A merge, force-push/rebase
+        (``diverged``/``behind``), an ``identical`` compare, and any API failure
+        (e.g. a GC'd SHA 404ing after a force-push) all return None — the caller
+        falls back to a full review rather than trusting a meaningless increment.
         """
         url = f"{self._api}/compare/{base_sha}...{head_sha}"
         try:
-            status = self._get_json(url).get("status")
+            comparison = self._get_json(url)
+            status = comparison.get("status")
             if status != "ahead":
                 _log.info(
                     "incremental compare not usable — falling back to full review",
                     extra={"status": status},
                 )
+                return None
+            if any(
+                len(commit.get("parents") or []) > 1 for commit in comparison.get("commits") or []
+            ):
+                _log.info("incremental compare contains a merge — falling back to full review")
                 return None
             resp = self._client.get(
                 url,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,3 +78,9 @@ def _isolate_provider_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     """Start every test from a clean, credential-free environment."""
     for var in _PROVIDER_CRED_ENV:
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_working_directory(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep tests independent of files in the developer's checkout."""
+    monkeypatch.chdir(tmp_path)

--- a/tests/docs/test_homepage.py
+++ b/tests/docs/test_homepage.py
@@ -1,9 +1,11 @@
 import re
 from pathlib import Path
 
+_ROOT = Path(__file__).parents[2]
+
 
 def test_homepage_shows_change_diagram_example() -> None:
-    homepage = Path("docs/index.md").read_text(encoding="utf-8")
+    homepage = (_ROOT / "docs/index.md").read_text(encoding="utf-8")
 
     assert "```mermaid\nflowchart LR" in homepage
     assert "(changed)" in homepage
@@ -15,7 +17,7 @@ def test_homepage_shows_change_diagram_example() -> None:
 
 
 def test_homepage_overview_is_concise_without_hiding_features() -> None:
-    homepage = Path("docs/index.md").read_text(encoding="utf-8")
+    homepage = (_ROOT / "docs/index.md").read_text(encoding="utf-8")
     overview = homepage.split("## Start here", 1)[0].casefold()
 
     assert len(re.findall(r"\b[\w'-]+\b", overview)) <= 400
@@ -35,9 +37,9 @@ def test_homepage_overview_is_concise_without_hiding_features() -> None:
 
 def test_model_selection_guide_is_linked_from_readme_and_docs_nav() -> None:
     guide = "how-to/choose-a-review-model.md"
-    guide_text = Path("docs", guide).read_text(encoding="utf-8")
-    readme = Path("README.md").read_text(encoding="utf-8")
-    mkdocs = Path("mkdocs.yml").read_text(encoding="utf-8")
+    guide_text = (_ROOT / "docs" / guide).read_text(encoding="utf-8")
+    readme = (_ROOT / "README.md").read_text(encoding="utf-8")
+    mkdocs = (_ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 
     assert "## Choose a Cloud Model" in guide_text
     assert "## Choose a Local Model" in guide_text

--- a/tests/github/test_incremental.py
+++ b/tests/github/test_incremental.py
@@ -300,11 +300,13 @@ def test_automatic_diagram_uses_only_the_trusted_completion_sha() -> None:
 COMPARE_URL = f"{BASE_URL}/repos/{REPO}/compare/cafe1234...headsha123"
 
 
-def _mock_compare(status: str, diff: str = SAMPLE_DIFF) -> None:
+def _mock_compare(
+    status: str, diff: str = SAMPLE_DIFF, *, commits: list[dict[str, object]] | None = None
+) -> None:
     def respond(request: httpx.Request) -> httpx.Response:
         if "diff" in request.headers.get("Accept", ""):
             return httpx.Response(200, text=diff)
-        return httpx.Response(200, json={"status": status})
+        return httpx.Response(200, json={"status": status, "commits": commits or []})
 
     respx.route(method="GET", url=COMPARE_URL).mock(side_effect=respond)
 
@@ -314,6 +316,16 @@ def test_compare_diff_returns_increment_when_ahead() -> None:
     _mock_compare("ahead")
 
     assert _gateway().compare_diff("cafe1234", "headsha123") == SAMPLE_DIFF
+
+
+@respx.mock
+def test_compare_diff_none_when_comparison_contains_merge() -> None:
+    _mock_compare(
+        "ahead",
+        commits=[{"sha": "merge123", "parents": [{"sha": "pr123"}, {"sha": "base123"}]}],
+    )
+
+    assert _gateway().compare_diff("cafe1234", "headsha123") is None
 
 
 @respx.mock


### PR DESCRIPTION
## Summary
- fall back to a full PR review when an incremental comparison contains a merge commit
- keep linear incremental pushes unchanged
- isolate tests from active OpenSpec proposals in the developer checkout

## Verification
- 2447 passed, 2 skipped, 19 deselected
- ruff check and format check
- mypy src
- strict OpenSpec validation