### PR TITLE
ci: pin third-party actions by SHA

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.11"
           enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
       - name: Build site
@@ -42,4 +42,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -49,10 +49,12 @@ jobs:
     steps:
       - name: Resolve version
         id: ver
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           raw="${{ inputs.version }}"
           if [ -z "$raw" ] && [ "${{ github.event_name }}" = "release" ]; then
-            raw="${{ github.event.release.tag_name }}"
+            raw="$RELEASE_TAG"
           fi
           if [ -z "$raw" ]; then
             raw="$(curl -fsSL https://pypi.org/pypi/lgtmaybe/json \
@@ -63,12 +65,12 @@ jobs:
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Checkout lgtmaybe (for the generator script)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: lgtmaybe
 
       - name: Checkout the tap
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: MattJColes/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
           enable-cache: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,13 +76,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_tag || needs.release-please.outputs.tag_name }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
       - name: Build sdist + wheel
         run: uv build
       - name: Publish to PyPI (OIDC trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   # GHCR image + floating major tag — fine as a reusable workflow (no OIDC
   # trusted-publishing constraint; uses GITHUB_TOKEN).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
           echo "version=$v" >> "$GITHUB_OUTPUT"
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -59,7 +59,7 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ steps.ver.outputs.version }}
             type=raw,value=latest
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0 # the dangling check scans a merge-base worktree
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install uv
         if: steps.idem.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.13"
           enable-cache: true

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -12,7 +12,11 @@ _ROOT = Path(__file__).parent.parent
 def test_main_ci_runs_only_minimum_python_on_linux_and_windows() -> None:
     _text, workflow = read_workflow("ci.yml")
     job = workflow["jobs"]["test"]
-    setup_uv = next(step for step in job["steps"] if step.get("uses") == "astral-sh/setup-uv@v7")
+    setup_uv = next(
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+    )
 
     assert job["strategy"]["matrix"] == {
         "os": ["ubuntu-latest", "windows-latest"],

--- a/tests/test_windows_distribution.py
+++ b/tests/test_windows_distribution.py
@@ -13,9 +13,7 @@ def test_main_ci_runs_only_minimum_python_on_linux_and_windows() -> None:
     _text, workflow = read_workflow("ci.yml")
     job = workflow["jobs"]["test"]
     setup_uv = next(
-        step
-        for step in job["steps"]
-        if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+        step for step in job["steps"] if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
     )
 
     assert job["strategy"]["matrix"] == {

--- a/tests/test_workflow_examples.py
+++ b/tests/test_workflow_examples.py
@@ -25,6 +25,14 @@ _SELF_TRIGGERED_EVENTS = {
 }
 
 
+def test_repository_workflows_pin_external_actions_to_commits() -> None:
+    for workflow in (_REPO_ROOT / ".github" / "workflows").glob("*.yml"):
+        for ref in re.findall(
+            r"^\s*uses:\s+[^./\s]+/[^@\s]+@(\S+)", workflow.read_text(), re.MULTILINE
+        ):
+            assert re.fullmatch(r"[0-9a-f]{40}", ref), f"{workflow.name} uses mutable ref {ref}"
+
+
 def _workflows() -> list[Path]:
     return [_DOGFOOD_WORKFLOW, *sorted(_STARTER_WORKFLOWS.glob("*.yml"))]
 


### PR DESCRIPTION
Closes #569

Pin every external action in `.github/workflows` to the commit behind its advertised ref, preserve Dependabot version comments, and route the release tag through `env` before shell use.

Checks:
- `uv run pytest -q` (2467 passed, 3 skipped, 19 deselected)
- workflow tests (19 passed)
- `uv run ruff check .`
- anchors/spec drift checks

`zizmor` is not installed in the local environment; the repository audit/CI workflow remains the authoritative scanner.