### PR TITLE
fix: remember rejected model parameters

### DIFF
--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -687,6 +687,7 @@ class LiteLLMProvider:
         # enforcement preserved by another mechanism, that one is enforcement
         # given up. Keyed by MODEL for the same reason.
         self._schema_tool: set[str] = set()
+        self._rejected_params: dict[str, set[str]] = {}
         # Memoized supports-cache-control answers: the review fans out many
         # completions on the same model string, and the capability lookup is a
         # pure function of it. Instance-scoped (not lru_cache) so tests that
@@ -988,6 +989,8 @@ class LiteLLMProvider:
         def _call() -> ProviderResult:
             # A prior call already settled how this model takes (or refuses) the
             # schema, so don't pay the wasted round-trip again — apply it up front.
+            for param in self._rejected_params.get(model, ()):
+                kwargs.pop(param, None)
             if model in self._schema_dropped:
                 self._strip_schema(kwargs)
             elif model in self._schema_tool:
@@ -1089,6 +1092,7 @@ class LiteLLMProvider:
             # The param is accepted, only our value isn't — let the model use its
             # own default.
             kwargs.pop("temperature")
+            self._rejected_params.setdefault(model, set()).add("temperature")
             return True
         # Before the schema branch, deliberately: a refused reasoning effort
         # arrives naming `output_config.effort`, which the schema matcher below
@@ -1096,6 +1100,7 @@ class LiteLLMProvider:
         # fails identically, with structured output disabled as collateral.
         if "reasoning_effort" in kwargs and _rejects_reasoning_effort(exc):
             kwargs.pop("reasoning_effort")
+            self._rejected_params.setdefault(model, set()).add("reasoning_effort")
             return True
         # Both branches remember the outcome for this model's later calls, not
         # just this one: the lens fan-out sends the same shape N times, and

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -372,12 +372,13 @@ class TestTemperatureRejection:
 
         with patch("litellm.completion", side_effect=side_effect):
             provider = LiteLLMProvider()
-            result = provider.complete(
-                [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
-            )
+            for _ in range(2):
+                result = provider.complete(
+                    [{"role": "user", "content": "hi"}], "openai/gpt-5.5", temperature=0.0
+                )
 
         assert result.text == "ok without temperature"
-        assert seen_temperatures == [0.0, "absent"]
+        assert seen_temperatures == [0.0, "absent", "absent"]
 
     def test_unrelated_bad_request_is_not_swallowed(self) -> None:
         """A non-temperature error must still propagate, not be retried bare."""
@@ -2555,14 +2556,16 @@ class TestBedrockRejectedReasoningEffort:
 
         with patch("litellm.completion", side_effect=side_effect):
             provider = LiteLLMProvider()
-            result = provider.complete(
-                [{"role": "user", "content": "hi"}],
-                self.MODEL,
-                response_format=ReviewResult,
-                reasoning_effort="medium",
-            )
+            for _ in range(2):
+                result = provider.complete(
+                    [{"role": "user", "content": "hi"}],
+                    self.MODEL,
+                    response_format=ReviewResult,
+                    reasoning_effort="medium",
+                )
 
         assert result.text == '{"findings": []}'
+        assert len(seen) == 3
         assert "reasoning_effort" not in seen[-1]
         assert "response_format" in seen[-1], "the schema was blamed for the effort's refusal"
 


### PR DESCRIPTION
Closes #587

Remember rejected `temperature` and `reasoning_effort` parameters per model so later lens calls skip the known-failing request instead of paying another 400 round trip.

Checks:
- `uv run pytest -q` (2454 passed, 3 skipped, 19 deselected)
- `uv run pytest tests/providers/test_retry.py -q` (148 passed)
- `uv run mypy src/lgtmaybe/providers/litellm_provider.py`
- `uv run ruff check ...`
- anchor/spec drift checks