### PR TITLE
feat(provider): use litellm's capability map for schema, window, and thinking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ github / gitlab / gitea, and `Provider` stays the model backend. Never overload
 | Provider               | Auth                                                              |
 |------------------------|------------------------------------------------------------------|
 | openai / openrouter / anthropic | API key from `secrets.*` / env / `--api-key`            |
-| zai (GLM / Zhipu AI)   | API key (`ZAI_API_KEY` / `--api-key`); litellm-native `zai/` route. Optional `--api-base` / `ZAI_API_BASE` override for the China / coding-plan endpoint |
+| zai (GLM / Zhipu AI)   | API key (`ZAI_API_KEY` / `--api-key`); litellm-native `zai/` route (its param list omits `response_format`, so the schema goes as a forced tool call — `_honour_route_schema_support` reads litellm's per-route list before the first call). Optional `--api-base` / `ZAI_API_BASE` override for the China / coding-plan endpoint |
 | bedrock                | ambient AWS creds (GitHub OIDC role, or local `~/.aws`); IAM `bedrock:InvokeModel*` only |
 | vertex                 | ambient GCP creds (WIF, or local ADC)                            |
 | azure                  | needs the resource endpoint (`--api-base` / `AZURE_API_BASE`); `AZURE_API_KEY` / `--api-key` when supplied → else ambient Entra creds (GitHub OIDC federation via `azure/login`, or local `az login` / managed identity) |
@@ -291,7 +291,13 @@ pattern, event bus, plugin framework.
      each call's context stays small — better recall on big files, especially for
      smaller models. Files within budget are reviewed whole (context preserved).
      `ReviewConfig.recursive` (default **on**; CLI `--recursive/--no-recursive`,
-     Action input `recursive`); the on-demand A/B benchmark `python -m evals.ab
+     Action input `recursive`). A defaulted `max_input_tokens` is first
+     **fitted to the model's window** (`engine._fit_input_budget`, off the
+     adapter's feature-detected `input_budget()`: litellm's model map, or
+     ollama's `num_ctx`, less the output ceiling) — a configured value is left
+     alone. Token counts are one `cl100k_base` encoder for every model: litellm's
+     tokenizer registry resolves to the same encoding for every provider, so a
+     per-model lookup bought nothing; the on-demand A/B benchmark `python -m evals.ab
      --sweep recursive=false,true`
      measures recall + token cost of the walk vs sending whole against a live model.
    - **Incremental review (commit-scoped):** on a re-run, `run_review` reads a
@@ -333,7 +339,10 @@ pattern, event bus, plugin framework.
      `model`, `reflect_model`) share one provider/credentials. CLI
      `--triage-model`, Action input `triage_model`.
    - **Truncation ladder (escalation is LAST):** a truncated lens is first given
-     the remedy its token counts named, on the model the user chose —
+     the remedy its token counts named, on the model the user chose (a prompt the
+     model's context window refuses — litellm's `ContextWindowExceededError`,
+     surfaced as `ProviderInputTooLarge` — takes the same split, with nothing to
+     salvage) —
      `_review_split` (smaller pieces) when the answer outgrew the ceiling,
      `_retry_lower_effort` when the *thinking* did. Only if that fails does
      `engine._escalate_model` re-run the lens once on `fallback_model`. Switching

--- a/docs/how-to/reduce-review-cost.md
+++ b/docs/how-to/reduce-review-cost.md
@@ -89,8 +89,11 @@ input tokens  ≈  batches × lenses × (diff + context padding + hints)
 - **lenses** — the `fast` preset (the default) makes **four** calls per batch;
   `full` makes one per category, up to nine. This is the biggest multiplier in
   the formula.
-- **batches** — a diff larger than `max_input_tokens` (default 100k) is split,
-  and *each* batch pays the full lens fan-out again.
+- **batches** — a diff larger than `max_input_tokens` is split, and *each*
+  batch pays the full lens fan-out again. The default is 100k, fitted down to
+  what the model's context window can take when that is known (litellm's model
+  map for hosted models, `num_ctx` for ollama, less the output ceiling); a value
+  you set is used as-is.
 - **reflection** — one more pass over the findings, on top.
 - **triage** — an extra cheap call when enabled.
 - **the change overview** (`auto_diagram`, on by default) — up to three extra

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4506,8 +4506,11 @@ input tokens  ≈  batches × lenses × (diff + context padding + hints)
 - **lenses** — the `fast` preset (the default) makes **four** calls per batch;
   `full` makes one per category, up to nine. This is the biggest multiplier in
   the formula.
-- **batches** — a diff larger than `max_input_tokens` (default 100k) is split,
-  and *each* batch pays the full lens fan-out again.
+- **batches** — a diff larger than `max_input_tokens` is split, and *each*
+  batch pays the full lens fan-out again. The default is 100k, fitted down to
+  what the model's context window can take when that is known (litellm's model
+  map for hosted models, `num_ctx` for ollama, less the output ceiling); a value
+  you set is used as-is.
 - **reflection** — one more pass over the findings, on top.
 - **triage** — an extra cheap call when enabled.
 - **the change overview** (`auto_diagram`, on by default) — up to three extra

--- a/openspec/specs/provider-gateway/anchors.yml
+++ b/openspec/specs/provider-gateway/anchors.yml
@@ -46,6 +46,28 @@ provider.param-drop:
     has: { field: name, regex: '^_drop_rejected_param$' }
   files: [src/lgtmaybe/providers/**/*.py]
 
+provider.schema-route:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_honour_route_schema_support$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
+provider.thinking-sampling:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_withhold_temperature_under_thinking$' }
+  files: [src/lgtmaybe/providers/**/*.py]
+
+provider.input-budget:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^input_budget$' }
+    inside:
+      kind: class_definition
+      has: { field: name, regex: '^LiteLLMProvider$' }
+      stopBy: end
+  files: [src/lgtmaybe/providers/**/*.py]
+
 provider.schema-subset:
   rule:
     kind: function_definition

--- a/openspec/specs/provider-gateway/spec.md
+++ b/openspec/specs/provider-gateway/spec.md
@@ -223,6 +223,67 @@ is not findings.
 - **WHEN** litellm maps a provider error while `--format json` is in force
 - **THEN** nothing is printed to stdout, so the findings array stays parseable
 
+### Requirement: The schema mechanism is chosen for the route before the first call
+
+The adapter SHALL consult the same supported-params list litellm's `drop_params`
+consults, once per model, before the first request that carries a schema: a
+route that omits `response_format` but takes `tools` gets the schema as the
+forced tool call up front, a route with neither drops it up front and announces
+the downgrade, and a lookup failure leaves the schema on so the request-level
+recoveries still apply. Without this a route litellm strips the field from (zai)
+reviewed with no schema while the adapter reported enforcement was on — no 400,
+no empty body, nothing for the existing recoveries to see.
+<!-- anchor: provider.schema-route -->
+
+#### Scenario: the route lists tools but not response_format
+- **WHEN** the first schema-carrying call for a zai model is made
+- **THEN** it goes out as a forced tool call, `sends_response_format` stays true,
+  and no round-trip is spent learning it
+
+#### Scenario: the route lists neither
+- **WHEN** a route takes no structured-output mechanism at all
+- **THEN** the schema is dropped before the first call and the drop is announced
+
+### Requirement: A Claude request that turns thinking on carries no temperature
+
+The factory SHALL withhold `temperature` from a request whose `reasoning_effort`
+turns extended thinking on for a Claude model on the anthropic, bedrock or
+vertex route, and SHALL say so: Anthropic refuses a temperature beside
+thinking (`temperature` may only be set to 1 when thinking is enabled) and
+litellm forwards both. An effort that switches thinking off (`none`,
+`default`), no effort, or a non-Claude model keeps the temperature. The
+adapter's temperature-rejection matcher SHALL recognise Anthropic's wording as
+the backstop for a gateway route the factory does not recognise.
+<!-- anchor: provider.thinking-sampling -->
+
+#### Scenario: an effort is configured on the anthropic route
+- **WHEN** `reasoning_effort: medium` and the default `temperature: 0.0` are set
+- **THEN** the request carries the effort and no temperature, and the omission
+  is logged
+
+#### Scenario: the effort is `none`
+- **WHEN** `reasoning_effort: none` is set on a Claude model
+- **THEN** the temperature is sent, because thinking is off
+
+### Requirement: The adapter reports how much prompt its model can take
+
+The adapter SHALL expose `input_budget()`: ollama's `num_ctx` when it sends
+one, else the `max_input_tokens` litellm's model map records for the resolved
+model string, less the output ceiling the adapter will send; None when the map
+has no entry or no window, so an unknown model never shrinks a budget. A
+prompt the backend refuses for its window SHALL be raised as
+`ProviderInputTooLarge` — never retried in place, never stamped unrecoverable,
+and handed to a caller that owns the remedy exactly as a truncation is.
+<!-- anchor: provider.input-budget -->
+
+#### Scenario: an ollama model
+- **WHEN** the factory sent `num_ctx` and a finite `max_tokens`
+- **THEN** the budget is their difference, whatever the map says of the model
+
+#### Scenario: the backend refuses the prompt
+- **WHEN** litellm raises `ContextWindowExceededError`
+- **THEN** the call fails once as `ProviderInputTooLarge`, and the engine splits
+
 ### Requirement: The bedrock schema is narrowed to the subset its validator takes
 
 On the bedrock route the structured-output schema SHALL go out without the

--- a/openspec/specs/review-pipeline/anchors.yml
+++ b/openspec/specs/review-pipeline/anchors.yml
@@ -68,6 +68,12 @@ engine.size-cap:
     has: { field: name, regex: '^passes_size_cap$' }
   files: [src/lgtmaybe/engine/**/*.py]
 
+engine.input-budget:
+  rule:
+    kind: function_definition
+    has: { field: name, regex: '^_fit_input_budget$' }
+  files: [src/lgtmaybe/engine/**/*.py]
+
 engine.recursive-walk:
   - rule:
       kind: function_definition

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -275,7 +275,7 @@ salvage). Findings completed before a truncation SHALL be kept; the lens fails.
 
 #### Scenario: a call runs past its output ceiling, or its context window
 - **WHEN** a lens call's answer stops at the `max_tokens` ceiling, or its prompt
-  is refused for the window
+  is refused for the window (which alone may also slice inside a lone hunk)
 - **THEN** the batch is split the same way; findings finished before a cut are kept
 
 #### Scenario: a piece exhausts its budget as well

--- a/openspec/specs/review-pipeline/spec.md
+++ b/openspec/specs/review-pipeline/spec.md
@@ -216,6 +216,25 @@ name-based filter cannot recognise.
 - **WHEN** `max_file_diff_lines` is `0`
 - **THEN** no file is skipped for size and no size notice is posted
 
+### Requirement: The batching budget is fitted to the model's window
+
+The engine SHALL cap a defaulted `max_input_tokens` at the prompt budget the
+provider reports for its model (feature-detected `input_budget()`; the litellm
+adapter reads litellm's model map, or ollama's `num_ctx`, less the output
+ceiling it sends), before batching. A value the user configured SHALL be left
+alone, a provider with no method or no opinion SHALL change nothing, and the
+fit is only ever downward — the default is also a spend ceiling. Without it a
+100k batch is refused by a 65k-window model and silently truncated by ollama.
+<!-- anchor: engine.input-budget -->
+
+#### Scenario: the model's window is smaller than the default
+- **WHEN** `max_input_tokens` is unset and the provider reports a smaller budget
+- **THEN** batches are built against the reported budget, and the fit is logged
+
+#### Scenario: the user set a budget
+- **WHEN** `max_input_tokens` is configured, even above what the provider reports
+- **THEN** the configured value is used unchanged
+
 ### Requirement: Over-budget files walk hunk-by-hunk
 
 When one file's diff exceeds `max_input_tokens`, the engine SHALL decompose it
@@ -237,11 +256,11 @@ within budget are reviewed whole.
 ### Requirement: An oversized batch is retried smaller, never repeated
 
 A lens call that exhausts a per-request budget SHALL be retried on smaller
-pieces of the same batch rather than re-sent unchanged, bounded to one split
-level, the pieces reviewed concurrently, with the shrink disclosed in the
-summary. Both budgets trigger it: the wall clock, and the `max_tokens` ceiling
-an answer runs into. Findings the model completed before a truncation SHALL be
-kept, and the lens SHALL still count as failed.
+pieces of the same batch rather than re-sent unchanged: one split level, the
+pieces reviewed concurrently, the shrink disclosed in the summary. Three budgets
+trigger it: the wall clock, the `max_tokens` ceiling an answer hits, and the
+context window a prompt is refused by (`ProviderInputTooLarge`, nothing to
+salvage). Findings completed before a truncation SHALL be kept; the lens fails.
 <!-- anchor: engine.timeout-split -->
 
 #### Scenario: a multi-file batch times out
@@ -254,10 +273,10 @@ kept, and the lens SHALL still count as failed.
 - **THEN** its hunks are divided into two groups, one review call each, so an
   oversized lone file still shrinks
 
-#### Scenario: a call runs past its output ceiling
-- **WHEN** a lens call's answer stops at the `max_tokens` ceiling
-- **THEN** the batch is split the same way, and the findings finished before the
-  cut are kept alongside the pieces' findings
+#### Scenario: a call runs past its output ceiling, or its context window
+- **WHEN** a lens call's answer stops at the `max_tokens` ceiling, or its prompt
+  is refused for the window
+- **THEN** the batch is split the same way; findings finished before a cut are kept
 
 #### Scenario: a piece exhausts its budget as well
 - **WHEN** a piece of an already-split batch times out or truncates again

--- a/src/lgtmaybe/core/ports.py
+++ b/src/lgtmaybe/core/ports.py
@@ -84,6 +84,23 @@ class ProviderTruncated(Exception):
         self.cost_usd = cost_usd
 
 
+class ProviderInputTooLarge(Exception):
+    """Part of the provider contract: the prompt outgrew the model's context window.
+
+    The third payload-sized failure, beside :class:`ProviderWallTimeout` (ran out
+    of time) and :class:`ProviderTruncated` (ran out of room to answer): this
+    one ran out of room to *ask*. The backend refuses the request outright — a
+    400 naming the window — so there is no partial answer to salvage, and
+    re-sending the identical prompt can only fail identically. But a smaller
+    prompt succeeds, and only the engine holds the batch, so the engine reacts
+    exactly as it does to the other two: split the batch and review the pieces.
+
+    Named here rather than left as the adapter's generic bad request because the
+    engine must tell it apart from a failure no later call can fix (a dead key,
+    a spent quota): those end the lens, this one earns the split.
+    """
+
+
 class ProviderClient(Protocol):
     """Port: an LLM backend that returns a normalised completion."""
 

--- a/src/lgtmaybe/engine/compress.py
+++ b/src/lgtmaybe/engine/compress.py
@@ -32,69 +32,31 @@ _SCALE = 5_000
 # past the configured budget, which is the failure that collapses recall.
 _FALLBACK_CHARS_PER_TOKEN = 3
 
-# The model whose tokenizer the budget is measured in. Set once per review by
-# the engine; None means "no model in hand", which is the CLI-less/library case
-# and keeps the previous OpenAI-tokenizer behaviour.
-_counting_model: str | None = None
-
-
-def set_counting_model(model: str | None) -> None:
-    """Measure token budgets in the tokenizer of the model that will read them.
-
-    ``cl100k_base`` is OpenAI's; applied to an anthropic or vertex run it can be
-    off by well over 10% in either direction, and every batching decision is
-    made against it. The engine calls this once per review.
-
-    Clears the memo when the model changes: the cache is keyed on text alone,
-    since one review counts against one model.
-    """
-    global _counting_model
-    if model == _counting_model:
-        return
-    _counting_model = model
-    count_tokens.cache_clear()
-
-
-def _load_model_counter(model: str) -> Callable[[str], int] | None:
-    """A counter using *model*'s own tokenizer, via litellm's registry.
-
-    Imported lazily: litellm is a heavy import and the engine must not pay it
-    to count characters. litellm caches the tokenizer it selects, so the cost
-    lands on the first call only. Returns None when litellm has no opinion.
-    """
-    import litellm
-
-    litellm.encode(model=model, text="probe")  # resolve + cache the tokenizer
-    return lambda text: len(litellm.encode(model=model, text=text))
-
 
 def _load_tiktoken_counter() -> Callable[[str], int] | None:
-    """A counter using ``cl100k_base``, the model-agnostic fallback."""
+    """A counter using ``cl100k_base``, for every model.
+
+    Deliberately one encoding rather than "the model's own": litellm's tokenizer
+    registry was tried here and resolves to this same OpenAI encoding for every
+    provider it knows — anthropic, vertex, bedrock and ollama alike — so a
+    per-model lookup bought a multi-second import and byte-identical counts.
+    The budget is approximate for a non-OpenAI model either way; the file cap and
+    the recursive walk are what keep an under-count from shipping an oversized
+    batch.
+    """
     import tiktoken
 
     encoder = tiktoken.get_encoding("cl100k_base")
     return lambda text: len(encoder.encode(text))
 
 
-@lru_cache(maxsize=8)
-def _counter_for(model: str | None) -> Callable[[str], int] | None:
-    """The best available token counter for *model*, or None for the estimate.
+@lru_cache(maxsize=1)
+def _counter_for() -> Callable[[str], int] | None:
+    """The token counter, or None for the character estimate.
 
-    Resolved once per model: building an encoder is slow and ``count_tokens``
-    runs per file — and, inside ``take_lines``, per line.
+    Resolved once: building an encoder is slow and ``count_tokens`` runs per
+    file — and, inside ``take_lines``, per line.
     """
-    if model is not None:
-        try:
-            counter = _load_model_counter(model)
-            if counter is not None:
-                return counter
-        except Exception as exc:  # noqa: BLE001 — counting must never fail a review
-            _log.warning(
-                "no tokenizer for this model; falling back to a generic one — "
-                "token budgets are approximate for %s: %s",
-                model,
-                exc,
-            )
     try:
         return _load_tiktoken_counter()
     except Exception as exc:  # noqa: BLE001 — counting must never fail a review
@@ -111,14 +73,14 @@ def _counter_for(model: str | None) -> Callable[[str], int] | None:
 
 @lru_cache(maxsize=256)
 def count_tokens(text: str) -> int:
-    """Return the token count for *text*, in the counting model's tokenizer.
+    """Return the token count for *text*.
 
     Memoized: the same text is counted repeatedly across a review — each
     over-budget patch twice during recursive batching, the whole diff once per
     reflection deferral hop — and encoding is O(len) each time. Bounded so the
     cache can't retain an unbounded number of large diff strings.
     """
-    counter = _counter_for(_counting_model)
+    counter = _counter_for()
     if counter is not None:
         return counter(text)
     return max(1, len(text) // _FALLBACK_CHARS_PER_TOKEN)

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -39,6 +39,7 @@ from lgtmaybe.core.models import (
 from lgtmaybe.core.ports import (
     Message,
     ProviderClient,
+    ProviderInputTooLarge,
     ProviderTruncated,
     ProviderWallTimeout,
 )
@@ -52,7 +53,6 @@ from .compress import (
     context_lines_for_budget,
     count_tokens,
     expand_hunks,
-    set_counting_model,
     split_patch_into_hunks,
     trailing_context_lines,
 )
@@ -789,12 +789,45 @@ class LLMReviewEngine:
         # fetcher above can pull it. None keeps the prior path-only behaviour.
         self._resolve_symbol = resolve_symbol
 
+    def _fit_input_budget(self, cfg: ReviewConfig) -> ReviewConfig:
+        """Shrink the default batching budget to what the model can actually take.
+
+        `max_input_tokens` defaults to a flat number that knows nothing about the
+        model: a 100k batch to a 65k-window model is refused outright, and to an
+        ollama server it is silently cut to `num_ctx` — the review reads a
+        fraction of the diff and reports on the rest as if it had. A provider
+        that can say how much prompt fits (feature-detected: the litellm adapter
+        reads litellm's model map, or ollama's `num_ctx`, less the output
+        ceiling it will send) is asked, and the default is capped at its answer.
+
+        A value the user configured is left alone — they may know something the
+        map does not, and the split on a refused prompt still covers them. A
+        provider with no method, or no opinion, changes nothing. Only ever
+        down, never up: the default is also a spend ceiling.
+        """
+        if "max_input_tokens" in cfg.model_fields_set:
+            return cfg
+        probe = getattr(self._provider, "input_budget", None)
+        if probe is None:
+            return cfg
+        try:
+            budget = probe()
+        except Exception:  # noqa: BLE001 — a capability lookup must never fail a review
+            _log.warning("could not read the model's input budget", exc_info=True)
+            return cfg
+        if not isinstance(budget, int) or isinstance(budget, bool) or budget <= 0:
+            return cfg
+        if budget >= cfg.max_input_tokens:
+            return cfg
+        _log.info(
+            "max_input_tokens fitted to the model's context window",
+            extra={"default": cfg.max_input_tokens, "fitted": budget},
+        )
+        return cfg.model_copy(update={"max_input_tokens": budget})
+
     def review(self, ctx: PRContext, cfg: ReviewConfig) -> tuple[list[ReviewFinding], str]:
         """Run the review pipeline and return (findings, summary)."""
-        # Measure the budget in the tokenizer of the model that will read it.
-        # cl100k_base is OpenAI's; every batching decision on an anthropic or
-        # vertex run was being made against the wrong model's token counts.
-        set_counting_model(cfg.model)
+        cfg = self._fit_input_budget(cfg)
         # Soft whole-review deadline: model calls reaching execution after this
         # instant are skipped (in-flight ones finish), so a pathological run
         # degrades to partial-with-a-notice instead of grinding on. Measured
@@ -2116,7 +2149,9 @@ class LLMReviewEngine:
             #   re-deriving it here from the message text would be a second copy
             #   of the rule, drifting from the first.
             reason: str = _error_reason(exc)
-            if not isinstance(exc, ProviderTruncated) and not is_unrecoverable(exc):
+            if not isinstance(
+                exc, ProviderTruncated | ProviderInputTooLarge
+            ) and not is_unrecoverable(exc):
                 # A wall timeout is retryable, but it is also the signal the split
                 # acts on, so it is marked as such — see _PayloadReason.
                 mark = _PayloadReason if isinstance(exc, ProviderWallTimeout) else _RetryableReason
@@ -2127,7 +2162,13 @@ class LLMReviewEngine:
                 extra={"lens": lens.id, "reason": reason},
                 exc_info=True,
             )
-            if isinstance(exc, ProviderWallTimeout | ProviderTruncated):
+            if isinstance(exc, ProviderWallTimeout | ProviderTruncated | ProviderInputTooLarge):
+                # Three payload-sized failures, one remedy: ran out of time, ran
+                # out of room to answer, ran out of room to ask. A refused prompt
+                # (the model's context window) has no partial answer and no
+                # reasoning breakdown, so the salvage and the exhaustion check
+                # below are no-ops for it and it goes straight to the split.
+                #
                 # Whatever the model finished before the ceiling cut it off is real,
                 # schema-valid work — kept, exactly as the parse path keeps it, so
                 # the exception path is not the one place a partial answer is binned.

--- a/src/lgtmaybe/engine/engine.py
+++ b/src/lgtmaybe/engine/engine.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from lgtmaybe.core.diff import is_reviewable
 from lgtmaybe.core.diffparse import changed_line_index, split_by_file
@@ -53,6 +53,7 @@ from .compress import (
     context_lines_for_budget,
     count_tokens,
     expand_hunks,
+    split_hunk_by_budget,
     split_patch_into_hunks,
     trailing_context_lines,
 )
@@ -648,7 +649,19 @@ class _Run:
     changed_files: tuple[str, ...] = ()
 
 
-def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
+class _OnOversized(Protocol):
+    """The split a lens call may fall back to: ``(reason, slice_hunks=...)``.
+
+    A Protocol rather than a ``Callable`` alias because the second argument is
+    keyword-only, which ``Callable[...]`` cannot express.
+    """
+
+    def __call__(self, reason: str, *, slice_hunks: bool = ...) -> _LensOutcome: ...
+
+
+def _split_batch(
+    batch: list[tuple[str, str]], *, slice_hunks: bool = False
+) -> list[list[tuple[str, str]]]:
     """Split a timed-out batch into smaller review units.
 
     Multi-file: halve the file list — the coarsest cut that halves the payload,
@@ -656,6 +669,13 @@ def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
     hunks, the same unit the recursive walk uses, so an oversized lone file still
     shrinks. Returns fewer than two pieces when there is nothing smaller to try
     (an empty batch, or one file with a single hunk).
+
+    ``slice_hunks`` lets a lone hunk be cut *inside*, at half its own size, with
+    the same slicer the recursive walk uses. Only for a prompt the model's
+    context window refused: that failure is purely about input size, so a
+    smaller slice is guaranteed to help, where a timeout or a truncation on a
+    single hunk may be about the answer or the thinking, and slicing there is
+    the speculative recursion this split deliberately refuses.
     """
     if len(batch) > 1:
         middle = len(batch) // 2
@@ -665,7 +685,10 @@ def _split_batch(batch: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
     path, patch = batch[0]
     hunks = split_patch_into_hunks(patch)
     if len(hunks) < 2:
-        return []
+        if not slice_hunks or not hunks:
+            return []
+        slices = split_hunk_by_budget(hunks[0], max(1, count_tokens(hunks[0]) // 2))
+        return [[(path, piece)] for piece in slices] if len(slices) >= 2 else []
     middle = len(hunks) // 2
     return [
         [(path, hunk) for hunk in hunks[:middle]],
@@ -1656,6 +1679,7 @@ class LLMReviewEngine:
         lens: _Lens,
         spec_block: str | None = None,
         hidden_block: str | None = None,
+        slice_hunks: bool = False,
     ) -> _LensOutcome:
         """Re-review an oversized batch as smaller pieces, one call each.
 
@@ -1685,7 +1709,7 @@ class LLMReviewEngine:
         Not attempted at all when the truncation was reasoning-bound; see
         :func:`_reasoning_exhausted_reason`, which decides that before we get here.
         """
-        pieces = _split_batch(batch)
+        pieces = _split_batch(batch, slice_hunks=slice_hunks)
         if len(pieces) < 2:
             # Nothing smaller to try, so nothing has retried this call at all —
             # the reason travels on unchanged, retryable flag and all, and a
@@ -2081,7 +2105,7 @@ class LLMReviewEngine:
         response_format: type[ReviewResult] | None,
         batch_num: int,
         lens: _Lens,
-        on_oversized: Callable[[str], _LensOutcome] | None = None,
+        on_oversized: _OnOversized | None = None,
         on_needs: Callable[[list[str], list[ReviewFinding]], _LensOutcome] | None = None,
         *,
         effort: dict[str, Any] | None = None,
@@ -2210,7 +2234,12 @@ class LLMReviewEngine:
                     # rather than recurse — an unbounded cascade would spend the
                     # whole review on a model that cannot answer at any size.
                     return completed, reason
-                findings, split_reason = on_oversized(reason)
+                # A refused prompt may cut inside a lone hunk (see _split_batch):
+                # input size is the whole of that failure, so a smaller slice is
+                # guaranteed to help where for the other two it is a guess.
+                findings, split_reason = on_oversized(
+                    reason, slice_hunks=isinstance(exc, ProviderInputTooLarge)
+                )
                 if split_reason is None:
                     return completed + findings, None
                 # The pieces did not cover the batch either, so the payload was

--- a/src/lgtmaybe/providers/factory.py
+++ b/src/lgtmaybe/providers/factory.py
@@ -263,6 +263,51 @@ def _honour_param_support(provider: Provider, model: str, opts: dict[str, Any]) 
         )
 
 
+# Efforts that switch a Claude model's extended thinking OFF rather than on.
+# `none` is the literal off switch; `default` names no budget at all, so
+# litellm sends no thinking block for it either.
+_THINKING_OFF_EFFORTS = frozenset({"none", "default"})
+
+
+def _is_claude_route(provider: Provider, model: str) -> bool:
+    """Whether (*provider*, *model*) reaches a Claude model on one of its
+    direct routes — the ones whose reasoning effort litellm turns into
+    Anthropic's `thinking` block."""
+    if provider is Provider.anthropic:
+        return True
+    if provider in (Provider.bedrock, Provider.vertex):
+        return "claude" in model.lower()
+    return False
+
+
+def _withhold_temperature_under_thinking(
+    provider: Provider, model: str, opts: dict[str, Any]
+) -> None:
+    """Drop `temperature` from a Claude request that turns thinking on.
+
+    litellm maps a `reasoning_effort` on the anthropic, bedrock and vertex
+    Claude routes into Anthropic's extended-thinking block, and Anthropic
+    refuses a temperature beside it (`temperature` may only be set to 1 when
+    thinking is enabled) — a 400, permanent, on every lens at once. litellm
+    forwards both regardless: it strips sampling params only for the models
+    that reject them outright. So the one the user did not ask for is withheld
+    here: the effort was configured; the temperature is our determinism
+    default, and thinking is not deterministic anyway. Said out loud, like
+    every other param this factory declines to send.
+    """
+    effort = opts.get("reasoning_effort")
+    if "temperature" not in opts or not isinstance(effort, str):
+        return
+    if effort in _THINKING_OFF_EFFORTS or not _is_claude_route(provider, model):
+        return
+    del opts["temperature"]
+    _log.info(
+        "temperature not sent: extended thinking is on for this Claude model, and "
+        "Anthropic rejects a temperature beside it",
+        extra={"provider": provider.value, "model": litellm_model_string(provider, model)},
+    )
+
+
 def build_provider(
     provider: Provider,
     model: str,
@@ -296,6 +341,7 @@ def build_provider(
     # judged here because this is where the litellm model string the capability
     # map keys on comes into existence.
     _honour_param_support(provider, model, opts)
+    _withhold_temperature_under_thinking(provider, model, opts)
 
     opts["timeout"] = (
         timeout if timeout is not None else default_timeout_for(provider, concurrency=concurrency)

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -32,6 +32,7 @@ from litellm.cost_calculator import cost_per_token
 from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
+    ContextWindowExceededError,
     NotFoundError,
     PermissionDeniedError,
     RateLimitError,
@@ -58,6 +59,7 @@ from lgtmaybe.core.models import (
 )
 from lgtmaybe.core.ports import (
     Message,
+    ProviderInputTooLarge,
     ProviderTruncated,
     ProviderWallTimeout,
 )
@@ -222,7 +224,14 @@ def _is_permanent(exc: BaseException) -> bool:
     # labour. Only the engine holds the batch, so only the engine can change the
     # payload; the adapter can only re-send the same oversized one, which is the
     # attempt worth refusing.
-    return isinstance(exc, ProviderTruncated)
+    if isinstance(exc, ProviderTruncated):
+        return True
+    # And a refused prompt: the identical request is the identical size. Not
+    # unrecoverable, though — `_is_unrecoverable` never sees this type, because
+    # litellm's ContextWindowExceededError is translated into it before the
+    # BadRequestError check there could claim it — so the engine keeps the
+    # remedy it holds and the adapter cannot: a smaller payload.
+    return isinstance(exc, ProviderInputTooLarge)
 
 
 # How long to back off between attempts, by what failed.
@@ -631,7 +640,15 @@ def _rejects_temperature(exc: Exception) -> bool:
     not catch this — the param is supported, only the value is rejected."""
     msg = str(exc).lower()
     return "temperature" in msg and (
-        "does not support" in msg or "unsupported value" in msg or "only the default" in msg
+        "does not support" in msg
+        or "unsupported value" in msg
+        or "only the default" in msg
+        # Anthropic, with extended thinking on: "`temperature` may only be set to
+        # 1 when thinking is enabled". The factory withholds the temperature up
+        # front on the Claude routes it recognises; this covers a route it does
+        # not (a gateway fronting Claude), where the 400 is the first sign.
+        or "may only be set to" in msg
+        or "when thinking is enabled" in msg
     )
 
 
@@ -694,12 +711,73 @@ class LiteLLMProvider:
         # enforcement preserved by another mechanism, that one is enforcement
         # given up. Keyed by MODEL for the same reason.
         self._schema_tool: set[str] = set()
+        # Models whose route was already asked whether it takes `response_format`
+        # at all (see `_honour_route_schema_support`). One lookup per model, for
+        # the same reason the two sets above are keyed per model.
+        self._schema_probed: set[str] = set()
         self._rejected_params: dict[str, set[str]] = {}
         # Memoized supports-cache-control answers: the review fans out many
         # completions on the same model string, and the capability lookup is a
         # pure function of it. Instance-scoped (not lru_cache) so tests that
         # patch the litellm lookup stay isolated.
         self._cache_capable: dict[str, bool] = {}
+
+    def _honour_route_schema_support(self, model: str, kwargs: dict[str, Any]) -> None:
+        """Choose the schema mechanism the ROUTE takes before the first request.
+
+        The two recoveries in :meth:`_drop_rejected_param` react to evidence — a
+        400 naming the field, an empty body. A third case leaves none: litellm
+        runs with ``drop_params``, which strips every OpenAI-vocabulary param a
+        route's own supported-params list omits, silently, before the request
+        goes out. The zai route lists ``tools`` but not ``response_format``, so
+        the schema vanished on the wire, the model answered prose, and this
+        adapter still reported enforcement was on.
+
+        So the same list litellm consults is consulted here first: a route that
+        omits ``response_format`` but takes ``tools`` gets the schema as the
+        forced tool call up front (enforcement kept), and a route with neither
+        drops it up front and says so (enforcement given up, announced, exactly
+        as the 400 path does). A lookup failure — an unknown route — leaves the
+        schema on: the request-level recoveries still cover it, and a capability
+        lookup must never cost enforcement on a route that would have taken it.
+        Once per model: the fan-out sends the same shape N times.
+        """
+        if model in self._schema_probed or kwargs.get("response_format") is None:
+            return
+        self._schema_probed.add(model)
+        supported = _supported_params(model)
+        if supported is None or "response_format" in supported:
+            return
+        if "tools" in supported and self._use_schema_tool(model, kwargs):
+            return
+        self._disable_response_format(model, "route-unsupported")
+        self._strip_schema(kwargs)
+
+    def input_budget(self) -> int | None:
+        """How many prompt tokens this provider's model can take, or None.
+
+        Adapter-only, feature-detected by the engine like ``escalate_model``:
+        the engine's batching budget (``max_input_tokens``) defaults to a flat
+        number, and this is what lets it fit that default to the model instead
+        of learning the window from a refused prompt — or, on ollama, never
+        learning it at all, because the server silently truncates to ``num_ctx``.
+
+        Two sources, in order: ollama's ``num_ctx`` when this provider sends one
+        (the server's window IS that number, whatever litellm's map says of the
+        model), else the ``max_input_tokens`` litellm's model map records for the
+        resolved model string. The output ceiling this provider will send is
+        subtracted, because the backends reserve it: prompt plus ``max_tokens``
+        must fit the window. None when the map has never heard of the model or
+        records no window for it — "no opinion", so the engine keeps its default.
+        """
+        window: Any = self.default_opts.get("num_ctx")
+        if not isinstance(window, int) or isinstance(window, bool) or window <= 0:
+            window = _mapped_input_window(self.model)
+        if window is None:
+            return None
+        ceiling = self.default_opts.get("max_tokens")
+        reserve = ceiling if isinstance(ceiling, int) and not isinstance(ceiling, bool) else 0
+        return max(0, window - max(0, reserve)) or None
 
     def _disable_response_format(self, model: str, why: str) -> None:
         """Record — and announce — that *model* will not take the schema.
@@ -930,16 +1008,17 @@ class LiteLLMProvider:
                 # request to the model that just failed it — a second full-price
                 # answer to a question already answered wrong.
                 raise
-            if defer_truncation and isinstance(exc, ProviderTruncated):
-                # The caller asked to own this one. A truncation is the only
-                # failure where somebody upstream has a *better* remedy than
-                # switching model: the engine holds the batch and the token
-                # counts, so it can shrink the payload or lower the thinking
-                # budget — cheap, aimed at the cause the counts named, and still
-                # on the model the user chose. All this adapter could do is
-                # re-send the identical oversized request to a second model.
-                # It still gets to, from `escalate_model`, once the cheap remedy
-                # has had its go. Every other failure falls back here as before.
+            if defer_truncation and isinstance(exc, ProviderTruncated | ProviderInputTooLarge):
+                # The caller asked to own this one. A truncation — or a prompt the
+                # window refused — is the one failure where somebody upstream has
+                # a *better* remedy than switching model: the engine holds the
+                # batch and the token counts, so it can shrink the payload or
+                # lower the thinking budget — cheap, aimed at the cause the
+                # counts named, and still on the model the user chose. All this
+                # adapter could do is re-send the identical oversized request to
+                # a second model. It still gets to, from `escalate_model`, once
+                # the cheap remedy has had its go. Every other failure falls back
+                # here as before.
                 raise
             # The primary's requests were still issued and still billed, so they
             # stay in the total: a fallback rescue that reported one request would
@@ -1017,8 +1096,11 @@ class LiteLLMProvider:
             reraise=True,
         )
         def _call() -> ProviderResult:
-            # A prior call already settled how this model takes (or refuses) the
-            # schema, so don't pay the wasted round-trip again — apply it up front.
+            # What the route can take at all is settled before the first request;
+            # a prior call may already have settled how this model takes (or
+            # refuses) the schema, so don't pay the wasted round-trip again —
+            # apply either up front.
+            self._honour_route_schema_support(model, kwargs)
             for param in self._rejected_params.get(model, ()):
                 kwargs.pop(param, None)
             if model in self._schema_dropped:
@@ -1103,6 +1185,15 @@ class LiteLLMProvider:
                     model,
                     _configured_ceiling(kwargs),
                 )
+            except ContextWindowExceededError as exc:
+                # litellm names this one itself, on every route that reports it
+                # (anthropic's "prompt is too long", OpenAI's "maximum context
+                # length"). Handed up under the port's name so the engine can tell
+                # it from the generic bad request it subclasses: that one ends
+                # the lens, this one earns the split. Raised from here — inside
+                # the retry — so `_is_permanent` sees the translated type and
+                # declines the identical re-send.
+                raise ProviderInputTooLarge(str(exc)) from exc
             except Exception as exc:
                 if not self._drop_rejected_param(exc, model, kwargs):
                     raise
@@ -1484,6 +1575,38 @@ def _merge_user_messages(messages: list[Message]) -> list[Message]:
         return messages
     joined = "\n\n".join(str(m.get("content")) for m in run)
     return [*messages[:start], {"role": "user", "content": joined}]
+
+
+def _supported_params(model: str) -> frozenset[str] | None:
+    """The OpenAI-vocabulary params litellm forwards on *model*'s route, or None.
+
+    The same list litellm's own ``drop_params`` consults, so what this answers
+    is exactly what would be silently removed. None on any lookup failure — an
+    unknown route is a route to try, not a route to strip.
+    """
+    try:
+        supported = litellm.get_supported_openai_params(model=model)
+    except Exception:
+        return None
+    if supported is None:
+        return None
+    return frozenset(str(name) for name in supported)
+
+
+def _mapped_input_window(model: str) -> int | None:
+    """The context window litellm's model map records for *model*, or None.
+
+    A lookup failure or a missing/zero entry is "no opinion": the map does not
+    know the newest models, and an unknown window must never shrink a budget.
+    """
+    try:
+        info = litellm.get_model_info(model)
+    except Exception:
+        return None
+    window = info.get("max_input_tokens") if isinstance(info, Mapping) else None
+    if isinstance(window, bool) or not isinstance(window, int) or window <= 0:
+        return None
+    return window
 
 
 def _supports_cache_control(model: str) -> bool:

--- a/src/lgtmaybe/providers/litellm_provider.py
+++ b/src/lgtmaybe/providers/litellm_provider.py
@@ -711,10 +711,13 @@ class LiteLLMProvider:
         # enforcement preserved by another mechanism, that one is enforcement
         # given up. Keyed by MODEL for the same reason.
         self._schema_tool: set[str] = set()
-        # Models whose route was already asked whether it takes `response_format`
-        # at all (see `_honour_route_schema_support`). One lookup per model, for
-        # the same reason the two sets above are keyed per model.
-        self._schema_probed: set[str] = set()
+        # What each model's route takes, as litellm's per-route list answers it
+        # (see `_honour_route_schema_support`): None for a route the lookup
+        # could not name. A memo of the LOOKUP only — the decision it feeds is
+        # re-derived on every call, so a lens that arrives while a sibling's
+        # first call is still being shaped derives the same answer for itself
+        # instead of reading a marker the sibling set before it finished.
+        self._route_params: dict[str, frozenset[str] | None] = {}
         self._rejected_params: dict[str, set[str]] = {}
         # Memoized supports-cache-control answers: the review fans out many
         # completions on the same model string, and the capability lookup is a
@@ -740,12 +743,21 @@ class LiteLLMProvider:
         as the 400 path does). A lookup failure — an unknown route — leaves the
         schema on: the request-level recoveries still cover it, and a capability
         lookup must never cost enforcement on a route that would have taken it.
-        Once per model: the fan-out sends the same shape N times.
+
+        The lookup is memoised per model; the decision is not. The lens fan-out
+        calls this concurrently on one instance, and a "probed" marker set
+        before the outcome was recorded let a second lens skip the probe, find
+        neither set populated yet, and send the schema litellm then dropped. Each
+        call deriving its own answer from the same list cannot race: the sets
+        the outcome lands in are idempotent, and the announcements fire once.
+        A model that has since given the schema up entirely keeps that: the
+        route's list must not re-enable a tool the route already refused.
         """
-        if model in self._schema_probed or kwargs.get("response_format") is None:
+        if kwargs.get("response_format") is None or model in self._schema_dropped:
             return
-        self._schema_probed.add(model)
-        supported = _supported_params(model)
+        if model not in self._route_params:
+            self._route_params[model] = _supported_params(model)
+        supported = self._route_params[model]
         if supported is None or "response_format" in supported:
             return
         if "tools" in supported and self._use_schema_tool(model, kwargs):

--- a/tests/engine/test_compress.py
+++ b/tests/engine/test_compress.py
@@ -30,7 +30,7 @@ def test_the_token_counter_is_cached() -> None:
     """The encoder is built once and reused across count_tokens calls — it is
     resolved once per file during batching, and per LINE inside take_lines, so
     building it each time is slow."""
-    assert _counter_for(None) is _counter_for(None)
+    assert _counter_for() is _counter_for()
 
 
 def test_count_tokens_is_stable_and_positive() -> None:
@@ -706,21 +706,19 @@ def test_a_definition_far_above_the_hunk_is_out_of_reach() -> None:
     assert "def long_one" not in expanded
 
 
-class TestTokenCountingIsVisibleAndProviderAware:
+class TestTokenCountingIsVisible:
     """Batching decisions are only as good as the count behind them.
 
-    Two silent failures made the budget meaningless: `tiktoken.get_encoding`
+    One silent failure made the budget meaningless: `tiktoken.get_encoding`
     needs a network fetch on first use, and any failure was swallowed into a
-    `len // 4` character estimate with nothing logged; and `cl100k_base` is
-    OpenAI's tokenizer, applied to every provider, so a non-OpenAI run measured
-    its budget in the wrong model's tokens.
+    `len // 4` character estimate with nothing logged.
+
+    There is deliberately no per-model tokenizer. litellm's registry was tried
+    and resolves to the same OpenAI encoding for every provider it knows
+    (anthropic, vertex, bedrock, ollama alike), so "count in the model's own
+    tokenizer" bought a heavy import and nothing else. One encoder, resolved
+    once.
     """
-
-    def setup_method(self) -> None:
-        compress.set_counting_model(None)
-
-    def teardown_method(self) -> None:
-        compress.set_counting_model(None)
 
     @staticmethod
     def _warnings_while(action) -> list[str]:
@@ -738,6 +736,14 @@ class TestTokenCountingIsVisibleAndProviderAware:
         finally:
             compress._log.removeHandler(handler)
         return [record.getMessage() for record in captured]
+
+    def test_counting_never_imports_litellm(self) -> None:
+        """The engine must not pay a multi-second import to count characters —
+        and a per-model lookup that resolves to the same encoding for every
+        model is not worth one either."""
+        import inspect
+
+        assert "import litellm" not in inspect.getsource(compress)
 
     def test_the_character_fallback_says_so_instead_of_failing_silently(self, monkeypatch) -> None:
         compress._counter_for.cache_clear()
@@ -763,37 +769,3 @@ class TestTokenCountingIsVisibleAndProviderAware:
         estimate = compress.count_tokens(code)
 
         assert estimate >= len(code) / 4, "a 4-chars-per-token estimate under-counts code"
-
-    def test_the_counter_follows_the_configured_model(self, monkeypatch) -> None:
-        """Same text, different tokenizer ⇒ a different count. The cache must not
-        keep serving the previous model's answer."""
-        compress._counter_for.cache_clear()
-        compress.count_tokens.cache_clear()
-        monkeypatch.setattr(
-            compress,
-            "_load_model_counter",
-            lambda model: lambda text: 7 if model == "a-model" else 11,
-        )
-
-        compress.set_counting_model("a-model")
-        first = compress.count_tokens("identical text")
-        compress.set_counting_model("b-model")
-        second = compress.count_tokens("identical text")
-
-        assert (first, second) == (7, 11)
-
-    def test_an_unusable_model_tokenizer_falls_back_rather_than_raising(self, monkeypatch) -> None:
-        compress._counter_for.cache_clear()
-        compress.count_tokens.cache_clear()
-        monkeypatch.setattr(
-            compress,
-            "_load_model_counter",
-            lambda model: (_ for _ in ()).throw(RuntimeError("no tokenizer")),
-        )
-        compress.set_counting_model("mystery-model")
-
-        counted: list[int] = []
-        messages = self._warnings_while(lambda: counted.append(compress.count_tokens("text")))
-
-        assert counted[0] > 0, "counting must never fail a review"
-        assert any("tokenizer" in message for message in messages)

--- a/tests/engine/test_context_window_split.py
+++ b/tests/engine/test_context_window_split.py
@@ -140,3 +140,52 @@ def test_a_piece_that_is_still_too_long_is_reported_not_recursed() -> None:
     # The whole batch, then one attempt per half. No third level.
     assert provider.calls == 3
     assert "too long" in str(exc_info.value)
+
+
+# One file, ONE hunk — every brand-new file looks like this. A truncation on it
+# has nothing smaller to try (see test_truncation_split); a refused prompt does.
+_ONE_BIG_HUNK = (
+    """diff --git a/new.py b/new.py
+--- /dev/null
++++ b/new.py
+@@ -0,0 +1,12 @@
++first_change = 1
+"""
+    + "".join(f"+padding_line_{i} = {i}\n" for i in range(10))
+    + "+last_change = 12\n"
+)
+
+
+class _RefusesTheWholeHunk(FakeProvider):
+    """Refuses the prompt while the whole hunk is in it; answers any slice."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.diffs: list[str] = []
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        self.diffs.append(diff)
+        if "first_change = 1" in diff and "last_change = 12" in diff:
+            raise ProviderInputTooLarge("prompt is too long: 214000 tokens > 200000 maximum")
+        return ProviderResult(text='{"findings": []}', input_tokens=5, output_tokens=5)
+
+
+def test_a_refused_lone_hunk_is_sliced_inside() -> None:
+    """A context-window refusal is purely about input size, so cutting inside the
+    one hunk is guaranteed to help — the truncation path's "nothing smaller to
+    try" would leave a new file entirely unreviewed here."""
+    provider = _RefusesTheWholeHunk()
+    ctx = PRContext(
+        diff=_ONE_BIG_HUNK,
+        changed_files=["new.py"],
+        base_sha="b",
+        head_sha="h",
+        repo="o/r",
+        pr_number=1,
+    )
+    _findings, summary = LLMReviewEngine(provider).review(ctx, _cfg())
+
+    assert len(provider.diffs) >= 3  # the whole hunk, then at least two slices
+    assert sum("first_change = 1" in d and "last_change = 12" in d for d in provider.diffs) == 1
+    assert "incomplete" not in summary.lower()

--- a/tests/engine/test_context_window_split.py
+++ b/tests/engine/test_context_window_split.py
@@ -1,0 +1,142 @@
+"""A prompt the model's context window cannot hold is retried SMALLER.
+
+Third sibling of ``test_timeout_split`` and ``test_truncation_split``. A wall
+timeout, a blown output ceiling and a blown INPUT window all say the same thing
+about the payload — one call was asked to carry more than the model could take
+— so they earn the same remedy: split the batch and review the pieces.
+
+Before this, the failure arrived as litellm's ``ContextWindowExceededError``, a
+``BadRequestError`` subclass the adapter (rightly) never retries in place and
+(wrongly) stamped unrecoverable — so the engine gave the lens up as a dead key
+would be, when the split it already had was exactly the fix.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.core.ports import Message, ProviderInputTooLarge
+from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine.engine import ReviewIncompleteError
+from tests.fakes import FakeProvider
+
+_TWO_FILE_DIFF = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,2 +1,3 @@
+ import os
++first_change = os.getcwd()
+ print(os.name)
+diff --git a/two.py b/two.py
+--- a/two.py
++++ b/two.py
+@@ -1,2 +1,3 @@
+ import sys
++second_change = sys.maxsize
+ print(sys.argv)
+"""
+
+_ADDED = {
+    "one.py": "first_change = os.getcwd()",
+    "two.py": "second_change = sys.maxsize",
+}
+
+
+def _shows(diff: str, *paths: str) -> bool:
+    return all(_ADDED[path] in diff for path in paths)
+
+
+def _ctx() -> PRContext:
+    return PRContext(
+        diff=_TWO_FILE_DIFF,
+        changed_files=["one.py", "two.py"],
+        base_sha="b",
+        head_sha="h",
+        repo="o/r",
+        pr_number=1,
+    )
+
+
+def _cfg() -> ReviewConfig:
+    return ReviewConfig(
+        provider=Provider.anthropic,
+        model="claude-sonnet-4-5",
+        categories=[ReviewCategory.security],
+        reflect=False,
+    )
+
+
+def _finding_json(path: str) -> str:
+    return json.dumps(
+        {
+            "findings": [
+                {
+                    "path": path,
+                    "line": 2,
+                    "severity": "medium",
+                    "title": f"unchecked value in {path}",
+                    "body": "the new binding is never validated",
+                    "anchor": _ADDED[path],
+                    "failure_scenario": "A caller reads the new binding before it is set.",
+                }
+            ]
+        }
+    )
+
+
+class _TooLongUntilSmaller(FakeProvider):
+    """Refuses the prompt while both files ride one call; answers a half."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.diffs: list[str] = []
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        diff = "\n".join(str(m.get("content", "")) for m in messages)
+        self.diffs.append(diff)
+        if _shows(diff, "one.py", "two.py"):
+            raise ProviderInputTooLarge("prompt is too long: 214000 tokens > 200000 maximum")
+        path = "one.py" if _shows(diff, "one.py") else "two.py"
+        return ProviderResult(text=_finding_json(path), input_tokens=5, output_tokens=5)
+
+
+def test_an_over_window_batch_is_split_and_its_halves_reviewed() -> None:
+    provider = _TooLongUntilSmaller()
+    findings, summary = LLMReviewEngine(provider).review(_ctx(), _cfg())
+
+    assert sorted(f.path for f in findings) == ["one.py", "two.py"]
+    # The oversized call, then one per half — never the same oversized prompt twice.
+    assert len(provider.diffs) == 3
+    assert sum(_shows(d, "one.py", "two.py") for d in provider.diffs) == 1
+    assert "incomplete" not in summary.lower()
+
+
+class _AlwaysTooLong(FakeProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        self.calls += 1
+        raise ProviderInputTooLarge("prompt is too long")
+
+
+def test_a_piece_that_is_still_too_long_is_reported_not_recursed() -> None:
+    """One split level, then the failure stands — named, never an endless cascade."""
+    provider = _AlwaysTooLong()
+    with pytest.raises(ReviewIncompleteError) as exc_info:
+        LLMReviewEngine(provider).review(_ctx(), _cfg())
+
+    # The whole batch, then one attempt per half. No third level.
+    assert provider.calls == 3
+    assert "too long" in str(exc_info.value)

--- a/tests/engine/test_input_budget.py
+++ b/tests/engine/test_input_budget.py
@@ -1,0 +1,153 @@
+"""The batching budget is fitted to the model's context window.
+
+`max_input_tokens` defaults to a flat number that knows nothing about the model.
+A provider that can say how much prompt its model takes (the litellm adapter
+reads it off litellm's model map, or off ollama's `num_ctx`) is asked, and the
+default is shrunk to fit — so a batch is never built that the model refuses,
+or that ollama silently truncates. A configured value is the user's call and
+is left alone; a provider with no opinion changes nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lgtmaybe.core.models import (
+    PRContext,
+    Provider,
+    ProviderResult,
+    ReviewCategory,
+    ReviewConfig,
+)
+from lgtmaybe.core.ports import Message
+from lgtmaybe.engine import LLMReviewEngine
+from lgtmaybe.engine.compress import count_tokens
+from tests.fakes import FakeProvider
+
+# Two equal-sized files, padded so the per-file token count is well clear of
+# the counting noise between tokenizers (CI has the real encoder; an
+# egress-restricted box falls back to the character estimate).
+_TWO_FILE_DIFF = """diff --git a/one.py b/one.py
+--- a/one.py
++++ b/one.py
+@@ -1,14 +1,15 @@
+ import os
++first_change = os.getcwd()
+ pad_0 = 0
+ pad_1 = 1
+ pad_2 = 2
+ pad_3 = 3
+ pad_4 = 4
+ pad_5 = 5
+ pad_6 = 6
+ pad_7 = 7
+ pad_8 = 8
+ pad_9 = 9
+ pad_10 = 10
+ pad_11 = 11
+ print(os.name)
+diff --git a/two.py b/two.py
+--- a/two.py
++++ b/two.py
+@@ -1,14 +1,15 @@
+ import sys
++second_change = sys.maxsize
+ pad_0 = 0
+ pad_1 = 1
+ pad_2 = 2
+ pad_3 = 3
+ pad_4 = 4
+ pad_5 = 5
+ pad_6 = 6
+ pad_7 = 7
+ pad_8 = 8
+ pad_9 = 9
+ pad_10 = 10
+ pad_11 = 11
+ print(sys.argv)
+"""
+
+
+def _ctx() -> PRContext:
+    return PRContext(
+        diff=_TWO_FILE_DIFF,
+        changed_files=["one.py", "two.py"],
+        base_sha="b",
+        head_sha="h",
+        repo="o/r",
+        pr_number=1,
+    )
+
+
+def _cfg(**overrides: Any) -> ReviewConfig:
+    return ReviewConfig(
+        provider=Provider.ollama,
+        model="qwen3:8b",
+        categories=[ReviewCategory.security],
+        reflect=False,
+        context_lines=0,
+        **overrides,
+    )
+
+
+class _Counting(FakeProvider):
+    def __init__(self, budget: int | None) -> None:
+        super().__init__()
+        self._budget = budget
+        self.calls = 0
+
+    def input_budget(self) -> int | None:
+        return self._budget
+
+    def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+        self.calls += 1
+        return ProviderResult(text='{"findings": []}', input_tokens=1, output_tokens=1)
+
+
+def _one_file_fits_two_do_not() -> int:
+    """A budget one file clears and two together overflow, in whatever counter
+    this box has — the two files are the same size by construction."""
+    return int(count_tokens(_TWO_FILE_DIFF) * 0.6)
+
+
+def test_a_small_window_splits_what_the_default_would_send_whole() -> None:
+    """Two files fit one call at the default budget; a provider whose model
+    takes only one of them at a time gets them one per call."""
+    provider = _Counting(budget=_one_file_fits_two_do_not())
+    LLMReviewEngine(provider).review(_ctx(), _cfg())
+    assert provider.calls == 2
+
+
+def test_a_generous_window_leaves_the_default_alone() -> None:
+    provider = _Counting(budget=1_000_000)
+    LLMReviewEngine(provider).review(_ctx(), _cfg())
+    assert provider.calls == 1
+
+
+def test_a_configured_budget_is_the_users_call() -> None:
+    """An explicit `max_input_tokens` is honoured even past what the provider
+    reports — the user may know something the map does not."""
+    provider = _Counting(budget=_one_file_fits_two_do_not())
+    LLMReviewEngine(provider).review(_ctx(), _cfg(max_input_tokens=100_000))
+    assert provider.calls == 1
+
+
+def test_a_provider_with_no_opinion_changes_nothing() -> None:
+    provider = _Counting(budget=None)
+    LLMReviewEngine(provider).review(_ctx(), _cfg())
+    assert provider.calls == 1
+
+
+def test_a_provider_that_cannot_answer_changes_nothing() -> None:
+    class _Plain(FakeProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def complete(self, messages: list[Message], model: str, **opts: Any) -> ProviderResult:
+            self.calls += 1
+            return ProviderResult(text='{"findings": []}', input_tokens=1, output_tokens=1)
+
+    provider = _Plain()
+    LLMReviewEngine(provider).review(_ctx(), _cfg())
+    assert provider.calls == 1

--- a/tests/providers/test_factory.py
+++ b/tests/providers/test_factory.py
@@ -553,3 +553,126 @@ def test_build_provider_defaults_to_capable_when_the_map_is_silent() -> None:
     provider = build_provider(Provider.openai, "gpt-5.5", api_key="k")
 
     assert provider._effort_override_supported is True
+
+
+class TestClaudeThinkingSampling:
+    """A reasoning effort on a Claude route turns into extended thinking, and
+    Anthropic rejects a temperature beside it ("`temperature` may only be set
+    to 1 when thinking is enabled"). litellm forwards both regardless, so the
+    factory withholds the one the user did not ask for: the effort was
+    configured, the temperature is our determinism default.
+    """
+
+    def test_anthropic_effort_withholds_temperature(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="lgtmaybe.providers.factory"):
+            built = build_provider(
+                Provider.anthropic,
+                "claude-sonnet-4-5",
+                api_key="k",
+                reasoning_effort="medium",
+                temperature=0.0,
+            )
+        assert "temperature" not in built.default_opts
+        assert built.default_opts["reasoning_effort"] == "medium"
+        assert any("temperature" in record.getMessage() for record in caplog.records)
+
+    def test_effort_none_keeps_temperature(self) -> None:
+        """`none` disables thinking, and a non-thinking request takes a temperature."""
+        built = build_provider(
+            Provider.anthropic,
+            "claude-sonnet-4-5",
+            api_key="k",
+            reasoning_effort="none",
+            temperature=0.0,
+        )
+        assert built.default_opts["temperature"] == 0.0
+
+    def test_no_effort_keeps_temperature(self) -> None:
+        built = build_provider(
+            Provider.anthropic, "claude-sonnet-4-5", api_key="k", temperature=0.0
+        )
+        assert built.default_opts["temperature"] == 0.0
+
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [
+            (Provider.bedrock, "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            (Provider.bedrock, "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            (Provider.vertex, "claude-sonnet-4-5@20250929"),
+        ],
+    )
+    def test_claude_on_a_cloud_route_is_treated_the_same(
+        self, provider: Provider, model: str
+    ) -> None:
+        built = build_provider(provider, model, reasoning_effort="low", temperature=0.0)
+        assert "temperature" not in built.default_opts
+
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [
+            (Provider.openai, "gpt-5"),
+            (Provider.vertex, "gemini-2.5-pro"),
+            (Provider.bedrock, "amazon.nova-pro-v1:0"),
+            (Provider.ollama, "qwen3:8b"),
+        ],
+    )
+    def test_other_reasoning_routes_keep_temperature(self, provider: Provider, model: str) -> None:
+        built = build_provider(
+            provider, model, api_key="k", reasoning_effort="low", temperature=0.0
+        )
+        assert built.default_opts["temperature"] == 0.0
+
+
+class TestInputBudget:
+    """The prompt budget a model can actually take, read off the route.
+
+    The engine's batching budget (`max_input_tokens`) defaults to a flat number
+    that knows nothing about the model. litellm knows the context window of
+    every hosted model in its map, and ollama's window is the `num_ctx` the
+    factory itself sends — so the adapter can say how much prompt fits, and
+    the engine can fit its batches to it instead of learning from a 400.
+    """
+
+    def test_ollama_budget_is_num_ctx_less_the_output_ceiling(self) -> None:
+        built = build_provider(Provider.ollama, "qwen3:8b")
+        assert (
+            built.input_budget() == built.default_opts["num_ctx"] - built.default_opts["max_tokens"]
+        )
+
+    def test_ollama_budget_follows_an_overridden_num_ctx(self) -> None:
+        built = build_provider(Provider.ollama, "qwen3:8b", num_ctx=8192, max_tokens=1024)
+        assert built.input_budget() == 8192 - 1024
+
+    def test_hosted_budget_comes_from_the_model_map(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import litellm
+
+        monkeypatch.setattr(litellm, "get_model_info", lambda model: {"max_input_tokens": 65536})
+        built = build_provider(Provider.openrouter, "deepseek/deepseek-chat", api_key="k")
+        # openrouter carries the default finite ceiling, which the prompt must leave room for.
+        assert built.input_budget() == 65536 - built.default_opts["max_tokens"]
+
+    def test_an_uncapped_route_gets_the_whole_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import litellm
+
+        monkeypatch.setattr(litellm, "get_model_info", lambda model: {"max_input_tokens": 200000})
+        built = build_provider(Provider.anthropic, "claude-sonnet-4-5", api_key="k")
+        assert built.input_budget() == 200000
+
+    def test_an_unmapped_model_has_no_opinion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import litellm
+
+        def unmapped(model: str) -> dict:
+            raise ValueError("This model isn't mapped yet")
+
+        monkeypatch.setattr(litellm, "get_model_info", unmapped)
+        built = build_provider(Provider.openai_compatible, "my-local", api_base="http://x")
+        assert built.input_budget() is None
+
+    def test_a_map_entry_without_a_window_has_no_opinion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+
+        monkeypatch.setattr(litellm, "get_model_info", lambda model: {"max_input_tokens": None})
+        built = build_provider(Provider.openai, "gpt-5", api_key="k")
+        assert built.input_budget() is None

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import litellm
 import pytest
+from pydantic import BaseModel
 
 from lgtmaybe.core.models import ProviderResult
 from lgtmaybe.core.ports import ProviderTruncated
@@ -343,3 +344,192 @@ class TestCostEstimation:
                 )
 
         assert excinfo.value.cost_usd == pytest.approx(0.070)
+
+
+def _tool_call_response(arguments: str, name: str = "lgtmaybe_structured_output") -> Any:
+    """A reply that answered through the forced schema tool, content empty."""
+    call = SimpleNamespace(function=SimpleNamespace(name=name, arguments=arguments))
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[call]), finish_reason="tool_calls"
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+class _Schema(BaseModel):
+    findings: list[str]
+
+
+class TestRouteSchemaSupport:
+    """The schema is chosen for the ROUTE before the first call, not learned from
+    a 400 that never comes.
+
+    litellm runs with `drop_params`, which strips every OpenAI-vocabulary param
+    a route's capability list omits — silently. The zai route lists `tools`
+    but not `response_format`, so the schema vanished on the way out, the model
+    answered prose, and the adapter still reported that structured output was
+    on. Neither of the two existing recoveries (a 400 naming the field, an
+    empty body) can see a param litellm removed before the request left.
+    """
+
+    _WITH_TOOLS = ["max_tokens", "temperature", "tools", "tool_choice"]
+    _BARE = ["max_tokens", "temperature"]
+
+    def test_a_route_that_drops_response_format_gets_the_schema_as_a_tool(self) -> None:
+        sent: list[dict[str, Any]] = []
+
+        def capture(**kwargs: Any) -> Any:
+            sent.append(kwargs)
+            return _tool_call_response('{"findings": ["x"]}')
+
+        with (
+            patch("litellm.get_supported_openai_params", return_value=self._WITH_TOOLS),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}], "zai/glm-4.6", response_format=_Schema
+            )
+
+        assert result.text == '{"findings": ["x"]}'
+        assert len(sent) == 1, "decided up front — no wasted round-trip first"
+        assert "response_format" not in sent[0]
+        assert sent[0]["tools"][0]["function"]["name"] == "lgtmaybe_structured_output"
+        assert sent[0]["tool_choice"]["function"]["name"] == "lgtmaybe_structured_output"
+        # Enforcement was kept, by another mechanism — not given up.
+        assert provider.sends_response_format("zai/glm-4.6")
+        assert not provider.schema_dropped()
+
+    def test_a_route_with_no_structured_output_mechanism_drops_the_schema_up_front(self) -> None:
+        sent: list[dict[str, Any]] = []
+
+        def capture(**kwargs: Any) -> Any:
+            sent.append(kwargs)
+            return _fake_response('{"findings": []}')
+
+        with (
+            patch("litellm.get_supported_openai_params", return_value=self._BARE),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            provider = LiteLLMProvider()
+            provider.complete(
+                [{"role": "user", "content": "hi"}], "some/route", response_format=_Schema
+            )
+
+        assert len(sent) == 1
+        assert "response_format" not in sent[0] and "tools" not in sent[0]
+        # Given up, and said so: the engine reads this to name the downgrade.
+        assert provider.schema_dropped()
+        assert not provider.sends_response_format("some/route")
+
+    def test_a_route_that_takes_the_schema_sends_it_unchanged(self) -> None:
+        sent: list[dict[str, Any]] = []
+
+        def capture(**kwargs: Any) -> Any:
+            sent.append(kwargs)
+            return _fake_response('{"findings": []}')
+
+        with (
+            patch(
+                "litellm.get_supported_openai_params",
+                return_value=[*self._WITH_TOOLS, "response_format"],
+            ),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            LiteLLMProvider().complete(
+                [{"role": "user", "content": "hi"}], "openai/gpt-5", response_format=_Schema
+            )
+
+        assert sent[0]["response_format"] is _Schema
+        assert "tools" not in sent[0]
+
+    def test_a_capability_lookup_failure_leaves_the_schema_on(self) -> None:
+        """Unknown route ⇒ trial by request, exactly as before: the 400 path
+        still recovers, and a lookup error must never cost enforcement."""
+        sent: list[dict[str, Any]] = []
+
+        def capture(**kwargs: Any) -> Any:
+            sent.append(kwargs)
+            return _fake_response('{"findings": []}')
+
+        def unknown(**kwargs: Any) -> Any:
+            raise ValueError("unknown provider")
+
+        with (
+            patch("litellm.get_supported_openai_params", side_effect=unknown),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            LiteLLMProvider().complete(
+                [{"role": "user", "content": "hi"}], "mystery/model", response_format=_Schema
+            )
+
+        assert sent[0]["response_format"] is _Schema
+
+    def test_the_lookup_is_made_once_per_model(self) -> None:
+        calls: list[str] = []
+
+        def lookup(**kwargs: Any) -> Any:
+            calls.append(kwargs["model"])
+            return self._WITH_TOOLS
+
+        with (
+            patch("litellm.get_supported_openai_params", side_effect=lookup),
+            patch("litellm.completion", return_value=_tool_call_response('{"findings": []}')),
+        ):
+            provider = LiteLLMProvider()
+            for _ in range(3):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "zai/glm-4.6", response_format=_Schema
+                )
+
+        assert calls == ["zai/glm-4.6"]
+
+
+class TestContextWindowExceeded:
+    """A prompt the model's window cannot hold is a payload problem, not a
+    permanent one: the identical request can never succeed, but a smaller one
+    can, and the engine owns the split. litellm names the case with its own
+    exception type; the adapter hands it up under the port's name rather than
+    letting it fall through as a generic bad request the engine would give up on.
+    """
+
+    @staticmethod
+    def _too_long() -> Exception:
+        from litellm.exceptions import ContextWindowExceededError
+
+        return ContextWindowExceededError(
+            message="prompt is too long: 214000 tokens > 200000 maximum",
+            model="claude-sonnet-4-5",
+            llm_provider="anthropic",
+        )
+
+    def test_surfaces_as_input_too_large_after_one_request(self) -> None:
+        from lgtmaybe.core.models import is_unrecoverable
+        from lgtmaybe.core.ports import ProviderInputTooLarge
+
+        with patch("litellm.completion", side_effect=self._too_long()) as completion:
+            with pytest.raises(ProviderInputTooLarge, match="too long") as info:
+                LiteLLMProvider().complete([{"role": "user", "content": "hi"}], "anthropic/x")
+
+        # Never retried in place: the same prompt is the same size.
+        assert completion.call_count == 1
+        # But not unrecoverable either — a smaller request is the remedy, and
+        # the engine must not be told this call's failure is beyond saving.
+        assert not is_unrecoverable(info.value)
+
+    def test_is_handed_to_the_caller_when_it_owns_the_remedy(self) -> None:
+        """With `defer_truncation` the engine holds the batch, so the adapter
+        must not spend the fallback model on the identical oversized prompt."""
+        from lgtmaybe.core.ports import ProviderInputTooLarge
+
+        with patch("litellm.completion", side_effect=self._too_long()) as completion:
+            provider = LiteLLMProvider(fallback_model="anthropic/bigger")
+            with pytest.raises(ProviderInputTooLarge):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "anthropic/x", defer_truncation=True
+                )
+
+        assert completion.call_count == 1

--- a/tests/providers/test_litellm_provider.py
+++ b/tests/providers/test_litellm_provider.py
@@ -533,3 +533,80 @@ class TestContextWindowExceeded:
                 )
 
         assert completion.call_count == 1
+
+
+class TestRouteSchemaSupportUnderConcurrency:
+    def test_every_concurrent_first_call_gets_the_tool(self) -> None:
+        """The lens fan-out hits one instance at once. A lens arriving while a
+        sibling's first call is still being shaped must reach the same shape,
+        not find a half-recorded state and send the schema litellm then drops."""
+        import threading
+        import time
+
+        sent: list[dict[str, Any]] = []
+        lock = threading.Lock()
+
+        def slow_lookup(**kwargs: Any) -> Any:
+            time.sleep(0.05)  # long enough for every thread to be inside complete()
+            return ["max_tokens", "temperature", "tools", "tool_choice"]
+
+        def capture(**kwargs: Any) -> Any:
+            with lock:
+                sent.append(kwargs)
+            return _tool_call_response('{"findings": []}')
+
+        provider = LiteLLMProvider()
+        errors: list[BaseException] = []
+
+        def one_lens() -> None:
+            try:
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "zai/glm-4.6", response_format=_Schema
+                )
+            except BaseException as exc:  # noqa: BLE001 — surfaced below
+                errors.append(exc)
+
+        with (
+            patch("litellm.get_supported_openai_params", side_effect=slow_lookup),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            threads = [threading.Thread(target=one_lens) for _ in range(6)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not errors
+        assert len(sent) == 6
+        assert all("response_format" not in kwargs and "tools" in kwargs for kwargs in sent)
+
+    def test_a_route_that_gave_the_schema_up_is_not_re_armed_by_the_list(self) -> None:
+        """Once the tool itself was refused, the route's list saying "tools" must
+        not put the tool back on the next call."""
+        sent: list[dict[str, Any]] = []
+
+        def capture(**kwargs: Any) -> Any:
+            sent.append(kwargs)
+            if "tools" in kwargs:
+                raise RuntimeError("BadRequestError: toolConfig is not supported for this model")
+            return _fake_response('{"findings": []}')
+
+        with (
+            patch(
+                "litellm.get_supported_openai_params",
+                return_value=["max_tokens", "tools", "tool_choice"],
+            ),
+            patch("litellm.completion", side_effect=capture),
+        ):
+            provider = LiteLLMProvider()
+            for _ in range(2):
+                provider.complete(
+                    [{"role": "user", "content": "hi"}], "some/route", response_format=_Schema
+                )
+
+        # Tool, refused; bare re-send; then the second call goes bare up front.
+        assert [("tools" in k, "response_format" in k) for k in sent] == [
+            (True, False),
+            (False, False),
+            (False, False),
+        ]

--- a/tests/providers/test_provider_matrix.py
+++ b/tests/providers/test_provider_matrix.py
@@ -13,7 +13,10 @@ skipping a variation. Three axes are covered per provider:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+from pydantic import BaseModel
 
 from lgtmaybe.core.models import Provider
 from lgtmaybe.providers.credentials import resolve_credentials
@@ -248,3 +251,115 @@ class TestEndpointProviderCredentials:
     def test_build_provider_threads_the_endpoint(self, provider: Provider) -> None:
         built = build_provider(provider, "deepseek-chat", api_key="k", api_base=_CUSTOM_BASE)
         assert built.default_opts.get("api_base") == _CUSTOM_BASE
+
+
+# --- structured output survives litellm's translation, per provider ---------
+
+# One representative model per provider: real ids, so litellm's capability map
+# (and each route's own supported-params list) answers as it would in the field.
+_SCHEMA_MODELS: dict[Provider, str] = {
+    Provider.openai: "gpt-5",
+    Provider.anthropic: "claude-sonnet-4-5",
+    Provider.openrouter: "deepseek/deepseek-chat",
+    Provider.bedrock: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    Provider.vertex: "gemini-2.5-pro",
+    Provider.azure: "gpt-4.1",
+    Provider.ollama: "qwen3:8b",
+    Provider.openai_compatible: "my-local-model",
+    Provider.zai: "glm-4.6",
+}
+
+# The request-shape keys under which a route carries a structured-output
+# contract after translation: OpenAI's own field, a forced tool (our recovery
+# and litellm's own for anthropic), anthropic's native output_format, the
+# bedrock Converse field, ollama's `format`, and Gemini's response_json_schema.
+_SCHEMA_CARRIERS = (
+    "response_format",
+    "tools",
+    "output_format",
+    "outputConfig",
+    "format",
+    "response_json_schema",
+)
+
+
+class _Findings(BaseModel):
+    findings: list[str]
+
+
+@pytest.mark.parametrize("provider", list(Provider))
+def test_the_schema_survives_litellm_translation(provider: Provider) -> None:
+    """What the adapter sends is not what goes on the wire: litellm translates
+    every request per route and, with `drop_params` on, silently removes any
+    OpenAI-vocabulary param the route's list omits. Every other provider test
+    patches `litellm.completion`, so that translation is never exercised — and
+    a route that drops `response_format` (zai) reviewed with no schema at all
+    while the adapter reported enforcement was on. This runs the real
+    translation on the adapter's real kwargs, offline, for every provider.
+    """
+    import litellm
+
+    built = build_provider(
+        provider,
+        _SCHEMA_MODELS[provider],
+        api_key="k",
+        api_base="https://example.invalid"
+        if provider in (*HYBRID_PROVIDERS, *ENDPOINT_PROVIDERS)
+        else None,
+    )
+    translated: list[dict] = []
+
+    def translate(**kwargs):
+        model, custom_llm_provider, _key, _base = litellm.get_llm_provider(kwargs["model"])
+        request = {
+            k: v
+            for k, v in kwargs.items()
+            if k in ("response_format", "tools", "tool_choice", "temperature", "max_tokens")
+        }
+        translated.append(
+            litellm.get_optional_params(
+                model=model, custom_llm_provider=custom_llm_provider, **request
+            )
+        )
+        return _tool_reply() if "tools" in kwargs else _plain_reply()
+
+    with patch("litellm.completion", side_effect=translate):
+        built.complete(
+            [{"role": "user", "content": "hi"}], _SCHEMA_MODELS[provider], response_format=_Findings
+        )
+
+    assert translated, "the adapter never reached litellm"
+    on_the_wire = translated[-1]
+    assert any(key in on_the_wire for key in _SCHEMA_CARRIERS), (
+        f"{provider.value}: litellm's {built.model} translation carries no schema: "
+        f"{sorted(on_the_wire)}"
+    )
+
+
+def _plain_reply():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content='{"findings": []}'), finish_reason="stop"
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def _tool_reply():
+    from types import SimpleNamespace
+
+    call = SimpleNamespace(
+        function=SimpleNamespace(name="lgtmaybe_structured_output", arguments='{"findings": []}')
+    )
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[call]), finish_reason="tool_calls"
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )

--- a/tests/providers/test_retry.py
+++ b/tests/providers/test_retry.py
@@ -2761,3 +2761,37 @@ class TestTheAnsweringModelRidesTheResult:
             result = provider.complete(self.MESSAGES, "openrouter/deepseek")
 
         assert result.model == "openrouter/backup"
+
+
+class TestThinkingTemperatureRejection:
+    def test_anthropics_thinking_wording_is_recognised(self) -> None:
+        """Anthropic phrases the refusal differently from OpenAI: the value is not
+        "unsupported", it "may only be set to 1 when thinking is enabled". The
+        factory withholds the temperature up front on the Claude routes, and
+        this is the backstop for a route it did not recognise."""
+        good = _fake_response("ok without temperature")
+        seen: list[Any] = []
+
+        def side_effect(*args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs.get("temperature", "absent"))
+            if "temperature" in kwargs:
+                raise RuntimeError(
+                    'litellm.BadRequestError: AnthropicException - {"type":"error",'
+                    '"error":{"type":"invalid_request_error","message":"`temperature` '
+                    "may only be set to 1 when thinking is enabled. Please consult our "
+                    "documentation at https://docs.claude.com/en/docs/build-with-claude/"
+                    'extended-thinking#important-considerations-when-using-extended-thinking"}}'
+                )
+            return good
+
+        with patch("litellm.completion", side_effect=side_effect):
+            provider = LiteLLMProvider()
+            result = provider.complete(
+                [{"role": "user", "content": "hi"}],
+                "openrouter/anthropic/claude-sonnet-4-5",
+                temperature=0.0,
+                reasoning_effort="medium",
+            )
+
+        assert result.text == "ok without temperature"
+        assert seen == [0.0, "absent"]


### PR DESCRIPTION
## Summary

Four changes that come from reading what litellm already knows about a route (its per-route supported-params list and its model map) instead of learning it from a failed call. Two of them are latent bugs.

### 1. zai silently lost structured output

litellm's zai route lists `tools` and `tool_choice` but not `response_format`, so with `drop_params` on the schema was stripped before the request left. No 400 came back, no empty body, so neither existing recovery fired and `sends_response_format` still reported enforcement was on.

- `LiteLLMProvider._honour_route_schema_support` consults the same per-route list litellm's `drop_params` consults, once per model, before the first schema-carrying call. Tools-but-no-`response_format` goes out as the forced tool call (enforcement kept); neither drops the schema and announces it; a lookup failure leaves the request-level recoveries in charge.
- New provider-matrix test runs litellm's real `get_optional_params` translation offline on the adapter's real kwargs for every provider and asserts a schema survives. Every other provider test patches `litellm.completion`, so translation was never exercised. This test is red on `main` for zai.

### 2. The batching budget is fitted to the model's window

`max_input_tokens` defaulted to a flat 100k regardless of model. A 100k batch is refused outright by a 65k-window model (deepseek-chat on OpenRouter) and silently truncated by ollama to `num_ctx` (32k default).

- `LiteLLMProvider.input_budget()` reports ollama's `num_ctx`, else `litellm.get_model_info(...)["max_input_tokens"]`, less the output ceiling the adapter will send. None when the map has no opinion.
- `LLMReviewEngine._fit_input_budget` caps a *defaulted* `max_input_tokens` at that answer (feature-detected, like `escalate_model`). A configured value is left alone. Only ever downward.
- A prompt the backend still refuses arrives as litellm's `ContextWindowExceededError`, a `BadRequestError` subclass the adapter treated as permanent and unrecoverable. It is now surfaced as `ProviderInputTooLarge` (new port exception beside `ProviderTruncated` / `ProviderWallTimeout`) and routed to the existing batch split. Never retried in place, never stamped unrecoverable, handed to the engine under `defer_truncation` like a truncation.

### 3. Claude thinking plus temperature

A `reasoning_effort` on the anthropic, bedrock or vertex Claude routes becomes Anthropic's extended-thinking block, and Anthropic refuses a temperature beside it. litellm forwards both (verified offline via `transform_request`: `temperature: 0.0` and `thinking: enabled` in the same body). The factory now withholds the determinism-default temperature when the effort turns thinking on (not for `none`/`default`, not for non-Claude models), and logs it. `_rejects_temperature` learns Anthropic's "may only be set to 1 when thinking is enabled" wording as the backstop for gateway routes.

This one could not be verified against the live API from here. The factory change is safe either way (thinking is not deterministic, so the temperature bought nothing under it).

### 4. The per-model tokenizer path was a no-op

`compress._load_model_counter` called `litellm.encode` on the theory that it picks the model's own tokenizer. litellm's `_select_tokenizer` resolves to the same OpenAI encoding for anthropic, vertex, bedrock, ollama and gpt-5 alike, so the counts were byte-identical to the tiktoken fallback and the engine paid a multi-second import for them. Removed, along with `set_counting_model`. One `cl100k_base` encoder, resolved once.

## Verification

- `uv run pytest tests` green (2641 passed), including `tests/specs` and the docs freshness gates
- ruff check, ruff format, mypy clean
- `openspec validate --specs` passes; `scripts/check_spec_drift.py --base origin/main` reports no drift
- New spec requirements and ast-grep anchors: `engine.input-budget`, `provider.schema-route`, `provider.thinking-sampling`, `provider.input-budget`; `engine.timeout-split` updated for the third trigger

## Deliberately not adopted

`litellm.Router` (fallbacks, cooldowns, `context_window_fallbacks`) would replace the adapter's retry layer with a less specific one and lose the Retry-After parsing and quota-vs-capacity split. `acompletion` gains nothing over the thread pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGwJk8qDwPALhydHrD1VNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGwJk8qDwPALhydHrD1VNX)_