### PR TITLE
fix: protect scanner findings from feedback

### DIFF
--- a/src/lgtmaybe/engine/labels.py
+++ b/src/lgtmaybe/engine/labels.py
@@ -47,7 +47,7 @@ _MIN_SPRAWL_DIRS = 4
 _MIN_SPRAWL_FILES = 10
 
 
-def _is_security(finding: ReviewFinding) -> bool:
+def is_security_finding(finding: ReviewFinding) -> bool:
     """Whether *finding* is a security finding, from the lens or from a scanner.
 
     A secret scanner's finding is the most label-worthy thing this reviewer
@@ -61,7 +61,7 @@ def _is_security(finding: ReviewFinding) -> bool:
 def compute_labels(findings: list[ReviewFinding], ctx: PRContext) -> list[str]:
     """The labels this review's outcome earns for the PR."""
     labels = [f"{EFFORT_PREFIX}{_effort_score(ctx.diff)}"]
-    if any(_is_security(f) and f.severity >= Severity.high for f in findings):
+    if any(is_security_finding(f) and f.severity >= Severity.high for f in findings):
         labels.append(SECURITY_LABEL)
     if _sprawls(ctx.changed_files):
         labels.append(SPLITTING_LABEL)

--- a/src/lgtmaybe/engine/suppress.py
+++ b/src/lgtmaybe/engine/suppress.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import re
 
 from lgtmaybe.core.findings import finding_fingerprint
-from lgtmaybe.core.models import ReviewCategory, ReviewConfig, ReviewFinding, Severity
+from lgtmaybe.core.models import ReviewConfig, ReviewFinding, Severity
+
+from .labels import is_security_finding
 
 # A `# lgtmaybe: ignore` pragma anywhere in a line (after a `#` comment marker).
 # Case-insensitive so `# LGTMAYBE: IGNORE` works too.
@@ -34,7 +36,7 @@ def _is_protected_security(finding: ReviewFinding) -> bool:
     config ``ignore_fingerprints`` dismissal is a deliberate maintainer decision
     and still applies — this carve-out is for the feedback channel only.
     """
-    return finding.category == ReviewCategory.security.value and finding.severity >= Severity.high
+    return is_security_finding(finding) and finding.severity >= Severity.high
 
 
 def _is_suppressed(

--- a/tests/engine/test_suppress.py
+++ b/tests/engine/test_suppress.py
@@ -32,6 +32,15 @@ def test_downvoted_fingerprint_fed_in_is_suppressed() -> None:
     assert apply_suppressions([f], cfg, {}) == []
 
 
+def test_downvote_cannot_suppress_high_severity_scanner_finding() -> None:
+    finding = _finding(title="Leaked secret").model_copy(
+        update={"severity": Severity.high, "category": "scan:gitleaks"}
+    )
+    downvoted = frozenset({finding_fingerprint(finding.path, finding.title)})
+
+    assert apply_suppressions([finding], _CFG, {}, downvoted) == [finding]
+
+
 def test_inline_pragma_on_the_line_suppresses() -> None:
     f = _finding(line=2)
     contents = {"a.py": "import os\nx = eval(data)  # lgtmaybe: ignore\ny = 1\n"}


### PR DESCRIPTION
Closes #556

Share the scanner-aware security predicate between labels and suppression so downvotes cannot hide high/critical gitleaks, bandit, or semgrep findings.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`