### PR TITLE
fix(gitlab): preserve renamed file paths

### DIFF
--- a/src/lgtmaybe/gitlab/gateway.py
+++ b/src/lgtmaybe/gitlab/gateway.py
@@ -105,6 +105,7 @@ class GitLabGateway:
         # MR payload, because posting a finding needs them and post_review is
         # reachable without a preceding get_pr_context (a failure notice).
         self._diff_refs: dict[str, str] | None = None
+        self._old_paths: dict[str, str] = {}
         self._scan_manifests = False
         self._active_findings: list[ActiveFinding] | None = None
         self._validated_fixed_thread_ids: set[str] | None = None
@@ -138,11 +139,14 @@ class GitLabGateway:
         }
 
         diff = self._fetch_mr_diff()
-        changed_files = [
-            item.get("new_path") or item.get("old_path") or ""
-            for item in self._paginate(f"{self._mr_api}/diffs")
-        ]
+        diff_items = list(self._paginate(f"{self._mr_api}/diffs"))
+        changed_files = [item.get("new_path") or item.get("old_path") or "" for item in diff_items]
         changed_files = [path for path in changed_files if path]
+        self._old_paths = {
+            item["new_path"]: item["old_path"]
+            for item in diff_items
+            if item.get("new_path") and item.get("old_path")
+        }
 
         reviewable = [path for path in changed_files if is_reviewable(path)]
         scannable = (
@@ -380,7 +384,7 @@ class GitLabGateway:
             position: dict[str, Any] = {
                 **self._diff_refs,
                 "position_type": "text",
-                "old_path": f.path,
+                "old_path": self._old_paths.get(f.path, f.path),
                 "new_path": f.path,
             }
             # RIGHT is a line in the new file, LEFT a line in the old one.

--- a/tests/gitlab/test_gateway.py
+++ b/tests/gitlab/test_gateway.py
@@ -154,6 +154,29 @@ class TestDiscussionFetching:
 
 class TestPostReview:
     @respx.mock
+    def test_renamed_file_uses_its_real_old_path(self) -> None:
+        renamed_diff = DIFF.replace("a/app.py b/app.py", "a/old.py b/app.py").replace(
+            "--- a/app.py", "--- a/old.py"
+        )
+        _stub_context_routes()
+        _stub_post_routes()
+        respx.get(f"{MR_URL}/raw_diffs").mock(return_value=httpx.Response(200, text=renamed_diff))
+        respx.route(method="GET", url__startswith=f"{MR_URL}/diffs").mock(
+            return_value=httpx.Response(200, json=[{"new_path": "app.py", "old_path": "old.py"}])
+        )
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={"id": "abc"})
+        )
+        gateway = _gateway()
+
+        ctx = gateway.get_pr_context()
+        gateway.post_review([FINDING], "1 finding", diff=ctx.diff)
+
+        position = json.loads(created.calls[0].request.content)["position"]
+        assert position["old_path"] == "old.py"
+        assert position["new_path"] == "app.py"
+
+    @respx.mock
     def test_note_families_share_one_notes_fetch(self) -> None:
         _stub_post_routes()
         listed = respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(


### PR DESCRIPTION
Closes #570

Retain GitLab diff old/new path pairs and use the real old path when positioning findings on renamed files.

Validation:
- `uv run --frozen pytest -q` (2467 passed, 3 skipped)
- ruff and mypy
- spec drift check
- Docker build and CLI smoke test