### PR TITLE
fix: preserve duplicate forge findings

### DIFF
--- a/src/lgtmaybe/gitea/gateway.py
+++ b/src/lgtmaybe/gitea/gateway.py
@@ -180,10 +180,16 @@ class GiteaGateway:
         inline, demoted, broad = self._partition_findings(findings, commentable)
 
         if inline:
-            already = self._existing_finding_keys()
-            inline = [
-                (comment, f) for comment, f in inline if not (current_finding_keys([f]) & already)
-            ]
+            unmatched = self._existing_finding_keys()
+            new_inline: list[tuple[dict[str, Any], ReviewFinding]] = []
+            for comment, finding in inline:
+                keys = current_finding_keys([finding])
+                already = next((i for i, existing in enumerate(unmatched) if existing & keys), None)
+                if already is None:
+                    new_inline.append((comment, finding))
+                else:
+                    unmatched.pop(already)
+            inline = new_inline
 
         if inline:
             resp = self._client.post(
@@ -321,13 +327,13 @@ class GiteaGateway:
             inline.append((comment, f))
         return inline, demoted, broad
 
-    def _existing_finding_keys(self) -> set[str]:
+    def _existing_finding_keys(self) -> list[set[str]]:
         """Every hidden finding id already posted on this PR by us.
 
         Best-effort: a failure here means a duplicate comment, which is far
         better than failing the whole review.
         """
-        keys: set[str] = set()
+        keys: list[set[str]] = []
         try:
             # Gitea reviews are immutable, so every past lgtmaybe run left its
             # own review object and there is no flat "all review comments for
@@ -345,7 +351,8 @@ class GiteaGateway:
                     lambda rid: self._paginate(f"{self._pr_api}/reviews/{rid}/comments"), review_ids
                 ):
                     for comment in comments:
-                        keys |= finding_keys(comment.get("body") or "")
+                        if found := finding_keys(comment.get("body") or ""):
+                            keys.append(found)
         except Exception as exc:  # noqa: BLE001 — dedupe is best-effort
             _log.warning("reading existing review comments failed: %s", exc)
         return keys

--- a/src/lgtmaybe/gitlab/gateway.py
+++ b/src/lgtmaybe/gitlab/gateway.py
@@ -201,10 +201,16 @@ class GitLabGateway:
         inline, demoted, broad = self._partition_findings(findings, commentable)
 
         if inline:
-            already = self._existing_finding_keys()
-            inline = [
-                (position, f) for position, f in inline if not (current_finding_keys([f]) & already)
-            ]
+            unmatched = self._existing_finding_keys()
+            new_inline: list[tuple[dict[str, Any], ReviewFinding]] = []
+            for position, finding in inline:
+                keys = current_finding_keys([finding])
+                already = next((i for i, existing in enumerate(unmatched) if existing & keys), None)
+                if already is None:
+                    new_inline.append((position, finding))
+                else:
+                    unmatched.pop(already)
+            inline = new_inline
         for position, finding in inline:
             if not self._post_discussion(position, render_inline_body(finding)):
                 demoted.append(finding)
@@ -437,16 +443,17 @@ class GitLabGateway:
             except Exception as exc:  # noqa: BLE001 — resolving never fails a review
                 _log.warning("resolving thread %s failed: %s", thread_id, exc)
 
-    def _existing_finding_keys(self) -> set[str]:
-        """Every hidden finding id already posted on this MR by us."""
-        keys: set[str] = set()
+    def _existing_finding_keys(self) -> list[set[str]]:
+        """Hidden finding ids grouped by posted comment for one-for-one dedupe."""
+        keys: list[set[str]] = []
         try:
             for discussion in self._discussions():
                 notes = discussion.get("notes") or []
                 if notes and notes[0].get("resolved"):
                     continue
                 for note in notes:
-                    keys |= finding_keys(note.get("body") or "")
+                    if found := finding_keys(note.get("body") or ""):
+                        keys.append(found)
         except Exception as exc:  # noqa: BLE001 — dedupe is best-effort
             _log.warning("reading existing discussions failed: %s", exc)
         return keys

--- a/tests/gitea/test_gateway.py
+++ b/tests/gitea/test_gateway.py
@@ -8,6 +8,8 @@ upserted issue comment; inline comments are positioned by ``new_position`` /
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -236,6 +238,46 @@ class TestPostReview:
         _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
 
         assert not reviews.called, "the only finding was already on the PR"
+
+    @respx.mock
+    def test_dedupe_consumes_each_existing_finding_once(self) -> None:
+        from lgtmaybe.core.findings import finding_fingerprint
+
+        already = finding_fingerprint("app.py", "Hardcoded password")
+        respx.get(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json=[{"id": 5}]))
+        respx.get(f"{PR_URL}/reviews/5/comments").mock(
+            return_value=httpx.Response(
+                200, json=[{"body": f"old\n<!-- lgtmaybe-finding:{already} -->"}]
+            )
+        )
+        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{API}/issues/{PR_NUMBER}/comments").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        reviews = respx.post(f"{PR_URL}/reviews").mock(return_value=httpx.Response(200, json={}))
+        duplicate_diff = DIFF.replace(
+            '+password = "hunter2"', '+password = "hunter2"\n+password = "hunter2"'
+        )
+        findings = [
+            ReviewFinding(
+                path="app.py",
+                line=line,
+                side="RIGHT",
+                severity=Severity.high,
+                title="Hardcoded password",
+                body="Move it to the environment.",
+                anchor='password = "hunter2"',
+                anchored=True,
+            )
+            for line in (2, 3)
+        ]
+
+        _gateway(httpx.Client()).post_review(findings, "2 findings", diff=duplicate_diff)
+
+        assert reviews.call_count == 1
+        assert len(json.loads(reviews.calls[0].request.content)["comments"]) == 1
 
     @respx.mock
     def test_dedupe_reads_every_past_review_not_just_the_first(self) -> None:

--- a/tests/gitlab/test_gateway.py
+++ b/tests/gitlab/test_gateway.py
@@ -285,6 +285,44 @@ class TestPostReview:
         assert not created.called
 
     @respx.mock
+    def test_dedupe_consumes_each_existing_finding_once(self) -> None:
+        from lgtmaybe.core.findings import finding_fingerprint
+
+        already = finding_fingerprint("app.py", "Hardcoded password")
+        respx.route(method="GET", url__startswith=f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "notes": [
+                            {
+                                "body": f"old\n<!-- lgtmaybe-finding:{already} -->",
+                                "resolved": False,
+                            }
+                        ]
+                    }
+                ],
+            )
+        )
+        respx.route(method="GET", url__startswith=f"{MR_URL}/notes").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.post(f"{MR_URL}/notes").mock(return_value=httpx.Response(201, json={}))
+        created = respx.post(f"{MR_URL}/discussions").mock(
+            return_value=httpx.Response(201, json={})
+        )
+        duplicate_diff = DIFF.replace(
+            '+password = "hunter2"', '+password = "hunter2"\n+password = "hunter2"'
+        )
+        findings = [FINDING, FINDING.model_copy(update={"line": 3})]
+        gateway = _gateway()
+        gateway._diff_refs = MR_DETAIL["diff_refs"]
+
+        gateway.post_review(findings, "2 findings", diff=duplicate_diff)
+
+        assert created.call_count == 1
+
+    @respx.mock
     def test_a_resolved_finding_may_be_posted_again(self) -> None:
         from lgtmaybe.core.findings import finding_fingerprint
 


### PR DESCRIPTION
Closes #571

Consume GitLab and Gitea finding markers one-for-one so a prior identical occurrence suppresses only one current finding, matching the GitHub adapter.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`