### PR TITLE
fix: bound truncated finding salvage

### DIFF
--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -2131,7 +2131,7 @@ class LLMReviewEngine:
                 # Whatever the model finished before the ceiling cut it off is real,
                 # schema-valid work — kept, exactly as the parse path keeps it, so
                 # the exception path is not the one place a partial answer is binned.
-                completed = _salvage_truncated(exc, lens)
+                completed = self._stamp_and_bound(_salvage_truncated(exc, lens), lens)
                 exhausted = _reasoning_exhausted_reason(exc)
                 if exhausted is not None:
                     # The ceiling went on thinking, not on findings: shrinking the
@@ -2350,7 +2350,7 @@ def _salvage_truncated(exc: BaseException, lens: _Lens) -> list[ReviewFinding]:
         findings = parse_exc.recovered
     if findings:
         _log.info("salvaged findings from truncated response", extra={"lens": lens.id})
-    return _stamp_categories(findings, lens)
+    return findings
 
 
 def _stamp_categories(findings: list[ReviewFinding], lens: _Lens) -> list[ReviewFinding]:

--- a/tests/engine/test_lens_flood.py
+++ b/tests/engine/test_lens_flood.py
@@ -11,6 +11,7 @@ from lgtmaybe.core.models import (
     ReviewCategory,
     ReviewConfig,
 )
+from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.engine import LLMReviewEngine
 from tests.fakes import FakeProvider
 
@@ -56,6 +57,14 @@ class _FloodingProvider(FakeProvider):
         return ProviderResult(text=_flood(self._count), input_tokens=1, output_tokens=1)
 
 
+class _TruncatedFloodProvider(FakeProvider):
+    def complete(self, messages, model, **opts):  # type: ignore[override]
+        self.calls.append({"messages": messages, "model": model, "opts": opts})
+        if len(self.calls) == 1:
+            raise ProviderTruncated("ceiling", text=_flood(200))
+        return ProviderResult(text="[]", input_tokens=1, output_tokens=1)
+
+
 def _cfg(**overrides: object) -> ReviewConfig:
     defaults: dict[str, object] = {
         "provider": Provider.openai,
@@ -80,6 +89,13 @@ class TestPerLensFindingBound:
     def test_a_flooding_lens_is_bounded_with_a_notice(self) -> None:
         provider = _FloodingProvider(count=200)
         findings, summary = LLMReviewEngine(provider).review(_CTX, _cfg(max_findings_per_lens=25))
+        assert len(findings) == 25
+        assert "security" in summary and "175" in summary
+
+    def test_a_truncated_flood_is_bounded_with_a_notice(self) -> None:
+        findings, summary = LLMReviewEngine(_TruncatedFloodProvider()).review(
+            _CTX, _cfg(max_findings_per_lens=25)
+        )
         assert len(findings) == 25
         assert "security" in summary and "175" in summary
 


### PR DESCRIPTION
## Summary
- route exception-path truncation salvage through the existing per-lens finding bound
- keep category stamping and flood-summary accounting on the shared path
- cover a truncated response carrying 200 distinct findings

## Validation
- `uv run pytest -q tests/engine/test_lens_flood.py tests/engine/test_truncation_split.py` (28 passed)
- `uv run pytest -q` (2473 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #560