### PR TITLE
fix(security): isolate static analysis config

### DIFF
--- a/src/lgtmaybe/engine/static_analysis.py
+++ b/src/lgtmaybe/engine/static_analysis.py
@@ -466,7 +466,16 @@ def _run_tool(
     report = report_dir / f"{tool.value}.json"
 
     if tool is StaticAnalysisTool.ruff:
-        argv = [binary, "check", "--output-format", "json", "--exit-zero", "--no-cache", "."]
+        argv = [
+            binary,
+            "check",
+            "--isolated",
+            "--output-format",
+            "json",
+            "--exit-zero",
+            "--no-cache",
+            ".",
+        ]
     elif tool is StaticAnalysisTool.bandit:
         argv = [binary, "-f", "json", "-q", "-r", "."]
     elif tool is StaticAnalysisTool.mypy:
@@ -477,8 +486,12 @@ def _run_tool(
         # it chasing sibling modules that were never fetched. What survives is
         # exactly what it can prove from a single file's own text — which is where
         # the unguarded-Optional bugs live.
+        mypy_config = report_dir / "mypy.ini"
+        mypy_config.write_text("[mypy]\n", encoding="utf-8")
         argv = [
             binary,
+            "--config-file",
+            str(mypy_config),
             "--output",
             "json",
             "--ignore-missing-imports",

--- a/tests/engine/test_static_analysis.py
+++ b/tests/engine/test_static_analysis.py
@@ -224,6 +224,7 @@ def test_ruff_findings_parsed_and_relativised(monkeypatch) -> None:  # type: ign
 
     findings = run_static_analysis(FILES, _cfg(tools=[StaticAnalysisTool.ruff]))
 
+    assert "--isolated" in run.calls[0]["argv"]
     assert findings == [
         ToolFinding(
             tool="ruff",
@@ -288,10 +289,27 @@ def test_mypy_runs_isolated_from_the_wider_codebase(monkeypatch) -> None:  # typ
     run_static_analysis(FILES, _cfg(tools=[StaticAnalysisTool.mypy]))
 
     argv = [str(a) for a in run.calls[0]["argv"]]  # type: ignore[union-attr]
+    config = Path(argv[argv.index("--config-file") + 1])
+    assert config.name == "mypy.ini"
+    assert config.parent != Path(str(run.calls[0]["cwd"]))
     assert "--ignore-missing-imports" in argv
     assert "--follow-imports=skip" in argv
     # Never reuse or write a cache keyed to another run's corpus.
     assert "--no-incremental" in argv
+
+
+@pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy not installed")
+def test_mypy_does_not_execute_a_corpus_plugin(tmp_path: Path) -> None:
+    marker = tmp_path / "plugin-ran"
+    files = {
+        "mypy.ini": "[mypy]\nplugins = evil.py\n",
+        "evil.py": f'from pathlib import Path\nPath({str(marker)!r}).write_text("ran")\n',
+        "app.py": "answer: int = 42\n",
+    }
+
+    run_static_analysis(files, _cfg(tools=[StaticAnalysisTool.mypy]))
+
+    assert not marker.exists()
 
 
 @pytest.mark.skipif(shutil.which("mypy") is None, reason="mypy not installed")


### PR DESCRIPTION
Closes #549

Pin mypy to a trusted minimal config written outside the untrusted changed-file corpus, preventing PR-supplied `plugins` from importing and executing attacker code. Ruff now also uses its native `--isolated` mode so PR config cannot reshape results.

A live regression supplies a malicious mypy plugin and verifies it never executes. Focused and full tests, lint, types, drift, and Docker smoke all pass.