### PR TITLE
fix: budget context for reviewed files

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -987,7 +987,7 @@ class LLMReviewEngine:
         #    understanding only — inline-comment positions are always built
         #    from the real diff.
         with profiler.stage("expand"):
-            used_tokens = count_tokens(clean_diff)
+            used_tokens = sum(count_tokens(patch) for _, patch in file_patches)
             remaining = max(0, cfg.max_input_tokens - used_tokens)
             ctx_lines = min(cfg.context_lines, context_lines_for_budget(remaining))
             if ctx_lines > 0 and ctx.file_contents:

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -633,6 +633,34 @@ def test_context_lines_zero_disables_expansion() -> None:
     assert "\n e\n" in sent
 
 
+def test_excluded_files_do_not_consume_context_budget() -> None:
+    kept = "diff --git a/f.py b/f.py\n@@ -5,2 +5,2 @@\n e\n+E2\n"
+    excluded = (
+        "diff --git a/vendor/data.py b/vendor/data.py\n@@ -1,1 +1,1 @@\n+" + "x" * 50_000 + "\n"
+    )
+    ctx = PRContext(
+        diff=kept + excluded,
+        changed_files=["f.py", "vendor/data.py"],
+        base_sha="abc",
+        head_sha="def",
+        repo="org/repo",
+        pr_number=10,
+        file_contents={"f.py": _FILE_TEXT},
+    )
+    provider = _provider_for([_HIGH], reflection_keeps_all=True)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        exclude_paths=["vendor/**"],
+        max_input_tokens=10_000,
+        context_lines=1,
+    )
+
+    LLMReviewEngine(provider).review(ctx, cfg)
+
+    assert "\n d\n" in _first_user_diff(provider)
+
+
 def test_prompt_injection_in_diff_produces_normal_review() -> None:
     malicious_ctx = PRContext(
         diff=(


### PR DESCRIPTION
Closes #585

Calculate context-expansion budget from the surviving review patches, so filtered, capped, oversized, and triage-dropped files cannot consume context they never receive.

Validation:
- `uv run --frozen pytest -q` (2455 passed, 3 skipped)
- ruff and mypy
- Docker build and CLI smoke test