### PR TITLE
fix: cap files after triage ranking

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -934,11 +934,8 @@ class LLMReviewEngine:
                     oversized.append(path)
             file_patches = kept
 
-            # 3. File cap: review only the first N reviewable files, note the rest.
             total_files = len(file_patches)
-            capped_files = total_files > cfg.max_files
-            if capped_files:
-                file_patches = file_patches[: cfg.max_files]
+            capped_files = False
 
         # 3b. Static-analysis grounding (default off): deterministic tool
         #     findings over the reviewed files' head texts, fed to each batch's
@@ -977,6 +974,12 @@ class LLMReviewEngine:
                 file_patches, skipped_by_triage = triage_files(
                     file_patches, sa_hints, cfg, self._provider
                 )
+
+        # 3d. File cap: after triage so it drops the lowest-risk survivors,
+        # rather than whichever paths happened to appear last in the diff.
+        capped_files = len(file_patches) > cfg.max_files
+        if capped_files:
+            file_patches = file_patches[: cfg.max_files]
 
         # 4. Pad each hunk with surrounding lines so the model sees the function
         #    and definitions around a change. The amount is budget-scaled and

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -1962,6 +1962,26 @@ def test_exclude_paths_wins_over_include_paths() -> None:
     assert "+y = 2" not in sent
 
 
+def test_file_cap_applies_after_triage_ranking(monkeypatch: pytest.MonkeyPatch) -> None:
+    def rank_tail_first(file_patches, *_args):  # type: ignore[no-untyped-def]
+        return list(reversed(file_patches)), []
+
+    monkeypatch.setattr("lgtmaybe.engine.engine.triage_files", rank_tail_first)
+    provider = _provider_for([], reflection_keeps_all=True)
+    cfg = ReviewConfig(
+        provider=Provider.ollama,
+        model="llama3",
+        triage_model="tiny",
+        max_files=1,
+    )
+
+    LLMReviewEngine(provider).review(_TWO_FILE_CTX, cfg)
+
+    sent = _first_user_diff(provider)
+    assert "+y = 2" in sent
+    assert "+x = 1" not in sent
+
+
 def test_empty_path_filters_review_everything() -> None:
     provider = _provider_for([], reflection_keeps_all=True)
     engine = LLMReviewEngine(provider)


### PR DESCRIPTION
Closes #579

Apply `max_files` after triage so the cap keeps the highest-risk survivors instead of the first paths in diff order.

Validation:
- `uv run --frozen pytest -q` (2457 passed, 3 skipped)
- ruff and mypy
- Docker build and CLI smoke test