### PR TITLE
fix(action): reject unsupported GHES hosts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -330,7 +330,7 @@ runs:
         # newlines survive because the file holds names, never values.
         # The cloud-auth steps export the AWS_/GOOGLE_/CLOUDSDK_/AZURE_ vars.
         compgen -e \
-          | grep -E '^(GITHUB_TOKEN|GITHUB_EVENT_NAME|GITHUB_EVENT_PATH)$|^(INPUT|AWS|GOOGLE|CLOUDSDK|AZURE)_' \
+          | grep -E '^(GITHUB_TOKEN|GITHUB_EVENT_NAME|GITHUB_EVENT_PATH|GITHUB_SERVER_URL|GITHUB_API_URL)$|^(INPUT|AWS|GOOGLE|CLOUDSDK|AZURE)_' \
           > "${RUNNER_TEMP}/lgtmaybe.env"
         # host-gateway mapping: lets api_base reach a model server on the
         # runner host (ollama / openai-compatible) at host.docker.internal,

--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -955,9 +955,9 @@ def _change_url(repo: str, number: int) -> str:
     Gitea Actions reimplements GitHub Actions' env contract — same
     ``GITHUB_EVENT_NAME``, same ``GITHUB_EVENT_PATH``, same ``INPUT_*`` — so the
     entrypoint needs no forge switch of its own. The one variable that does
-    differ is ``GITHUB_SERVER_URL``, which points at the Gitea instance; reading
-    it is the whole difference between reviewing the right PR and posting to
-    github.com. Absent (or github.com), the URL is unchanged from before.
+    differ are ``GITHUB_SERVER_URL`` and ``GITHUB_API_URL``. Together they
+    distinguish Gitea from unsupported GitHub Enterprise Server. Absent (or
+    github.com), the URL is unchanged from before.
 
     The path segment is what ``core.forge`` discriminates on, so it has to match
     the host's own convention: GitHub singularises ``pull``, Gitea pluralises it.
@@ -965,6 +965,11 @@ def _change_url(repo: str, number: int) -> str:
     server = os.environ.get("GITHUB_SERVER_URL", "").rstrip("/")
     if not server or server == "https://github.com":
         return f"https://github.com/{repo}/pull/{number}"
+    if os.environ.get("GITHUB_API_URL", "").rstrip("/").endswith("/api/v3"):
+        raise click.ClickException(
+            "GitHub Enterprise Server is not supported; run lgtmaybe on GitHub.com, "
+            "GitLab, or Gitea."
+        )
     return f"{server}/{repo}/pulls/{number}"
 
 

--- a/tests/gitea/test_actions_entrypoint.py
+++ b/tests/gitea/test_actions_entrypoint.py
@@ -35,6 +35,7 @@ class TestPRUrlFromEvent:
     ) -> None:
         """Gitea pluralises the segment, which is also how the forge is told apart."""
         monkeypatch.setenv("GITHUB_SERVER_URL", "https://gitea.example.com")
+        monkeypatch.setenv("GITHUB_API_URL", "https://gitea.example.com/api/v1")
         url = pr_url_from_event(EVENT)
 
         assert url == "https://gitea.example.com/team/service/pulls/12"
@@ -43,6 +44,15 @@ class TestPRUrlFromEvent:
         assert located.host == "gitea.example.com"
         assert located.repo == "team/service"
         assert located.number == 12
+
+    def test_github_enterprise_is_rejected_instead_of_misclassified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.example.com")
+        monkeypatch.setenv("GITHUB_API_URL", "https://github.example.com/api/v3")
+
+        with pytest.raises(Exception, match="GitHub Enterprise Server is not supported"):
+            pr_url_from_event(EVENT)
 
     def test_a_trailing_slash_on_the_server_url_does_not_break_the_path(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -231,4 +231,6 @@ def test_docker_run_forwards_the_step_environment_by_env_file() -> None:
 
     assert "compgen -e" in run
     assert '--env-file "${RUNNER_TEMP}/lgtmaybe.env"' in run
+    assert "GITHUB_SERVER_URL" in run
+    assert "GITHUB_API_URL" in run
     assert not re.search(r"-e\s+INPUT_[A-Z0-9_]+", run)


### PR DESCRIPTION
Closes #564

Forward `GITHUB_SERVER_URL` and `GITHUB_API_URL` into the review container. The entrypoint now preserves Gitea URL semantics but rejects GitHub Enterprise Server explicitly, since the current GitHub gateway targets api.github.com and cannot safely serve GHES.

This prevents an enterprise GitHub host from being silently classified as Gitea and using the wrong gateway/token. Focused and full tests, lint, types, spec drift, and Docker smoke all pass.