### PR TITLE
perf(gitlab): cache merge request notes

### DIFF
--- a/src/lgtmaybe/gitlab/gateway.py
+++ b/src/lgtmaybe/gitlab/gateway.py
@@ -111,6 +111,7 @@ class GitLabGateway:
         # The MR's discussion list, read by three callers per run and never
         # mutated between them (see `_discussions`).
         self._discussions_cache: list[dict[str, Any]] | None = None
+        self._notes_cache: list[dict[str, Any]] | None = None
 
     # ------------------------------------------------------------------
     # ReviewGateway implementation
@@ -480,7 +481,9 @@ class GitLabGateway:
 
     def _find_note(self, family: str) -> int | None:
         """The id of our existing note in ``family``, or None."""
-        for note in self._paginate(f"{self._mr_api}/notes"):
+        if self._notes_cache is None:
+            self._notes_cache = self._paginate(f"{self._mr_api}/notes")
+        for note in self._notes_cache:
             if family in (note.get("body") or ""):
                 note_id = note.get("id")
                 return int(note_id) if note_id is not None else None

--- a/tests/gitlab/test_gateway.py
+++ b/tests/gitlab/test_gateway.py
@@ -154,6 +154,20 @@ class TestDiscussionFetching:
 
 class TestPostReview:
     @respx.mock
+    def test_note_families_share_one_notes_fetch(self) -> None:
+        _stub_post_routes()
+        listed = respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        gateway = _gateway()
+
+        gateway.post_review([], "summary", diff=DIFF)
+        gateway.post_describe_comment("description")
+        gateway.post_diagram_comment("diagram")
+
+        assert listed.call_count == 1
+
+    @respx.mock
     def test_each_finding_becomes_its_own_positioned_discussion(self) -> None:
         """GitLab has no batched review object — a discussion per finding."""
         _stub_post_routes()


### PR DESCRIPTION
Closes #590

Cache the merge request notes list so summary, description, and diagram upserts do not paginate the same unchanged collection independently.

Checks:
- `uv run pytest` (2454 passed, 3 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `openspec validate --all`