### PR TITLE
fix: ignore root files in split heuristic

### DIFF
--- a/src/lgtmaybe/engine/labels.py
+++ b/src/lgtmaybe/engine/labels.py
@@ -82,5 +82,5 @@ def _sprawls(changed_files: list[str]) -> bool:
     """Whether the change set spans enough unrelated areas to suggest splitting."""
     if len(changed_files) < _MIN_SPRAWL_FILES:
         return False
-    top_level = {path.split("/", 1)[0] for path in changed_files}
+    top_level = {path.split("/", 1)[0] for path in changed_files if "/" in path}
     return len(top_level) >= _MIN_SPRAWL_DIRS

--- a/tests/engine/test_labels.py
+++ b/tests/engine/test_labels.py
@@ -86,6 +86,12 @@ def test_focused_diff_gets_no_splitting_hint() -> None:
     assert "consider-splitting" not in labels
 
 
+def test_root_files_do_not_count_as_top_level_directories() -> None:
+    files = [f"config{i}.yml" for i in range(10)]
+    labels = compute_labels([], _ctx(_SMALL_DIFF, files))
+    assert "consider-splitting" not in labels
+
+
 def test_a_leaked_secret_earns_the_security_label() -> None:
     """The most label-worthy finding lgtmaybe can produce must not be missed.
 


### PR DESCRIPTION
Closes #578

Count only real top-level directories when deciding whether a change sprawls enough to suggest splitting.

Checks:
- `uv run pytest -q` (2459 passed, 3 skipped, 19 deselected)
- focused/spec tests (24 passed)
- ruff, mypy, formatting, and spec drift checks