### PR TITLE
fix: retain schema retry salvage

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -2226,6 +2226,7 @@ class LLMReviewEngine:
                         )
                         if retry_error is None:
                             return retried, None
+                        return retried, reason
                 return [], reason
             # A response cut off at the output ceiling is not a badly-behaved
             # model, and saying "unparseable" sends the reader looking for a

--- a/tests/engine/test_schemaless_retry.py
+++ b/tests/engine/test_schemaless_retry.py
@@ -35,6 +35,7 @@ from lgtmaybe.core.models import (
     ReviewFinding,
     Severity,
 )
+from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.engine.engine import LLMReviewEngine, ReviewIncompleteError, _response_digest
 from tests.conftest import make_cfg
 from tests.fakes import FakeProvider
@@ -169,6 +170,20 @@ def test_a_failed_retry_reports_and_stops() -> None:
     # reformat again, or every recovery level doubles the one below it.
     assert len(_lens_calls(provider)) == 2
     assert len(_repair_calls(provider)) == 1
+
+
+def test_a_truncated_retry_keeps_its_completed_findings() -> None:
+    class _TruncatesWithoutSchema(_NeverComplies):
+        def complete(self, messages, model, **opts):  # type: ignore[override]
+            self.calls.append({"messages": messages, "model": model, "opts": opts})
+            if not _is_repair(messages) and "response_format" not in opts:
+                raise ProviderTruncated("ceiling", text=_FINDINGS_JSON[:-2])
+            return ProviderResult(text="prose", input_tokens=50, output_tokens=20)
+
+    findings, summary = LLMReviewEngine(_TruncatesWithoutSchema()).review(_CTX, _cfg())
+
+    assert [finding.title for finding in findings] == ["SQL injection"]
+    assert "unparseable" in summary
 
 
 def test_the_cheap_repair_runs_first() -> None:


### PR DESCRIPTION
Closes #575

Keep completed findings salvaged from a truncated schema-less retry while preserving the original unparseable failure reason.

Checks:
- `uv run pytest -q` (2461 passed, 3 skipped, 19 deselected)
- schema-less retry tests (21 passed)
- ruff, mypy, formatting, anchors, and spec drift checks