### PR TITLE
fix: enable manifest scan before prefetch

### DIFF
--- a/src/lgtmaybe/cli/__init__.py
+++ b/src/lgtmaybe/cli/__init__.py
@@ -847,6 +847,9 @@ def execute_review(
 
     ctx: PRContext | None = None
     if describe or diagram:
+        want_manifests = getattr(github, "set_scan_manifests", None)
+        if callable(want_manifests):
+            want_manifests(cfg.static_analysis.enabled)
         # A failed prefetch means run_review fetches and surfaces the failure
         # itself. Fetching here lets the review, required diagram, and optional
         # description share one current-head context.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -346,6 +346,35 @@ class TestModuleEntrypoint:
 class TestGitHubReviewErrorSurfacing:
     """The GitHub path (execute_review, used by the action) posts a failure notice."""
 
+    def test_prefetch_enables_dependency_manifests(self, monkeypatch):
+        import lgtmaybe.cli as cli_module
+
+        class ManifestAwareGitHub(FakeGitHub):
+            def __init__(self):
+                super().__init__()
+                self.scan_manifests = False
+
+            def set_scan_manifests(self, enabled):
+                self.scan_manifests = enabled
+
+            def get_pr_context(self):
+                assert self.scan_manifests
+                return super().get_pr_context()
+
+        github = ManifestAwareGitHub()
+        provider = FakeProvider()
+        monkeypatch.setattr(
+            cli_module,
+            "build_review_context",
+            lambda cfg, runtime: (github, FakeEngine(provider), provider),
+        )
+
+        cli_module.execute_review(
+            _default_cfg(static_analysis={"enabled": True}),
+            RuntimeOptions(pr_url="x"),
+            describe=True,
+        )
+
     def test_engine_failure_posts_comment_and_raises(self, monkeypatch):
         import click
 


### PR DESCRIPTION
## Summary
- enable dependency-manifest collection before the shared context prefetch used by automatic extras
- preserve the existing direct `run_review` opt-in path
- verify static analysis is enabled before prefetched context is read

## Validation
- `uv run pytest -q tests/cli/test_cli.py tests/cli/test_action.py` (66 passed)
- `uv run pytest -q` (2471 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #563