### PR TITLE
fix(engine): preserve scanner findings on model failure

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -1164,7 +1164,12 @@ class LLMReviewEngine:
         #     raise "every review call failed" would lose a genuine finding. The
         #     failure still reaches the summary through the incomplete-results
         #     notice, so nothing is hidden either way.
-        if total_calls > 0 and failed_calls == total_calls and not all_findings:
+        if (
+            total_calls > 0
+            and failed_calls == total_calls
+            and not all_findings
+            and not scan_findings
+        ):
             # The most common error, not the last — see _build_notices.
             detail = Counter(errors).most_common(1)[0][0] if errors else "no usable output"
             hint = f" {_SCHEMA_DROP_NOTE}" if self._schema_dropped() else ""

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -2152,6 +2152,19 @@ def test_finding_mode_posts_without_the_model_reporting_it(monkeypatch) -> None:
     ]
 
 
+def test_scan_finding_survives_total_model_failure(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "lgtmaybe.engine.engine.run_static_analysis", lambda files, cfg: [_scan_hit()]
+    )
+    engine = LLMReviewEngine(_TimeoutProvider())
+    cfg = _sa_cfg().model_copy(update={"reflect": False})
+
+    findings, summary = engine.review(_HINT_CTX, cfg)
+
+    assert [finding.category for finding in findings] == ["scan:gitleaks"]
+    assert "review calls failed" in summary
+
+
 def test_finding_mode_output_never_becomes_a_hint(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """A tool posts or it grounds — never both, or the model re-reports it."""
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #577

Keep deterministic scanner findings when every model call fails so the partial-results path can post them with the incomplete warning.

Checks:
- `uv run pytest tests/engine/test_engine.py` (139 passed)
- `uv run ruff check ...`
- `uv run ruff format --check .`
- `uv run mypy src/lgtmaybe/engine/engine.py`