### PR TITLE
fix(action): keep config file optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,7 +173,7 @@ inputs:
   config_path:
     description: "Path to the .lgtmaybe.yml config file, relative to the repo root."
     required: false
-    default: ".lgtmaybe.yml"
+    default: ""
   image:
     description: "Override the container image (advanced; defaults to the released GHCR image)."
     required: false

--- a/tests/test_action_yml.py
+++ b/tests/test_action_yml.py
@@ -66,6 +66,10 @@ def test_declares_explicit_github_identity_inputs() -> None:
     assert inputs["identity_broker_url"]["default"].startswith("https://")
 
 
+def test_optional_config_path_defaults_to_empty() -> None:
+    assert _action()["inputs"]["config_path"]["default"] == ""
+
+
 def test_marketplace_setup_explains_workflow_configuration() -> None:
     action = _action()
     marketplace_copy = " ".join(


### PR DESCRIPTION
Closes #552

Default the composite Action’s `config_path` input to empty so the CLI uses its lenient `.lgtmaybe.yml` probe. Explicit paths still fail loudly when missing, while repositories without a config file now run with defaults as documented.

A parity test pins the empty Action default. Focused and full tests, lint, types, drift, and Docker smoke all pass.