### PR TITLE
fix: preserve JSON string content during repair

### DIFF
--- a/src/lgtmaybe/engine/parse.py
+++ b/src/lgtmaybe/engine/parse.py
@@ -156,6 +156,15 @@ def _balanced_spans(text: str) -> Iterator[str]:
             yield text[start:end]
 
 
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas outside JSON string literals."""
+    outside_commas = {i for i, ch in _outside_strings(text) if ch == ","}
+    return _TRAILING_COMMA_RE.sub(
+        lambda match: match.group(1) if match.start() in outside_commas else match.group(0),
+        text,
+    )
+
+
 def iter_json_values(raw: str) -> Iterator[Any]:
     """Yield every JSON value recoverable from *raw*, most-likely first.
 
@@ -172,14 +181,22 @@ def iter_json_values(raw: str) -> Iterator[Any]:
     seen: set[str] = set()
 
     def _try(candidate: str) -> Iterator[Any]:
-        repaired = _TRAILING_COMMA_RE.sub(r"\1", candidate)
-        if repaired in seen:
+        if candidate in seen:
             return
-        seen.add(repaired)
+        seen.add(candidate)
         try:
-            yield json.loads(repaired)
+            yield json.loads(candidate)
         except json.JSONDecodeError:
-            return
+            if _TRAILING_COMMA_RE.search(candidate) is None:
+                return
+            repaired = _strip_trailing_commas(candidate)
+            if repaired == candidate or repaired in seen:
+                return
+            seen.add(repaired)
+            try:
+                yield json.loads(repaired)
+            except json.JSONDecodeError:
+                return
 
     yield from _try(text)
     for span in _balanced_spans(text):
@@ -225,7 +242,7 @@ def _classify(raw: str) -> ParseFailure:
         return ParseFailure.prose
     for span in spans:
         try:
-            json.loads(_TRAILING_COMMA_RE.sub(r"\1", span))
+            json.loads(_strip_trailing_commas(span))
         except json.JSONDecodeError:
             continue
         # Something decoded, so the syntax was fine and the shape was not — the

--- a/tests/engine/test_parse.py
+++ b/tests/engine/test_parse.py
@@ -127,6 +127,26 @@ def test_suggestion_code_fence_survives_verbatim() -> None:
     assert result[0].suggestion == suggestion
 
 
+def test_valid_json_commas_before_brackets_survive_verbatim() -> None:
+    suggestion = 'parts = re.findall(r"[^,]+", value)'
+    body = "must exclude commas, } included"
+    raw = json.dumps([dict(_VALID_FINDING, suggestion=suggestion, body=body)])
+
+    result = parse_findings(raw)
+
+    assert result[0].suggestion == suggestion
+    assert result[0].body == body
+
+
+def test_trailing_comma_repair_does_not_rewrite_string_values() -> None:
+    body = "must exclude commas, } included"
+    raw = json.dumps([dict(_VALID_FINDING, body=body)])[:-1] + ",]"
+
+    result = parse_findings(raw)
+
+    assert result[0].body == body
+
+
 def test_trailing_comma_tolerated() -> None:
     raw = '[{"path":"a.py","line":1,"severity":"low","title":"t","body":"b","suggestion":null,}]'
     result = parse_findings(raw)


### PR DESCRIPTION
## Summary
- parse clean JSON unchanged before attempting any repair
- remove trailing commas only when they occur outside JSON strings
- preserve code suggestions and prose containing comma/bracket sequences in both clean and repaired payloads

## Validation
- `uv run pytest -q tests/engine/test_parse.py tests/engine/test_repair.py tests/engine/test_reflect.py` (133 passed)
- `uv run pytest -q` (2488 passed, 3 skipped, 19 deselected)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pytest -q tests/specs/test_anchors.py`
- `uv run python scripts/check_spec_drift.py --base origin/main`

Closes #548