### PR TITLE
fix(security): keep clone token out of argv

### DIFF
--- a/src/lgtmaybe/github/checkout.py
+++ b/src/lgtmaybe/github/checkout.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import os
 import shutil
 import stat
 import subprocess
@@ -86,13 +87,10 @@ def clone_base_tree(
     *repo* is ``owner/name`` (the base repo). *ref* is the base branch name. The
     temp dir is registered for cleanup at process exit. Returns None on any
     filesystem or git failure — the caller treats that as "no corpus". The token
-    is passed as a one-shot ``git -c http.<url>.extraheader`` basic-auth header
-    (the actions/checkout approach) rather than embedded in the clone URL — a
-    URL-embedded token is visible in the clear via /proc/*/cmdline and gets
-    persisted as the remote URL in the temp clone's .git/config. The global
-    ``-c`` applies to this invocation only (unlike ``git clone --config`` it is
-    never written into the new clone's config); ``capture_output`` keeps it out
-    of surfaced stderr, and the clone lands in an ephemeral dir removed at exit.
+    is passed through Git's one-shot ``GIT_CONFIG_*`` environment rather than
+    argv or the clone URL, keeping it out of /proc/*/cmdline and the temp clone's
+    .git/config. ``capture_output`` keeps it out of surfaced stderr, and the
+    clone lands in an ephemeral dir removed at exit.
     """
     try:
         dest = Path(tempfile.mkdtemp(prefix="lgtmaybe-base-"))
@@ -100,13 +98,16 @@ def clone_base_tree(
         return None
     url = f"https://github.com/{repo}.git"
     basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
-    auth_config = f"http.https://github.com/.extraheader=Authorization: basic {basic}"
+    git_env = {
+        **os.environ,
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: basic {basic}",
+    }
     try:
         runner(
             [
                 "git",
-                "-c",
-                auth_config,
                 "clone",
                 "--depth",
                 "1",
@@ -117,6 +118,7 @@ def clone_base_tree(
                 str(dest),
             ],
             capture_output=True,
+            env=git_env,
             timeout=_CLONE_TIMEOUT,
             check=True,
         )

--- a/tests/github/test_checkout.py
+++ b/tests/github/test_checkout.py
@@ -36,29 +36,24 @@ def test_clone_builds_shallow_single_branch_command() -> None:
     assert captured["kwargs"]["timeout"] > 0
 
 
-def test_clone_authenticates_via_extraheader_not_url() -> None:
-    """The token rides in a one-shot ``git -c http.<url>.extraheader`` basic-auth
-    header (the actions/checkout approach), never embedded in the clone URL —
-    a URL-embedded token is visible in /proc/*/cmdline in the clear and gets
-    persisted as the remote URL in the temp clone's .git/config."""
+def test_clone_authenticates_via_environment_not_argv() -> None:
     captured: dict[str, Any] = {}
 
     def runner(cmd: list[str], **kwargs: Any) -> Any:
         captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
         return subprocess.CompletedProcess(cmd, 0)
 
     dest = clone_base_tree("owner/repo", "main", "tok-123", runner=runner)
 
     assert dest is not None
     cmd = captured["cmd"]
-    # The raw token appears nowhere in argv.
     assert all("tok-123" not in arg for arg in cmd)
     b64 = base64.b64encode(b"x-access-token:tok-123").decode()
-    header = f"http.https://github.com/.extraheader=Authorization: basic {b64}"
-    assert "-c" in cmd and cmd[cmd.index("-c") + 1] == header
-    # ``-c`` precedes the clone subcommand: a per-invocation config that is never
-    # written into the new clone's .git/config (unlike ``git clone --config``).
-    assert cmd.index("-c") < cmd.index("clone")
+    assert b64 not in " ".join(cmd)
+    assert captured["env"]["GIT_CONFIG_COUNT"] == "1"
+    assert captured["env"]["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert captured["env"]["GIT_CONFIG_VALUE_0"] == f"Authorization: basic {b64}"
 
 
 def test_clone_failure_returns_none_and_cleans_up(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #561

Pass the one-shot Git extraheader through `GIT_CONFIG_*` environment variables instead of `git -c`, so the Base64-encoded clone token no longer appears in `/proc/*/cmdline` or process listings. The header remains invocation-scoped and is not persisted in the clone config.

Focused and full tests, lint, types, spec drift, and Docker smoke all pass.