### PR TITLE
fix(cli): disclose incomplete JSON reviews

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -733,6 +733,8 @@ def execute_local_review(
     except Exception as exc:
         raise click.ClickException(str(exc)) from exc
 
+    if fmt == "json" and INCOMPLETE_MARKER in summary:
+        click.echo(summary.replace(INCOMPLETE_MARKER, "").strip(), err=True)
     click.echo(render_findings(findings, summary, fmt=fmt))
     _write_profile_json(runtime)
     if runtime.profile:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from lgtmaybe.cli import RuntimeOptions, build_review_context, main, run_review
 from lgtmaybe.core.models import PRContext, ReviewConfig, ReviewFinding
+from lgtmaybe.engine import INCOMPLETE_MARKER
 from tests.fakes import FakeEngine, FakeGitHub, FakeProvider
 
 
@@ -17,6 +18,12 @@ class _BoomEngine:
 
     def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
         raise RuntimeError("provider exploded")
+
+
+class _IncompleteEngine(FakeEngine):
+    def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
+        findings, _summary = super().review(ctx, cfg)
+        return findings, f"results may be incomplete\n{INCOMPLETE_MARKER}"
 
 
 def _default_cfg(**overrides: object) -> ReviewConfig:
@@ -125,6 +132,17 @@ class TestReviewCommandLocal:
         parsed = json.loads(json_line)
         assert isinstance(parsed, list)
         assert parsed[0]["severity"] == "low"
+
+    def test_json_flag_reports_incomplete_review_on_stderr(self, monkeypatch):
+        _patch_local(monkeypatch, _IncompleteEngine(FakeProvider()))
+
+        result = CliRunner().invoke(
+            main, ["review", "--provider", "ollama", "--model", "llama3", "--json"]
+        )
+
+        assert result.exit_code == 0, result.output
+        json.loads(result.stdout)
+        assert "results may be incomplete" in result.stderr
 
     def test_format_agent_outputs_correction_instructions(self, monkeypatch):
         """`review --format agent` emits directive instructions for an AI to apply."""


### PR DESCRIPTION
Closes #583

Keep JSON stdout parseable and emit the visible incomplete-review notice on stderr when the engine marks a partial run.

Checks:
- `uv run pytest` (2458 passed, 3 skipped)
- `uv run ruff check .`
- `uv run mypy`
- `openspec validate --all`