### PR TITLE
fix: reject unknown config get keys

### DIFF
--- a/src/lgtmaybe/cli/commands.py
+++ b/src/lgtmaybe/cli/commands.py
@@ -621,7 +621,10 @@ def config_show() -> None:
 @click.argument("key")
 def config_get(key: str) -> None:
     """Print one config value."""
-    value = store.get_key(key)
+    try:
+        value = store.get_key(key)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
     if value is not None:
         click.echo(str(value))
 

--- a/src/lgtmaybe/config/store.py
+++ b/src/lgtmaybe/config/store.py
@@ -52,6 +52,7 @@ def as_yaml(path: Path | None = None) -> str:
 
 def get_key(key: str, path: Path | None = None) -> Any:
     """Return one stored value, or None when unset."""
+    _validate_key(key)
     return load(path).get(key)
 
 

--- a/tests/cli/test_config_cmd.py
+++ b/tests/cli/test_config_cmd.py
@@ -52,6 +52,12 @@ def test_set_unknown_key_is_refused(cfg_home: Path) -> None:
     assert "unknown config key" in result.output
 
 
+def test_get_unknown_key_is_refused(cfg_home: Path) -> None:
+    result = CliRunner().invoke(main, ["config", "get", "nope"])
+    assert result.exit_code != 0
+    assert "valid keys:" in result.output
+
+
 def test_init_wizard_writes_file(cfg_home: Path) -> None:
     result = CliRunner().invoke(
         main, ["config", "init"], input="ollama\nqwen3:27b\nhttp://localhost:11434\n"


### PR DESCRIPTION
Closes #581

Validate `config get` keys at the config-store boundary and surface the same valid-key guidance as `config set`.

Checks:
- `uv run pytest -q` (2456 passed, 3 skipped, 19 deselected)
- focused config tests (17 passed)
- ruff, mypy, anchors, and spec drift checks