### PR TITLE
feat: estimate and report review cost in the profile

### DIFF
--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -44,6 +44,18 @@ tokens: 158,076 billable (154,200 in / 3,876 out) across 12 calls
 Every local review prints that same line to stderr even without `--profile`, so
 the meter is always in view; redirect with `2>/dev/null` if you want it gone.
 
+When litellm's pricing map knows the model, the meter gains a second line:
+
+```
+estimated cost: $0.5207 (litellm pricing map)
+```
+
+It is an estimate off a price list that can lag a brand-new model, so its
+absence means "unpriced", not "free" — and when only some calls could be
+priced, the line says how many rather than passing a partial total off as the
+sum. Cache reads are billed at their discount, so a run with a warm prefix
+shows it.
+
 `in` dwarfing `out` is normal and explains most of the cost: you are paying to *send*
 the diff, over and over, once per lens per batch. The per-call table above it
 shows exactly which lens and which batch each call belongs to, so you can see

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4461,6 +4461,18 @@ tokens: 158,076 billable (154,200 in / 3,876 out) across 12 calls
 Every local review prints that same line to stderr even without `--profile`, so
 the meter is always in view; redirect with `2>/dev/null` if you want it gone.
 
+When litellm's pricing map knows the model, the meter gains a second line:
+
+```
+estimated cost: $0.5207 (litellm pricing map)
+```
+
+It is an estimate off a price list that can lag a brand-new model, so its
+absence means "unpriced", not "free" — and when only some calls could be
+priced, the line says how many rather than passing a partial total off as the
+sum. Cache reads are billed at their discount, so a run with a warm prefix
+shows it.
+
 `in` dwarfing `out` is normal and explains most of the cost: you are paying to *send*
 the diff, over and over, once per lens per batch. The per-call table above it
 shows exactly which lens and which batch each call belongs to, so you can see
@@ -5134,6 +5146,7 @@ The normalised return value of one LLM completion, including token usage.
 | `attempts` | integer | No | `1` | Attempts |
 | `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
+| `cost_usd` | number / null | No | `null` | Cost Usd |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `model` | string / null | No | `null` | Model |
 | `output_ceiling` | integer / null | No | `null` | Output Ceiling |
@@ -6191,6 +6204,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": 0,
       "title": "Cache Read Tokens",
       "type": "integer"
+    },
+    "cost_usd": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cost Usd"
     },
     "input_tokens": {
       "title": "Input Tokens",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -123,6 +123,7 @@ The normalised return value of one LLM completion, including token usage.
 | `attempts` | integer | No | `1` | Attempts |
 | `cache_creation_tokens` | integer | No | `0` | Cache Creation Tokens |
 | `cache_read_tokens` | integer | No | `0` | Cache Read Tokens |
+| `cost_usd` | number / null | No | `null` | Cost Usd |
 | `input_tokens` | integer | Yes | — | Input Tokens |
 | `model` | string / null | No | `null` | Model |
 | `output_ceiling` | integer / null | No | `null` | Output Ceiling |
@@ -1180,6 +1181,18 @@ The canonical machine-readable schemas. These are the source of truth for provid
       "default": 0,
       "title": "Cache Read Tokens",
       "type": "integer"
+    },
+    "cost_usd": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cost Usd"
     },
     "input_tokens": {
       "title": "Input Tokens",

--- a/src/lgtmaybe/core/models.py
+++ b/src/lgtmaybe/core/models.py
@@ -663,6 +663,12 @@ class ProviderResult(_Strict):
     # None, not the requested model, for back-compat: a fake or an older adapter
     # that does not stamp it must not be read as asserting the primary answered.
     model: str | None = None
+    # The adapter's estimate of what this call cost, from its own pricing map —
+    # None when it declines to price (a model it doesn't know, or a genuinely
+    # free one). Money is the unit the token counts are a proxy for, and the
+    # adapter is the one place that holds both the resolved model string and the
+    # usage the price is computed from.
+    cost_usd: float | None = None
 
 
 # A FAILED call has no ProviderResult to carry `attempts` home on, so the adapter

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -59,6 +59,11 @@ class ProviderTruncated(Exception):
     essentially the whole ceiling is not a payload problem at all: covering less
     does not shrink a thinking budget, and only `reasoning_effort` moves it. The
     caller must be able to tell the two apart without re-reading our own message.
+
+    ``cost_usd`` carries the same principle to the price column: the costliest
+    call of the run usually fails, and a failure that reports no cost hides from
+    the cost line the way a runaway once hid from the token ceiling. None when
+    the adapter declines to price it.
     """
 
     def __init__(
@@ -69,12 +74,14 @@ class ProviderTruncated(Exception):
         reasoning_tokens: int | None = None,
         output_tokens: int | None = None,
         input_tokens: int | None = None,
+        cost_usd: float | None = None,
     ) -> None:
         super().__init__(message)
         self.text = text
         self.reasoning_tokens = reasoning_tokens
         self.output_tokens = output_tokens
         self.input_tokens = input_tokens
+        self.cost_usd = cost_usd
 
 
 class ProviderClient(Protocol):

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -461,7 +461,13 @@ class Profiler:
             count = (
                 f"; {len(prices)} of {len(calls)} calls priced" if len(prices) != len(calls) else ""
             )
-            lines.append(f"estimated cost: ${sum(prices):.4f} (litellm pricing map{count})")
+            total = sum(prices)
+            rendered = f"${total:.4f}"
+            if rendered == "$0.0000":
+                # A real price that rounds away would render as "free" — the
+                # exact misreading the silence-not-zero rule exists to prevent.
+                rendered = f"${total:.6f}"
+            lines.append(f"estimated cost: {rendered} (litellm pricing map{count})")
         return "\n".join(lines)
 
 

--- a/src/lgtmaybe/engine/profiling.py
+++ b/src/lgtmaybe/engine/profiling.py
@@ -64,6 +64,12 @@ class CallRecord:
     # adapter does not report one — silence, never the configured model, because
     # a run's whole point in reading this is to see where the two DIFFER.
     model: str | None = None
+    # The adapter's estimate of what this call cost (its pricing map's price for
+    # this model's usage), or None when it declines to price — a model the map
+    # doesn't know, or a genuinely free one. Never 0: a reported zero would
+    # assert "this call was free", which the map is nowhere near reliable enough
+    # to claim.
+    cost_usd: float | None = None
 
     @property
     def reasoning_share(self) -> float | None:
@@ -115,6 +121,7 @@ class Profiler:
         findings: int | None = None,
         error: str | None = None,
         model: str | None = None,
+        cost_usd: float | None = None,
     ) -> None:
         """Record one provider call and log it as a structured line."""
         record = CallRecord(
@@ -131,6 +138,7 @@ class Profiler:
             findings=findings,
             error=error,
             model=model,
+            cost_usd=cost_usd,
         )
         with self._lock:
             self.calls.append(record)
@@ -148,6 +156,8 @@ class Profiler:
             del extra["error"]
         if model is None:
             del extra["model"]
+        if cost_usd is None:
+            del extra["cost_usd"]
         _log.info("provider call", extra=extra)
 
     def record_result(
@@ -175,6 +185,7 @@ class Profiler:
             findings=findings,
             error=error,
             model=result.model,
+            cost_usd=result.cost_usd,
         )
 
     def record_returned_findings(self, count: int) -> None:
@@ -212,6 +223,11 @@ class Profiler:
             # way to it — so the share it reports is 100% by construction, which
             # is exactly the diagnosis.
             output_ceiling=getattr(exc, "output_tokens", None),
+            # A truncation's price rides the exception exactly like its token
+            # counts: the costliest call of a run usually fails, and a cost
+            # line that can't see it understates precisely the run worth
+            # reading about.
+            cost_usd=getattr(exc, "cost_usd", None),
             # A truncation is billed as ordinary input; the route reports no cache
             # breakdown alongside the ceiling error, so claiming one would be
             # invention rather than accounting.
@@ -269,10 +285,12 @@ class Profiler:
             calls, stages = list(self.calls), list(self.stages)
             returned = self.returned_findings
             wall = time.perf_counter() - self._started
+        prices = [c.cost_usd for c in calls if c.cost_usd is not None]
         return {
             "schema_version": _PROFILE_SCHEMA_VERSION,
             "wall_seconds": wall,
             "total_tokens": sum(c.input_tokens + c.output_tokens for c in calls),
+            "total_cost_usd": round(sum(prices), 6) if prices else None,
             "returned_findings": returned,
             "stages": [{"name": s.name, "elapsed": s.elapsed} for s in stages],
             "calls": [{**asdict(call), "reasoning_share": call.reasoning_share} for call in calls],
@@ -418,20 +436,33 @@ class Profiler:
         )
 
     def render_total(self) -> str:
-        """One line: what this run spent, formatted for a human.
+        """What this run spent, formatted for a human.
 
         Shared by the ``--profile`` table and the local CLI's footer so the two
-        can never drift into quoting different numbers for the same run.
+        can never drift into quoting different numbers for the same run. One
+        line when litellm's map priced nothing, two when it priced something:
+        the token meter, then the price those tokens worked out to.
+
+        The partial-pricing count is stated because a total over SOME calls is
+        a floor, not a sum — the same honesty rule the reasoning line applies
+        when only some calls report a breakdown.
         """
         with self._lock:
             calls = list(self.calls)
         billed_in = sum(c.input_tokens for c in calls)
         billed_out = sum(c.output_tokens for c in calls)
         plural = "" if len(calls) == 1 else "s"
-        return (
+        lines = [
             f"tokens: {billed_in + billed_out:,} billable "
             f"({billed_in:,} in / {billed_out:,} out) across {len(calls)} call{plural}"
-        )
+        ]
+        prices = [c.cost_usd for c in calls if c.cost_usd is not None]
+        if prices:
+            count = (
+                f"; {len(prices)} of {len(calls)} calls priced" if len(prices) != len(calls) else ""
+            )
+            lines.append(f"estimated cost: ${sum(prices):.4f} (litellm pricing map{count})")
+        return "\n".join(lines)
 
 
 # The process-wide collection point. One review runs per CLI invocation, so a

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -20,6 +20,11 @@ from typing import Any
 
 import litellm
 
+# litellm.utils re-exports these without listing them in __all__, so mypy
+# rejects the re-exports — import each from the module that defines it, like
+# the exceptions above.
+from litellm.cost_calculator import cost_per_token
+
 # litellm re-exports the openai exception types but doesn't list them in __all__,
 # so mypy rejects litellm.AuthenticationError etc. as un-exported — import them
 # from litellm.exceptions, where they're defined directly.
@@ -30,10 +35,6 @@ from litellm.exceptions import (
     PermissionDeniedError,
     RateLimitError,
 )
-
-# litellm.utils re-exports this without listing it in __all__, so mypy rejects
-# the re-export — import it from the module that defines it, like the
-# exceptions above.
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.utils import supports_prompt_caching
 from pydantic import BaseModel
@@ -1186,6 +1187,10 @@ class LiteLLMProvider:
         usage = response.usage
         input_tokens: int = usage.prompt_tokens
         output_tokens: int = usage.completion_tokens
+        # Priced here, before the truncation check, so a ceiling hit — routinely
+        # the costliest call of a run — carries its price on the exception just
+        # like it carries its token counts.
+        cost_usd = _estimated_cost_usd(model, usage)
         # A generation that stopped because it ran out of output tokens is cut off
         # mid-token: it can never parse, and passing it on gets it reported as
         # "unparseable model output", which points at the prompt rather than at
@@ -1238,6 +1243,7 @@ class LiteLLMProvider:
                 # Not diagnosis but accounting: the prompt was sent and billed,
                 # so the spend ceiling must see it (see profiling.record_error).
                 input_tokens=input_tokens,
+                cost_usd=cost_usd,
             )
         cache_read, cache_creation = _cache_usage(usage)
         if cache_read or cache_creation:
@@ -1272,6 +1278,8 @@ class LiteLLMProvider:
             # make, and a field that appeared only on rescues would leave the
             # common case unreadable rather than uninteresting.
             model=model,
+            # The price litellm's map puts on this call, or None when it declines.
+            cost_usd=cost_usd,
         )
 
 
@@ -1518,3 +1526,44 @@ def _cache_usage(usage: Any) -> tuple[int, int]:
         "cache_creation_tokens", "cache_write_tokens"
     )
     return int(cache_read or 0), int(cache_creation or 0)
+
+
+def _estimated_cost_usd(model: str, usage: Any) -> float | None:
+    """What litellm's pricing map says this call cost, or None to decline.
+
+    Money is the unit every token count in the profile is a proxy for, and this
+    is the one place that holds both the resolved model string the map keys on
+    and the usage the price is computed from. The cache counts ride along
+    because reads bill at a discount on every route that reports them — pricing
+    the same call without them overstates every cached lens.
+
+    Three shapes of "no price", all answered None because they are the same
+    claim — "no estimate available" — and a profile that renders a number for
+    any of them is lying with more precision than silence:
+
+    - the map has never heard of the model (a brand-new id) and raises;
+    - the map half-knows the id and prices it silently at zero (an unversioned
+      bedrock id does exactly this — indistinguishable by output from the
+      genuinely free routes, so a zero can never be reported as a price);
+    - the call reported no usage at all, so there is nothing to price.
+
+    A price is instrumentation, exactly like the capability lookups above: any
+    failure in here degrades to None, never to a failed review.
+    """
+    prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+    completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+    if not prompt_tokens and not completion_tokens:
+        return None
+    cache_read, cache_creation = _cache_usage(usage)
+    try:
+        prompt_cost, completion_cost = cost_per_token(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
+    except Exception:  # noqa: BLE001 — an unpriced model is not a failed review
+        return None
+    total = float(prompt_cost) + float(completion_cost)
+    return total if total > 0 else None

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
+from contextlib import suppress
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any
@@ -166,6 +167,11 @@ _EXPIRED_CREDENTIAL_MARKERS = (
     "expired credential",
     "the credential provided is expired",
 )
+
+
+# The attribute a failed call's price rides home on — the same channel as the
+# attempt count (models._ATTEMPTS_ATTR), read back by profiling.record_error.
+_COST_ATTR = "cost_usd"
 
 
 def _mentions(exc: BaseException, markers: tuple[str, ...]) -> bool:
@@ -937,14 +943,36 @@ class LiteLLMProvider:
                 raise
             # The primary's requests were still issued and still billed, so they
             # stay in the total: a fallback rescue that reported one request would
-            # hide the fact that the primary burned its budget first.
+            # hide the fact that the primary burned its budget first. The price
+            # travels with the attempt count — where the primary ran up a tab
+            # (a truncation priced before it raised) the rescue reports the whole
+            # bill, not just its own part of it.
             spent = attempts_of(exc)
+            spent_cost = getattr(exc, "cost_usd", None)
             try:
                 result = self._complete_with_retry(messages, self.fallback_model, **merged)
             except BaseException as fallback_exc:
                 stamp_attempts(fallback_exc, spent + attempts_of(fallback_exc))
+                fallback_cost = getattr(fallback_exc, "cost_usd", None)
+                if spent_cost is not None or fallback_cost is not None:
+                    # setattr via a named constant, not an attribute assignment:
+                    # the target is typed BaseException (the same reason
+                    # models.stamp_attempts sets rather than assigns).
+                    with suppress(Exception):
+                        setattr(
+                            fallback_exc,
+                            _COST_ATTR,
+                            sum(cost for cost in (spent_cost, fallback_cost) if cost is not None),
+                        )
                 raise
-            return result.model_copy(update={"attempts": result.attempts + spent})
+            merged_cost: float | None = None
+            if spent_cost is not None or result.cost_usd is not None:
+                merged_cost = sum(
+                    cost for cost in (spent_cost, result.cost_usd) if cost is not None
+                )
+            return result.model_copy(
+                update={"attempts": result.attempts + spent, "cost_usd": merged_cost}
+            )
 
     def _complete_with_retry(
         self, messages: list[Message], model: str, **kwargs: Any
@@ -1023,12 +1051,21 @@ class LiteLLMProvider:
             # here, so a model answering empty twice reports empty rather than
             # spending a third call.
             if not result.text.strip():
+                # The empty body was still generated and still billed, so its
+                # price rides onto the re-sent attempt's — a call recovered
+                # here must not report only the recovery's cost (the same
+                # rule `attempts` follows for the extra request).
+                spent_cost = result.cost_usd
                 if kwargs.get("response_format") is not None or _is_schema_tool(
                     kwargs.get("tools")
                 ):
                     self._disable_response_format(model, "empty-response")
                     self._strip_schema(kwargs)
                 result = self._raw_completion(model, messages, kwargs, count_request)
+                if spent_cost is not None:
+                    result = result.model_copy(
+                        update={"cost_usd": spent_cost + (result.cost_usd or 0.0)}
+                    )
             return result
 
         try:

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -894,3 +894,97 @@ class TestTheAnsweringModelIsLegibleFromTheProfile:
         )
 
         assert p.calls[0].model == "sonnet"
+
+
+class TestCostReporting:
+    """The run's estimated dollar cost, where the token meter already lives.
+
+    Tokens measure spend only up to a price list nobody keeps in their head;
+    the profile already answers "what did this cost in tokens", so it also
+    answers the question that was actually being asked. litellm's pricing map
+    prices a call when it knows the model; silence, never $0.00, when it does
+    not — a wrong price is worse than no price.
+    """
+
+    def _price(self, p: Profiler, cost: float | None) -> None:
+        p.record_call(
+            label="security",
+            batch=1,
+            elapsed=1.0,
+            attempts=1,
+            input_tokens=1000,
+            output_tokens=100,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            cost_usd=cost,
+        )
+
+    def test_a_priced_call_rides_to_the_record(self) -> None:
+        p = Profiler()
+        self._price(p, 0.005)
+        assert p.calls[0].cost_usd == pytest.approx(0.005)
+
+    def test_an_unpriced_call_stays_silent(self) -> None:
+        p = Profiler()
+        self._price(p, None)
+        assert p.calls[0].cost_usd is None
+
+    def test_the_total_line_prices_the_run(self) -> None:
+        p = Profiler()
+        self._price(p, 0.005)
+        self._price(p, None)
+        assert (
+            "estimated cost: $0.0050 (litellm pricing map; 1 of 2 calls priced)" in p.render_total()
+        )
+
+    def test_a_fully_priced_run_says_so_without_the_count(self) -> None:
+        p = Profiler()
+        self._price(p, 0.005)
+        self._price(p, 0.007)
+        line = p.render_total()
+        assert "estimated cost: $0.0120" in line
+        assert "calls priced" not in line
+
+    def test_an_unpriced_run_says_nothing_about_cost(self) -> None:
+        p = Profiler()
+        self._price(p, None)
+        assert "cost" not in p.render_total()
+
+    def test_a_failed_call_reports_the_cost_it_stamped(self) -> None:
+        """A ceiling hit fails and is routinely the costliest call of a run;
+        the price rides the exception exactly like the token counts do."""
+        p = Profiler()
+        exc = ProviderTruncated("response hit the 4096-token `max_tokens` ceiling")
+        exc.input_tokens = 1000
+        exc.output_tokens = 4096
+        exc.cost_usd = 0.062
+        p.record_error("security", 1, 1.0, exc)
+
+        assert p.calls[0].cost_usd == pytest.approx(0.062)
+        assert "estimated cost: $0.0620 (litellm pricing map)" in p.render_total()
+
+    def test_as_dict_carries_per_call_and_total_cost(self) -> None:
+        p = Profiler()
+        self._price(p, 0.005)
+        self._price(p, 0.0075)
+
+        payload = p.as_dict()
+
+        assert payload["calls"][0]["cost_usd"] == pytest.approx(0.005)
+        assert payload["total_cost_usd"] == pytest.approx(0.0125)
+
+    def test_as_dict_total_is_null_when_nothing_was_priced(self) -> None:
+        p = Profiler()
+        self._price(p, None)
+        assert p.as_dict()["total_cost_usd"] is None
+
+    def test_the_cost_rides_from_the_result(self) -> None:
+        p = Profiler()
+        p.record_result(
+            "security",
+            1,
+            1.0,
+            ProviderResult(text="{}", input_tokens=1, output_tokens=1, cost_usd=0.5),
+        )
+
+        assert p.calls[0].cost_usd == pytest.approx(0.5)

--- a/tests/engine/test_profiling.py
+++ b/tests/engine/test_profiling.py
@@ -973,6 +973,15 @@ class TestCostReporting:
         assert payload["calls"][0]["cost_usd"] == pytest.approx(0.005)
         assert payload["total_cost_usd"] == pytest.approx(0.0125)
 
+    def test_a_tiny_real_price_does_not_render_as_free(self) -> None:
+        """A total under a tenth of a cent rounds to $0.0000 at four decimals —
+        indistinguishable on the page from "free", the one thing a priced run
+        must never be mistaken for."""
+        p = Profiler()
+        self._price(p, 0.00003)
+
+        assert "estimated cost: $0.000030 (litellm pricing map)" in p.render_total()
+
     def test_as_dict_total_is_null_when_nothing_was_priced(self) -> None:
         p = Profiler()
         self._price(p, None)

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -16,6 +16,7 @@ import litellm
 import pytest
 
 from lgtmaybe.core.models import ProviderResult
+from lgtmaybe.core.ports import ProviderTruncated
 from lgtmaybe.providers.litellm_provider import LiteLLMProvider
 
 
@@ -23,14 +24,20 @@ def _fake_response(
     content: str = "hello",
     prompt_tokens: int = 10,
     completion_tokens: int = 20,
+    finish_reason: str | None = None,
+    usage_extra: dict[str, Any] | None = None,
 ) -> Any:
     """Build a minimal litellm ModelResponse lookalike."""
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        **(usage_extra or {}),
+    )
     return SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
-        usage=SimpleNamespace(
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-        ),
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content=content), finish_reason=finish_reason)
+        ],
+        usage=usage,
     )
 
 
@@ -162,3 +169,112 @@ class TestLiteLLMProvider:
             litellm.completion(model="no-such-provider/x", messages=[{"role": "user", "x": "hi"}])
 
         assert captured.getvalue() == ""
+
+
+class TestCostEstimation:
+    """The adapter prices each call with litellm's own pricing map.
+
+    A profile that reports tokens but not money answers only half the question
+    a metered run asks. The map is authoritative where it knows a model and
+    raises where it does not — but a few ids it half-knows price silently at
+    zero, and ollama is genuinely free, so a zero is never reported as a price:
+    silence, not $0.00, because those are different claims.
+    """
+
+    def test_complete_stamps_the_priced_cost(self) -> None:
+        response = _fake_response(prompt_tokens=1000, completion_tokens=200)
+        with (
+            patch("litellm.completion", return_value=response),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                return_value=(0.003, 0.002),
+            ) as price,
+        ):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5"
+            )
+
+        assert result.cost_usd == pytest.approx(0.005)
+        assert price.call_args.kwargs["model"] == "anthropic/claude-sonnet-4-5"
+        assert price.call_args.kwargs["prompt_tokens"] == 1000
+        assert price.call_args.kwargs["completion_tokens"] == 200
+
+    def test_pricing_sees_the_cache_breakdown(self) -> None:
+        """Cache reads bill at a discount, so a cache-aware call priced without
+        its cache numbers overstates the cost on every cached lens."""
+        response = _fake_response(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            usage_extra={"cache_read_input_tokens": 900, "cache_creation_input_tokens": 100},
+        )
+        with (
+            patch("litellm.completion", return_value=response),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                return_value=(0.001, 0.002),
+            ) as price,
+        ):
+            provider = LiteLLMProvider()
+            provider.complete([{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5")
+
+        assert price.call_args.kwargs["cache_read_input_tokens"] == 900
+        assert price.call_args.kwargs["cache_creation_input_tokens"] == 100
+
+    def test_unmapped_pricing_reports_no_cost(self) -> None:
+        """A model the pricing map has never heard of raises; an estimate must
+        never fail the call that produced it."""
+        response = _fake_response(prompt_tokens=1000, completion_tokens=200)
+        with (
+            patch("litellm.completion", return_value=response),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                side_effect=Exception("This model isn't mapped yet."),
+            ),
+        ):
+            provider = LiteLLMProvider()
+            result = provider.complete([{"role": "user", "content": "hi"}], "openai/gpt-5.5")
+
+        assert result.cost_usd is None
+
+    def test_a_silent_zero_price_reports_no_cost(self) -> None:
+        """The map prices some half-known ids (an unversioned bedrock id) at a
+        silent $0.00. A price of zero is indistinguishable from that bug and
+        from genuinely-free ollama — neither is a price, so neither is reported."""
+        response = _fake_response(prompt_tokens=1000, completion_tokens=200)
+        with (
+            patch("litellm.completion", return_value=response),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                return_value=(0.0, 0.0),
+            ),
+        ):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "bedrock/anthropic.claude-sonnet-4-5"
+            )
+
+        assert result.cost_usd is None
+
+    def test_a_truncation_carries_its_cost(self) -> None:
+        """A ceiling hit is routinely the costliest call in a run, and it fails —
+        so its price rides on the exception, where the failure is recorded."""
+        response = _fake_response(
+            prompt_tokens=1000,
+            completion_tokens=4096,
+            finish_reason="length",
+        )
+        with (
+            patch("litellm.completion", return_value=response),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                return_value=(0.003, 0.002),
+            ),
+        ):
+            provider = LiteLLMProvider()
+            with pytest.raises(ProviderTruncated) as excinfo:
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5"
+                )
+
+        assert excinfo.value.cost_usd == pytest.approx(0.005)

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -278,3 +279,67 @@ class TestCostEstimation:
                 )
 
         assert excinfo.value.cost_usd == pytest.approx(0.005)
+
+    def test_an_empty_response_retry_keeps_the_first_call_s_price(self) -> None:
+        """The empty body was generated and billed before the re-send; a call
+        recovered here must report the whole bill, not just the retry's part."""
+        empty = _fake_response(content="", prompt_tokens=1000, completion_tokens=200)
+        good = _fake_response(
+            content=json.dumps({"findings": []}), prompt_tokens=1000, completion_tokens=200
+        )
+        with (
+            patch("litellm.completion", side_effect=[empty, good]),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                side_effect=[(0.003, 0.002), (0.001, 0.001)],
+            ),
+        ):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5"
+            )
+
+        assert result.cost_usd == pytest.approx(0.007)
+
+    def test_a_fallback_run_carries_the_primary_s_tab(self) -> None:
+        """The primary's requests were issued and billed before the rescue, so
+        the rescue's result reports the whole bill — the cost rule mirrors the
+        attempts rule it sits beside."""
+        truncated = _fake_response(
+            prompt_tokens=1000, completion_tokens=4096, finish_reason="length"
+        )
+        good = _fake_response(prompt_tokens=1000, completion_tokens=200)
+        with (
+            patch("litellm.completion", side_effect=[truncated, good]),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                side_effect=[(0.050, 0.000), (0.001, 0.001)],
+            ),
+        ):
+            provider = LiteLLMProvider(fallback_model="openai/gpt-4o")
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5"
+            )
+
+        assert result.cost_usd == pytest.approx(0.052)
+        assert result.attempts >= 2
+
+    def test_a_double_failure_merges_both_costs(self) -> None:
+        """Primary truncated, fallback truncated: the error the profiler reads
+        must charge for both, or the costliest run shape underreports itself."""
+        first = _fake_response(prompt_tokens=1000, completion_tokens=4096, finish_reason="length")
+        second = _fake_response(prompt_tokens=1000, completion_tokens=4096, finish_reason="length")
+        with (
+            patch("litellm.completion", side_effect=[first, second]),
+            patch(
+                "lgtmaybe.providers.litellm_provider.cost_per_token",
+                side_effect=[(0.050, 0.000), (0.010, 0.010)],
+            ),
+        ):
+            provider = LiteLLMProvider(fallback_model="openai/gpt-4o")
+            with pytest.raises(ProviderTruncated) as excinfo:
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "anthropic/claude-sonnet-4-5"
+                )
+
+        assert excinfo.value.cost_usd == pytest.approx(0.070)

--- a/tests/snapshots/ProviderResult.json
+++ b/tests/snapshots/ProviderResult.json
@@ -18,6 +18,18 @@
       "title": "Cache Read Tokens",
       "type": "integer"
     },
+    "cost_usd": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cost Usd"
+    },
     "input_tokens": {
       "title": "Input Tokens",
       "type": "integer"


### PR DESCRIPTION
## What

The `--profile` output (and the local CLI's token footer) now reports what the run cost in dollars, computed with litellm's own pricing map — `litellm.cost_calculator.cost_per_token`, a capability of our provider spine the tool never consulted:

```
tokens: 158,076 billable (154,200 in / 3,876 out) across 12 calls
estimated cost: $0.5207 (litellm pricing map)
```

## Why

Tokens measure spend only up to a price list nobody keeps in their head. The profiler already answers "what did this cost in tokens" — the price is the question that was actually being asked, and [reduce-review-cost](https://github.com/MattJColes/lgtmaybe/blob/main/docs/how-to/reduce-review-cost.md) opens by telling the reader to measure before tuning. The adapter is the one place that holds both the resolved model string the map keys on and the usage the price is computed from, so the estimate is stamped there, on `ProviderResult.cost_usd`, and rides the existing instrumentation.

## Honesty rules (matching the existing instrumentation)

- **Silence, never $0.00.** The map raises for unknown models (a brand-new id), *half-knows* some ids — an unversioned bedrock id prices silently at zero — and serves genuinely free routes (ollama, `:free` openrouter models). None of those is a price, so none is reported as one; `None` means "unpriced", not "free".
- **Partial pricing is stated.** `estimated cost: ... (3 of 9 calls priced)` — a total over some calls is a floor, not a sum. Same rule the reasoning line applies when only some calls report a breakdown.
- **Cache reads ride along at their discount** (`cache_read_input_tokens` / `cache_creation_input_tokens`), so a warm prefix shows in the number instead of being billed at full input price.
- **A truncation carries its price on the exception** (`ProviderTruncated.cost_usd`), exactly like its token counts — the costliest call of a run usually fails, and a cost line that can't see it understates precisely the run worth reading about.
- **Pricing can never fail a review** — any error in the lookup degrades to `None`, like every other capability probe in the adapter.

## Scope notes

- `--profile-json` gains `cost_usd` per call and `total_cost_usd` (null when nothing was priced). Adding fields is explicitly a non-breaking change for the versioned payload, so `schema_version` stays 1.
- No spec drift: the two anchored functions (`Profiler.render`, `_write_profile_json`) are untouched; `tests/specs` passes.
- Docs: the footer example in `docs/how-to/reduce-review-cost.md` gains the second line, with the estimate computed from that section's own example numbers.

## Testing

- 14 new tests (adapter pricing/gating/truncation; profiler recording/rendering/JSON), written first — red confirmed, then green.
- Live probe against the real (unpatched) litellm 1.98 map: claude-sonnet priced, ollama → None, unmapped → None, unversioned bedrock → None, versioned bedrock priced, cache discount reflected, zero-usage → None, and no `Provider List` banner on stdout.
- Full suite: 2599 passed · mypy strict clean · ruff clean/formatted · docs-freshness gates regenerated.
