### PR TITLE
perf(local): remove redundant git subprocesses

### DIFF
--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from lgtmaybe.core.diff import is_reviewable, is_scannable_manifest
+from lgtmaybe.core.diffparse import split_by_file
 from lgtmaybe.core.models import PRContext
 
 # `git diff` over a large working tree (or a repo whose objects are cold) can
@@ -56,14 +57,12 @@ def local_pr_context(
     if working and uncommitted:
         raise ValueError("--working and --uncommitted are mutually exclusive")
 
-    _ensure_repo(cwd)
-    # Everything downstream — the patch headers, `--name-only`, the reader that
+    cwd = _ensure_repo(cwd)
+    # Everything downstream — the patch paths and the reader that
     # opens each changed file — speaks repo-relative paths, because that is what
     # `git diff` reports wherever it is invoked from. Anchor on the repo root so
     # a review run from a subdirectory sees the same worktree as one run from
     # the top, rather than half of it against the wrong base directory.
-    cwd = _repo_root(cwd)
-
     head_sha = _git(cwd, "rev-parse", "HEAD").strip()
 
     if uncommitted:
@@ -84,8 +83,7 @@ def local_pr_context(
         commit_messages = _commit_subjects(cwd, base_ref)
 
     diff = _git(cwd, "diff", spec)
-    name_output = _git(cwd, "diff", "--name-only", spec)
-    changed_files = [line for line in name_output.splitlines() if line]
+    changed_files = [path for path, _patch in split_by_file(diff, []) if path != "unknown"]
 
     # `git diff` only ever reports content git already tracks, so a file you
     # just created is invisible to it — and "review my working tree" almost
@@ -234,14 +232,12 @@ def _git(cwd: Path | None, *args: str) -> str:
     return result.stdout
 
 
-def _ensure_repo(cwd: Path | None) -> None:
-    """Raise a clear ValueError unless cwd is inside a git work tree."""
+def _ensure_repo(cwd: Path | None) -> Path:
+    """Return the worktree root, or raise a clear ValueError outside one."""
     try:
-        inside = _git(cwd, "rev-parse", "--is-inside-work-tree").strip()
+        return Path(_git(cwd, "rev-parse", "--show-toplevel").strip())
     except ValueError as exc:
         raise ValueError("not a git repository (run lgtmaybe from inside one)") from exc
-    if inside != "true":
-        raise ValueError("not a git repository (run lgtmaybe from inside one)")
 
 
 def _current_branch(cwd: Path | None) -> str:

--- a/tests/local/test_git_context.py
+++ b/tests/local/test_git_context.py
@@ -262,6 +262,31 @@ def test_uncommitted_resolves_head_with_a_single_rev_parse(
     assert ctx.base_sha == ctx.head_sha
 
 
+def test_local_context_uses_one_diff_and_one_repo_lookup(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import lgtmaybe.local as local_mod
+
+    real_git = local_mod._git
+    calls: list[tuple[str, ...]] = []
+
+    def counting_git(cwd: Path | None, *args: str) -> str:
+        calls.append(args)
+        return real_git(cwd, *args)
+
+    monkeypatch.setattr(local_mod, "_git", counting_git)
+    _git(repo, "remote", "add", "origin", "git@github.com:owner/repo.git")
+    (repo / "app.py").write_text("def f():\n    return 2\n")
+    _git(repo, "commit", "-am", "change")
+
+    ctx = local_pr_context(base="main", working=False, cwd=repo)
+
+    assert ctx.changed_files == ["app.py"]
+    assert sum(call[0] == "diff" for call in calls) == 1
+    assert calls.count(("rev-parse", "--show-toplevel")) == 1
+    assert ("rev-parse", "--is-inside-work-tree") not in calls
+
+
 # ---------------------------------------------------------------------------
 # untracked files — a brand-new file is the most common thing to review locally
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #592

Derive changed paths from the unified diff already in memory and reuse `rev-parse --show-toplevel` for both repository validation and root resolution.

Checks:
- `uv run pytest` (2453 passed, 3 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `openspec validate --all`
- local working-tree runtime check