### PR TITLE
fix: redact exact captured secret span

### DIFF
--- a/src/lgtmaybe/engine/redact.py
+++ b/src/lgtmaybe/engine/redact.py
@@ -96,8 +96,9 @@ _VALUE_PATTERNS: list[re.Pattern[str]] = [
 def _replace_value(m: re.Match[str]) -> str:
     """Replace only the captured ``secret`` group, preserving the key name / scheme."""
     full = m.group(0)
-    value = m.group("secret")
-    return full.replace(value, REDACTED_PLACEHOLDER, 1)
+    start = m.start("secret") - m.start()
+    end = m.end("secret") - m.start()
+    return full[:start] + REDACTED_PLACEHOLDER + full[end:]
 
 
 @lru_cache(maxsize=128)

--- a/tests/engine/test_redact.py
+++ b/tests/engine/test_redact.py
@@ -155,6 +155,10 @@ def test_quoted_password_literal_redacted() -> None:
     assert "password" in result
 
 
+def test_password_value_overlapping_key_name_is_redacted() -> None:
+    assert redact('password: "sword"') == 'password: "[REDACTED]"'
+
+
 def test_password_prose_not_redacted() -> None:
     """Plain English mentioning a password must not trip the redactor."""
     result = redact("+# Send the user a password reset email when requested\n")
@@ -178,6 +182,12 @@ def test_connection_string_password_redacted() -> None:
     # Host stays visible — only the password segment is scrubbed.
     assert "db.internal" in result
     assert "admin" in result
+
+
+def test_connection_password_matching_username_is_redacted() -> None:
+    result = redact('url = "postgres://alice:alice@db.example.com/app"')
+
+    assert result == 'url = "postgres://alice:[REDACTED]@db.example.com/app"'
 
 
 def test_value_pattern_preserves_key_name() -> None:


### PR DESCRIPTION
Closes #547

Replace the regex named `secret` group by its exact span rather than the first equal substring in the full match, preventing password leakage when the value also appears in a key name or username.

Checks:
- `uv run pytest -q`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`