### PR TITLE
fix(aws): defer credentials to sdk

### DIFF
--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -45,32 +45,6 @@ _ENV_VAR: dict[Provider, str] = {
 }
 
 
-def _default_aws_probe() -> bool:
-    """Detect ambient AWS credentials.
-
-    Covers the CI/OIDC env vars and exported keys, plus a local shared-config
-    file (`~/.aws/credentials` / `~/.aws/config`, or the path given by
-    ``AWS_SHARED_CREDENTIALS_FILE`` / ``AWS_CONFIG_FILE``) so the documented
-    "credentials via ~/.aws" local flow is recognised even without
-    ``AWS_PROFILE`` exported.
-    """
-
-    if (
-        os.environ.get("AWS_ACCESS_KEY_ID")
-        or os.environ.get("AWS_PROFILE")
-        or os.environ.get("AWS_ROLE_ARN")
-        or os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")
-    ):
-        return True
-
-    aws_home = Path.home() / ".aws"
-    candidates = (
-        os.environ.get("AWS_SHARED_CREDENTIALS_FILE") or str(aws_home / "credentials"),
-        os.environ.get("AWS_CONFIG_FILE") or str(aws_home / "config"),
-    )
-    return any(Path(path).is_file() for path in candidates)
-
-
 def _default_gcp_probe() -> bool:
     """Detect ambient GCP credentials.
 
@@ -143,16 +117,8 @@ def resolve_credentials(
     can be found.
     """
     if provider is Provider.bedrock:
-        probe = ambient_probe if ambient_probe is not None else _default_aws_probe
-        if not probe():
-            raise ValueError(
-                "bedrock requires ambient AWS credentials. "
-                "Configure an OIDC role (AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE), "
-                "a named profile (AWS_PROFILE), or set AWS_ACCESS_KEY_ID / "
-                "AWS_SECRET_ACCESS_KEY in the environment."
-            )
-        # Ambient creds carry the auth; an explicit base (e.g. a gateway)
-        # still passes through.
+        # The AWS SDK owns this chain: unlike a local probe it can resolve ECS,
+        # EKS Pod Identity and EC2 instance-profile credentials as well as env/files.
         return AuthConfig(api_base=api_base)
 
     if provider is Provider.vertex:

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -7,7 +7,6 @@ import pytest
 import lgtmaybe.providers.credentials as credentials
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.credentials import (
-    _default_aws_probe,
     _default_gcp_probe,
     resolve_credentials,
 )
@@ -31,22 +30,9 @@ class TestBedrock:
         )
         assert config.api_key is None
 
-    def test_bedrock_without_ambient_creds_raises_helpful_error(self) -> None:
-        with pytest.raises(ValueError, match="bedrock") as exc_info:
-            resolve_credentials(
-                Provider.bedrock,
-                ambient_probe=_ambient_absent,
-            )
-        # Error must name a concrete remediation
-        assert (
-            "AWS" in str(exc_info.value)
-            or "OIDC" in str(exc_info.value)
-            or "aws" in str(exc_info.value).lower()
-        )
-
-    def test_bedrock_error_message_names_the_provider(self) -> None:
-        with pytest.raises(ValueError, match="bedrock"):
-            resolve_credentials(Provider.bedrock, ambient_probe=_ambient_absent)
+    def test_bedrock_defers_ambient_credentials_to_the_aws_sdk(self) -> None:
+        config = resolve_credentials(Provider.bedrock, ambient_probe=_ambient_absent)
+        assert config.api_key is None
 
     def test_bedrock_threads_api_base_through(self) -> None:
         """A custom endpoint (e.g. a gateway) passes through untouched."""
@@ -316,15 +302,6 @@ _GCP_ENV_VARS = (
     "CLOUDSDK_CONFIG",
 )
 
-_AWS_ENV_VARS = (
-    "AWS_ACCESS_KEY_ID",
-    "AWS_PROFILE",
-    "AWS_ROLE_ARN",
-    "AWS_WEB_IDENTITY_TOKEN_FILE",
-    "AWS_SHARED_CREDENTIALS_FILE",
-    "AWS_CONFIG_FILE",
-)
-
 
 def _clear(monkeypatch: pytest.MonkeyPatch, names: tuple[str, ...], home: str) -> None:
     for name in names:
@@ -402,20 +379,3 @@ class TestDefaultGcpProbe:
         monkeypatch.setenv("VERTEXAI_PROJECT", "my-project")
         config = resolve_credentials(Provider.vertex)
         assert config.api_key is None
-
-
-class TestDefaultAwsProbe:
-    """The real ambient-AWS probe must recognise a shared-credentials file (`~/.aws`)."""
-
-    def test_shared_credentials_file_is_detected(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
-        _clear(monkeypatch, _AWS_ENV_VARS, str(tmp_path))
-        creds = tmp_path / "credentials"
-        creds.write_text("[default]\naws_access_key_id = AKIA\n")
-        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds))
-        assert _default_aws_probe() is True
-
-    def test_no_creds_anywhere_is_absent(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-        _clear(monkeypatch, _AWS_ENV_VARS, str(tmp_path))
-        assert _default_aws_probe() is False

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -109,7 +109,10 @@ class TestCloudProviderCredentials:
     def test_ambient_present_resolves_keyless(self, provider: Provider) -> None:
         assert resolve_credentials(provider, ambient_probe=lambda: True).api_key is None
 
-    def test_ambient_absent_raises_actionable_error(self, provider: Provider) -> None:
+    def test_ambient_absent_uses_provider_native_behavior(self, provider: Provider) -> None:
+        if provider is Provider.bedrock:
+            assert resolve_credentials(provider, ambient_probe=lambda: False).api_key is None
+            return
         with pytest.raises(ValueError, match=provider.value):
             resolve_credentials(provider, ambient_probe=lambda: False)
 


### PR DESCRIPTION
Closes #567

Bedrock now delegates ambient credential resolution to the AWS SDK instead of rejecting sources the local preflight cannot observe, including ECS task roles, EKS Pod Identity, and EC2 instance profiles.

Tests cover the provider-specific behavior; the full suite and Docker smoke test pass.

Anchored spec update proposed (not applied automatically): clarify that Bedrock delegates its ambient credential chain to the AWS SDK and surfaces credential errors from that authoritative chain, while preflight failure remains for providers whose credentials can be checked safely.