### PR TITLE
fix(ollama): preserve chat message roles

### DIFF
--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -7,7 +7,7 @@ litellm model-string conventions:
   bedrock    → bedrock/<model>
   vertex     → vertex_ai/<model>
   azure      → azure/<model>   (+ api_base = resource endpoint)
-  ollama     → ollama/<model>  (+ api_base)
+  ollama     → ollama_chat/<model>  (+ api_base)
   openai-compatible → openai/<model>  (+ api_base = custom endpoint)
   zai        → zai/<model>     (GLM / Zhipu AI; optional api_base override)
 """
@@ -36,7 +36,7 @@ _PREFIXES: dict[Provider, str] = {
     Provider.bedrock: "bedrock",
     Provider.vertex: "vertex_ai",
     Provider.azure: "azure",
-    Provider.ollama: "ollama",
+    Provider.ollama: "ollama_chat",
     # OpenAI-compatible servers (DeepSeek, llama.cpp, LM Studio, vLLM) ride the
     # openai route; the custom endpoint comes through api_base.
     Provider.openai_compatible: "openai",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -605,7 +605,7 @@ class TestBuildReviewContext:
 
         _github, _engine, provider = build_review_context(cfg, runtime)
 
-        assert provider.fallback_model == "ollama/llama2"
+        assert provider.fallback_model == "ollama_chat/llama2"
 
     def test_a_configured_fallback_model_threads_to_provider(self, monkeypatch):
         """It belongs in `.lgtmaybe.yml` beside `model`, `triage_model` and
@@ -617,7 +617,7 @@ class TestBuildReviewContext:
 
         _github, _engine, provider = build_review_context(cfg, runtime)
 
-        assert provider.fallback_model == "ollama/llama2"
+        assert provider.fallback_model == "ollama_chat/llama2"
 
     def test_the_flag_wins_over_the_configured_fallback_model(self, monkeypatch):
         """Same precedence as `api_base`: the invocation overrides the repo."""
@@ -629,7 +629,7 @@ class TestBuildReviewContext:
 
         _github, _engine, provider = build_review_context(cfg, runtime)
 
-        assert provider.fallback_model == "ollama/from-flag"
+        assert provider.fallback_model == "ollama_chat/from-flag"
 
     def test_azure_keyless_ad_token_threads_to_provider(self, monkeypatch):
         """Keyless azure resolves an ambient AD token and threads it to litellm."""

--- a/tests/cli/test_provider_threading.py
+++ b/tests/cli/test_provider_threading.py
@@ -108,7 +108,7 @@ CASES = [
         "azure/gpt-4o",
         True,
     ),
-    ("ollama", "ollama", "llama3", [], {}, "ollama/llama3", False),
+    ("ollama", "ollama", "llama3", [], {}, "ollama_chat/llama3", False),
     (
         "openai-compatible",
         "openai-compatible",

--- a/tests/e2e/test_local_providers.py
+++ b/tests/e2e/test_local_providers.py
@@ -8,7 +8,7 @@ resolution, the litellm wire format, structured-output parsing, and rendering.
 
 The three backends split across exactly two adapters:
 
-  - ollama            → litellm's native ``ollama/`` route (api_base + ``num_ctx``)
+  - ollama            → litellm's native ``ollama_chat/`` route (api_base + ``num_ctx``)
   - llama.cpp / vLLM  → the ``openai-compatible`` route (``openai/`` + custom base)
 
 so running all three covers both code paths plus each server's quirks (vLLM is

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -39,7 +39,7 @@ class TestLiteLLMModelString:
         )
 
     def test_ollama_prefix(self) -> None:
-        assert litellm_model_string(Provider.ollama, "llama2") == "ollama/llama2"
+        assert litellm_model_string(Provider.ollama, "llama2") == "ollama_chat/llama2"
 
     def test_azure_prefix(self) -> None:
         assert litellm_model_string(Provider.azure, "gpt-4o") == "azure/gpt-4o"
@@ -143,7 +143,7 @@ class TestBuildProvider:
 
     def test_build_provider_resolves_fallback_model(self) -> None:
         provider = build_provider(Provider.ollama, "qwen3:27b", fallback_model="llama2")
-        assert provider.fallback_model == "ollama/llama2"
+        assert provider.fallback_model == "ollama_chat/llama2"
 
     def test_build_provider_threads_timeout_into_default_opts(self) -> None:
         provider = build_provider(Provider.ollama, "llama2", timeout=600)
@@ -251,7 +251,7 @@ class TestDefaultTimeout:
         with patch("litellm.completion", return_value=response) as mock_completion:
             provider.complete([{"role": "user", "content": "hi"}], model="qwen3:27b")
 
-        assert mock_completion.call_args.kwargs["model"] == "ollama/qwen3:27b"
+        assert mock_completion.call_args.kwargs["model"] == "ollama_chat/qwen3:27b"
 
 
 class TestParamSupport:

--- a/tests/providers/test_ollama.py
+++ b/tests/providers/test_ollama.py
@@ -14,7 +14,7 @@ class TestOllamaPath:
 
     def test_ollama_model_string_has_ollama_prefix(self) -> None:
         provider = build_provider(Provider.ollama, "llama2")
-        assert provider.model == "ollama/llama2"
+        assert provider.model == "ollama_chat/llama2"
 
     def test_ollama_default_api_base_is_localhost(self) -> None:
         provider = build_provider(Provider.ollama, "llama2")

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -29,7 +29,7 @@ EXPECTED_PREFIX: dict[Provider, str] = {
     Provider.bedrock: "bedrock/",
     Provider.vertex: "vertex_ai/",
     Provider.azure: "azure/",
-    Provider.ollama: "ollama/",
+    Provider.ollama: "ollama_chat/",
     # OpenAI-compatible servers ride the openai route with a custom api_base.
     Provider.openai_compatible: "openai/",
     # GLM / Zhipu AI rides litellm's native zai/ route.


### PR DESCRIPTION
Closes #558

Route Ollama through LiteLLM’s `ollama_chat/` adapter instead of the raw `ollama/` generation adapter. This preserves native system/user roles at `/api/chat` and matches the existing thinking-response handling.

The pinned LiteLLM version resolves the new prefix to `ollama_chat`; 209 focused and 2,476 full tests, lint, types, drift, and Docker smoke pass. Live local-provider tests were invoked but skipped because no Ollama/model server is running on this host.