### PR TITLE
fix: split diffs only on newline bytes

### DIFF
--- a/src/lgtmaybe/core/diffparse.py
+++ b/src/lgtmaybe/core/diffparse.py
@@ -72,7 +72,7 @@ def walk_diff(diff: str) -> Iterator[tuple[str, str, int, int, str]]:
     old_line = 0
     in_hunk = False
 
-    for raw_line in diff.splitlines():
+    for raw_line in diff.removesuffix("\n").split("\n"):
         file_match = FILE_HEADER_RE.match(raw_line)
         if file_match:
             fallback = _FALLBACK_FILE_HEADER_RE.match(raw_line)
@@ -152,7 +152,7 @@ def changed_line_count(diff: str) -> int:
     """
     count = 0
     in_hunk = False
-    for line in diff.splitlines():
+    for line in diff.removesuffix("\n").split("\n"):
         if HUNK_HEADER_RE.match(line):
             in_hunk = True
         elif FILE_HEADER_RE.match(line):
@@ -178,7 +178,7 @@ def hunk_for_line(diff: str, path: str, line: int, side: str = "RIGHT") -> str |
     for patch_path, patch in split_by_file(diff, [path]):
         if patch_path != path:
             continue
-        lines = patch.splitlines()
+        lines = patch.removesuffix("\n").split("\n")
         hunk_starts = [i for i, raw in enumerate(lines) if parse_hunk_header(raw) is not None]
         if not hunk_starts:
             return None

--- a/tests/core/test_diffparse.py
+++ b/tests/core/test_diffparse.py
@@ -122,6 +122,11 @@ class TestHunkForLine:
         assert hunk is not None
         assert "-old" in hunk
 
+    def test_preserves_non_newline_unicode_separator_in_hunk(self):
+        diff = "diff --git a/a.js b/a.js\n@@ -1 +1 @@\n-old\n+const s = 'a\u2028b'\n"
+
+        assert "a\u2028b" in (hunk_for_line(diff, "a.js", 1) or "")
+
 
 class TestWalkDiff:
     def test_yields_kind_and_both_line_numbers_per_in_hunk_line(self):
@@ -188,6 +193,11 @@ class TestWalkDiff:
             ("query.sql", "+", 3, 2, "new tail"),
         ]
 
+    def test_non_newline_unicode_separator_stays_inside_source_line(self):
+        diff = "diff --git a/a.js b/a.js\n@@ -1 +1,2 @@\n context\n+const s = 'a\u2028b'\n"
+
+        assert list(walk_diff(diff))[-1] == ("a.js", "+", 2, 2, "const s = 'a\u2028b'")
+
 
 class TestChangedLineIndex:
     def test_indexes_added_line_on_right_at_new_line(self):
@@ -235,6 +245,11 @@ class TestChangedLineIndex:
 class TestChangedLineCount:
     def test_counts_added_and_removed_lines(self):
         assert changed_line_count(_TWO_FILE_DIFF) == 3
+
+    def test_non_newline_separator_does_not_create_a_second_changed_line(self):
+        diff = "diff --git a/a b/a\n@@ -0,0 +1 @@\n+added\u2028-embedded\n"
+
+        assert changed_line_count(diff) == 1
 
     def test_file_headers_are_not_changed_lines(self):
         # The `---`/`+++` pair every per-file patch carries is diff metadata,


### PR DESCRIPTION
Closes #550

Split unified diffs only at literal newline boundaries, preserving Unicode line-separator characters embedded in source while retaining the prior trailing-newline behavior.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`