### PR TITLE
fix: bound unpaginated Gitea reads

### DIFF
--- a/src/lgtmaybe/gitea/gateway.py
+++ b/src/lgtmaybe/gitea/gateway.py
@@ -348,7 +348,7 @@ class GiteaGateway:
             ]
             with ThreadPoolExecutor(max_workers=_CONTENT_FETCH_WORKERS) as pool:
                 for comments in pool.map(
-                    lambda rid: self._paginate(f"{self._pr_api}/reviews/{rid}/comments"), review_ids
+                    lambda rid: self._list(f"{self._pr_api}/reviews/{rid}/comments"), review_ids
                 ):
                     for comment in comments:
                         if found := finding_keys(comment.get("body") or ""):
@@ -378,7 +378,7 @@ class GiteaGateway:
 
     def _find_comment(self, family: str) -> int | None:
         """The id of our existing comment in ``family``, or None."""
-        for comment in self._paginate(f"{self._issue_api}/comments"):
+        for comment in self._list(f"{self._issue_api}/comments"):
             if family in (comment.get("body") or ""):
                 comment_id = comment.get("id")
                 return int(comment_id) if comment_id is not None else None
@@ -431,6 +431,11 @@ class GiteaGateway:
         resp = self._client.get(url, headers=self._headers, timeout=_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
+
+    def _list(self, url: str) -> list[dict[str, Any]]:
+        """One unpaginated Gitea list response."""
+        payload = self._get_json(url)
+        return payload if isinstance(payload, list) else []
 
     def _paginate(self, url: str) -> list[dict[str, Any]]:
         """Every page of a Gitea list endpoint, flattened."""

--- a/tests/gitea/test_gateway.py
+++ b/tests/gitea/test_gateway.py
@@ -185,10 +185,15 @@ class TestPostReview:
         respx.route(method="GET", url__startswith=f"{PR_URL}/reviews").mock(
             return_value=httpx.Response(200, json=[])
         )
-        respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
+        listed = respx.route(
+            method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments"
+        ).mock(
             return_value=httpx.Response(
                 200,
-                json=[{"id": 99, "body": "old summary\n\n<!-- lgtmaybe -->"}],
+                json=[
+                    *[{"id": i, "body": "human comment"} for i in range(49)],
+                    {"id": 99, "body": "old summary\n\n<!-- lgtmaybe -->"},
+                ],
             )
         )
         edit = respx.patch(f"{API}/issues/comments/99").mock(
@@ -202,6 +207,7 @@ class TestPostReview:
 
         assert edit.called, "an existing summary must be edited"
         assert not create.called, "and not duplicated"
+        assert listed.call_count == 1
 
     @respx.mock
     def test_a_finding_already_posted_is_not_posted_twice(self) -> None:
@@ -222,9 +228,13 @@ class TestPostReview:
         respx.route(method="GET", url=f"{PR_URL}/reviews").mock(
             return_value=httpx.Response(200, json=[{"id": 5}])
         )
-        respx.get(f"{PR_URL}/reviews/5/comments").mock(
+        listed = respx.get(f"{PR_URL}/reviews/5/comments").mock(
             return_value=httpx.Response(
-                200, json=[{"body": f"old text\n<!-- lgtmaybe-finding:{already} -->"}]
+                200,
+                json=[
+                    *[{"body": "human comment"} for _ in range(49)],
+                    {"body": f"old text\n<!-- lgtmaybe-finding:{already} -->"},
+                ],
             )
         )
         respx.route(method="GET", url__startswith=f"{API}/issues/{PR_NUMBER}/comments").mock(
@@ -238,6 +248,7 @@ class TestPostReview:
         _gateway(httpx.Client()).post_review([finding], "1 finding", diff=DIFF)
 
         assert not reviews.called, "the only finding was already on the PR"
+        assert listed.call_count == 1
 
     @respx.mock
     def test_dedupe_consumes_each_existing_finding_once(self) -> None:


### PR DESCRIPTION
Closes #553

Fetch Gitea issue comments and review comments once because those endpoints ignore page parameters. This prevents 50+ item responses from looping and growing memory forever while leaving genuinely paginated endpoints unchanged.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`