### PR TITLE
fix: preserve Azure authentication errors

### DIFF
--- a/src/lgtmaybe/providers/credentials.py
+++ b/src/lgtmaybe/providers/credentials.py
@@ -113,7 +113,7 @@ def _default_azure_token() -> str | None:
     clear error.
     """
     try:
-        from azure.identity import DefaultAzureCredential
+        from azure.identity import CredentialUnavailableError, DefaultAzureCredential
     except ImportError as exc:
         raise ValueError(
             "keyless azure needs the azure-identity package. "
@@ -125,7 +125,7 @@ def _default_azure_token() -> str | None:
         credential = DefaultAzureCredential()
         token: str = credential.get_token(_AZURE_OPENAI_SCOPE).token
         return token
-    except Exception:
+    except CredentialUnavailableError:
         return None
 
 

--- a/tests/providers/test_credentials.py
+++ b/tests/providers/test_credentials.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import pytest
 
 import lgtmaybe.providers.credentials as credentials
@@ -21,6 +24,20 @@ def _ambient_present() -> bool:
 
 def _ambient_absent() -> bool:
     return False
+
+
+def _stub_azure_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    credential: type[object],
+    unavailable_error: type[Exception],
+) -> None:
+    azure = ModuleType("azure")
+    identity = ModuleType("azure.identity")
+    identity.CredentialUnavailableError = unavailable_error  # type: ignore[attr-defined]
+    identity.DefaultAzureCredential = credential  # type: ignore[attr-defined]
+    azure.identity = identity  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "azure", azure)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity)
 
 
 class TestBedrock:
@@ -181,6 +198,38 @@ class TestZai:
 
 
 class TestAzure:
+    def test_default_token_returns_none_when_azure_credentials_are_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CredentialUnavailableError(Exception):
+            pass
+
+        class UnavailableCredential:
+            def get_token(self, scope: str) -> None:
+                raise CredentialUnavailableError("no ambient credential")
+
+        _stub_azure_identity(monkeypatch, UnavailableCredential, CredentialUnavailableError)
+
+        assert credentials._default_azure_token() is None
+
+    def test_default_token_preserves_azure_authentication_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class CredentialUnavailableError(Exception):
+            pass
+
+        class ClientAuthenticationError(Exception):
+            pass
+
+        class MisconfiguredCredential:
+            def get_token(self, scope: str) -> None:
+                raise ClientAuthenticationError("AADSTS700213: no matching federated identity")
+
+        _stub_azure_identity(monkeypatch, MisconfiguredCredential, CredentialUnavailableError)
+
+        with pytest.raises(ClientAuthenticationError, match="AADSTS700213"):
+            credentials._default_azure_token()
+
     def test_azure_with_api_key_and_base_resolves(self) -> None:
         config = resolve_credentials(
             Provider.azure,


### PR DESCRIPTION
## Summary
- fall through only when Azure reports that no ambient credential is available
- preserve actionable authentication failures such as federated-identity AADSTS errors
- cover both outcomes at the default token-provider boundary

## Validation
- `uv run pytest -q tests/cli/test_cli.py::TestBuildReviewContext::test_azure_keyless_ad_token_threads_to_provider tests/providers/test_credentials.py` (49 passed)
- `uv run pytest -q` (2471 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #566