### PR TITLE
perf: skip supplied cache key derivation

### DIFF
--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -905,7 +905,8 @@ class LiteLLMProvider:
         # a cache hit — too late for a fan-out that dispatches its lenses at
         # once. OpenAI uses the same field as a hint for prefix-sharing
         # requests, so one param serves both; drop_params strips it elsewhere.
-        merged.setdefault("prompt_cache_key", _prefix_cache_key(messages))
+        if "prompt_cache_key" not in merged:
+            merged["prompt_cache_key"] = _prefix_cache_key(messages)
         # A factory-built provider carries the resolved litellm model string
         # (e.g. "ollama/qwen3:27b"); prefer it over the caller's raw cfg.model.
         # An explicit override outranks both: it is the caller naming a model

--- a/tests/providers/test_prompt_cache.py
+++ b/tests/providers/test_prompt_cache.py
@@ -420,7 +420,11 @@ class TestStickyCacheKey:
 
     def test_caller_supplied_key_wins(self) -> None:
         model = "openrouter/anthropic/claude-sonnet-4.5"
-        with patch("litellm.completion", return_value=_fake_response()) as mock:
+        with (
+            patch("litellm.completion", return_value=_fake_response()) as mock,
+            patch("lgtmaybe.providers.litellm_provider._prefix_cache_key") as derive,
+        ):
             provider = LiteLLMProvider(model=model)
             provider.complete(_split_messages(), model, prompt_cache_key="mine")
         assert mock.call_args.kwargs["prompt_cache_key"] == "mine"
+        derive.assert_not_called()


### PR DESCRIPTION
Closes #588

Avoid eagerly hashing the full prompt prefix when the caller already supplied `prompt_cache_key`.

Validation:
- `uv run --frozen pytest -q` (2453 passed, 3 skipped)
- ruff and mypy
- Docker build and CLI smoke test