### PR TITLE
fix: root local symbols at repository

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -60,7 +60,7 @@ from lgtmaybe.engine.profiling import profiler
 from lgtmaybe.gitea import GiteaGateway
 from lgtmaybe.github import RestGitHubGateway
 from lgtmaybe.gitlab import GitLabGateway
-from lgtmaybe.local import local_file_reader, local_pr_context
+from lgtmaybe.local import local_file_reader, local_pr_context, local_repo_root
 from lgtmaybe.providers.credentials import resolve_credentials
 from lgtmaybe.providers.factory import (
     build_provider,
@@ -724,9 +724,7 @@ def execute_local_review(
         fetch_file = local_file_reader()
         # And let ast-grep resolve a deferred symbol to its defining file by searching
         # that same worktree — the corpus is already on disk, so no clone is needed.
-        resolve_symbol = (
-            build_symbol_resolver(lambda: Path.cwd()) if cfg.symbol_resolution else None
-        )
+        resolve_symbol = build_symbol_resolver(local_repo_root) if cfg.symbol_resolution else None
         engine, _provider = build_provider_engine(
             cfg, runtime, fetch_file=fetch_file, resolve_symbol=resolve_symbol
         )

--- a/src/lgtmaybe/local/__init__.py
+++ b/src/lgtmaybe/local/__init__.py
@@ -140,7 +140,7 @@ def local_file_reader(cwd: Path | None = None) -> Callable[[str], str | None]:
     process's directory: the paths handed to the reader are repo-relative,
     because that is what git reports wherever it runs.
     """
-    root = (Path(cwd) if cwd is not None else _repo_root(None)).resolve()
+    root = (Path(cwd) if cwd is not None else local_repo_root()).resolve()
 
     def read(path: str) -> str | None:
         try:
@@ -153,7 +153,7 @@ def local_file_reader(cwd: Path | None = None) -> Callable[[str], str | None]:
     return read
 
 
-def _repo_root(cwd: Path | None) -> Path:
+def local_repo_root(cwd: Path | None = None) -> Path:
     """The worktree's top level, or *cwd* itself when git can't say.
 
     Falling back rather than raising keeps a non-repo caller (the file reader's
@@ -296,4 +296,4 @@ def _repo_name(cwd: Path | None) -> str:
     if url:
         parts = re.split(r"[:/]", url.removesuffix(".git"))
         return "/".join(parts[-2:])
-    return _repo_root(cwd).name
+    return local_repo_root(cwd).name

--- a/tests/local/test_git_context.py
+++ b/tests/local/test_git_context.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from lgtmaybe.local import local_file_reader, local_pr_context
+from lgtmaybe.local import local_file_reader, local_pr_context, local_repo_root
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -448,6 +448,15 @@ def test_default_file_reader_resolves_against_the_repo_root(
     assert read("../outside.py") is None
 
 
+def test_default_repo_root_resolves_from_a_subdirectory(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (repo / "pkg").mkdir()
+    monkeypatch.chdir(repo / "pkg")
+
+    assert local_repo_root() == repo
+
+
 def test_explicit_file_reader_root_is_used_verbatim(tmp_path: Path) -> None:
     """An explicit root is a root, not a hint — the eval harness points this at a
     fixture corpus that is not a git repo of its own."""
@@ -461,7 +470,7 @@ def test_explicit_file_reader_root_is_used_verbatim(tmp_path: Path) -> None:
 
 
 def test_repo_name_falls_back_to_the_directory_name_outside_a_repo(tmp_path: Path) -> None:
-    """`_repo_name` reuses `_repo_root`, whose fallback makes it answer for a
+    """`_repo_name` reuses `local_repo_root`, whose fallback makes it answer for a
     directory git knows nothing about instead of raising."""
     from lgtmaybe.local import _repo_name
 


### PR DESCRIPTION
Closes #582

Resolve local ast-grep symbols from the Git worktree root, matching local diff and file-reader paths even when the CLI runs in a subdirectory.

Validation:
- `uv run --frozen pytest -q` (2456 passed, 3 skipped)
- ruff and mypy
- Docker build and CLI smoke test