### PR TITLE
fix: report unsplit parser truncation

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -2248,9 +2248,8 @@ class LLMReviewEngine:
             # is usually a value the user set, not the model's own limit.
             reason = (
                 f"response truncated at the {result.output_tokens}-token `max_tokens` "
-                "ceiling — the batch is re-reviewed in smaller pieces automatically, so a "
-                "lens that keeps doing it is usually generation instability in the model, "
-                f"which a higher ceiling makes more expensive rather than prevents"
+                "ceiling — truncation was detected from the incomplete response body, so no "
+                "automatic split was attempted; raise `max_tokens` if it repeats"
                 f"{recovered_note}"
             )
             _log.warning(reason, extra={"lens": lens.id, "recovered": salvaged})

--- a/tests/engine/test_truncation_split.py
+++ b/tests/engine/test_truncation_split.py
@@ -258,6 +258,23 @@ def test_an_unsplittable_batch_reports_the_ceiling_with_its_salvage() -> None:
     assert "`max_tokens`" in summary
 
 
+def test_parser_detected_truncation_does_not_claim_a_split() -> None:
+    provider = FakeProvider(
+        result=ProviderResult(
+            text=_cut_off_json("one.py", "first_change = os.getcwd()", "cwd is never validated"),
+            input_tokens=10,
+            output_tokens=16_384,
+        )
+    )
+
+    _findings, summary = LLMReviewEngine(provider).review(
+        _ctx(_ONE_FILE_ONE_HUNK, ["one.py"]), _cfg()
+    )
+
+    assert "no automatic split was attempted" in summary
+    assert "re-reviewed in smaller pieces automatically" not in summary
+
+
 class _TruncatesOnReasoning(FakeProvider):
     """Every call spends the whole ceiling thinking, whatever the payload is.
 


### PR DESCRIPTION
Closes #576

Correct the parser-detected truncation notice: this path preserves salvage but does not invoke automatic batch splitting, so it now says so and points to `max_tokens`.

Validation:
- `uv run --frozen pytest -q` (2462 passed, 3 skipped)
- ruff and mypy
- Docker build and CLI smoke test