### PR TITLE
fix: distinguish finding identity sides

### DIFF
--- a/src/lgtmaybe/core/findings.py
+++ b/src/lgtmaybe/core/findings.py
@@ -37,6 +37,7 @@ def finding_identity(finding: ReviewFinding) -> str:
     - ``path`` — the file.
     - ``category`` — the lens that raised it (engine-stamped, a fixed vocabulary),
       so two different concerns about one line stay distinct.
+    - ``side`` — whether the finding is on the old or new side of the diff.
     - ``anchor`` — the verbatim source line the finding is about. Copied out of the
       diff rather than composed, so it is code, not prose. It also absorbs line
       drift: the model miscounts diff line numbers (the reason anchors exist at
@@ -50,5 +51,7 @@ def finding_identity(finding: ReviewFinding) -> str:
     # as a different line; keep case, because code is case-sensitive.
     anchor = " ".join(finding.anchor.split()) if finding.anchor else ""
     locator = anchor or f"L{finding.line}"
-    digest = hashlib.sha256(f"{finding.path}\n{finding.category or ''}\n{locator}".encode())
+    digest = hashlib.sha256(
+        f"{finding.path}\n{finding.category or ''}\n{finding.side}\n{locator}".encode()
+    )
     return digest.hexdigest()[:12]

--- a/tests/github/test_reword_dedupe.py
+++ b/tests/github/test_reword_dedupe.py
@@ -282,13 +282,14 @@ def test_finding_identity_ignores_prose() -> None:
 
 
 def test_finding_identity_separates_distinct_findings() -> None:
-    """Different file, different lens, or different flagged code — different id."""
+    """Different file, lens, side, or flagged code — different id."""
     base = RUN_1[0]
     assert finding_identity(base) != finding_identity(RUN_1[1])
     assert finding_identity(base) != finding_identity(base.model_copy(update={"path": "b.py"}))
     assert finding_identity(base) != finding_identity(
         base.model_copy(update={"category": "security"})
     )
+    assert finding_identity(base) != finding_identity(base.model_copy(update={"side": "LEFT"}))
     assert finding_identity(base) != finding_identity(
         base.model_copy(update={"anchor": "import json"})
     )


### PR DESCRIPTION
Closes #573

Include diff side in the prose-free finding identity so LEFT and RIGHT findings at the same locator cannot keep one another open. Existing comments retain compatibility through the separately embedded path-and-title fingerprint.

Anchored spec update proposed (not applied automatically): change `path + category + anchor` to `path + category + side + anchor` in the Findings carry fingerprints requirement.

Validation:
- `uv run --frozen pytest -q` (2464 passed, 3 skipped)
- ruff and mypy
- spec drift check
- Docker build and CLI smoke test