### PR TITLE
fix: surface config file errors cleanly

### DIFF
--- a/src/lgtmaybe/config/loader.py
+++ b/src/lgtmaybe/config/loader.py
@@ -47,7 +47,10 @@ def load_config(
     merged: dict[str, Any] = dict(_DEFAULTS)
 
     if user_config_path is not None:
-        merged.update(store.load(user_config_path))
+        try:
+            merged.update(store.load(user_config_path))
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(f"could not read YAML file {user_config_path}: {exc}") from exc
 
     file_data = _load_file(config_path, required=config_required)
     merged.update(file_data)
@@ -85,7 +88,7 @@ def _load_lens_files(lens_paths: Any) -> list[dict[str, Any]]:
         else:
             files = [path]
         for file in files:
-            parsed = yaml.safe_load(file.read_text(encoding="utf-8"))
+            parsed = _read_yaml(file)
             if isinstance(parsed, list):
                 lenses.extend(item for item in parsed if isinstance(item, dict))
             elif isinstance(parsed, dict):
@@ -136,11 +139,9 @@ def _load_file(
             raise ValueError(f"config file not found: {config_path}")
         return {}
 
-    raw = config_path.read_text(encoding="utf-8")
-    if not raw.strip():
+    parsed = _read_yaml(config_path)
+    if parsed is None:
         return {}
-
-    parsed = yaml.safe_load(raw)
     if not isinstance(parsed, dict):
         if required:
             raise ValueError(
@@ -149,3 +150,13 @@ def _load_file(
         return {}
 
     return parsed
+
+
+def _read_yaml(path: Path) -> Any:
+    """Read YAML while preserving the failing path at the config boundary."""
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"could not read YAML file {path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"could not parse YAML file {path}: {exc}") from exc

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -512,6 +512,16 @@ class TestConfigPathOption:
         assert result.exit_code != 0
         assert "mapping" in result.output
 
+    def test_malformed_config_errors_without_a_traceback(self, monkeypatch, tmp_path):
+        cfg_file = tmp_path / "broken.yml"
+        cfg_file.write_text("provider: [unclosed")
+        _patch_local(monkeypatch)
+
+        result = CliRunner().invoke(main, ["review", "--config", str(cfg_file)])
+
+        assert result.exit_code != 0
+        assert f"Error: could not parse YAML file {cfg_file}" in result.output
+
     def test_missing_default_config_is_fine(self, monkeypatch):
         """No --config given and no ./.lgtmaybe.yml present still reviews."""
         _patch_local(monkeypatch)

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -183,6 +183,14 @@ def test_required_config_must_parse_to_a_mapping(tmp_path):
         load_config(config_path=cfg_file, config_required=True)
 
 
+def test_malformed_config_names_the_file(tmp_path):
+    cfg_file = tmp_path / "broken.yml"
+    cfg_file.write_text("provider: [unclosed")
+
+    with pytest.raises(ValueError, match=r"broken\.yml"):
+        load_config(config_path=cfg_file)
+
+
 def test_non_mapping_default_config_is_ignored(tmp_path):
     """Without config_required (the default ./.lgtmaybe.yml probe), a non-mapping
     file is skipped leniently, as before."""
@@ -317,6 +325,18 @@ def test_lens_paths_accept_a_list_of_lenses_in_one_file(tmp_path):
     cfg = load_config(config_path=cfg_file)
 
     assert sorted(lens.id for lens in cfg.extra_lenses) == ["a", "b"]
+
+
+@pytest.mark.parametrize("contents", [None, "id: [unclosed"])
+def test_bad_lens_file_names_the_path(tmp_path, contents):
+    lens_file = tmp_path / "broken-lens.yml"
+    if contents is not None:
+        lens_file.write_text(contents)
+    cfg_file = tmp_path / ".lgtmaybe.yml"
+    cfg_file.write_text(f"lens_paths: [{lens_file}]\n")
+
+    with pytest.raises(ValueError, match=r"broken-lens\.yml"):
+        load_config(config_path=cfg_file)
 
 
 def test_lens_paths_pack_scheme_loads_a_bundled_pack(tmp_path):


### PR DESCRIPTION
Closes #565

Convert config and lens file I/O/YAML parser failures into path-specific `ValueError`s at the loader boundary, allowing the existing CLI wrapper to render a clean Click error.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`