### PR TITLE
fix: preserve header-like diff content

### DIFF
--- a/src/lgtmaybe/core/diffparse.py
+++ b/src/lgtmaybe/core/diffparse.py
@@ -79,14 +79,15 @@ def walk_diff(diff: str) -> Iterator[tuple[str, str, int, int, str]]:
             current_file = fallback.group(1) if fallback is not None else None
             in_hunk = False
             continue
-        old_file_match = OLD_FILE_HEADER_RE.match(raw_line)
-        if old_file_match:
-            current_file = old_file_match.group(1)
-            continue
-        new_file_match = NEW_FILE_HEADER_RE.match(raw_line)
-        if new_file_match:
-            current_file = new_file_match.group(1)
-            continue
+        if not in_hunk:
+            old_file_match = OLD_FILE_HEADER_RE.match(raw_line)
+            if old_file_match:
+                current_file = old_file_match.group(1)
+                continue
+            new_file_match = NEW_FILE_HEADER_RE.match(raw_line)
+            if new_file_match:
+                current_file = new_file_match.group(1)
+                continue
         if current_file is None:
             continue
         hunk = parse_hunk_header(raw_line)

--- a/tests/core/test_diffparse.py
+++ b/tests/core/test_diffparse.py
@@ -169,6 +169,25 @@ class TestWalkDiff:
 
         assert {path for path, *_ in walk_diff(diff)} == {"dir b/file.py"}
 
+    def test_in_hunk_content_that_looks_like_file_headers_is_walked(self):
+        diff = (
+            "diff --git a/query.sql b/query.sql\n"
+            "--- a/query.sql\n"
+            "+++ b/query.sql\n"
+            "@@ -1,2 +1,2 @@\n"
+            "--- a/deceptive-path.sql\n"
+            "+++ b/deceptive-path.sql\n"
+            "-old tail\n"
+            "+new tail\n"
+        )
+
+        assert list(walk_diff(diff)) == [
+            ("query.sql", "-", 1, 1, "-- a/deceptive-path.sql"),
+            ("query.sql", "+", 2, 1, "++ b/deceptive-path.sql"),
+            ("query.sql", "-", 2, 2, "old tail"),
+            ("query.sql", "+", 3, 2, "new tail"),
+        ]
+
 
 class TestChangedLineIndex:
     def test_indexes_added_line_on_right_at_new_line(self):


### PR DESCRIPTION
## Summary
- recognize old/new file headers only before a diff hunk opens
- preserve deleted `-- a/...` and added `++ b/...` content as real changed lines
- verify the real path and line counters remain intact after deceptive content

## Validation
- `uv run pytest -q tests/core/test_diffparse.py tests/core/test_diff.py tests/github/test_post_review.py` (112 passed)
- `uv run pytest -q` (2484 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #551