### PR TITLE
fix: prevent quadratic token redaction

### DIFF
--- a/src/lgtmaybe/engine/redact.py
+++ b/src/lgtmaybe/engine/redact.py
@@ -34,10 +34,10 @@ _SIMPLE_PATTERNS: list[re.Pattern[str]] = [
     # base64url JSON header, so the three-part JWT pattern below never matches a
     # JWE; without this it would egress whole. Listed first so the 5-segment form
     # is consumed before the 3-segment pattern can claim a prefix of it.
-    re.compile(r"eyJ[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,}){4}"),
+    re.compile(r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,}){4}"),
     # JSON Web Tokens: header.payload.signature, each base64url. The payload
     # carries claims/PII, so the whole token must go — not just up to a dot.
-    re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+    re.compile(r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
     # npm automation/auth tokens: npm_ followed by 36 base62 chars.
     re.compile(r"npm_[A-Za-z0-9]{36,}"),
     # PyPI API tokens: pypi- followed by a long base64 macaroon.

--- a/tests/engine/test_redact.py
+++ b/tests/engine/test_redact.py
@@ -276,6 +276,16 @@ def test_connection_string_pattern_is_not_quadratic() -> None:
     assert time.perf_counter() - start < 2.0
 
 
+def test_web_token_patterns_are_not_quadratic() -> None:
+    """Repeated token prefixes must not start a full backtracking scan at every offset."""
+    import time
+
+    pathological = "eyJ" * 20_000
+    start = time.perf_counter()
+    redact(pathological)
+    assert time.perf_counter() - start < 2.0
+
+
 def test_redact_memoizes_repeated_text() -> None:
     """The same file head text is redacted at several pipeline stages (hunk
     expansion, reflection grounding, every deferral hop) — repeats must hit a


### PR DESCRIPTION
## Summary
- require a base64url token boundary before JWT and JWE prefix matching
- prevent repeated `eyJ` prefixes from starting overlapping backtracking scans
- add an adversarial performance regression while preserving token redaction coverage

## Validation
- current pattern benchmark: 6 KB 0.068 s, 12 KB 0.273 s, 24 KB 1.090 s
- fixed pattern benchmark: 6 KB 0.0001 s, 12 KB 0.0002 s, 24 KB 0.0004 s
- `uv run pytest -q tests/engine/test_redact.py tests/engine/test_injection.py` (66 passed)
- `uv run pytest -q` (2480 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #554