### PR TITLE
fix(security): redact AWS secret credentials

### DIFF
--- a/src/lgtmaybe/engine/redact.py
+++ b/src/lgtmaybe/engine/redact.py
@@ -66,7 +66,8 @@ def _replace_pem(m: re.Match[str]) -> str:
 _VALUE_PATTERNS: list[re.Pattern[str]] = [
     # Generic high-entropy assignments: api_key = "..." or token = "..." (value ≥ 16 chars)
     re.compile(
-        r"(?i)(?:api[_\-]?key|api[_\-]?secret|access[_\-]?token|secret[_\-]?key|token)"
+        r"(?i)(?:api[_\-]?key|api[_\-]?secret|secret[_\-]?access[_\-]?key|"
+        r"session[_\-]?token|access[_\-]?token|secret[_\-]?key|token)"
         r'\s*[=:]\s*["\']?(?P<secret>[A-Za-z0-9\-_/+=]{16,})["\']?'
     ),
     # Quoted password / passphrase literals: password = "hunter2" (value ≥ 4 chars).

--- a/tests/engine/test_redact.py
+++ b/tests/engine/test_redact.py
@@ -18,6 +18,20 @@ def test_aws_key_redacted() -> None:
     assert REDACTED_PLACEHOLDER in result
 
 
+def test_aws_secret_access_key_redacted() -> None:
+    secret = "wJalrXUtnFEMI" + "/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    result = redact(f'+AWS_SECRET_ACCESS_KEY = "{secret}"\n')
+    assert secret not in result
+    assert "AWS_SECRET_ACCESS_KEY" in result
+
+
+def test_aws_session_token_redacted() -> None:
+    token = "AQoDYXdzEJr" + "//////////wEaEXAMPLETEMPORARYTOKEN"
+    result = redact(f'+AWS_SESSION_TOKEN = "{token}"\n')
+    assert token not in result
+    assert "AWS_SESSION_TOKEN" in result
+
+
 def test_openai_key_redacted() -> None:
     diff = f"+OPENAI_API_KEY={_OPENAI_KEY}\n"
     result = redact(diff)


### PR DESCRIPTION
Closes #555

Extend the existing assignment redactor to cover `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, preserving the variable names while replacing their values before diffs reach a model provider.

Direct regressions cover both long-lived and temporary AWS credentials. Focused and full tests, lint, types, drift, and Docker smoke all pass.