### PR TITLE
docs: correct automatic concurrency defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,8 +338,8 @@ pattern, event bus, plugin framework.
      four run on **every** provider: worker count decides only whether they
      overlap, never how many there are. **`full`** runs one call per category.
      An explicit `categories` list overrides the grouping. Every (batch, lens) call runs through **one global
-     `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 8
-     cloud, 1 ollama/openai-compatible), then the findings are **merged and
+     `ThreadPoolExecutor`** sized by `ReviewConfig.max_concurrency` (auto: 6
+     for every provider), then the findings are **merged and
      de-duped** (`engine._dedupe`, keyed on path/line/side) before reflection.
      A soft whole-review deadline (`max_review_seconds`, default 3600s, 0 = off)
      skips still-queued calls once passed — partial results with a notice,

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -1045,13 +1045,8 @@ class ReviewConfig(_Strict):
     # bound.
     max_findings_per_lens: int = Field(default=50, ge=0)
     # Ceiling on concurrent review calls across the WHOLE fan-out (every
-    # (batch, lens) task shares one pool). None means auto: 6 for hosted cloud
-    # providers (wide enough to overlap the fan-out, narrow enough that one API
-    # key does not rate-limit itself against a per-minute-metered gateway —
-    # raise it if your rate tier is generous), 1 for ollama (a single instance
-    # serves a model serially — concurrent calls just queue and time out), and
-    # 1 for openai-compatible (a llama.cpp/LM Studio single-slot server wants
-    # 1; a vLLM server batches happily — raise it explicitly for those).
+    # (batch, lens) task shares one pool). None means 6 for every provider.
+    # Local throughput is set on the server; use 1 here for a serial local run.
     max_concurrency: int | None = Field(default=None, ge=1)
     # Constrain model output to the findings JSON schema via litellm
     # response_format (provider-native JSON mode). Keeps models from returning


### PR DESCRIPTION
Closes #584

Correct the model and contributor documentation: automatic concurrency is six for every provider, with local serialization configured explicitly.

Checks:
- `uv run pytest tests/engine/test_concurrency.py tests/specs/test_anchors.py tests/specs/test_spec_drift.py -q` (41 passed)
- `uv run pytest tests/test_models.py -q`
- ruff, mypy, and spec drift checks