### PR TITLE
perf(github): request larger review pages

### DIFF
--- a/src/lgtmaybe/github/rest_gateway.py
+++ b/src/lgtmaybe/github/rest_gateway.py
@@ -955,7 +955,7 @@ class RestGitHubGateway:
         """
         if self._existing_review_done:
             return self._existing_review_entry
-        for resp in self._paginate(f"{self._pr_api}/reviews"):
+        for resp in self._paginate(f"{self._pr_api}/reviews?per_page=100"):
             for review in resp.json():
                 body: str = review.get("body", "") or ""
                 if self._marker in body:

--- a/tests/github/test_post_review.py
+++ b/tests/github/test_post_review.py
@@ -1104,6 +1104,7 @@ def test_reviews_list_fetched_once_per_run() -> None:
     gw.post_review(FINDINGS, "New summary", diff=SAMPLE_DIFF)
 
     assert len(reviews_calls) == 1, "the unchanged reviews list must not be re-paginated"
+    assert reviews_calls[0].url.params["per_page"] == "100"
 
 
 @respx.mock


### PR DESCRIPTION
Closes #589

Request 100 reviews per page, matching sibling GitHub list calls and reducing pagination round trips on busy PRs.

Checks:
- `uv run pytest` (2454 passed, 3 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `openspec validate --all`